### PR TITLE
async/stream/future support for wasmtime-wit-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,7 +3849,7 @@ version = "0.14.0+wasi-0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.37.0",
 ]
 
 [[package]]
@@ -3960,9 +3960,9 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e636076193fa68103e937ac951b5f2f587624097017d764b8984d9c0f149464"
+checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
  "wasmparser",
@@ -3970,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c730c3379d3d20e5a0245b0724b924483e853588ca8fba547c1e21f19e7d735"
+checksum = "79d13d93febc749413cb6f327e4fdba8c84e4d03bd69fcc4a220c66f113c8de1"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
@@ -3987,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-mutate"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1ebeb8f91eda0710e5d556927696d06e1b8cc806bdffb0b8a44889ff54a77c"
+checksum = "1d0ede8b5d000e2ea09926ae5c4783fa1503f779c3f5132a8c8b791121fe5a99"
 dependencies = [
  "egg",
  "log",
@@ -4001,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccae1e6cf6af813ea27efc5230a6db78260b5acfb2d4339b0300669bd213de0"
+checksum = "d1c7826d83ef9b83db810c0b8442093cf51e726bf1ed3a75448617c5718fcc79"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4023,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9362c422fad4e55376dbc937432bada2a9e4f4e3a6cbbc65363fa3323f897b"
+checksum = "598c5e8b9f70d086d121e47153c44e35a5528e766eb817e4bb9dcacb8804c1be"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
@@ -4079,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a99faceb1a5a84dd6084ec4bfa4b2ab153b5793b43fd8f58b89232634afc35"
+checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9235722b8cdb6c1c6daa537d4be4e230e76ce3ce0e4ba991956a1c6aed50305a"
+checksum = "bc039e211f6c2137425726f0d76fdd9c439a442e5272bc3627a19274d0eb9686"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4123,6 +4123,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "env_logger 0.11.5",
+ "futures",
  "fxprof-processed-profile",
  "gimli",
  "hashbrown 0.15.2",
@@ -4316,7 +4317,7 @@ dependencies = [
  "wasmtime-wasi-threads",
  "wasmtime-wast",
  "wasmtime-wast-util",
- "wast 223.0.0",
+ "wast 224.0.0",
  "wat",
  "windows-sys 0.59.0",
  "wit-component",
@@ -4683,7 +4684,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 223.0.0",
+ "wast 224.0.0",
 ]
 
 [[package]]
@@ -4736,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "223.0.0"
+version = "224.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59b2ba8a2ff9f06194b7be9524f92e45e70149f4dacc0d0c7ad92b59ac875e4"
+checksum = "d722a51e62b669d17e5a9f6bc8ec210178b37d869114355aa46989686c5c6391"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -4749,11 +4750,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.223.0"
+version = "1.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662786915c427e4918ff01eabb3c4756d4d947cd8f635761526b4cc9da2eaaad"
+checksum = "71dece6a7dd5bcbcf8d256606c7fb3faa36286d46bf3f98185407719a5ceede2"
 dependencies = [
- "wast 223.0.0",
+ "wast 224.0.0",
 ]
 
 [[package]]
@@ -5118,19 +5119,19 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9219694564701fa935754f1552ce299154fc74948d6d148134ce55f3504c8bf1"
+checksum = "b550e454e4cce8984398539a94a0226511e1f295b14afdc8f08b4e2e2ff9de3a"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.38.0",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba105733ba146c94e067793fb46505265ea8720eb14ceae65b10797c7728a65"
+checksum = "70e2f98d49960a416074c5d72889f810ed3032a32ffef5e4760094426fefbfe8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5144,15 +5145,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6f8d372a2d4a1227f2556e051cc24b2a5f15768d53451c84ff91e2527139e3"
+dependencies = [
+ "bitflags 2.6.0",
  "futures",
  "once_cell",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257e0d217bc06635837d751447c39e77b9901752e052288ff6fe0fdb17850bc5"
+checksum = "1cc49091f84e4f2ace078bbc86082b57e667b9e789baece4b1184e0963382b6e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5166,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac98caa9302234687b8e67ce7dfcf31ae5238523f166b93c23988fd0d4e0594"
+checksum = "3545a699dc9d72298b2064ce71b771fc10fc6b757d29306b1e54a4283a75abba"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5181,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10ed2aeee4c8ec5715875f62f4a3de3608d6987165c116810d8c2908aa9d93b"
+checksum = "ad555ab4f4e676474df746d937823c7279c2d6dd36c3e97a61db893d4ef64ee5"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5200,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.223.0"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92772f4dcacb804b275981eea1d920b12b377993b53307f1e33d87404e080281"
+checksum = "23e2925a7365d2c6709ae17bdbb5777ffd8154fd70906b413fc01b75f0dba59e"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,20 +294,20 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "0.38.43"
 # wit-bindgen:
-wit-bindgen = { version = "0.37.0", default-features = false }
-wit-bindgen-rust-macro = { version = "0.37.0", default-features = false }
+wit-bindgen = { version = "0.38.0", default-features = false }
+wit-bindgen-rust-macro = { version = "0.38.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.223.0", default-features = false, features = ['simd'] }
-wat = "1.223.0"
-wast = "223.0.0"
-wasmprinter = "0.223.0"
-wasm-encoder = "0.223.0"
-wasm-smith = "0.223.0"
-wasm-mutate = "0.223.0"
-wit-parser = "0.223.0"
-wit-component = "0.223.0"
-wasm-wave = "0.223.0"
+wasmparser = { version = "0.224.0", default-features = false, features = ['simd'] }
+wat = "1.224.0"
+wast = "224.0.0"
+wasmprinter = "0.224.0"
+wasm-encoder = "0.224.0"
+wasm-smith = "0.224.0"
+wasm-mutate = "0.224.0"
+wit-parser = "0.224.0"
+wit-component = "0.224.0"
+wasm-wave = "0.224.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -29,7 +29,8 @@ wasmtime-wit-bindgen = { workspace = true }
 wit-parser = { workspace = true }
 
 [dev-dependencies]
-wasmtime = { path = '../wasmtime', features = ['component-model'] }
+wasmtime = { path = '../wasmtime', features = ['component-model', 'component-model-async'] }
+wasmtime-wit-bindgen = { workspace = true, features = ['component-model-async'] }
 component-macro-test-helpers = { path = 'test-helpers' }
 tracing = { workspace = true }
 # For use with the custom attributes test
@@ -41,3 +42,4 @@ similar = { workspace = true }
 [features]
 async = []
 std = ['wasmtime-wit-bindgen/std']
+component-model-async = ['std', 'async', 'wasmtime-wit-bindgen/component-model-async']

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -12,6 +12,14 @@ macro_rules! gentest {
                     async: true,
                 });
             }
+            mod concurrent {
+                wasmtime::component::bindgen!({
+                    path: $path,
+                    async: true,
+                    concurrent_imports: true,
+                    concurrent_exports: true,
+                });
+            }
             mod tracing {
                 wasmtime::component::bindgen!({
                     path: $path,

--- a/crates/component-macro/tests/expanded.rs
+++ b/crates/component-macro/tests/expanded.rs
@@ -15,6 +15,14 @@ macro_rules! genexpand {
             stringify: true,
         }))?;
 
+        process_expanded($path, "_concurrent", wasmtime::component::bindgen!({
+            path: $path,
+            async: true,
+            concurrent_imports: true,
+            concurrent_exports: true,
+            stringify: true,
+        }))?;
+
         process_expanded($path, "_tracing_async", wasmtime::component::bindgen!({
             path: $path,
             async: true,

--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -194,19 +194,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap(
@@ -354,7 +358,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: char,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (char,),
@@ -369,7 +376,10 @@ pub mod exports {
                     pub fn call_return_char<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<char> {
+                    ) -> wasmtime::Result<char>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -202,19 +202,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -1,0 +1,492 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::chars::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::chars::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::chars::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::chars::Host<Data = T> + 'static,
+            U: Send + foo::foo::chars::Host<Data = T>,
+        {
+            foo::foo::chars::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_chars(&self) -> &exports::foo::foo::chars::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod chars {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                /// A function that accepts a character
+                fn take_char(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: char,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                /// A function that returns a character
+                fn return_char(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> char + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                inst.func_wrap_concurrent(
+                    "take-char",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (char,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::take_char(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-char",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_char(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(char,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(char,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                /// A function that accepts a character
+                fn take_char(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: char,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::take_char(store, x)
+                }
+                /// A function that returns a character
+                fn return_char(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> char + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_char(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod chars {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    take_char: wasmtime::component::Func,
+                    return_char: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    take_char: wasmtime::component::ComponentExportIndex,
+                    return_char: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/chars")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/chars`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/chars")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/chars`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/chars` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let take_char = lookup("take-char")?;
+                        let return_char = lookup("return-char")?;
+                        Ok(GuestIndices {
+                            take_char,
+                            return_char,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let take_char = *_instance
+                            .get_typed_func::<(char,), ()>(&mut store, &self.take_char)?
+                            .func();
+                        let return_char = *_instance
+                            .get_typed_func::<
+                                (),
+                                (char,),
+                            >(&mut store, &self.return_char)?
+                            .func();
+                        Ok(Guest { take_char, return_char })
+                    }
+                }
+                impl Guest {
+                    /// A function that accepts a character
+                    pub async fn call_take_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: char,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (char,),
+                                (),
+                            >::new_unchecked(self.take_char)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    /// A function that returns a character
+                    pub async fn call_return_char<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<char>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (char,),
+                            >::new_unchecked(self.return_char)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -202,19 +202,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -242,19 +242,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap(
@@ -646,7 +650,10 @@ pub mod exports {
                     pub fn call_kebab_case<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -661,7 +668,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: LudicrousSpeed,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (LudicrousSpeed,),
@@ -675,7 +685,10 @@ pub mod exports {
                     pub fn call_function_with_dashes<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -688,7 +701,10 @@ pub mod exports {
                     }
                     pub fn call_function_with_no_weird_characters<
                         S: wasmtime::AsContextMut,
-                    >(&self, mut store: S) -> wasmtime::Result<()> {
+                    >(&self, mut store: S) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -702,7 +718,10 @@ pub mod exports {
                     pub fn call_apple<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -716,7 +735,10 @@ pub mod exports {
                     pub fn call_apple_pear<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -730,7 +752,10 @@ pub mod exports {
                     pub fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -744,7 +769,10 @@ pub mod exports {
                     pub fn call_a0<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -763,7 +791,10 @@ pub mod exports {
                     pub fn call_is_xml<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -777,7 +808,10 @@ pub mod exports {
                     pub fn call_explicit<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -791,7 +825,10 @@ pub mod exports {
                     pub fn call_explicit_kebab<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -806,7 +843,10 @@ pub mod exports {
                     pub fn call_bool<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -250,19 +250,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -1,0 +1,1364 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::conventions::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::conventions::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::conventions::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::conventions::Host<Data = T> + 'static,
+            U: Send + foo::foo::conventions::Host<Data = T>,
+        {
+            foo::foo::conventions::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod conventions {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LudicrousSpeed {
+                #[component(name = "how-fast-are-you-going")]
+                pub how_fast_are_you_going: u32,
+                #[component(name = "i-am-going-extremely-slow")]
+                pub i_am_going_extremely_slow: u64,
+            }
+            impl core::fmt::Debug for LudicrousSpeed {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LudicrousSpeed")
+                        .field("how-fast-are-you-going", &self.how_fast_are_you_going)
+                        .field(
+                            "i-am-going-extremely-slow",
+                            &self.i_am_going_extremely_slow,
+                        )
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            pub trait Host {
+                type Data;
+                fn kebab_case(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: LudicrousSpeed,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn function_with_dashes(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn function_with_no_weird_characters(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn apple(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn apple_pear(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn apple_pear_grape(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a0(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                ///  https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                fn is_xml(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn explicit(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn explicit_kebab(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                /// Identifiers with the same name as keywords are quoted.
+                fn bool(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                inst.func_wrap_concurrent(
+                    "kebab-case",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::kebab_case(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LudicrousSpeed,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::foo(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "function-with-dashes",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::function_with_dashes(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "function-with-no-weird-characters",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::function_with_no_weird_characters(
+                            host,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "apple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::apple(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "apple-pear",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::apple_pear(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "apple-pear-grape",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::apple_pear_grape(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a0",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a0(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "is-XML",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::is_xml(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "explicit",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::explicit(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "explicit-kebab",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::explicit_kebab(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bool",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::bool(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn kebab_case(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::kebab_case(store)
+                }
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: LudicrousSpeed,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::foo(store, x)
+                }
+                fn function_with_dashes(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::function_with_dashes(store)
+                }
+                fn function_with_no_weird_characters(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::function_with_no_weird_characters(store)
+                }
+                fn apple(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::apple(store)
+                }
+                fn apple_pear(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::apple_pear(store)
+                }
+                fn apple_pear_grape(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::apple_pear_grape(store)
+                }
+                fn a0(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a0(store)
+                }
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                ///  https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                fn is_xml(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::is_xml(store)
+                }
+                fn explicit(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::explicit(store)
+                }
+                fn explicit_kebab(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::explicit_kebab(store)
+                }
+                /// Identifiers with the same name as keywords are quoted.
+                fn bool(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bool(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod conventions {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct LudicrousSpeed {
+                    #[component(name = "how-fast-are-you-going")]
+                    pub how_fast_are_you_going: u32,
+                    #[component(name = "i-am-going-extremely-slow")]
+                    pub i_am_going_extremely_slow: u64,
+                }
+                impl core::fmt::Debug for LudicrousSpeed {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("LudicrousSpeed")
+                            .field(
+                                "how-fast-are-you-going",
+                                &self.how_fast_are_you_going,
+                            )
+                            .field(
+                                "i-am-going-extremely-slow",
+                                &self.i_am_going_extremely_slow,
+                            )
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < LudicrousSpeed as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    kebab_case: wasmtime::component::Func,
+                    foo: wasmtime::component::Func,
+                    function_with_dashes: wasmtime::component::Func,
+                    function_with_no_weird_characters: wasmtime::component::Func,
+                    apple: wasmtime::component::Func,
+                    apple_pear: wasmtime::component::Func,
+                    apple_pear_grape: wasmtime::component::Func,
+                    a0: wasmtime::component::Func,
+                    is_xml: wasmtime::component::Func,
+                    explicit: wasmtime::component::Func,
+                    explicit_kebab: wasmtime::component::Func,
+                    bool: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    kebab_case: wasmtime::component::ComponentExportIndex,
+                    foo: wasmtime::component::ComponentExportIndex,
+                    function_with_dashes: wasmtime::component::ComponentExportIndex,
+                    function_with_no_weird_characters: wasmtime::component::ComponentExportIndex,
+                    apple: wasmtime::component::ComponentExportIndex,
+                    apple_pear: wasmtime::component::ComponentExportIndex,
+                    apple_pear_grape: wasmtime::component::ComponentExportIndex,
+                    a0: wasmtime::component::ComponentExportIndex,
+                    is_xml: wasmtime::component::ComponentExportIndex,
+                    explicit: wasmtime::component::ComponentExportIndex,
+                    explicit_kebab: wasmtime::component::ComponentExportIndex,
+                    bool: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/conventions")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/conventions`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/conventions`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/conventions` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let kebab_case = lookup("kebab-case")?;
+                        let foo = lookup("foo")?;
+                        let function_with_dashes = lookup("function-with-dashes")?;
+                        let function_with_no_weird_characters = lookup(
+                            "function-with-no-weird-characters",
+                        )?;
+                        let apple = lookup("apple")?;
+                        let apple_pear = lookup("apple-pear")?;
+                        let apple_pear_grape = lookup("apple-pear-grape")?;
+                        let a0 = lookup("a0")?;
+                        let is_xml = lookup("is-XML")?;
+                        let explicit = lookup("explicit")?;
+                        let explicit_kebab = lookup("explicit-kebab")?;
+                        let bool = lookup("bool")?;
+                        Ok(GuestIndices {
+                            kebab_case,
+                            foo,
+                            function_with_dashes,
+                            function_with_no_weird_characters,
+                            apple,
+                            apple_pear,
+                            apple_pear_grape,
+                            a0,
+                            is_xml,
+                            explicit,
+                            explicit_kebab,
+                            bool,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let kebab_case = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.kebab_case)?
+                            .func();
+                        let foo = *_instance
+                            .get_typed_func::<
+                                (LudicrousSpeed,),
+                                (),
+                            >(&mut store, &self.foo)?
+                            .func();
+                        let function_with_dashes = *_instance
+                            .get_typed_func::<
+                                (),
+                                (),
+                            >(&mut store, &self.function_with_dashes)?
+                            .func();
+                        let function_with_no_weird_characters = *_instance
+                            .get_typed_func::<
+                                (),
+                                (),
+                            >(&mut store, &self.function_with_no_weird_characters)?
+                            .func();
+                        let apple = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.apple)?
+                            .func();
+                        let apple_pear = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.apple_pear)?
+                            .func();
+                        let apple_pear_grape = *_instance
+                            .get_typed_func::<
+                                (),
+                                (),
+                            >(&mut store, &self.apple_pear_grape)?
+                            .func();
+                        let a0 = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.a0)?
+                            .func();
+                        let is_xml = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.is_xml)?
+                            .func();
+                        let explicit = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.explicit)?
+                            .func();
+                        let explicit_kebab = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.explicit_kebab)?
+                            .func();
+                        let bool = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.bool)?
+                            .func();
+                        Ok(Guest {
+                            kebab_case,
+                            foo,
+                            function_with_dashes,
+                            function_with_no_weird_characters,
+                            apple,
+                            apple_pear,
+                            apple_pear_grape,
+                            a0,
+                            is_xml,
+                            explicit,
+                            explicit_kebab,
+                            bool,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_kebab_case<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.kebab_case)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_foo<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: LudicrousSpeed,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LudicrousSpeed,),
+                                (),
+                            >::new_unchecked(self.foo)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_function_with_dashes<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_dashes)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_function_with_no_weird_characters<
+                        S: wasmtime::AsContextMut,
+                    >(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.function_with_no_weird_characters)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_apple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_apple_pear<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_apple_pear_grape<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.apple_pear_grape)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a0<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.a0)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                    ///  https://github.com/WebAssembly/component-model/issues/118
+                    /// APPLE: func()
+                    /// APPLE-pear-GRAPE: func()
+                    /// apple-PEAR-grape: func()
+                    pub async fn call_is_xml<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.is_xml)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_explicit<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_explicit_kebab<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.explicit_kebab)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    /// Identifiers with the same name as keywords are quoted.
+                    pub async fn call_bool<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.bool)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -250,19 +250,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -200,19 +200,23 @@ pub mod a {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap(
@@ -247,19 +251,23 @@ pub mod a {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -208,19 +208,23 @@ pub mod a {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -262,19 +266,23 @@ pub mod a {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -1,0 +1,344 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `imports`.
+///
+/// This structure is created through [`ImportsPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Imports`] as well.
+pub struct ImportsPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: ImportsIndices,
+}
+impl<T> Clone for ImportsPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> ImportsPre<_T> {
+    /// Creates a new copy of `ImportsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ImportsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Imports`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Imports>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `imports`.
+///
+/// This is an implementation detail of [`ImportsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Imports`] as well.
+#[derive(Clone)]
+pub struct ImportsIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `imports`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Imports::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ImportsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ImportsPre::instantiate_async`] to
+///   create a [`Imports`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Imports::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`ImportsIndices::new_instance`] followed
+///   by [`ImportsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Imports {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl ImportsIndices {
+        /// Creates a new copy of `ImportsIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(ImportsIndices {})
+        }
+        /// Creates a new instance of [`ImportsIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Imports`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Imports`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(ImportsIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Imports`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Imports> {
+            let _instance = instance;
+            Ok(Imports {})
+        }
+    }
+    impl Imports {
+        /// Convenience wrapper around [`ImportsPre::new`] and
+        /// [`ImportsPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Imports>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            ImportsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`ImportsIndices::new_instance`] and
+        /// [`ImportsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Imports> {
+            let indices = ImportsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + a::b::interface_with_live_type::Host<Data = T>
+                + a::b::interface_with_dead_type::Host + 'static,
+            U: Send + a::b::interface_with_live_type::Host<Data = T>
+                + a::b::interface_with_dead_type::Host,
+        {
+            a::b::interface_with_live_type::add_to_linker(linker, get)?;
+            a::b::interface_with_dead_type::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod a {
+    pub mod b {
+        #[allow(clippy::all)]
+        pub mod interface_with_live_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct LiveType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for LiveType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("LiveType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                type Data;
+                fn f(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> LiveType + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                inst.func_wrap_concurrent(
+                    "f",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(LiveType,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(LiveType,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn f(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> LiveType + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f(store)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod interface_with_dead_type {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("a:b/interface-with-dead-type")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
@@ -208,19 +208,23 @@ pub mod a {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -275,19 +279,23 @@ pub mod a {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -97,10 +97,11 @@ pub trait FooImports {
 }
 pub trait FooImportsGetHost<
     T,
->: Fn(T) -> <Self as FooImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as FooImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: FooImports;
 }
-impl<F, T, O> FooImportsGetHost<T> for F
+impl<F, T, D, O> FooImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: FooImports,
@@ -175,9 +176,12 @@ const _: () = {
             let indices = FooIndices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> FooImportsGetHost<&'a mut T, T, Host: FooImports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> FooImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()> {
             let mut linker = linker.root();
             linker

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -101,10 +101,11 @@ pub trait FooImports: Send {
 }
 pub trait FooImportsGetHost<
     T,
->: Fn(T) -> <Self as FooImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as FooImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: FooImports;
 }
-impl<F, T, O> FooImportsGetHost<T> for F
+impl<F, T, D, O> FooImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: FooImports,
@@ -182,9 +183,12 @@ const _: () = {
             let indices = FooIndices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> FooImportsGetHost<&'a mut T, T, Host: FooImports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> FooImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -1,0 +1,260 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `foo`.
+///
+/// This structure is created through [`FooPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
+}
+impl<T> Clone for FooPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `foo`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Foo {}
+pub trait FooImports {
+    type Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+}
+pub trait FooImportsGetHost<
+    T,
+    D,
+>: Fn(T) -> <Self as FooImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+    type Host: FooImports<Data = D>;
+}
+impl<F, T, D, O> FooImportsGetHost<T, D> for F
+where
+    F: Fn(T) -> O + Send + Sync + Copy + 'static,
+    O: FooImports<Data = D>,
+{
+    type Host = O;
+}
+impl<_T: FooImports> FooImports for &mut _T {
+    type Data = _T::Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as FooImports>::foo(store)
+    }
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(FooIndices {})
+        }
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(FooIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
+            Ok(Foo {})
+        }
+    }
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Foo>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> FooImportsGetHost<&'a mut T, T, Host: FooImports<Data = T>>,
+        >(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: G,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + 'static,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap_concurrent(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as FooImports>::foo(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            Ok(())
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + FooImports<Data = T> + 'static,
+            U: Send + FooImports<Data = T>,
+        {
+            Self::add_to_linker_imports_get_host(linker, get)?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
@@ -101,10 +101,11 @@ pub trait FooImports: Send {
 }
 pub trait FooImportsGetHost<
     T,
->: Fn(T) -> <Self as FooImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as FooImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: FooImports;
 }
-impl<F, T, O> FooImportsGetHost<T> for F
+impl<F, T, D, O> FooImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: FooImports,
@@ -182,9 +183,12 @@ const _: () = {
             let indices = FooIndices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> FooImportsGetHost<&'a mut T, T, Host: FooImports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> FooImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,

--- a/crates/component-macro/tests/expanded/empty_concurrent.rs
+++ b/crates/component-macro/tests/expanded/empty_concurrent.rs
@@ -1,0 +1,165 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `empty`.
+///
+/// This structure is created through [`EmptyPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Empty`] as well.
+pub struct EmptyPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: EmptyIndices,
+}
+impl<T> Clone for EmptyPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> EmptyPre<_T> {
+    /// Creates a new copy of `EmptyPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = EmptyIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Empty`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Empty>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `empty`.
+///
+/// This is an implementation detail of [`EmptyPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Empty`] as well.
+#[derive(Clone)]
+pub struct EmptyIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `empty`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Empty::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`EmptyPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`EmptyPre::instantiate_async`] to
+///   create a [`Empty`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Empty::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`EmptyIndices::new_instance`] followed
+///   by [`EmptyIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Empty {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl EmptyIndices {
+        /// Creates a new copy of `EmptyIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(EmptyIndices {})
+        }
+        /// Creates a new instance of [`EmptyIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Empty`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Empty`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(EmptyIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Empty`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Empty> {
+            let _instance = instance;
+            Ok(Empty {})
+        }
+    }
+    impl Empty {
+        /// Convenience wrapper around [`EmptyPre::new`] and
+        /// [`EmptyPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Empty>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            EmptyPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`EmptyIndices::new_instance`] and
+        /// [`EmptyIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Empty> {
+            let indices = EmptyIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -311,19 +311,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap(
@@ -751,7 +755,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag1,
-                    ) -> wasmtime::Result<Flag1> {
+                    ) -> wasmtime::Result<Flag1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag1,),
@@ -766,7 +773,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag2,
-                    ) -> wasmtime::Result<Flag2> {
+                    ) -> wasmtime::Result<Flag2>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag2,),
@@ -781,7 +791,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag4,
-                    ) -> wasmtime::Result<Flag4> {
+                    ) -> wasmtime::Result<Flag4>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag4,),
@@ -796,7 +809,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag8,
-                    ) -> wasmtime::Result<Flag8> {
+                    ) -> wasmtime::Result<Flag8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag8,),
@@ -811,7 +827,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag16,
-                    ) -> wasmtime::Result<Flag16> {
+                    ) -> wasmtime::Result<Flag16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag16,),
@@ -826,7 +845,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag32,
-                    ) -> wasmtime::Result<Flag32> {
+                    ) -> wasmtime::Result<Flag32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag32,),
@@ -841,7 +863,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Flag64,
-                    ) -> wasmtime::Result<Flag64> {
+                    ) -> wasmtime::Result<Flag64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Flag64,),

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -319,19 +319,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -1,0 +1,1191 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-flags`.
+///
+/// This structure is created through [`TheFlagsPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheFlags`] as well.
+pub struct TheFlagsPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheFlagsIndices,
+}
+impl<T> Clone for TheFlagsPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheFlagsPre<_T> {
+    /// Creates a new copy of `TheFlagsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheFlagsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheFlags`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheFlags>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-flags`.
+///
+/// This is an implementation detail of [`TheFlagsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheFlags`] as well.
+#[derive(Clone)]
+pub struct TheFlagsIndices {
+    interface0: exports::foo::foo::flegs::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-flags`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheFlags::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheFlagsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheFlagsPre::instantiate_async`] to
+///   create a [`TheFlags`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheFlags::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheFlagsIndices::new_instance`] followed
+///   by [`TheFlagsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheFlags {
+    interface0: exports::foo::foo::flegs::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheFlagsIndices {
+        /// Creates a new copy of `TheFlagsIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new(_component)?;
+            Ok(TheFlagsIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheFlagsIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheFlags`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheFlags`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::flegs::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheFlagsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheFlags`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheFlags> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheFlags { interface0 })
+        }
+    }
+    impl TheFlags {
+        /// Convenience wrapper around [`TheFlagsPre::new`] and
+        /// [`TheFlagsPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheFlags>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheFlagsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheFlagsIndices::new_instance`] and
+        /// [`TheFlagsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheFlags> {
+            let indices = TheFlagsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::flegs::Host<Data = T> + 'static,
+            U: Send + foo::foo::flegs::Host<Data = T>,
+        {
+            foo::foo::flegs::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod flegs {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            wasmtime::component::flags!(Flag1 { #[component(name = "b0")] const B0; });
+            const _: () = {
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; }
+            );
+            const _: () = {
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; }
+            );
+            const _: () = {
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; }
+            );
+            const _: () = {
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag16 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; }
+            );
+            const _: () = {
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag32 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; }
+            );
+            const _: () = {
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            wasmtime::component::flags!(
+                Flag64 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                const B1; #[component(name = "b2")] const B2; #[component(name = "b3")]
+                const B3; #[component(name = "b4")] const B4; #[component(name = "b5")]
+                const B5; #[component(name = "b6")] const B6; #[component(name = "b7")]
+                const B7; #[component(name = "b8")] const B8; #[component(name = "b9")]
+                const B9; #[component(name = "b10")] const B10; #[component(name =
+                "b11")] const B11; #[component(name = "b12")] const B12; #[component(name
+                = "b13")] const B13; #[component(name = "b14")] const B14;
+                #[component(name = "b15")] const B15; #[component(name = "b16")] const
+                B16; #[component(name = "b17")] const B17; #[component(name = "b18")]
+                const B18; #[component(name = "b19")] const B19; #[component(name =
+                "b20")] const B20; #[component(name = "b21")] const B21; #[component(name
+                = "b22")] const B22; #[component(name = "b23")] const B23;
+                #[component(name = "b24")] const B24; #[component(name = "b25")] const
+                B25; #[component(name = "b26")] const B26; #[component(name = "b27")]
+                const B27; #[component(name = "b28")] const B28; #[component(name =
+                "b29")] const B29; #[component(name = "b30")] const B30; #[component(name
+                = "b31")] const B31; #[component(name = "b32")] const B32;
+                #[component(name = "b33")] const B33; #[component(name = "b34")] const
+                B34; #[component(name = "b35")] const B35; #[component(name = "b36")]
+                const B36; #[component(name = "b37")] const B37; #[component(name =
+                "b38")] const B38; #[component(name = "b39")] const B39; #[component(name
+                = "b40")] const B40; #[component(name = "b41")] const B41;
+                #[component(name = "b42")] const B42; #[component(name = "b43")] const
+                B43; #[component(name = "b44")] const B44; #[component(name = "b45")]
+                const B45; #[component(name = "b46")] const B46; #[component(name =
+                "b47")] const B47; #[component(name = "b48")] const B48; #[component(name
+                = "b49")] const B49; #[component(name = "b50")] const B50;
+                #[component(name = "b51")] const B51; #[component(name = "b52")] const
+                B52; #[component(name = "b53")] const B53; #[component(name = "b54")]
+                const B54; #[component(name = "b55")] const B55; #[component(name =
+                "b56")] const B56; #[component(name = "b57")] const B57; #[component(name
+                = "b58")] const B58; #[component(name = "b59")] const B59;
+                #[component(name = "b60")] const B60; #[component(name = "b61")] const
+                B61; #[component(name = "b62")] const B62; #[component(name = "b63")]
+                const B63; }
+            );
+            const _: () = {
+                assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn roundtrip_flag1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag2,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag2 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag4,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag4 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag16(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag32(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn roundtrip_flag64(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag1,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag1(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag1,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag1,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag2",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag2,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag2(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag2,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag2,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag4,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag4(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag4,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag4,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag8",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag8,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag8(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag8,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag8,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag16",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag16,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag16(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag16,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag16,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag32",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag32,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag32(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "roundtrip-flag64",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Flag64,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::roundtrip_flag64(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Flag64,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Flag64,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn roundtrip_flag1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag1(store, x)
+                }
+                fn roundtrip_flag2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag2,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag2 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag2(store, x)
+                }
+                fn roundtrip_flag4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag4,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag4 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag4(store, x)
+                }
+                fn roundtrip_flag8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag8(store, x)
+                }
+                fn roundtrip_flag16(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag16(store, x)
+                }
+                fn roundtrip_flag32(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag32(store, x)
+                }
+                fn roundtrip_flag64(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Flag64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Flag64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::roundtrip_flag64(store, x)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod flegs {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                wasmtime::component::flags!(
+                    Flag1 { #[component(name = "b0")] const B0; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag2 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag4 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag8 { #[component(name = "b0")] const B0; #[component(name = "b1")]
+                    const B1; #[component(name = "b2")] const B2; #[component(name =
+                    "b3")] const B3; #[component(name = "b4")] const B4; #[component(name
+                    = "b5")] const B5; #[component(name = "b6")] const B6;
+                    #[component(name = "b7")] const B7; }
+                );
+                const _: () = {
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Flag8 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag16 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; }
+                );
+                const _: () = {
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        2 == < Flag16 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag32 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31; }
+                );
+                const _: () = {
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag32 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                wasmtime::component::flags!(
+                    Flag64 { #[component(name = "b0")] const B0; #[component(name =
+                    "b1")] const B1; #[component(name = "b2")] const B2; #[component(name
+                    = "b3")] const B3; #[component(name = "b4")] const B4;
+                    #[component(name = "b5")] const B5; #[component(name = "b6")] const
+                    B6; #[component(name = "b7")] const B7; #[component(name = "b8")]
+                    const B8; #[component(name = "b9")] const B9; #[component(name =
+                    "b10")] const B10; #[component(name = "b11")] const B11;
+                    #[component(name = "b12")] const B12; #[component(name = "b13")]
+                    const B13; #[component(name = "b14")] const B14; #[component(name =
+                    "b15")] const B15; #[component(name = "b16")] const B16;
+                    #[component(name = "b17")] const B17; #[component(name = "b18")]
+                    const B18; #[component(name = "b19")] const B19; #[component(name =
+                    "b20")] const B20; #[component(name = "b21")] const B21;
+                    #[component(name = "b22")] const B22; #[component(name = "b23")]
+                    const B23; #[component(name = "b24")] const B24; #[component(name =
+                    "b25")] const B25; #[component(name = "b26")] const B26;
+                    #[component(name = "b27")] const B27; #[component(name = "b28")]
+                    const B28; #[component(name = "b29")] const B29; #[component(name =
+                    "b30")] const B30; #[component(name = "b31")] const B31;
+                    #[component(name = "b32")] const B32; #[component(name = "b33")]
+                    const B33; #[component(name = "b34")] const B34; #[component(name =
+                    "b35")] const B35; #[component(name = "b36")] const B36;
+                    #[component(name = "b37")] const B37; #[component(name = "b38")]
+                    const B38; #[component(name = "b39")] const B39; #[component(name =
+                    "b40")] const B40; #[component(name = "b41")] const B41;
+                    #[component(name = "b42")] const B42; #[component(name = "b43")]
+                    const B43; #[component(name = "b44")] const B44; #[component(name =
+                    "b45")] const B45; #[component(name = "b46")] const B46;
+                    #[component(name = "b47")] const B47; #[component(name = "b48")]
+                    const B48; #[component(name = "b49")] const B49; #[component(name =
+                    "b50")] const B50; #[component(name = "b51")] const B51;
+                    #[component(name = "b52")] const B52; #[component(name = "b53")]
+                    const B53; #[component(name = "b54")] const B54; #[component(name =
+                    "b55")] const B55; #[component(name = "b56")] const B56;
+                    #[component(name = "b57")] const B57; #[component(name = "b58")]
+                    const B58; #[component(name = "b59")] const B59; #[component(name =
+                    "b60")] const B60; #[component(name = "b61")] const B61;
+                    #[component(name = "b62")] const B62; #[component(name = "b63")]
+                    const B63; }
+                );
+                const _: () = {
+                    assert!(
+                        8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    roundtrip_flag1: wasmtime::component::Func,
+                    roundtrip_flag2: wasmtime::component::Func,
+                    roundtrip_flag4: wasmtime::component::Func,
+                    roundtrip_flag8: wasmtime::component::Func,
+                    roundtrip_flag16: wasmtime::component::Func,
+                    roundtrip_flag32: wasmtime::component::Func,
+                    roundtrip_flag64: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    roundtrip_flag1: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag2: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag4: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag8: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag16: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag32: wasmtime::component::ComponentExportIndex,
+                    roundtrip_flag64: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/flegs")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/flegs`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/flegs`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/flegs` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let roundtrip_flag1 = lookup("roundtrip-flag1")?;
+                        let roundtrip_flag2 = lookup("roundtrip-flag2")?;
+                        let roundtrip_flag4 = lookup("roundtrip-flag4")?;
+                        let roundtrip_flag8 = lookup("roundtrip-flag8")?;
+                        let roundtrip_flag16 = lookup("roundtrip-flag16")?;
+                        let roundtrip_flag32 = lookup("roundtrip-flag32")?;
+                        let roundtrip_flag64 = lookup("roundtrip-flag64")?;
+                        Ok(GuestIndices {
+                            roundtrip_flag1,
+                            roundtrip_flag2,
+                            roundtrip_flag4,
+                            roundtrip_flag8,
+                            roundtrip_flag16,
+                            roundtrip_flag32,
+                            roundtrip_flag64,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let roundtrip_flag1 = *_instance
+                            .get_typed_func::<
+                                (Flag1,),
+                                (Flag1,),
+                            >(&mut store, &self.roundtrip_flag1)?
+                            .func();
+                        let roundtrip_flag2 = *_instance
+                            .get_typed_func::<
+                                (Flag2,),
+                                (Flag2,),
+                            >(&mut store, &self.roundtrip_flag2)?
+                            .func();
+                        let roundtrip_flag4 = *_instance
+                            .get_typed_func::<
+                                (Flag4,),
+                                (Flag4,),
+                            >(&mut store, &self.roundtrip_flag4)?
+                            .func();
+                        let roundtrip_flag8 = *_instance
+                            .get_typed_func::<
+                                (Flag8,),
+                                (Flag8,),
+                            >(&mut store, &self.roundtrip_flag8)?
+                            .func();
+                        let roundtrip_flag16 = *_instance
+                            .get_typed_func::<
+                                (Flag16,),
+                                (Flag16,),
+                            >(&mut store, &self.roundtrip_flag16)?
+                            .func();
+                        let roundtrip_flag32 = *_instance
+                            .get_typed_func::<
+                                (Flag32,),
+                                (Flag32,),
+                            >(&mut store, &self.roundtrip_flag32)?
+                            .func();
+                        let roundtrip_flag64 = *_instance
+                            .get_typed_func::<
+                                (Flag64,),
+                                (Flag64,),
+                            >(&mut store, &self.roundtrip_flag64)?
+                            .func();
+                        Ok(Guest {
+                            roundtrip_flag1,
+                            roundtrip_flag2,
+                            roundtrip_flag4,
+                            roundtrip_flag8,
+                            roundtrip_flag16,
+                            roundtrip_flag32,
+                            roundtrip_flag64,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag1,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag1>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag1,),
+                                (Flag1,),
+                            >::new_unchecked(self.roundtrip_flag1)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag2,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag2>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag2,),
+                                (Flag2,),
+                            >::new_unchecked(self.roundtrip_flag2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag4,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag4>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag4,),
+                                (Flag4,),
+                            >::new_unchecked(self.roundtrip_flag4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag8,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag8,),
+                                (Flag8,),
+                            >::new_unchecked(self.roundtrip_flag8)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag16,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag16,),
+                                (Flag16,),
+                            >::new_unchecked(self.roundtrip_flag16)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag32,),
+                                (Flag32,),
+                            >::new_unchecked(self.roundtrip_flag32)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Flag64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Flag64,),
+                                (Flag64,),
+                            >::new_unchecked(self.roundtrip_flag64)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -319,19 +319,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -194,19 +194,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap(
@@ -386,7 +390,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: f32,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (f32,),
@@ -401,7 +408,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: f64,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (f64,),
@@ -415,7 +425,10 @@ pub mod exports {
                     pub fn call_f32_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<f32> {
+                    ) -> wasmtime::Result<f32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -429,7 +442,10 @@ pub mod exports {
                     pub fn call_f64_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<f64> {
+                    ) -> wasmtime::Result<f64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -202,19 +202,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -1,0 +1,640 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::floats::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::floats::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::floats::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::floats::Host<Data = T> + 'static,
+            U: Send + foo::foo::floats::Host<Data = T>,
+        {
+            foo::foo::floats::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod floats {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn f32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: f32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: f64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f32_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> f32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f64_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> f64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                inst.func_wrap_concurrent(
+                    "f32-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f32_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f64-param",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f64,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f64_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f32-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f32_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(f32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(f32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f64-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f64_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(f64,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(f64,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn f32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: f32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f32_param(store, x)
+                }
+                fn f64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: f64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f64_param(store, x)
+                }
+                fn f32_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> f32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f32_result(store)
+                }
+                fn f64_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> f64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f64_result(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod floats {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    f32_param: wasmtime::component::Func,
+                    f64_param: wasmtime::component::Func,
+                    f32_result: wasmtime::component::Func,
+                    f64_result: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    f32_param: wasmtime::component::ComponentExportIndex,
+                    f64_param: wasmtime::component::ComponentExportIndex,
+                    f32_result: wasmtime::component::ComponentExportIndex,
+                    f64_result: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/floats")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/floats`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/floats")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/floats`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/floats` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let f32_param = lookup("f32-param")?;
+                        let f64_param = lookup("f64-param")?;
+                        let f32_result = lookup("f32-result")?;
+                        let f64_result = lookup("f64-result")?;
+                        Ok(GuestIndices {
+                            f32_param,
+                            f64_param,
+                            f32_result,
+                            f64_result,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let f32_param = *_instance
+                            .get_typed_func::<(f32,), ()>(&mut store, &self.f32_param)?
+                            .func();
+                        let f64_param = *_instance
+                            .get_typed_func::<(f64,), ()>(&mut store, &self.f64_param)?
+                            .func();
+                        let f32_result = *_instance
+                            .get_typed_func::<(), (f32,)>(&mut store, &self.f32_result)?
+                            .func();
+                        let f64_result = *_instance
+                            .get_typed_func::<(), (f64,)>(&mut store, &self.f64_result)?
+                            .func();
+                        Ok(Guest {
+                            f32_param,
+                            f64_param,
+                            f32_result,
+                            f64_result,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_f32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f32,),
+                                (),
+                            >::new_unchecked(self.f32_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_f64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: f64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (f64,),
+                                (),
+                            >::new_unchecked(self.f64_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_f32_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<f32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f32,),
+                            >::new_unchecked(self.f32_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_f64_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<f64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (f64,),
+                            >::new_unchecked(self.f64_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -202,19 +202,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -170,7 +170,10 @@ const _: () = {
         pub fn call_new<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
-        ) -> wasmtime::Result<()> {
+        ) -> wasmtime::Result<()>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
             };

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -1,0 +1,190 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `foo`.
+///
+/// This structure is created through [`FooPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
+}
+impl<T> Clone for FooPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    new: wasmtime::component::ComponentExportIndex,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `foo`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Foo {
+    new: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let new = _component
+                .export_index(None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
+                .1;
+            Ok(FooIndices { new })
+        }
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let new = _instance
+                .get_export(&mut store, None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
+            Ok(FooIndices { new })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
+            let new = *_instance.get_typed_func::<(), ()>(&mut store, &self.new)?.func();
+            Ok(Foo { new })
+        }
+    }
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Foo>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub async fn call_new<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+        where
+            <S as wasmtime::AsContext>::Data: Send + 'static,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
+            };
+            let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
+            Ok(promise)
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/host-world.rs
+++ b/crates/component-macro/tests/expanded/host-world.rs
@@ -97,10 +97,11 @@ pub trait Host_Imports {
 }
 pub trait Host_ImportsGetHost<
     T,
->: Fn(T) -> <Self as Host_ImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as Host_ImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: Host_Imports;
 }
-impl<F, T, O> Host_ImportsGetHost<T> for F
+impl<F, T, D, O> Host_ImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: Host_Imports,
@@ -175,9 +176,12 @@ const _: () = {
             let indices = Host_Indices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> Host_ImportsGetHost<&'a mut T, T, Host: Host_Imports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> Host_ImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()> {
             let mut linker = linker.root();
             linker

--- a/crates/component-macro/tests/expanded/host-world_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_async.rs
@@ -101,10 +101,11 @@ pub trait Host_Imports: Send {
 }
 pub trait Host_ImportsGetHost<
     T,
->: Fn(T) -> <Self as Host_ImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as Host_ImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: Host_Imports;
 }
-impl<F, T, O> Host_ImportsGetHost<T> for F
+impl<F, T, D, O> Host_ImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: Host_Imports,
@@ -182,9 +183,12 @@ const _: () = {
             let indices = Host_Indices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> Host_ImportsGetHost<&'a mut T, T, Host: Host_Imports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> Host_ImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -1,0 +1,260 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `host`.
+///
+/// This structure is created through [`Host_Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Host_`] as well.
+pub struct Host_Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Host_Indices,
+}
+impl<T> Clone for Host_Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Host_Pre<_T> {
+    /// Creates a new copy of `Host_Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Host_Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Host_`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Host_>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `host`.
+///
+/// This is an implementation detail of [`Host_Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Host_`] as well.
+#[derive(Clone)]
+pub struct Host_Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `host`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Host_::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Host_Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Host_Pre::instantiate_async`] to
+///   create a [`Host_`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Host_::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Host_Indices::new_instance`] followed
+///   by [`Host_Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Host_ {}
+pub trait Host_Imports {
+    type Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+}
+pub trait Host_ImportsGetHost<
+    T,
+    D,
+>: Fn(T) -> <Self as Host_ImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+    type Host: Host_Imports<Data = D>;
+}
+impl<F, T, D, O> Host_ImportsGetHost<T, D> for F
+where
+    F: Fn(T) -> O + Send + Sync + Copy + 'static,
+    O: Host_Imports<Data = D>,
+{
+    type Host = O;
+}
+impl<_T: Host_Imports> Host_Imports for &mut _T {
+    type Data = _T::Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as Host_Imports>::foo(store)
+    }
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Host_Indices {
+        /// Creates a new copy of `Host_Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Host_Indices {})
+        }
+        /// Creates a new instance of [`Host_Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Host_`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Host_`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Host_Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Host_`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Host_> {
+            let _instance = instance;
+            Ok(Host_ {})
+        }
+    }
+    impl Host_ {
+        /// Convenience wrapper around [`Host_Pre::new`] and
+        /// [`Host_Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Host_>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Host_Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Host_Indices::new_instance`] and
+        /// [`Host_Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Host_> {
+            let indices = Host_Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> Host_ImportsGetHost<&'a mut T, T, Host: Host_Imports<Data = T>>,
+        >(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: G,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + 'static,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap_concurrent(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host_Imports>::foo(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            Ok(())
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + Host_Imports<Data = T> + 'static,
+            U: Send + Host_Imports<Data = T>,
+        {
+            Self::add_to_linker_imports_get_host(linker, get)?;
+            Ok(())
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/host-world_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_tracing_async.rs
@@ -101,10 +101,11 @@ pub trait Host_Imports: Send {
 }
 pub trait Host_ImportsGetHost<
     T,
->: Fn(T) -> <Self as Host_ImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as Host_ImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: Host_Imports;
 }
-impl<F, T, O> Host_ImportsGetHost<T> for F
+impl<F, T, D, O> Host_ImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: Host_Imports,
@@ -182,9 +183,12 @@ const _: () = {
             let indices = Host_Indices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> Host_ImportsGetHost<&'a mut T, T, Host: Host_Imports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> Host_ImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -218,19 +218,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap(
@@ -714,7 +718,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: u8,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u8,),
@@ -729,7 +736,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: i8,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (i8,),
@@ -744,7 +754,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: u16,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u16,),
@@ -759,7 +772,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: i16,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (i16,),
@@ -774,7 +790,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: u32,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u32,),
@@ -789,7 +808,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: i32,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (i32,),
@@ -804,7 +826,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: u64,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u64,),
@@ -819,7 +844,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: i64,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (i64,),
@@ -841,7 +869,10 @@ pub mod exports {
                         arg5: i32,
                         arg6: u64,
                         arg7: i64,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u8, i8, u16, i16, u32, i32, u64, i64),
@@ -859,7 +890,10 @@ pub mod exports {
                     pub fn call_r1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u8> {
+                    ) -> wasmtime::Result<u8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -873,7 +907,10 @@ pub mod exports {
                     pub fn call_r2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<i8> {
+                    ) -> wasmtime::Result<i8>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -887,7 +924,10 @@ pub mod exports {
                     pub fn call_r3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u16> {
+                    ) -> wasmtime::Result<u16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -901,7 +941,10 @@ pub mod exports {
                     pub fn call_r4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<i16> {
+                    ) -> wasmtime::Result<i16>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -915,7 +958,10 @@ pub mod exports {
                     pub fn call_r5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -929,7 +975,10 @@ pub mod exports {
                     pub fn call_r6<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<i32> {
+                    ) -> wasmtime::Result<i32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -943,7 +992,10 @@ pub mod exports {
                     pub fn call_r7<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u64> {
+                    ) -> wasmtime::Result<u64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -957,7 +1009,10 @@ pub mod exports {
                     pub fn call_r8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<i64> {
+                    ) -> wasmtime::Result<i64>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -971,7 +1026,10 @@ pub mod exports {
                     pub fn call_pair_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<(i64, u8)> {
+                    ) -> wasmtime::Result<(i64, u8)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -226,19 +226,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -1,0 +1,1791 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::integers::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::integers::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::integers::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::integers::Host<Data = T> + 'static,
+            U: Send + foo::foo::integers::Host<Data = T>,
+        {
+            foo::foo::integers::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod integers {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn a1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a7(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn a9(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r7(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn r8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn pair_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (i64, u8) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                inst.func_wrap_concurrent(
+                    "a1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a1(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i8,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a2(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u16,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a3(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i16,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a4(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a5(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i32,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a6(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u64,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a7(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i64,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a8(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "a9",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                        ): (u8, i8, u16, i16, u32, i32, u64, i64)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::a9(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r1(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u8,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u8,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r2(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(i8,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(i8,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r3(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u16,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u16,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r4(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(i16,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(i16,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r5(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r6",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r6(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(i32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(i32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r7",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r7(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u64,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u64,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "r8",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::r8(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(i64,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(i64,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "pair-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::pair_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<((i64, u8),)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<((i64, u8),)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn a1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a1(store, x)
+                }
+                fn a2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i8,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a2(store, x)
+                }
+                fn a3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a3(store, x)
+                }
+                fn a4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i16,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a4(store, x)
+                }
+                fn a5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a5(store, x)
+                }
+                fn a6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a6(store, x)
+                }
+                fn a7(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: u64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a7(store, x)
+                }
+                fn a8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: i64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a8(store, x)
+                }
+                fn a9(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a9(store, p1, p2, p3, p4, p5, p6, p7, p8)
+                }
+                fn r1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r1(store)
+                }
+                fn r2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i8 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r2(store)
+                }
+                fn r3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r3(store)
+                }
+                fn r4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i16 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r4(store)
+                }
+                fn r5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r5(store)
+                }
+                fn r6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r6(store)
+                }
+                fn r7(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r7(store)
+                }
+                fn r8(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i64 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::r8(store)
+                }
+                fn pair_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (i64, u8) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::pair_ret(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod integers {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    a1: wasmtime::component::Func,
+                    a2: wasmtime::component::Func,
+                    a3: wasmtime::component::Func,
+                    a4: wasmtime::component::Func,
+                    a5: wasmtime::component::Func,
+                    a6: wasmtime::component::Func,
+                    a7: wasmtime::component::Func,
+                    a8: wasmtime::component::Func,
+                    a9: wasmtime::component::Func,
+                    r1: wasmtime::component::Func,
+                    r2: wasmtime::component::Func,
+                    r3: wasmtime::component::Func,
+                    r4: wasmtime::component::Func,
+                    r5: wasmtime::component::Func,
+                    r6: wasmtime::component::Func,
+                    r7: wasmtime::component::Func,
+                    r8: wasmtime::component::Func,
+                    pair_ret: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    a1: wasmtime::component::ComponentExportIndex,
+                    a2: wasmtime::component::ComponentExportIndex,
+                    a3: wasmtime::component::ComponentExportIndex,
+                    a4: wasmtime::component::ComponentExportIndex,
+                    a5: wasmtime::component::ComponentExportIndex,
+                    a6: wasmtime::component::ComponentExportIndex,
+                    a7: wasmtime::component::ComponentExportIndex,
+                    a8: wasmtime::component::ComponentExportIndex,
+                    a9: wasmtime::component::ComponentExportIndex,
+                    r1: wasmtime::component::ComponentExportIndex,
+                    r2: wasmtime::component::ComponentExportIndex,
+                    r3: wasmtime::component::ComponentExportIndex,
+                    r4: wasmtime::component::ComponentExportIndex,
+                    r5: wasmtime::component::ComponentExportIndex,
+                    r6: wasmtime::component::ComponentExportIndex,
+                    r7: wasmtime::component::ComponentExportIndex,
+                    r8: wasmtime::component::ComponentExportIndex,
+                    pair_ret: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/integers")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/integers`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/integers")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/integers`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/integers` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let a1 = lookup("a1")?;
+                        let a2 = lookup("a2")?;
+                        let a3 = lookup("a3")?;
+                        let a4 = lookup("a4")?;
+                        let a5 = lookup("a5")?;
+                        let a6 = lookup("a6")?;
+                        let a7 = lookup("a7")?;
+                        let a8 = lookup("a8")?;
+                        let a9 = lookup("a9")?;
+                        let r1 = lookup("r1")?;
+                        let r2 = lookup("r2")?;
+                        let r3 = lookup("r3")?;
+                        let r4 = lookup("r4")?;
+                        let r5 = lookup("r5")?;
+                        let r6 = lookup("r6")?;
+                        let r7 = lookup("r7")?;
+                        let r8 = lookup("r8")?;
+                        let pair_ret = lookup("pair-ret")?;
+                        Ok(GuestIndices {
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            r1,
+                            r2,
+                            r3,
+                            r4,
+                            r5,
+                            r6,
+                            r7,
+                            r8,
+                            pair_ret,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let a1 = *_instance
+                            .get_typed_func::<(u8,), ()>(&mut store, &self.a1)?
+                            .func();
+                        let a2 = *_instance
+                            .get_typed_func::<(i8,), ()>(&mut store, &self.a2)?
+                            .func();
+                        let a3 = *_instance
+                            .get_typed_func::<(u16,), ()>(&mut store, &self.a3)?
+                            .func();
+                        let a4 = *_instance
+                            .get_typed_func::<(i16,), ()>(&mut store, &self.a4)?
+                            .func();
+                        let a5 = *_instance
+                            .get_typed_func::<(u32,), ()>(&mut store, &self.a5)?
+                            .func();
+                        let a6 = *_instance
+                            .get_typed_func::<(i32,), ()>(&mut store, &self.a6)?
+                            .func();
+                        let a7 = *_instance
+                            .get_typed_func::<(u64,), ()>(&mut store, &self.a7)?
+                            .func();
+                        let a8 = *_instance
+                            .get_typed_func::<(i64,), ()>(&mut store, &self.a8)?
+                            .func();
+                        let a9 = *_instance
+                            .get_typed_func::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >(&mut store, &self.a9)?
+                            .func();
+                        let r1 = *_instance
+                            .get_typed_func::<(), (u8,)>(&mut store, &self.r1)?
+                            .func();
+                        let r2 = *_instance
+                            .get_typed_func::<(), (i8,)>(&mut store, &self.r2)?
+                            .func();
+                        let r3 = *_instance
+                            .get_typed_func::<(), (u16,)>(&mut store, &self.r3)?
+                            .func();
+                        let r4 = *_instance
+                            .get_typed_func::<(), (i16,)>(&mut store, &self.r4)?
+                            .func();
+                        let r5 = *_instance
+                            .get_typed_func::<(), (u32,)>(&mut store, &self.r5)?
+                            .func();
+                        let r6 = *_instance
+                            .get_typed_func::<(), (i32,)>(&mut store, &self.r6)?
+                            .func();
+                        let r7 = *_instance
+                            .get_typed_func::<(), (u64,)>(&mut store, &self.r7)?
+                            .func();
+                        let r8 = *_instance
+                            .get_typed_func::<(), (i64,)>(&mut store, &self.r8)?
+                            .func();
+                        let pair_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                ((i64, u8),),
+                            >(&mut store, &self.pair_ret)?
+                            .func();
+                        Ok(Guest {
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            r1,
+                            r2,
+                            r3,
+                            r4,
+                            r5,
+                            r6,
+                            r7,
+                            r8,
+                            pair_ret,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_a1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8,),
+                                (),
+                            >::new_unchecked(self.a1)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i8,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i8,),
+                                (),
+                            >::new_unchecked(self.a2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u16,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u16,),
+                                (),
+                            >::new_unchecked(self.a3)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i16,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i16,),
+                                (),
+                            >::new_unchecked(self.a4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.a5)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i32,),
+                                (),
+                            >::new_unchecked(self.a6)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u64,),
+                                (),
+                            >::new_unchecked(self.a7)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: i64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (i64,),
+                                (),
+                            >::new_unchecked(self.a8)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_a9<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u8,
+                        arg1: i8,
+                        arg2: u16,
+                        arg3: i16,
+                        arg4: u32,
+                        arg5: i32,
+                        arg6: u64,
+                        arg7: i64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u8, i8, u16, i16, u32, i32, u64, i64),
+                                (),
+                            >::new_unchecked(self.a9)
+                        };
+                        let promise = callee
+                            .call_concurrent(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+                            )
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_r1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u8,),
+                            >::new_unchecked(self.r1)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<i8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i8,),
+                            >::new_unchecked(self.r2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u16,),
+                            >::new_unchecked(self.r3)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<i16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i16,),
+                            >::new_unchecked(self.r4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.r5)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i32,),
+                            >::new_unchecked(self.r6)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r7<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u64,),
+                            >::new_unchecked(self.r7)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_r8<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<i64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (i64,),
+                            >::new_unchecked(self.r8)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_pair_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<(i64, u8)>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((i64, u8),),
+                            >::new_unchecked(self.pair_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -226,19 +226,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -467,19 +467,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap(
@@ -1573,7 +1577,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[u8],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u8],),
@@ -1588,7 +1595,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[u16],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u16],),
@@ -1603,7 +1613,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[u32],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u32],),
@@ -1618,7 +1631,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[u64],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u64],),
@@ -1633,7 +1649,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[i8],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[i8],),
@@ -1648,7 +1667,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[i16],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[i16],),
@@ -1663,7 +1685,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[i32],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[i32],),
@@ -1678,7 +1703,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[i64],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[i64],),
@@ -1693,7 +1721,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[f32],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[f32],),
@@ -1708,7 +1739,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[f64],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[f64],),
@@ -1722,7 +1756,10 @@ pub mod exports {
                     pub fn call_list_u8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1736,7 +1773,10 @@ pub mod exports {
                     pub fn call_list_u16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1750,7 +1790,10 @@ pub mod exports {
                     pub fn call_list_u32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1764,7 +1807,10 @@ pub mod exports {
                     pub fn call_list_u64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1778,7 +1824,10 @@ pub mod exports {
                     pub fn call_list_s8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1792,7 +1841,10 @@ pub mod exports {
                     pub fn call_list_s16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i16>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1806,7 +1858,10 @@ pub mod exports {
                     pub fn call_list_s32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1820,7 +1875,10 @@ pub mod exports {
                     pub fn call_list_s64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<i64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1834,7 +1892,10 @@ pub mod exports {
                     pub fn call_list_f32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1848,7 +1909,10 @@ pub mod exports {
                     pub fn call_list_f64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<f64>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1865,7 +1929,10 @@ pub mod exports {
                         arg0: &[(u8, i8)],
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<(i64, u32)>,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[(u8, i8)],),
@@ -1880,7 +1947,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[wasmtime::component::__internal::String],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[wasmtime::component::__internal::String],),
@@ -1898,7 +1968,10 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1921,7 +1994,10 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<
                             (wasmtime::component::__internal::String, u8),
                         >,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[(u8, wasmtime::component::__internal::String)],),
@@ -1944,7 +2020,10 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[wasmtime::component::__internal::String],),
@@ -1965,7 +2044,10 @@ pub mod exports {
                         arg0: &[SomeRecord],
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<OtherRecord>,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[SomeRecord],),
@@ -1982,7 +2064,10 @@ pub mod exports {
                         arg0: &[OtherRecord],
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<SomeRecord>,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[OtherRecord],),
@@ -1999,7 +2084,10 @@ pub mod exports {
                         arg0: &[SomeVariant],
                     ) -> wasmtime::Result<
                         wasmtime::component::__internal::Vec<OtherVariant>,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[SomeVariant],),
@@ -2014,7 +2102,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &LoadStoreAllSizes,
-                    ) -> wasmtime::Result<LoadStoreAllSizes> {
+                    ) -> wasmtime::Result<LoadStoreAllSizes>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&LoadStoreAllSizes,),

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -495,19 +495,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -1,0 +1,3434 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-lists`.
+///
+/// This structure is created through [`TheListsPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheLists`] as well.
+pub struct TheListsPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheListsIndices,
+}
+impl<T> Clone for TheListsPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheListsPre<_T> {
+    /// Creates a new copy of `TheListsPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheListsIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheLists`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheLists>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-lists`.
+///
+/// This is an implementation detail of [`TheListsPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheLists`] as well.
+#[derive(Clone)]
+pub struct TheListsIndices {
+    interface0: exports::foo::foo::lists::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-lists`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheLists::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheListsPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheListsPre::instantiate_async`] to
+///   create a [`TheLists`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheLists::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheListsIndices::new_instance`] followed
+///   by [`TheListsIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheLists {
+    interface0: exports::foo::foo::lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheListsIndices {
+        /// Creates a new copy of `TheListsIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new(_component)?;
+            Ok(TheListsIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheListsIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheLists`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheLists`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheListsIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheLists`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheLists> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheLists { interface0 })
+        }
+    }
+    impl TheLists {
+        /// Convenience wrapper around [`TheListsPre::new`] and
+        /// [`TheListsPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheLists>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheListsPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheListsIndices::new_instance`] and
+        /// [`TheListsIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheLists> {
+            let indices = TheListsIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::lists::Host<Data = T> + 'static,
+            U: Send + foo::foo::lists::Host<Data = T>,
+        {
+            foo::foo::lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct OtherRecord {
+                #[component(name = "a1")]
+                pub a1: u32,
+                #[component(name = "a2")]
+                pub a2: u64,
+                #[component(name = "a3")]
+                pub a3: i32,
+                #[component(name = "a4")]
+                pub a4: i64,
+                #[component(name = "b")]
+                pub b: wasmtime::component::__internal::String,
+                #[component(name = "c")]
+                pub c: wasmtime::component::__internal::Vec<u8>,
+            }
+            impl core::fmt::Debug for OtherRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("OtherRecord")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    48 == < OtherRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < OtherRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct SomeRecord {
+                #[component(name = "x")]
+                pub x: wasmtime::component::__internal::String,
+                #[component(name = "y")]
+                pub y: OtherRecord,
+                #[component(name = "z")]
+                pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                #[component(name = "c1")]
+                pub c1: u32,
+                #[component(name = "c2")]
+                pub c2: u64,
+                #[component(name = "c3")]
+                pub c3: i32,
+                #[component(name = "c4")]
+                pub c4: i64,
+            }
+            impl core::fmt::Debug for SomeRecord {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("SomeRecord")
+                        .field("x", &self.x)
+                        .field("y", &self.y)
+                        .field("z", &self.z)
+                        .field("c1", &self.c1)
+                        .field("c2", &self.c2)
+                        .field("c3", &self.c3)
+                        .field("c4", &self.c4)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    96 == < SomeRecord as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    8 == < SomeRecord as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum OtherVariant {
+                #[component(name = "a")]
+                A,
+                #[component(name = "b")]
+                B(u32),
+                #[component(name = "c")]
+                C(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for OtherVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                        OtherVariant::B(e) => {
+                            f.debug_tuple("OtherVariant::B").field(e).finish()
+                        }
+                        OtherVariant::C(e) => {
+                            f.debug_tuple("OtherVariant::C").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < OtherVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < OtherVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum SomeVariant {
+                #[component(name = "a")]
+                A(wasmtime::component::__internal::String),
+                #[component(name = "b")]
+                B,
+                #[component(name = "c")]
+                C(u32),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::Vec<OtherVariant>),
+            }
+            impl core::fmt::Debug for SomeVariant {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        SomeVariant::A(e) => {
+                            f.debug_tuple("SomeVariant::A").field(e).finish()
+                        }
+                        SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                        SomeVariant::C(e) => {
+                            f.debug_tuple("SomeVariant::C").field(e).finish()
+                        }
+                        SomeVariant::D(e) => {
+                            f.debug_tuple("SomeVariant::D").field(e).finish()
+                        }
+                    }
+                }
+            }
+            const _: () = {
+                assert!(
+                    12 == < SomeVariant as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeVariant as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                (
+                    wasmtime::component::__internal::String,
+                    u8,
+                    i8,
+                    u16,
+                    i16,
+                    u32,
+                    i32,
+                    u64,
+                    i64,
+                    f32,
+                    f64,
+                    char,
+                ),
+            >;
+            const _: () = {
+                assert!(
+                    8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::SIZE32
+                );
+                assert!(
+                    4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            pub trait Host {
+                type Data;
+                fn list_u8_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u16_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s8_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s16_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_f32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_f64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u8_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u16_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u16,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_u64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s8_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s16_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i16,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_s64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_f32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            f32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_f64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            f64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            (i64, u32),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn string_list_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn string_list_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_string_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            (wasmtime::component::__internal::String, u8),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn string_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn record_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            OtherRecord,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn record_list_reverse(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            SomeRecord,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn variant_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            OtherVariant,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn load_store_everything(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: LoadStoreAllSizes,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> LoadStoreAllSizes + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                inst.func_wrap_concurrent(
+                    "list-u8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u8_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u16_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u32_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u64_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s8-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s8_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s16-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s16_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s32_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s64_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-f32-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_f32_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-f64-param",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_f64_param(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u8_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<u8>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<u8>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u16_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<u16>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<u16>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u32_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<u32>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<u32>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-u64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_u64_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<u64>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<u64>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s8-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s8_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<i8>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<i8>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s16-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s16_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<i16>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<i16>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s32_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<i32>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<i32>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-s64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_s64_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<i64>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<i64>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-f32-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_f32_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<f32>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<f32>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-f64-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_f64_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<f64>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<f64>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_list(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "string-list-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::string_list_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "string-list-ret",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::string_list_ret(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                wasmtime::component::__internal::Vec<
+                                                    wasmtime::component::__internal::String,
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        wasmtime::component::__internal::Vec<
+                                                            wasmtime::component::__internal::String,
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                (u8, wasmtime::component::__internal::String),
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_string_list(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                wasmtime::component::__internal::Vec<
+                                                    (wasmtime::component::__internal::String, u8),
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        wasmtime::component::__internal::Vec<
+                                                            (wasmtime::component::__internal::String, u8),
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "string-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::string_list(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                wasmtime::component::__internal::Vec<
+                                                    wasmtime::component::__internal::String,
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        wasmtime::component::__internal::Vec<
+                                                            wasmtime::component::__internal::String,
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::record_list(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<OtherRecord>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<OtherRecord>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-list-reverse",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::record_list_reverse(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<SomeRecord>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<SomeRecord>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "variant-list",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::variant_list(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<OtherVariant>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<OtherVariant>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "load-store-everything",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (LoadStoreAllSizes,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::load_store_everything(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(LoadStoreAllSizes,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(LoadStoreAllSizes,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn list_u8_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u8_param(store, x)
+                }
+                fn list_u16_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u16_param(store, x)
+                }
+                fn list_u32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u32_param(store, x)
+                }
+                fn list_u64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u64_param(store, x)
+                }
+                fn list_s8_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s8_param(store, x)
+                }
+                fn list_s16_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s16_param(store, x)
+                }
+                fn list_s32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s32_param(store, x)
+                }
+                fn list_s64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s64_param(store, x)
+                }
+                fn list_f32_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_f32_param(store, x)
+                }
+                fn list_f64_param(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_f64_param(store, x)
+                }
+                fn list_u8_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u8_ret(store)
+                }
+                fn list_u16_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u16,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u16_ret(store)
+                }
+                fn list_u32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u32_ret(store)
+                }
+                fn list_u64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_u64_ret(store)
+                }
+                fn list_s8_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s8_ret(store)
+                }
+                fn list_s16_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i16,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s16_ret(store)
+                }
+                fn list_s32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s32_ret(store)
+                }
+                fn list_s64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            i64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_s64_ret(store)
+                }
+                fn list_f32_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            f32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_f32_ret(store)
+                }
+                fn list_f64_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            f64,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_f64_ret(store)
+                }
+                fn tuple_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            (i64, u32),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_list(store, x)
+                }
+                fn string_list_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::string_list_arg(store, a)
+                }
+                fn string_list_ret(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::string_list_ret(store)
+                }
+                fn tuple_string_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            (wasmtime::component::__internal::String, u8),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_string_list(store, x)
+                }
+                fn string_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::string_list(store, x)
+                }
+                fn record_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            OtherRecord,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::record_list(store, x)
+                }
+                fn record_list_reverse(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            SomeRecord,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::record_list_reverse(store, x)
+                }
+                fn variant_list(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            OtherVariant,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::variant_list(store, x)
+                }
+                fn load_store_everything(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: LoadStoreAllSizes,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> LoadStoreAllSizes + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::load_store_everything(store, a)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct OtherRecord {
+                    #[component(name = "a1")]
+                    pub a1: u32,
+                    #[component(name = "a2")]
+                    pub a2: u64,
+                    #[component(name = "a3")]
+                    pub a3: i32,
+                    #[component(name = "a4")]
+                    pub a4: i64,
+                    #[component(name = "b")]
+                    pub b: wasmtime::component::__internal::String,
+                    #[component(name = "c")]
+                    pub c: wasmtime::component::__internal::Vec<u8>,
+                }
+                impl core::fmt::Debug for OtherRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("OtherRecord")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        48 == < OtherRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < OtherRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct SomeRecord {
+                    #[component(name = "x")]
+                    pub x: wasmtime::component::__internal::String,
+                    #[component(name = "y")]
+                    pub y: OtherRecord,
+                    #[component(name = "z")]
+                    pub z: wasmtime::component::__internal::Vec<OtherRecord>,
+                    #[component(name = "c1")]
+                    pub c1: u32,
+                    #[component(name = "c2")]
+                    pub c2: u64,
+                    #[component(name = "c3")]
+                    pub c3: i32,
+                    #[component(name = "c4")]
+                    pub c4: i64,
+                }
+                impl core::fmt::Debug for SomeRecord {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("SomeRecord")
+                            .field("x", &self.x)
+                            .field("y", &self.y)
+                            .field("z", &self.z)
+                            .field("c1", &self.c1)
+                            .field("c2", &self.c2)
+                            .field("c3", &self.c3)
+                            .field("c4", &self.c4)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        96 == < SomeRecord as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        8 == < SomeRecord as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum OtherVariant {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "b")]
+                    B(u32),
+                    #[component(name = "c")]
+                    C(wasmtime::component::__internal::String),
+                }
+                impl core::fmt::Debug for OtherVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            OtherVariant::A => f.debug_tuple("OtherVariant::A").finish(),
+                            OtherVariant::B(e) => {
+                                f.debug_tuple("OtherVariant::B").field(e).finish()
+                            }
+                            OtherVariant::C(e) => {
+                                f.debug_tuple("OtherVariant::C").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < OtherVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < OtherVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum SomeVariant {
+                    #[component(name = "a")]
+                    A(wasmtime::component::__internal::String),
+                    #[component(name = "b")]
+                    B,
+                    #[component(name = "c")]
+                    C(u32),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::Vec<OtherVariant>),
+                }
+                impl core::fmt::Debug for SomeVariant {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            SomeVariant::A(e) => {
+                                f.debug_tuple("SomeVariant::A").field(e).finish()
+                            }
+                            SomeVariant::B => f.debug_tuple("SomeVariant::B").finish(),
+                            SomeVariant::C(e) => {
+                                f.debug_tuple("SomeVariant::C").field(e).finish()
+                            }
+                            SomeVariant::D(e) => {
+                                f.debug_tuple("SomeVariant::D").field(e).finish()
+                            }
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < SomeVariant as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < SomeVariant as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type LoadStoreAllSizes = wasmtime::component::__internal::Vec<
+                    (
+                        wasmtime::component::__internal::String,
+                        u8,
+                        i8,
+                        u16,
+                        i16,
+                        u32,
+                        i32,
+                        u64,
+                        i64,
+                        f32,
+                        f64,
+                        char,
+                    ),
+                >;
+                const _: () = {
+                    assert!(
+                        8 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < LoadStoreAllSizes as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    list_u8_param: wasmtime::component::Func,
+                    list_u16_param: wasmtime::component::Func,
+                    list_u32_param: wasmtime::component::Func,
+                    list_u64_param: wasmtime::component::Func,
+                    list_s8_param: wasmtime::component::Func,
+                    list_s16_param: wasmtime::component::Func,
+                    list_s32_param: wasmtime::component::Func,
+                    list_s64_param: wasmtime::component::Func,
+                    list_f32_param: wasmtime::component::Func,
+                    list_f64_param: wasmtime::component::Func,
+                    list_u8_ret: wasmtime::component::Func,
+                    list_u16_ret: wasmtime::component::Func,
+                    list_u32_ret: wasmtime::component::Func,
+                    list_u64_ret: wasmtime::component::Func,
+                    list_s8_ret: wasmtime::component::Func,
+                    list_s16_ret: wasmtime::component::Func,
+                    list_s32_ret: wasmtime::component::Func,
+                    list_s64_ret: wasmtime::component::Func,
+                    list_f32_ret: wasmtime::component::Func,
+                    list_f64_ret: wasmtime::component::Func,
+                    tuple_list: wasmtime::component::Func,
+                    string_list_arg: wasmtime::component::Func,
+                    string_list_ret: wasmtime::component::Func,
+                    tuple_string_list: wasmtime::component::Func,
+                    string_list: wasmtime::component::Func,
+                    record_list: wasmtime::component::Func,
+                    record_list_reverse: wasmtime::component::Func,
+                    variant_list: wasmtime::component::Func,
+                    load_store_everything: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    list_u8_param: wasmtime::component::ComponentExportIndex,
+                    list_u16_param: wasmtime::component::ComponentExportIndex,
+                    list_u32_param: wasmtime::component::ComponentExportIndex,
+                    list_u64_param: wasmtime::component::ComponentExportIndex,
+                    list_s8_param: wasmtime::component::ComponentExportIndex,
+                    list_s16_param: wasmtime::component::ComponentExportIndex,
+                    list_s32_param: wasmtime::component::ComponentExportIndex,
+                    list_s64_param: wasmtime::component::ComponentExportIndex,
+                    list_f32_param: wasmtime::component::ComponentExportIndex,
+                    list_f64_param: wasmtime::component::ComponentExportIndex,
+                    list_u8_ret: wasmtime::component::ComponentExportIndex,
+                    list_u16_ret: wasmtime::component::ComponentExportIndex,
+                    list_u32_ret: wasmtime::component::ComponentExportIndex,
+                    list_u64_ret: wasmtime::component::ComponentExportIndex,
+                    list_s8_ret: wasmtime::component::ComponentExportIndex,
+                    list_s16_ret: wasmtime::component::ComponentExportIndex,
+                    list_s32_ret: wasmtime::component::ComponentExportIndex,
+                    list_s64_ret: wasmtime::component::ComponentExportIndex,
+                    list_f32_ret: wasmtime::component::ComponentExportIndex,
+                    list_f64_ret: wasmtime::component::ComponentExportIndex,
+                    tuple_list: wasmtime::component::ComponentExportIndex,
+                    string_list_arg: wasmtime::component::ComponentExportIndex,
+                    string_list_ret: wasmtime::component::ComponentExportIndex,
+                    tuple_string_list: wasmtime::component::ComponentExportIndex,
+                    string_list: wasmtime::component::ComponentExportIndex,
+                    record_list: wasmtime::component::ComponentExportIndex,
+                    record_list_reverse: wasmtime::component::ComponentExportIndex,
+                    variant_list: wasmtime::component::ComponentExportIndex,
+                    load_store_everything: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/lists` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let list_u8_param = lookup("list-u8-param")?;
+                        let list_u16_param = lookup("list-u16-param")?;
+                        let list_u32_param = lookup("list-u32-param")?;
+                        let list_u64_param = lookup("list-u64-param")?;
+                        let list_s8_param = lookup("list-s8-param")?;
+                        let list_s16_param = lookup("list-s16-param")?;
+                        let list_s32_param = lookup("list-s32-param")?;
+                        let list_s64_param = lookup("list-s64-param")?;
+                        let list_f32_param = lookup("list-f32-param")?;
+                        let list_f64_param = lookup("list-f64-param")?;
+                        let list_u8_ret = lookup("list-u8-ret")?;
+                        let list_u16_ret = lookup("list-u16-ret")?;
+                        let list_u32_ret = lookup("list-u32-ret")?;
+                        let list_u64_ret = lookup("list-u64-ret")?;
+                        let list_s8_ret = lookup("list-s8-ret")?;
+                        let list_s16_ret = lookup("list-s16-ret")?;
+                        let list_s32_ret = lookup("list-s32-ret")?;
+                        let list_s64_ret = lookup("list-s64-ret")?;
+                        let list_f32_ret = lookup("list-f32-ret")?;
+                        let list_f64_ret = lookup("list-f64-ret")?;
+                        let tuple_list = lookup("tuple-list")?;
+                        let string_list_arg = lookup("string-list-arg")?;
+                        let string_list_ret = lookup("string-list-ret")?;
+                        let tuple_string_list = lookup("tuple-string-list")?;
+                        let string_list = lookup("string-list")?;
+                        let record_list = lookup("record-list")?;
+                        let record_list_reverse = lookup("record-list-reverse")?;
+                        let variant_list = lookup("variant-list")?;
+                        let load_store_everything = lookup("load-store-everything")?;
+                        Ok(GuestIndices {
+                            list_u8_param,
+                            list_u16_param,
+                            list_u32_param,
+                            list_u64_param,
+                            list_s8_param,
+                            list_s16_param,
+                            list_s32_param,
+                            list_s64_param,
+                            list_f32_param,
+                            list_f64_param,
+                            list_u8_ret,
+                            list_u16_ret,
+                            list_u32_ret,
+                            list_u64_ret,
+                            list_s8_ret,
+                            list_s16_ret,
+                            list_s32_ret,
+                            list_s64_ret,
+                            list_f32_ret,
+                            list_f64_ret,
+                            tuple_list,
+                            string_list_arg,
+                            string_list_ret,
+                            tuple_string_list,
+                            string_list,
+                            record_list,
+                            record_list_reverse,
+                            variant_list,
+                            load_store_everything,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let list_u8_param = *_instance
+                            .get_typed_func::<
+                                (&[u8],),
+                                (),
+                            >(&mut store, &self.list_u8_param)?
+                            .func();
+                        let list_u16_param = *_instance
+                            .get_typed_func::<
+                                (&[u16],),
+                                (),
+                            >(&mut store, &self.list_u16_param)?
+                            .func();
+                        let list_u32_param = *_instance
+                            .get_typed_func::<
+                                (&[u32],),
+                                (),
+                            >(&mut store, &self.list_u32_param)?
+                            .func();
+                        let list_u64_param = *_instance
+                            .get_typed_func::<
+                                (&[u64],),
+                                (),
+                            >(&mut store, &self.list_u64_param)?
+                            .func();
+                        let list_s8_param = *_instance
+                            .get_typed_func::<
+                                (&[i8],),
+                                (),
+                            >(&mut store, &self.list_s8_param)?
+                            .func();
+                        let list_s16_param = *_instance
+                            .get_typed_func::<
+                                (&[i16],),
+                                (),
+                            >(&mut store, &self.list_s16_param)?
+                            .func();
+                        let list_s32_param = *_instance
+                            .get_typed_func::<
+                                (&[i32],),
+                                (),
+                            >(&mut store, &self.list_s32_param)?
+                            .func();
+                        let list_s64_param = *_instance
+                            .get_typed_func::<
+                                (&[i64],),
+                                (),
+                            >(&mut store, &self.list_s64_param)?
+                            .func();
+                        let list_f32_param = *_instance
+                            .get_typed_func::<
+                                (&[f32],),
+                                (),
+                            >(&mut store, &self.list_f32_param)?
+                            .func();
+                        let list_f64_param = *_instance
+                            .get_typed_func::<
+                                (&[f64],),
+                                (),
+                            >(&mut store, &self.list_f64_param)?
+                            .func();
+                        let list_u8_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >(&mut store, &self.list_u8_ret)?
+                            .func();
+                        let list_u16_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >(&mut store, &self.list_u16_ret)?
+                            .func();
+                        let list_u32_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >(&mut store, &self.list_u32_ret)?
+                            .func();
+                        let list_u64_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >(&mut store, &self.list_u64_ret)?
+                            .func();
+                        let list_s8_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >(&mut store, &self.list_s8_ret)?
+                            .func();
+                        let list_s16_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >(&mut store, &self.list_s16_ret)?
+                            .func();
+                        let list_s32_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >(&mut store, &self.list_s32_ret)?
+                            .func();
+                        let list_s64_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >(&mut store, &self.list_s64_ret)?
+                            .func();
+                        let list_f32_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >(&mut store, &self.list_f32_ret)?
+                            .func();
+                        let list_f64_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >(&mut store, &self.list_f64_ret)?
+                            .func();
+                        let tuple_list = *_instance
+                            .get_typed_func::<
+                                (&[(u8, i8)],),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >(&mut store, &self.tuple_list)?
+                            .func();
+                        let string_list_arg = *_instance
+                            .get_typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (),
+                            >(&mut store, &self.string_list_arg)?
+                            .func();
+                        let string_list_ret = *_instance
+                            .get_typed_func::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >(&mut store, &self.string_list_ret)?
+                            .func();
+                        let tuple_string_list = *_instance
+                            .get_typed_func::<
+                                (&[(u8, wasmtime::component::__internal::String)],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >(&mut store, &self.tuple_string_list)?
+                            .func();
+                        let string_list = *_instance
+                            .get_typed_func::<
+                                (&[wasmtime::component::__internal::String],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >(&mut store, &self.string_list)?
+                            .func();
+                        let record_list = *_instance
+                            .get_typed_func::<
+                                (&[SomeRecord],),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >(&mut store, &self.record_list)?
+                            .func();
+                        let record_list_reverse = *_instance
+                            .get_typed_func::<
+                                (&[OtherRecord],),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >(&mut store, &self.record_list_reverse)?
+                            .func();
+                        let variant_list = *_instance
+                            .get_typed_func::<
+                                (&[SomeVariant],),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >(&mut store, &self.variant_list)?
+                            .func();
+                        let load_store_everything = *_instance
+                            .get_typed_func::<
+                                (&LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >(&mut store, &self.load_store_everything)?
+                            .func();
+                        Ok(Guest {
+                            list_u8_param,
+                            list_u16_param,
+                            list_u32_param,
+                            list_u64_param,
+                            list_s8_param,
+                            list_s16_param,
+                            list_s32_param,
+                            list_s64_param,
+                            list_f32_param,
+                            list_f64_param,
+                            list_u8_ret,
+                            list_u16_ret,
+                            list_u32_ret,
+                            list_u64_ret,
+                            list_s8_ret,
+                            list_s16_ret,
+                            list_s32_ret,
+                            list_s64_ret,
+                            list_f32_ret,
+                            list_f64_ret,
+                            tuple_list,
+                            string_list_arg,
+                            string_list_ret,
+                            tuple_string_list,
+                            string_list,
+                            record_list,
+                            record_list_reverse,
+                            variant_list,
+                            load_store_everything,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_list_u8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u8>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u8>,),
+                                (),
+                            >::new_unchecked(self.list_u8_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_u16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u16>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u16>,),
+                                (),
+                            >::new_unchecked(self.list_u16_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_u32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u32>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u32>,),
+                                (),
+                            >::new_unchecked(self.list_u32_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_u64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u64>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u64>,),
+                                (),
+                            >::new_unchecked(self.list_u64_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_s8_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<i8>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i8>,),
+                                (),
+                            >::new_unchecked(self.list_s8_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_s16_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<i16>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i16>,),
+                                (),
+                            >::new_unchecked(self.list_s16_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_s32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<i32>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i32>,),
+                                (),
+                            >::new_unchecked(self.list_s32_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_s64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<i64>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<i64>,),
+                                (),
+                            >::new_unchecked(self.list_s64_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_f32_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<f32>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<f32>,),
+                                (),
+                            >::new_unchecked(self.list_f32_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_f64_param<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<f64>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<f64>,),
+                                (),
+                            >::new_unchecked(self.list_f64_param)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_list_u8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<u8>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u8>,),
+                            >::new_unchecked(self.list_u8_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_u16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<u16>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u16>,),
+                            >::new_unchecked(self.list_u16_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_u32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.list_u32_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_u64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<u64>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u64>,),
+                            >::new_unchecked(self.list_u64_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_s8_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<i8>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i8>,),
+                            >::new_unchecked(self.list_s8_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_s16_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<i16>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i16>,),
+                            >::new_unchecked(self.list_s16_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_s32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<i32>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i32>,),
+                            >::new_unchecked(self.list_s32_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_s64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<i64>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<i64>,),
+                            >::new_unchecked(self.list_s64_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_f32_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<f32>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f32>,),
+                            >::new_unchecked(self.list_f32_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_list_f64_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<f64>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<f64>,),
+                            >::new_unchecked(self.list_f64_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_tuple_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<(u8, i8)>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<(i64, u32)>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<(u8, i8)>,),
+                                (wasmtime::component::__internal::Vec<(i64, u32)>,),
+                            >::new_unchecked(self.tuple_list)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_string_list_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                                (),
+                            >::new_unchecked(self.string_list_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_string_list_ret<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list_ret)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_tuple_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<
+                            (u8, wasmtime::component::__internal::String),
+                        >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<
+                                (wasmtime::component::__internal::String, u8),
+                            >,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (u8, wasmtime::component::__internal::String),
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        (wasmtime::component::__internal::String, u8),
+                                    >,
+                                ),
+                            >::new_unchecked(self.tuple_string_list)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_string_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::String,
+                        >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::String,
+                            >,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::String,
+                                    >,
+                                ),
+                            >::new_unchecked(self.string_list)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_record_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<SomeRecord>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<OtherRecord>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                            >::new_unchecked(self.record_list)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_record_list_reverse<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<OtherRecord>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<SomeRecord>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<OtherRecord>,),
+                                (wasmtime::component::__internal::Vec<SomeRecord>,),
+                            >::new_unchecked(self.record_list_reverse)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_variant_list<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<SomeVariant>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<OtherVariant>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<SomeVariant>,),
+                                (wasmtime::component::__internal::Vec<OtherVariant>,),
+                            >::new_unchecked(self.variant_list)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_load_store_everything<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: LoadStoreAllSizes,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<LoadStoreAllSizes>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (LoadStoreAllSizes,),
+                                (LoadStoreAllSizes,),
+                            >::new_unchecked(self.load_store_everything)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -495,19 +495,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -291,19 +291,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap(
@@ -659,7 +663,10 @@ pub mod exports {
                         arg13: u64,
                         arg14: u64,
                         arg15: u64,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
@@ -712,7 +719,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &BigStruct,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&BigStruct,),

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -299,19 +299,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -1,0 +1,830 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::manyarg::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::manyarg::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::manyarg::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::manyarg::Host<Data = T> + 'static,
+            U: Send + foo::foo::manyarg::Host<Data = T>,
+        {
+            foo::foo::manyarg::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod manyarg {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct BigStruct {
+                #[component(name = "a1")]
+                pub a1: wasmtime::component::__internal::String,
+                #[component(name = "a2")]
+                pub a2: wasmtime::component::__internal::String,
+                #[component(name = "a3")]
+                pub a3: wasmtime::component::__internal::String,
+                #[component(name = "a4")]
+                pub a4: wasmtime::component::__internal::String,
+                #[component(name = "a5")]
+                pub a5: wasmtime::component::__internal::String,
+                #[component(name = "a6")]
+                pub a6: wasmtime::component::__internal::String,
+                #[component(name = "a7")]
+                pub a7: wasmtime::component::__internal::String,
+                #[component(name = "a8")]
+                pub a8: wasmtime::component::__internal::String,
+                #[component(name = "a9")]
+                pub a9: wasmtime::component::__internal::String,
+                #[component(name = "a10")]
+                pub a10: wasmtime::component::__internal::String,
+                #[component(name = "a11")]
+                pub a11: wasmtime::component::__internal::String,
+                #[component(name = "a12")]
+                pub a12: wasmtime::component::__internal::String,
+                #[component(name = "a13")]
+                pub a13: wasmtime::component::__internal::String,
+                #[component(name = "a14")]
+                pub a14: wasmtime::component::__internal::String,
+                #[component(name = "a15")]
+                pub a15: wasmtime::component::__internal::String,
+                #[component(name = "a16")]
+                pub a16: wasmtime::component::__internal::String,
+                #[component(name = "a17")]
+                pub a17: wasmtime::component::__internal::String,
+                #[component(name = "a18")]
+                pub a18: wasmtime::component::__internal::String,
+                #[component(name = "a19")]
+                pub a19: wasmtime::component::__internal::String,
+                #[component(name = "a20")]
+                pub a20: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for BigStruct {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("BigStruct")
+                        .field("a1", &self.a1)
+                        .field("a2", &self.a2)
+                        .field("a3", &self.a3)
+                        .field("a4", &self.a4)
+                        .field("a5", &self.a5)
+                        .field("a6", &self.a6)
+                        .field("a7", &self.a7)
+                        .field("a8", &self.a8)
+                        .field("a9", &self.a9)
+                        .field("a10", &self.a10)
+                        .field("a11", &self.a11)
+                        .field("a12", &self.a12)
+                        .field("a13", &self.a13)
+                        .field("a14", &self.a14)
+                        .field("a15", &self.a15)
+                        .field("a16", &self.a16)
+                        .field("a17", &self.a17)
+                        .field("a18", &self.a18)
+                        .field("a19", &self.a19)
+                        .field("a20", &self.a20)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    160 == < BigStruct as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                type Data;
+                fn many_args(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn big_argument(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: BigStruct,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                inst.func_wrap_concurrent(
+                    "many-args",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                            arg8,
+                            arg9,
+                            arg10,
+                            arg11,
+                            arg12,
+                            arg13,
+                            arg14,
+                            arg15,
+                        ): (
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                            u64,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::many_args(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                            arg6,
+                            arg7,
+                            arg8,
+                            arg9,
+                            arg10,
+                            arg11,
+                            arg12,
+                            arg13,
+                            arg14,
+                            arg15,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "big-argument",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (BigStruct,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::big_argument(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn many_args(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::many_args(
+                        store,
+                        a1,
+                        a2,
+                        a3,
+                        a4,
+                        a5,
+                        a6,
+                        a7,
+                        a8,
+                        a9,
+                        a10,
+                        a11,
+                        a12,
+                        a13,
+                        a14,
+                        a15,
+                        a16,
+                    )
+                }
+                fn big_argument(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: BigStruct,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::big_argument(store, x)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod manyarg {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct BigStruct {
+                    #[component(name = "a1")]
+                    pub a1: wasmtime::component::__internal::String,
+                    #[component(name = "a2")]
+                    pub a2: wasmtime::component::__internal::String,
+                    #[component(name = "a3")]
+                    pub a3: wasmtime::component::__internal::String,
+                    #[component(name = "a4")]
+                    pub a4: wasmtime::component::__internal::String,
+                    #[component(name = "a5")]
+                    pub a5: wasmtime::component::__internal::String,
+                    #[component(name = "a6")]
+                    pub a6: wasmtime::component::__internal::String,
+                    #[component(name = "a7")]
+                    pub a7: wasmtime::component::__internal::String,
+                    #[component(name = "a8")]
+                    pub a8: wasmtime::component::__internal::String,
+                    #[component(name = "a9")]
+                    pub a9: wasmtime::component::__internal::String,
+                    #[component(name = "a10")]
+                    pub a10: wasmtime::component::__internal::String,
+                    #[component(name = "a11")]
+                    pub a11: wasmtime::component::__internal::String,
+                    #[component(name = "a12")]
+                    pub a12: wasmtime::component::__internal::String,
+                    #[component(name = "a13")]
+                    pub a13: wasmtime::component::__internal::String,
+                    #[component(name = "a14")]
+                    pub a14: wasmtime::component::__internal::String,
+                    #[component(name = "a15")]
+                    pub a15: wasmtime::component::__internal::String,
+                    #[component(name = "a16")]
+                    pub a16: wasmtime::component::__internal::String,
+                    #[component(name = "a17")]
+                    pub a17: wasmtime::component::__internal::String,
+                    #[component(name = "a18")]
+                    pub a18: wasmtime::component::__internal::String,
+                    #[component(name = "a19")]
+                    pub a19: wasmtime::component::__internal::String,
+                    #[component(name = "a20")]
+                    pub a20: wasmtime::component::__internal::String,
+                }
+                impl core::fmt::Debug for BigStruct {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("BigStruct")
+                            .field("a1", &self.a1)
+                            .field("a2", &self.a2)
+                            .field("a3", &self.a3)
+                            .field("a4", &self.a4)
+                            .field("a5", &self.a5)
+                            .field("a6", &self.a6)
+                            .field("a7", &self.a7)
+                            .field("a8", &self.a8)
+                            .field("a9", &self.a9)
+                            .field("a10", &self.a10)
+                            .field("a11", &self.a11)
+                            .field("a12", &self.a12)
+                            .field("a13", &self.a13)
+                            .field("a14", &self.a14)
+                            .field("a15", &self.a15)
+                            .field("a16", &self.a16)
+                            .field("a17", &self.a17)
+                            .field("a18", &self.a18)
+                            .field("a19", &self.a19)
+                            .field("a20", &self.a20)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        160 == < BigStruct as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < BigStruct as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    many_args: wasmtime::component::Func,
+                    big_argument: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    many_args: wasmtime::component::ComponentExportIndex,
+                    big_argument: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/manyarg")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/manyarg`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/manyarg`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/manyarg` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let many_args = lookup("many-args")?;
+                        let big_argument = lookup("big-argument")?;
+                        Ok(GuestIndices {
+                            many_args,
+                            big_argument,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let many_args = *_instance
+                            .get_typed_func::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >(&mut store, &self.many_args)?
+                            .func();
+                        let big_argument = *_instance
+                            .get_typed_func::<
+                                (&BigStruct,),
+                                (),
+                            >(&mut store, &self.big_argument)?
+                            .func();
+                        Ok(Guest { many_args, big_argument })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_many_args<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u64,
+                        arg1: u64,
+                        arg2: u64,
+                        arg3: u64,
+                        arg4: u64,
+                        arg5: u64,
+                        arg6: u64,
+                        arg7: u64,
+                        arg8: u64,
+                        arg9: u64,
+                        arg10: u64,
+                        arg11: u64,
+                        arg12: u64,
+                        arg13: u64,
+                        arg14: u64,
+                        arg15: u64,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                    u64,
+                                ),
+                                (),
+                            >::new_unchecked(self.many_args)
+                        };
+                        let promise = callee
+                            .call_concurrent(
+                                store.as_context_mut(),
+                                (
+                                    arg0,
+                                    arg1,
+                                    arg2,
+                                    arg3,
+                                    arg4,
+                                    arg5,
+                                    arg6,
+                                    arg7,
+                                    arg8,
+                                    arg9,
+                                    arg10,
+                                    arg11,
+                                    arg12,
+                                    arg13,
+                                    arg14,
+                                    arg15,
+                                ),
+                            )
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_big_argument<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: BigStruct,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (BigStruct,),
+                                (),
+                            >::new_unchecked(self.big_argument)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -299,19 +299,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/multi-return.rs
+++ b/crates/component-macro/tests/expanded/multi-return.rs
@@ -197,19 +197,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/multi-return")?;
                 inst.func_wrap(
@@ -401,7 +405,10 @@ pub mod exports {
                     pub fn call_mra<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -415,7 +422,10 @@ pub mod exports {
                     pub fn call_mrb<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -429,7 +439,10 @@ pub mod exports {
                     pub fn call_mrc<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -443,7 +456,10 @@ pub mod exports {
                     pub fn call_mrd<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -457,7 +473,10 @@ pub mod exports {
                     pub fn call_mre<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<(u32, f32)> {
+                    ) -> wasmtime::Result<(u32, f32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/multi-return_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/multi-return_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multi-return_concurrent.rs
@@ -1,0 +1,707 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::multi_return::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::multi_return::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new(
+                _component,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::multi_return::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::multi_return::Host<Data = T> + 'static,
+            U: Send + foo::foo::multi_return::Host<Data = T>,
+        {
+            foo::foo::multi_return::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_multi_return(&self) -> &exports::foo::foo::multi_return::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod multi_return {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn mra(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn mrb(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn mrc(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn mrd(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn mre(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, f32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/multi-return")?;
+                inst.func_wrap_concurrent(
+                    "mra",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::mra(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "mrb",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::mrb(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "mrc",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::mrc(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "mrd",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::mrd(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "mre",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::mre(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32, f32)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32, f32)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn mra(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::mra(store)
+                }
+                fn mrb(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::mrb(store)
+                }
+                fn mrc(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::mrc(store)
+                }
+                fn mrd(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::mrd(store)
+                }
+                fn mre(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, f32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::mre(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod multi_return {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    mra: wasmtime::component::Func,
+                    mrb: wasmtime::component::Func,
+                    mrc: wasmtime::component::Func,
+                    mrd: wasmtime::component::Func,
+                    mre: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    mra: wasmtime::component::ComponentExportIndex,
+                    mrb: wasmtime::component::ComponentExportIndex,
+                    mrc: wasmtime::component::ComponentExportIndex,
+                    mrd: wasmtime::component::ComponentExportIndex,
+                    mre: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/multi-return")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/multi-return`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/multi-return")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/multi-return`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/multi-return` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let mra = lookup("mra")?;
+                        let mrb = lookup("mrb")?;
+                        let mrc = lookup("mrc")?;
+                        let mrd = lookup("mrd")?;
+                        let mre = lookup("mre")?;
+                        Ok(GuestIndices {
+                            mra,
+                            mrb,
+                            mrc,
+                            mrd,
+                            mre,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let mra = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.mra)?
+                            .func();
+                        let mrb = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.mrb)?
+                            .func();
+                        let mrc = *_instance
+                            .get_typed_func::<(), (u32,)>(&mut store, &self.mrc)?
+                            .func();
+                        let mrd = *_instance
+                            .get_typed_func::<(), (u32,)>(&mut store, &self.mrd)?
+                            .func();
+                        let mre = *_instance
+                            .get_typed_func::<(), (u32, f32)>(&mut store, &self.mre)?
+                            .func();
+                        Ok(Guest { mra, mrb, mrc, mrd, mre })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_mra<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mra)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_mrb<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.mrb)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_mrc<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrc)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_mrd<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.mrd)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_mre<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<(u32, f32)>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32, f32),
+                            >::new_unchecked(self.mre)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multi-return_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multi-return_tracing_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -209,19 +209,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap(
@@ -260,19 +264,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap(
@@ -390,7 +398,10 @@ pub mod exports {
                     pub fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -490,7 +501,10 @@ pub mod exports {
                     pub fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -217,19 +217,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -275,19 +279,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -1,0 +1,622 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `foo`.
+///
+/// This structure is created through [`FooPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
+}
+impl<T> Clone for FooPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    interface0: exports::my::dep0_1_0::a::GuestIndices,
+    interface1: exports::my::dep0_2_0::a::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `foo`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Foo {
+    interface0: exports::my::dep0_1_0::a::Guest,
+    interface1: exports::my::dep0_2_0::a::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new(_component)?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new(_component)?;
+            Ok(FooIndices {
+                interface0,
+                interface1,
+            })
+        }
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(FooIndices {
+                interface0,
+                interface1,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            Ok(Foo { interface0, interface1 })
+        }
+    }
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Foo>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + my::dep0_1_0::a::Host<Data = T> + my::dep0_2_0::a::Host<Data = T>
+                + 'static,
+            U: Send + my::dep0_1_0::a::Host<Data = T> + my::dep0_2_0::a::Host<Data = T>,
+        {
+            my::dep0_1_0::a::add_to_linker(linker, get)?;
+            my::dep0_2_0::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
+            &self.interface0
+        }
+        pub fn my_dep0_2_0_a(&self) -> &exports::my::dep0_2_0::a::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod my {
+    pub mod dep0_1_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn x(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                inst.func_wrap_concurrent(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::x(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn x(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::x(store)
+                }
+            }
+        }
+    }
+    pub mod dep0_2_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn x(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                inst.func_wrap_concurrent(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::x(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn x(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::x(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod my {
+        pub mod dep0_1_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    x: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "my:dep/a@0.1.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.1.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.1.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `my:dep/a@0.1.0` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let x = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.x)?
+                            .func();
+                        Ok(Guest { x })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+        pub mod dep0_2_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    x: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "my:dep/a@0.2.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.2.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.2.0`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `my:dep/a@0.2.0` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let x = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.x)?
+                            .func();
+                        Ok(Guest { x })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_x<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.x)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -217,19 +217,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -288,19 +292,23 @@ pub mod my {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -176,19 +176,23 @@ pub mod paths {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("paths:path1/test")?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -184,19 +184,23 @@ pub mod paths {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/path1_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path1_concurrent.rs
@@ -1,0 +1,223 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path1`.
+///
+/// This structure is created through [`Path1Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path1`] as well.
+pub struct Path1Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path1Indices,
+}
+impl<T> Clone for Path1Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path1Pre<_T> {
+    /// Creates a new copy of `Path1Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path1Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path1`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path1>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path1`.
+///
+/// This is an implementation detail of [`Path1Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path1`] as well.
+#[derive(Clone)]
+pub struct Path1Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path1`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path1::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path1Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path1Pre::instantiate_async`] to
+///   create a [`Path1`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path1::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path1Indices::new_instance`] followed
+///   by [`Path1Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path1 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path1Indices {
+        /// Creates a new copy of `Path1Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path1Indices {})
+        }
+        /// Creates a new instance of [`Path1Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path1`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path1`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path1Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path1`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let _instance = instance;
+            Ok(Path1 {})
+        }
+    }
+    impl Path1 {
+        /// Convenience wrapper around [`Path1Pre::new`] and
+        /// [`Path1Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path1>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path1Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path1Indices::new_instance`] and
+        /// [`Path1Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path1> {
+            let indices = Path1Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + paths::path1::test::Host + 'static,
+            U: Send + paths::path1::test::Host,
+        {
+            paths::path1::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path1 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("paths:path1/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -184,19 +184,23 @@ pub mod paths {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -176,19 +176,23 @@ pub mod paths {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("paths:path2/test")?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -184,19 +184,23 @@ pub mod paths {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/path2_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path2_concurrent.rs
@@ -1,0 +1,223 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `path2`.
+///
+/// This structure is created through [`Path2Pre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Path2`] as well.
+pub struct Path2Pre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: Path2Indices,
+}
+impl<T> Clone for Path2Pre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> Path2Pre<_T> {
+    /// Creates a new copy of `Path2Pre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = Path2Indices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Path2`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Path2>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `path2`.
+///
+/// This is an implementation detail of [`Path2Pre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Path2`] as well.
+#[derive(Clone)]
+pub struct Path2Indices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `path2`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Path2::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`Path2Pre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`Path2Pre::instantiate_async`] to
+///   create a [`Path2`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Path2::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`Path2Indices::new_instance`] followed
+///   by [`Path2Indices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Path2 {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl Path2Indices {
+        /// Creates a new copy of `Path2Indices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(Path2Indices {})
+        }
+        /// Creates a new instance of [`Path2Indices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Path2`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Path2`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(Path2Indices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Path2`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let _instance = instance;
+            Ok(Path2 {})
+        }
+    }
+    impl Path2 {
+        /// Convenience wrapper around [`Path2Pre::new`] and
+        /// [`Path2Pre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Path2>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            Path2Pre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`Path2Indices::new_instance`] and
+        /// [`Path2Indices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Path2> {
+            let indices = Path2Indices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + paths::path2::test::Host + 'static,
+            U: Send + paths::path2::test::Host,
+        {
+            paths::path2::test::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod paths {
+    pub mod path2 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("paths:path2/test")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -184,19 +184,23 @@ pub mod paths {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -347,19 +347,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap(
@@ -893,7 +897,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: (char, u32),
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 ((char, u32),),
@@ -907,7 +914,10 @@ pub mod exports {
                     pub fn call_tuple_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<(char, u32)> {
+                    ) -> wasmtime::Result<(char, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -922,7 +932,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Empty,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Empty,),
@@ -936,7 +949,10 @@ pub mod exports {
                     pub fn call_empty_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Empty> {
+                    ) -> wasmtime::Result<Empty>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -951,7 +967,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: Scalars,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Scalars,),
@@ -965,7 +984,10 @@ pub mod exports {
                     pub fn call_scalar_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Scalars> {
+                    ) -> wasmtime::Result<Scalars>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -980,7 +1002,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: ReallyFlags,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (ReallyFlags,),
@@ -994,7 +1019,10 @@ pub mod exports {
                     pub fn call_flags_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<ReallyFlags> {
+                    ) -> wasmtime::Result<ReallyFlags>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1009,7 +1037,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &Aggregates,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&Aggregates,),
@@ -1023,7 +1054,10 @@ pub mod exports {
                     pub fn call_aggregate_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Aggregates> {
+                    ) -> wasmtime::Result<Aggregates>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1038,7 +1072,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: TupleTypedef2,
-                    ) -> wasmtime::Result<i32> {
+                    ) -> wasmtime::Result<i32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (TupleTypedef2,),

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -355,19 +355,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -1,0 +1,1558 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::records::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::records::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::records::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::records::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::records::Host<Data = T> + 'static,
+            U: Send + foo::foo::records::Host<Data = T>,
+        {
+            foo::foo::records::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod records {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record containing two scalar fields
+            /// that both have the same type
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Scalars {
+                /// The first field, named a
+                #[component(name = "a")]
+                pub a: u32,
+                /// The second field, named b
+                #[component(name = "b")]
+                pub b: u32,
+            }
+            impl core::fmt::Debug for Scalars {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Scalars")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Scalars as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record that is really just flags
+            /// All of the fields are bool
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct ReallyFlags {
+                #[component(name = "a")]
+                pub a: bool,
+                #[component(name = "b")]
+                pub b: bool,
+                #[component(name = "c")]
+                pub c: bool,
+                #[component(name = "d")]
+                pub d: bool,
+                #[component(name = "e")]
+                pub e: bool,
+                #[component(name = "f")]
+                pub f: bool,
+                #[component(name = "g")]
+                pub g: bool,
+                #[component(name = "h")]
+                pub h: bool,
+                #[component(name = "i")]
+                pub i: bool,
+            }
+            impl core::fmt::Debug for ReallyFlags {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("ReallyFlags")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .field("f", &self.f)
+                        .field("g", &self.g)
+                        .field("h", &self.h)
+                        .field("i", &self.i)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    9 == < ReallyFlags as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < ReallyFlags as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Aggregates {
+                #[component(name = "a")]
+                pub a: Scalars,
+                #[component(name = "b")]
+                pub b: u32,
+                #[component(name = "c")]
+                pub c: Empty,
+                #[component(name = "d")]
+                pub d: wasmtime::component::__internal::String,
+                #[component(name = "e")]
+                pub e: ReallyFlags,
+            }
+            impl core::fmt::Debug for Aggregates {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Aggregates")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    32 == < Aggregates as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type IntTypedef = i32;
+            const _: () = {
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type TupleTypedef2 = (IntTypedef,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {
+                type Data;
+                fn tuple_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (char, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (char, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn empty_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Empty,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn empty_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Empty + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn scalar_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Scalars,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn scalar_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Scalars + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn flags_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: ReallyFlags,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn flags_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> ReallyFlags + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn aggregate_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Aggregates,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn aggregate_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Aggregates + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn typedef_inout(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    e: TupleTypedef2,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                inst.func_wrap_concurrent(
+                    "tuple-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((char, u32),)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<((char, u32),)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<((char, u32),)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "empty-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Empty,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::empty_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "empty-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::empty_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Empty,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Empty,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "scalar-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Scalars,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::scalar_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "scalar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::scalar_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Scalars,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Scalars,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "flags-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (ReallyFlags,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::flags_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "flags-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::flags_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(ReallyFlags,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(ReallyFlags,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "aggregate-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Aggregates,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::aggregate_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "aggregate-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::aggregate_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Aggregates,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Aggregates,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "typedef-inout",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (TupleTypedef2,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::typedef_inout(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(i32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(i32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn tuple_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (char, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_arg(store, x)
+                }
+                fn tuple_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (char, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_result(store)
+                }
+                fn empty_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Empty,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::empty_arg(store, x)
+                }
+                fn empty_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Empty + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::empty_result(store)
+                }
+                fn scalar_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Scalars,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::scalar_arg(store, x)
+                }
+                fn scalar_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Scalars + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::scalar_result(store)
+                }
+                fn flags_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: ReallyFlags,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::flags_arg(store, x)
+                }
+                fn flags_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> ReallyFlags + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::flags_result(store)
+                }
+                fn aggregate_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Aggregates,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::aggregate_arg(store, x)
+                }
+                fn aggregate_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Aggregates + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::aggregate_result(store)
+                }
+                fn typedef_inout(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    e: TupleTypedef2,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> i32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::typedef_inout(store, e)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod records {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record containing two scalar fields
+                /// that both have the same type
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Scalars {
+                    /// The first field, named a
+                    #[component(name = "a")]
+                    pub a: u32,
+                    /// The second field, named b
+                    #[component(name = "b")]
+                    pub b: u32,
+                }
+                impl core::fmt::Debug for Scalars {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Scalars")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Scalars as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record that is really just flags
+                /// All of the fields are bool
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct ReallyFlags {
+                    #[component(name = "a")]
+                    pub a: bool,
+                    #[component(name = "b")]
+                    pub b: bool,
+                    #[component(name = "c")]
+                    pub c: bool,
+                    #[component(name = "d")]
+                    pub d: bool,
+                    #[component(name = "e")]
+                    pub e: bool,
+                    #[component(name = "f")]
+                    pub f: bool,
+                    #[component(name = "g")]
+                    pub g: bool,
+                    #[component(name = "h")]
+                    pub h: bool,
+                    #[component(name = "i")]
+                    pub i: bool,
+                }
+                impl core::fmt::Debug for ReallyFlags {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("ReallyFlags")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .field("f", &self.f)
+                            .field("g", &self.g)
+                            .field("h", &self.h)
+                            .field("i", &self.i)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        9 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        1 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct Aggregates {
+                    #[component(name = "a")]
+                    pub a: Scalars,
+                    #[component(name = "b")]
+                    pub b: u32,
+                    #[component(name = "c")]
+                    pub c: Empty,
+                    #[component(name = "d")]
+                    pub d: wasmtime::component::__internal::String,
+                    #[component(name = "e")]
+                    pub e: ReallyFlags,
+                }
+                impl core::fmt::Debug for Aggregates {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Aggregates")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        32 == < Aggregates as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type IntTypedef = i32;
+                const _: () = {
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef2 = (IntTypedef,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    tuple_arg: wasmtime::component::Func,
+                    tuple_result: wasmtime::component::Func,
+                    empty_arg: wasmtime::component::Func,
+                    empty_result: wasmtime::component::Func,
+                    scalar_arg: wasmtime::component::Func,
+                    scalar_result: wasmtime::component::Func,
+                    flags_arg: wasmtime::component::Func,
+                    flags_result: wasmtime::component::Func,
+                    aggregate_arg: wasmtime::component::Func,
+                    aggregate_result: wasmtime::component::Func,
+                    typedef_inout: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    tuple_arg: wasmtime::component::ComponentExportIndex,
+                    tuple_result: wasmtime::component::ComponentExportIndex,
+                    empty_arg: wasmtime::component::ComponentExportIndex,
+                    empty_result: wasmtime::component::ComponentExportIndex,
+                    scalar_arg: wasmtime::component::ComponentExportIndex,
+                    scalar_result: wasmtime::component::ComponentExportIndex,
+                    flags_arg: wasmtime::component::ComponentExportIndex,
+                    flags_result: wasmtime::component::ComponentExportIndex,
+                    aggregate_arg: wasmtime::component::ComponentExportIndex,
+                    aggregate_result: wasmtime::component::ComponentExportIndex,
+                    typedef_inout: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/records")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/records`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/records")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/records`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/records` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let tuple_arg = lookup("tuple-arg")?;
+                        let tuple_result = lookup("tuple-result")?;
+                        let empty_arg = lookup("empty-arg")?;
+                        let empty_result = lookup("empty-result")?;
+                        let scalar_arg = lookup("scalar-arg")?;
+                        let scalar_result = lookup("scalar-result")?;
+                        let flags_arg = lookup("flags-arg")?;
+                        let flags_result = lookup("flags-result")?;
+                        let aggregate_arg = lookup("aggregate-arg")?;
+                        let aggregate_result = lookup("aggregate-result")?;
+                        let typedef_inout = lookup("typedef-inout")?;
+                        Ok(GuestIndices {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let tuple_arg = *_instance
+                            .get_typed_func::<
+                                ((char, u32),),
+                                (),
+                            >(&mut store, &self.tuple_arg)?
+                            .func();
+                        let tuple_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                ((char, u32),),
+                            >(&mut store, &self.tuple_result)?
+                            .func();
+                        let empty_arg = *_instance
+                            .get_typed_func::<(Empty,), ()>(&mut store, &self.empty_arg)?
+                            .func();
+                        let empty_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Empty,),
+                            >(&mut store, &self.empty_result)?
+                            .func();
+                        let scalar_arg = *_instance
+                            .get_typed_func::<
+                                (Scalars,),
+                                (),
+                            >(&mut store, &self.scalar_arg)?
+                            .func();
+                        let scalar_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Scalars,),
+                            >(&mut store, &self.scalar_result)?
+                            .func();
+                        let flags_arg = *_instance
+                            .get_typed_func::<
+                                (ReallyFlags,),
+                                (),
+                            >(&mut store, &self.flags_arg)?
+                            .func();
+                        let flags_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (ReallyFlags,),
+                            >(&mut store, &self.flags_result)?
+                            .func();
+                        let aggregate_arg = *_instance
+                            .get_typed_func::<
+                                (&Aggregates,),
+                                (),
+                            >(&mut store, &self.aggregate_arg)?
+                            .func();
+                        let aggregate_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Aggregates,),
+                            >(&mut store, &self.aggregate_result)?
+                            .func();
+                        let typedef_inout = *_instance
+                            .get_typed_func::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >(&mut store, &self.typedef_inout)?
+                            .func();
+                        Ok(Guest {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_tuple_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: (char, u32),
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_tuple_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<(char, u32)>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_empty_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Empty,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_empty_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Empty>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_scalar_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Scalars,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_scalar_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Scalars>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_flags_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: ReallyFlags,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_flags_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<ReallyFlags>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_aggregate_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Aggregates,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_aggregate_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Aggregates>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_typedef_inout<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: TupleTypedef2,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -355,19 +355,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -182,19 +182,23 @@ pub mod foo {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/green")?;
                 Ok(())
@@ -224,19 +228,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap(

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -190,19 +190,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -237,19 +241,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -1,0 +1,332 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `neptune`.
+///
+/// This structure is created through [`NeptunePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Neptune`] as well.
+pub struct NeptunePre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NeptuneIndices,
+}
+impl<T> Clone for NeptunePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> NeptunePre<_T> {
+    /// Creates a new copy of `NeptunePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NeptuneIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Neptune`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Neptune>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `neptune`.
+///
+/// This is an implementation detail of [`NeptunePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Neptune`] as well.
+#[derive(Clone)]
+pub struct NeptuneIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `neptune`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Neptune::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NeptunePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NeptunePre::instantiate_async`] to
+///   create a [`Neptune`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Neptune::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`NeptuneIndices::new_instance`] followed
+///   by [`NeptuneIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Neptune {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl NeptuneIndices {
+        /// Creates a new copy of `NeptuneIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(NeptuneIndices {})
+        }
+        /// Creates a new instance of [`NeptuneIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Neptune`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Neptune`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NeptuneIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Neptune`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Neptune> {
+            let _instance = instance;
+            Ok(Neptune {})
+        }
+    }
+    impl Neptune {
+        /// Convenience wrapper around [`NeptunePre::new`] and
+        /// [`NeptunePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Neptune>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            NeptunePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`NeptuneIndices::new_instance`] and
+        /// [`NeptuneIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Neptune> {
+            let indices = NeptuneIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::green::Host + foo::foo::red::Host<Data = T> + 'static,
+            U: Send + foo::foo::green::Host + foo::foo::red::Host<Data = T>,
+        {
+            foo::foo::green::add_to_linker(linker, get)?;
+            foo::foo::red::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod green {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type Thing = i32;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/green")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+        #[allow(clippy::all)]
+        pub mod red {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type Thing = super::super::super::foo::foo::green::Thing;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Thing + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                inst.func_wrap_concurrent(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::foo(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Thing,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Thing,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Thing + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::foo(store)
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/rename_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/rename_tracing_async.rs
@@ -190,19 +190,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -237,19 +241,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -249,7 +249,7 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Y {}
-            pub trait HostY {
+            pub trait HostY: Sized {
                 fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<Y>,
@@ -263,22 +263,26 @@ pub mod foo {
                     HostY::drop(*self, rep)
                 }
             }
-            pub trait Host: HostY {}
+            pub trait Host: HostY + Sized {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/transitive-import")?;
                 inst.resource(
@@ -432,7 +436,10 @@ pub mod exports {
                     pub fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -446,7 +453,10 @@ pub mod exports {
                     pub fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -461,7 +471,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::ResourceAny,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (wasmtime::component::ResourceAny,),
@@ -602,7 +615,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::Resource<Y>,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (wasmtime::component::Resource<Y>,),
@@ -616,7 +632,10 @@ pub mod exports {
                     pub fn call_static_a<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -632,7 +651,10 @@ pub mod exports {
                         mut store: S,
                         arg0: wasmtime::component::ResourceAny,
                         arg1: wasmtime::component::Resource<Y>,
-                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>> {
+                    ) -> wasmtime::Result<wasmtime::component::Resource<Y>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
@@ -747,7 +769,10 @@ pub mod exports {
                     pub fn call_constructor<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -861,7 +886,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::ResourceAny,
-                    ) -> wasmtime::Result<wasmtime::component::ResourceAny> {
+                    ) -> wasmtime::Result<wasmtime::component::ResourceAny>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (wasmtime::component::ResourceAny,),

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -1,0 +1,938 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `w`.
+///
+/// This structure is created through [`WPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`W`] as well.
+pub struct WPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: WIndices,
+}
+impl<T> Clone for WPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> WPre<_T> {
+    /// Creates a new copy of `WPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`W`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<W>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `w`.
+///
+/// This is an implementation detail of [`WPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`W`] as well.
+#[derive(Clone)]
+pub struct WIndices {
+    interface0: exports::foo::foo::simple_export::GuestIndices,
+    interface1: exports::foo::foo::export_using_import::GuestIndices,
+    interface2: exports::foo::foo::export_using_export1::GuestIndices,
+    interface3: exports::foo::foo::export_using_export2::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `w`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`W::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WPre::instantiate_async`] to
+///   create a [`W`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`W::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`WIndices::new_instance`] followed
+///   by [`WIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct W {
+    interface0: exports::foo::foo::simple_export::Guest,
+    interface1: exports::foo::foo::export_using_import::Guest,
+    interface2: exports::foo::foo::export_using_export1::Guest,
+    interface3: exports::foo::foo::export_using_export2::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl WIndices {
+        /// Creates a new copy of `WIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new(
+                _component,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new(
+                _component,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new(
+                _component,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new(
+                _component,
+            )?;
+            Ok(WIndices {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        /// Creates a new instance of [`WIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`W`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`W`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(WIndices {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`W`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            let interface2 = self.interface2.load(&mut store, &_instance)?;
+            let interface3 = self.interface3.load(&mut store, &_instance)?;
+            Ok(W {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+    }
+    impl W {
+        /// Convenience wrapper around [`WPre::new`] and
+        /// [`WPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<W>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            WPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`WIndices::new_instance`] and
+        /// [`WIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let indices = WIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::transitive_import::Host + 'static,
+            U: Send + foo::foo::transitive_import::Host,
+        {
+            foo::foo::transitive_import::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_simple_export(&self) -> &exports::foo::foo::simple_export::Guest {
+            &self.interface0
+        }
+        pub fn foo_foo_export_using_import(
+            &self,
+        ) -> &exports::foo::foo::export_using_import::Guest {
+            &self.interface1
+        }
+        pub fn foo_foo_export_using_export1(
+            &self,
+        ) -> &exports::foo::foo::export_using_export1::Guest {
+            &self.interface2
+        }
+        pub fn foo_foo_export_using_export2(
+            &self,
+        ) -> &exports::foo::foo::export_using_export2::Guest {
+            &self.interface3
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod transitive_import {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Y {}
+            pub trait HostY: Sized {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostY + ?Sized> HostY for &mut _T {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()> {
+                    HostY::drop(*self, rep)
+                }
+            }
+            pub trait Host: HostY + Sized {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                inst.resource(
+                    "y",
+                    wasmtime::component::ResourceType::host::<Y>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostY::drop(
+                            &mut host_getter(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_export {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                    static_a_static_a: wasmtime::component::ComponentExportIndex,
+                    method_a_method_a: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/simple-export")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-export`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-export`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/simple-export` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        let static_a_static_a = *_instance
+                            .get_typed_func::<
+                                (),
+                                (u32,),
+                            >(&mut store, &self.static_a_static_a)?
+                            .func();
+                        let method_a_method_a = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >(&mut store, &self.method_a_method_a)?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::ResourceAny>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_import {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type Y = super::super::super::super::foo::foo::transitive_import::Y;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                    static_a_static_a: wasmtime::component::ComponentExportIndex,
+                    method_a_method_a: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/export-using-import")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-import`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-import`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-import` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        let static_a_static_a = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >(&mut store, &self.static_a_static_a)?
+                            .func();
+                        let method_a_method_a = *_instance
+                            .get_typed_func::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >(&mut store, &self.method_a_method_a)?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::ResourceAny>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::Resource<Y>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                        arg1: wasmtime::component::Resource<Y>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::Resource<Y>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export1 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/export-using-export1")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export1`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export1`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-export1` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        Ok(Guest { constructor_a_constructor })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::ResourceAny>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export2 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = super::super::super::super::exports::foo::foo::export_using_export1::A;
+                pub type B = wasmtime::component::ResourceAny;
+                pub struct GuestB<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_b_constructor: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_b_constructor: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/export-using-export2")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export2`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export2`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-export2` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_b_constructor = lookup("[constructor]b")?;
+                        Ok(GuestIndices {
+                            constructor_b_constructor,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let constructor_b_constructor = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_b_constructor)?
+                            .func();
+                        Ok(Guest { constructor_b_constructor })
+                    }
+                }
+                impl Guest {
+                    pub fn b(&self) -> GuestB<'_> {
+                        GuestB { funcs: self }
+                    }
+                }
+                impl GuestB<'_> {
+                    pub async fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<wasmtime::component::ResourceAny>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -1,0 +1,2386 @@
+pub enum WorldResource {}
+pub trait HostWorldResource: Sized {
+    type WorldResourceData;
+    fn new(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        self_: wasmtime::component::Resource<WorldResource>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+    fn static_foo(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()>;
+}
+impl<_T: HostWorldResource> HostWorldResource for &mut _T {
+    type WorldResourceData = _T::WorldResourceData;
+    fn new(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as HostWorldResource>::new(store)
+    }
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        self_: wasmtime::component::Resource<WorldResource>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as HostWorldResource>::foo(store, self_)
+    }
+    fn static_foo(
+        store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as HostWorldResource>::static_foo(store)
+    }
+    fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()> {
+        HostWorldResource::drop(*self, rep)
+    }
+}
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface1: exports::foo::foo::uses_resource_transitively::GuestIndices,
+    some_world_func2: wasmtime::component::ComponentExportIndex,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface1: exports::foo::foo::uses_resource_transitively::Guest,
+    some_world_func2: wasmtime::component::Func,
+}
+pub trait TheWorldImports: HostWorldResource {
+    type Data;
+    fn some_world_func(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+}
+pub trait TheWorldImportsGetHost<
+    T,
+    D,
+>: Fn(T) -> <Self as TheWorldImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+    type Host: TheWorldImports<WorldResourceData = D, Data = D>;
+}
+impl<F, T, D, O> TheWorldImportsGetHost<T, D> for F
+where
+    F: Fn(T) -> O + Send + Sync + Copy + 'static,
+    O: TheWorldImports<WorldResourceData = D, Data = D>,
+{
+    type Host = O;
+}
+impl<_T: TheWorldImports> TheWorldImports for &mut _T {
+    type Data = _T::Data;
+    fn some_world_func(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as TheWorldImports>::some_world_func(store)
+    }
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new(
+                _component,
+            )?;
+            let some_world_func2 = _component
+                .export_index(None, "some-world-func2")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no function export `some-world-func2` found")
+                })?
+                .1;
+            Ok(TheWorldIndices {
+                interface1,
+                some_world_func2,
+            })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            let some_world_func2 = _instance
+                .get_export(&mut store, None, "some-world-func2")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no function export `some-world-func2` found")
+                })?;
+            Ok(TheWorldIndices {
+                interface1,
+                some_world_func2,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            let some_world_func2 = *_instance
+                .get_typed_func::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >(&mut store, &self.some_world_func2)?
+                .func();
+            Ok(TheWorld {
+                interface1,
+                some_world_func2,
+            })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> TheWorldImportsGetHost<
+                    &'a mut T,
+                    T,
+                    Host: TheWorldImports<WorldResourceData = T, Data = T>,
+                >,
+        >(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: G,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + 'static,
+        {
+            let mut linker = linker.root();
+            linker
+                .resource(
+                    "world-resource",
+                    wasmtime::component::ResourceType::host::<WorldResource>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostWorldResource::drop(
+                            &mut host_getter(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[constructor]world-resource",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as HostWorldResource>::new(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::Resource<WorldResource>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::Resource<WorldResource>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[method]world-resource.foo",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<WorldResource>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as HostWorldResource>::foo(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[static]world-resource.static-foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as HostWorldResource>::static_foo(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "some-world-func",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as TheWorldImports>::some_world_func(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::Resource<WorldResource>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::Resource<WorldResource>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+            Ok(())
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::resources::Host<BarData = T, Data = T>
+                + foo::foo::long_use_chain1::Host + foo::foo::long_use_chain2::Host
+                + foo::foo::long_use_chain3::Host
+                + foo::foo::long_use_chain4::Host<Data = T>
+                + foo::foo::transitive_interface_with_resource::Host
+                + TheWorldImports<WorldResourceData = T, Data = T> + 'static,
+            U: Send + foo::foo::resources::Host<BarData = T, Data = T>
+                + foo::foo::long_use_chain1::Host + foo::foo::long_use_chain2::Host
+                + foo::foo::long_use_chain3::Host
+                + foo::foo::long_use_chain4::Host<Data = T>
+                + foo::foo::transitive_interface_with_resource::Host
+                + TheWorldImports<WorldResourceData = T, Data = T>,
+        {
+            Self::add_to_linker_imports_get_host(linker, get)?;
+            foo::foo::resources::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain1::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain2::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain3::add_to_linker(linker, get)?;
+            foo::foo::long_use_chain4::add_to_linker(linker, get)?;
+            foo::foo::transitive_interface_with_resource::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub async fn call_some_world_func2<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<
+            wasmtime::component::Promise<wasmtime::component::Resource<WorldResource>>,
+        >
+        where
+            <S as wasmtime::AsContext>::Data: Send + 'static,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            };
+            let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
+            Ok(promise.map(|(v,)| v))
+        }
+        pub fn foo_foo_uses_resource_transitively(
+            &self,
+        ) -> &exports::foo::foo::uses_resource_transitively::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod resources {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Bar {}
+            pub trait HostBar: Sized {
+                type BarData;
+                fn new(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn static_a(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn method_a(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostBar> HostBar for &mut _T {
+                type BarData = _T::BarData;
+                fn new(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as HostBar>::new(store)
+                }
+                fn static_a(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as HostBar>::static_a(store)
+                }
+                fn method_a(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as HostBar>::method_a(store, self_)
+                }
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()> {
+                    HostBar::drop(*self, rep)
+                }
+            }
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedOwn {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedOwn {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedOwn")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedBorrow {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedBorrow {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedBorrow")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type SomeHandle = wasmtime::component::Resource<Bar>;
+            const _: () = {
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host: HostBar + Sized {
+                type Data;
+                fn bar_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn bar_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn bar_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn tuple_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            wasmtime::component::Resource<Bar>,
+                            u32,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn option_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn option_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn option_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<
+                            wasmtime::component::Resource<Bar>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<
+                            wasmtime::component::Resource<Bar>,
+                            (),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn list_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::Resource<Bar>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn record_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: NestedOwn,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn record_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: NestedBorrow,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn record_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> NestedOwn + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn func_with_handle_typedef(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: SomeHandle,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<BarData = D, Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<BarData = D, Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<
+                        &'a mut T,
+                        T,
+                        Host: Host<BarData = T, Data = T> + Send,
+                    >,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                inst.resource(
+                    "bar",
+                    wasmtime::component::ResourceType::host::<Bar>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostBar::drop(
+                            &mut host_getter(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[constructor]bar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as HostBar>::new(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::Resource<Bar>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::Resource<Bar>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[static]bar.static-a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as HostBar>::static_a(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[method]bar.method-a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as HostBar>::method_a(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::bar_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::bar_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::bar_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::Resource<Bar>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::Resource<Bar>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::tuple_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            ((wasmtime::component::Resource<Bar>, u32),),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    ((wasmtime::component::Resource<Bar>, u32),),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (Option<wasmtime::component::Resource<Bar>>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (Option<wasmtime::component::Resource<Bar>>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (Result<wasmtime::component::Resource<Bar>, ()>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (Result<wasmtime::component::Resource<Bar>, ()>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::list_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                wasmtime::component::__internal::Vec<
+                                                    wasmtime::component::Resource<Bar>,
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        wasmtime::component::__internal::Vec<
+                                                            wasmtime::component::Resource<Bar>,
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-own-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedOwn,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::record_own_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-borrow-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (NestedBorrow,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::record_borrow_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::record_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(NestedOwn,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(NestedOwn,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "func-with-handle-typedef",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (SomeHandle,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::func_with_handle_typedef(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<BarData = T, Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn bar_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bar_own_arg(store, x)
+                }
+                fn bar_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bar_borrow_arg(store, x)
+                }
+                fn bar_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bar_result(store)
+                }
+                fn tuple_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_own_arg(store, x)
+                }
+                fn tuple_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_borrow_arg(store, x)
+                }
+                fn tuple_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            wasmtime::component::Resource<Bar>,
+                            u32,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::tuple_result(store)
+                }
+                fn option_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_own_arg(store, x)
+                }
+                fn option_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_borrow_arg(store, x)
+                }
+                fn option_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<
+                            wasmtime::component::Resource<Bar>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_result(store)
+                }
+                fn result_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_own_arg(store, x)
+                }
+                fn result_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_borrow_arg(store, x)
+                }
+                fn result_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<
+                            wasmtime::component::Resource<Bar>,
+                            (),
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_result(store)
+                }
+                fn list_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_own_arg(store, x)
+                }
+                fn list_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_borrow_arg(store, x)
+                }
+                fn list_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::Resource<Bar>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::list_result(store)
+                }
+                fn record_own_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: NestedOwn,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::record_own_arg(store, x)
+                }
+                fn record_borrow_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: NestedBorrow,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::record_borrow_arg(store, x)
+                }
+                fn record_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> NestedOwn + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::record_result(store)
+                }
+                fn func_with_handle_typedef(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: SomeHandle,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::func_with_handle_typedef(store, x)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain1 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum A {}
+            pub trait HostA: Sized {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostA + ?Sized> HostA for &mut _T {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()> {
+                    HostA::drop(*self, rep)
+                }
+            }
+            pub trait Host: HostA + Sized {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                inst.resource(
+                    "a",
+                    wasmtime::component::ResourceType::host::<A>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostA::drop(
+                            &mut host_getter(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain2 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain1::A;
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain2")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain3 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain2::A;
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain3")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain4 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain3::A;
+            pub trait Host {
+                type Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::Resource<A> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                inst.func_wrap_concurrent(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::foo(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::Resource<A>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::Resource<A>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::Resource<A> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::foo(store)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod transitive_interface_with_resource {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Foo {}
+            pub trait HostFoo: Sized {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostFoo + ?Sized> HostFoo for &mut _T {
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()> {
+                    HostFoo::drop(*self, rep)
+                }
+            }
+            pub trait Host: HostFoo + Sized {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                inst.resource(
+                    "foo",
+                    wasmtime::component::ResourceType::host::<Foo>(),
+                    move |mut store, rep| -> wasmtime::Result<()> {
+                        HostFoo::drop(
+                            &mut host_getter(store.data_mut()),
+                            wasmtime::component::Resource::new_own(rep),
+                        )
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod uses_resource_transitively {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type Foo = super::super::super::super::foo::foo::transitive_interface_with_resource::Foo;
+                pub struct Guest {
+                    handle: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    handle: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/uses-resource-transitively")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/uses-resource-transitively`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "foo:foo/uses-resource-transitively",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/uses-resource-transitively`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/uses-resource-transitively` does \
+                      not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let handle = lookup("handle")?;
+                        Ok(GuestIndices { handle })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let handle = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >(&mut store, &self.handle)?
+                            .func();
+                        Ok(Guest { handle })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_handle<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Foo>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -1,6 +1,6 @@
 pub enum WorldResource {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-pub trait HostWorldResource {
+pub trait HostWorldResource: Sized {
     async fn new(&mut self) -> wasmtime::component::Resource<WorldResource>;
     async fn foo(&mut self, self_: wasmtime::component::Resource<WorldResource>) -> ();
     async fn static_foo(&mut self) -> ();
@@ -135,10 +135,11 @@ pub trait TheWorldImports: Send + HostWorldResource {
 }
 pub trait TheWorldImportsGetHost<
     T,
->: Fn(T) -> <Self as TheWorldImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as TheWorldImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: TheWorldImports;
 }
-impl<F, T, O> TheWorldImportsGetHost<T> for F
+impl<F, T, D, O> TheWorldImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: TheWorldImports,
@@ -250,9 +251,12 @@ const _: () = {
             let indices = TheWorldIndices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> TheWorldImportsGetHost<&'a mut T, T, Host: TheWorldImports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
-            host_getter: impl for<'a> TheWorldImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,
@@ -437,7 +441,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Bar {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostBar {
+            pub trait HostBar: Sized {
                 async fn new(&mut self) -> wasmtime::component::Resource<Bar>;
                 async fn static_a(&mut self) -> u32;
                 async fn method_a(
@@ -525,7 +529,7 @@ pub mod foo {
                 );
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostBar {
+            pub trait Host: Send + HostBar + Sized {
                 async fn bar_own_arg(
                     &mut self,
                     x: wasmtime::component::Resource<Bar>,
@@ -592,19 +596,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -1347,7 +1355,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum A {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostA {
+            pub trait HostA: Sized {
                 async fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<A>,
@@ -1362,22 +1370,26 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostA {}
+            pub trait Host: Send + HostA + Sized {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -1419,19 +1431,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -1460,19 +1476,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -1503,19 +1523,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -1568,7 +1592,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Foo {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostFoo {
+            pub trait HostFoo: Sized {
                 async fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<Foo>,
@@ -1583,22 +1607,26 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostFoo {}
+            pub trait Host: Send + HostFoo + Sized {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -236,19 +236,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -290,19 +294,23 @@ pub mod http_fetch {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -1,0 +1,499 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `http-interface`.
+///
+/// This structure is created through [`HttpInterfacePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`HttpInterface`] as well.
+pub struct HttpInterfacePre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: HttpInterfaceIndices,
+}
+impl<T> Clone for HttpInterfacePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> HttpInterfacePre<_T> {
+    /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = HttpInterfaceIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`HttpInterface`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<HttpInterface>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `http-interface`.
+///
+/// This is an implementation detail of [`HttpInterfacePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`HttpInterface`] as well.
+#[derive(Clone)]
+pub struct HttpInterfaceIndices {
+    interface0: exports::http_handler::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `http-interface`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`HttpInterface::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`HttpInterfacePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`HttpInterfacePre::instantiate_async`] to
+///   create a [`HttpInterface`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`HttpInterface::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`HttpInterfaceIndices::new_instance`] followed
+///   by [`HttpInterfaceIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct HttpInterface {
+    interface0: exports::http_handler::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl HttpInterfaceIndices {
+        /// Creates a new copy of `HttpInterfaceIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::http_handler::GuestIndices::new(_component)?;
+            Ok(HttpInterfaceIndices { interface0 })
+        }
+        /// Creates a new instance of [`HttpInterfaceIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`HttpInterface`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`HttpInterface`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::http_handler::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(HttpInterfaceIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`HttpInterface`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(HttpInterface { interface0 })
+        }
+    }
+    impl HttpInterface {
+        /// Convenience wrapper around [`HttpInterfacePre::new`] and
+        /// [`HttpInterfacePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<HttpInterface>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            HttpInterfacePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`HttpInterfaceIndices::new_instance`] and
+        /// [`HttpInterfaceIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let indices = HttpInterfaceIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::http_types::Host + http_fetch::Host<Data = T> + 'static,
+            U: Send + foo::foo::http_types::Host + http_fetch::Host<Data = T>,
+        {
+            foo::foo::http_types::add_to_linker(linker, get)?;
+            http_fetch::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn http_handler(&self) -> &exports::http_handler::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod http_types {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Request {
+                #[component(name = "method")]
+                pub method: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Request {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Request").field("method", &self.method).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Response {
+                #[component(name = "body")]
+                pub body: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Response {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Response").field("body", &self.body).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < Response as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/http-types")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod http_fetch {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::{anyhow, Box};
+    pub type Request = super::foo::foo::http_types::Request;
+    const _: () = {
+        assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub type Response = super::foo::foo::http_types::Response;
+    const _: () = {
+        assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub trait Host {
+        type Data;
+        fn fetch_request(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+            request: Request,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> Response + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized;
+    }
+    pub trait GetHost<
+        T,
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+        type Host: Host<Data = D> + Send;
+    }
+    impl<F, T, D, O> GetHost<T, D> for F
+    where
+        F: Fn(T) -> O + Send + Sync + Copy + 'static,
+        O: Host<Data = D> + Send,
+    {
+        type Host = O;
+    }
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+    >(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: G,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send + 'static,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        inst.func_wrap_concurrent(
+            "fetch-request",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
+                let host = caller;
+                let r = <G::Host as Host>::fetch_request(host, arg0);
+                Box::pin(async move {
+                    let fun = r.await;
+                    Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                        let r = fun(caller);
+                        Ok((r,))
+                    })
+                        as Box<
+                            dyn FnOnce(
+                                wasmtime::StoreContextMut<'_, T>,
+                            ) -> wasmtime::Result<(Response,)> + Send + Sync,
+                        >
+                })
+                    as ::std::pin::Pin<
+                        Box<
+                            dyn ::std::future::Future<
+                                Output = Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Response,)> + Send + Sync,
+                                >,
+                            > + Send + Sync + 'static,
+                        >,
+                    >
+            },
+        )?;
+        Ok(())
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host<Data = T> + Send,
+        T: Send + 'static,
+    {
+        add_to_linker_get_host(linker, get)
+    }
+    impl<_T: Host> Host for &mut _T {
+        type Data = _T::Data;
+        fn fetch_request(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+            request: Request,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> Response + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized,
+        {
+            <_T as Host>::fetch_request(store, request)
+        }
+    }
+}
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod http_handler {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::{anyhow, Box};
+        pub type Request = super::super::foo::foo::http_types::Request;
+        const _: () = {
+            assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub type Response = super::super::foo::foo::http_types::Response;
+        const _: () = {
+            assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub struct Guest {
+            handle_request: wasmtime::component::Func,
+        }
+        #[derive(Clone)]
+        pub struct GuestIndices {
+            handle_request: wasmtime::component::ComponentExportIndex,
+        }
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
+            pub fn new(
+                component: &wasmtime::component::Component,
+            ) -> wasmtime::Result<GuestIndices> {
+                let (_, instance) = component
+                    .export_index(None, "http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `http-handler`")
+                    })?;
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `http-handler`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "instance export `http-handler` does \
+            not have export `{name}`"
+                            )
+                        })
+                };
+                let _ = &mut lookup;
+                let handle_request = lookup("handle-request")?;
+                Ok(GuestIndices { handle_request })
+            }
+            pub fn load(
+                &self,
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<Guest> {
+                let mut store = store.as_context_mut();
+                let _ = &mut store;
+                let _instance = instance;
+                let handle_request = *_instance
+                    .get_typed_func::<
+                        (&Request,),
+                        (Response,),
+                    >(&mut store, &self.handle_request)?
+                    .func();
+                Ok(Guest { handle_request })
+            }
+        }
+        impl Guest {
+            pub async fn call_handle_request<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+                arg0: Request,
+            ) -> wasmtime::Result<wasmtime::component::Promise<Response>>
+            where
+                <S as wasmtime::AsContext>::Data: Send + 'static,
+            {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                };
+                let promise = callee
+                    .call_concurrent(store.as_context_mut(), (arg0,))
+                    .await?;
+                Ok(promise.map(|(v,)| v))
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -236,19 +236,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -290,19 +294,23 @@ pub mod http_fetch {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -196,19 +196,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap(
@@ -427,7 +431,10 @@ pub mod exports {
                     pub fn call_f1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -442,7 +449,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: u32,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u32,),
@@ -458,7 +468,10 @@ pub mod exports {
                         mut store: S,
                         arg0: u32,
                         arg1: u32,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u32, u32),
@@ -472,7 +485,10 @@ pub mod exports {
                     pub fn call_f4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<u32> {
+                    ) -> wasmtime::Result<u32>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -486,7 +502,10 @@ pub mod exports {
                     pub fn call_f5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<(u32, u32)> {
+                    ) -> wasmtime::Result<(u32, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -503,7 +522,10 @@ pub mod exports {
                         arg0: u32,
                         arg1: u32,
                         arg2: u32,
-                    ) -> wasmtime::Result<(u32, u32, u32)> {
+                    ) -> wasmtime::Result<(u32, u32, u32)>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (u32, u32, u32),

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -204,19 +204,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -1,0 +1,808 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::simple::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::simple::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::simple::Host<Data = T> + 'static,
+            U: Send + foo::foo::simple::Host<Data = T>,
+        {
+            foo::foo::simple::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_simple(&self) -> &exports::foo::foo::simple::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn f1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                    b: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn f6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                    b: u32,
+                    c: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, u32, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                inst.func_wrap_concurrent(
+                    "f1",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f1(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f2(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1): (u32, u32)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::f3(host, arg0, arg1);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f4(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f5",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::f5(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<((u32, u32),)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<((u32, u32),)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "f6",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0, arg1, arg2): (u32, u32, u32)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::f6(host, arg0, arg1, arg2);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<((u32, u32, u32),)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<((u32, u32, u32),)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn f1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f1(store)
+                }
+                fn f2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f2(store, a)
+                }
+                fn f3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                    b: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f3(store, a, b)
+                }
+                fn f4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> u32 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f4(store)
+                }
+                fn f5(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f5(store)
+                }
+                fn f6(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: u32,
+                    b: u32,
+                    c: u32,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (u32, u32, u32) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::f6(store, a, b, c)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    f1: wasmtime::component::Func,
+                    f2: wasmtime::component::Func,
+                    f3: wasmtime::component::Func,
+                    f4: wasmtime::component::Func,
+                    f5: wasmtime::component::Func,
+                    f6: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    f1: wasmtime::component::ComponentExportIndex,
+                    f2: wasmtime::component::ComponentExportIndex,
+                    f3: wasmtime::component::ComponentExportIndex,
+                    f4: wasmtime::component::ComponentExportIndex,
+                    f5: wasmtime::component::ComponentExportIndex,
+                    f6: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/simple")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/simple` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let f1 = lookup("f1")?;
+                        let f2 = lookup("f2")?;
+                        let f3 = lookup("f3")?;
+                        let f4 = lookup("f4")?;
+                        let f5 = lookup("f5")?;
+                        let f6 = lookup("f6")?;
+                        Ok(GuestIndices {
+                            f1,
+                            f2,
+                            f3,
+                            f4,
+                            f5,
+                            f6,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let f1 = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.f1)?
+                            .func();
+                        let f2 = *_instance
+                            .get_typed_func::<(u32,), ()>(&mut store, &self.f2)?
+                            .func();
+                        let f3 = *_instance
+                            .get_typed_func::<(u32, u32), ()>(&mut store, &self.f3)?
+                            .func();
+                        let f4 = *_instance
+                            .get_typed_func::<(), (u32,)>(&mut store, &self.f4)?
+                            .func();
+                        let f5 = *_instance
+                            .get_typed_func::<(), ((u32, u32),)>(&mut store, &self.f5)?
+                            .func();
+                        let f6 = *_instance
+                            .get_typed_func::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >(&mut store, &self.f6)?
+                            .func();
+                        Ok(Guest { f1, f2, f3, f4, f5, f6 })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_f1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (),
+                            >::new_unchecked(self.f1)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_f2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32,),
+                                (),
+                            >::new_unchecked(self.f2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_f3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32),
+                                (),
+                            >::new_unchecked(self.f3)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_f4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.f4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_f5<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<(u32, u32)>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((u32, u32),),
+                            >::new_unchecked(self.f5)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_f6<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: u32,
+                        arg1: u32,
+                        arg2: u32,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<(u32, u32, u32)>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (u32, u32, u32),
+                                ((u32, u32, u32),),
+                            >::new_unchecked(self.f6)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0, arg1, arg2))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -204,19 +204,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -213,19 +213,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap(
@@ -464,7 +468,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &[u32],
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u32],),
@@ -478,7 +485,10 @@ pub mod exports {
                     pub fn call_simple_list2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>> {
+                    ) -> wasmtime::Result<wasmtime::component::__internal::Vec<u32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -499,7 +509,10 @@ pub mod exports {
                             wasmtime::component::__internal::Vec<u32>,
                             wasmtime::component::__internal::Vec<u32>,
                         ),
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[u32], &[u32]),
@@ -523,7 +536,10 @@ pub mod exports {
                         wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::Vec<u32>,
                         >,
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&[wasmtime::component::__internal::Vec<u32>],),

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -223,19 +223,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -1,0 +1,773 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `my-world`.
+///
+/// This structure is created through [`MyWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
+pub struct MyWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: MyWorldIndices,
+}
+impl<T> Clone for MyWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::simple_lists::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `my-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate_async`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct MyWorld {
+    interface0: exports::foo::foo::simple_lists::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new(
+                _component,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(MyWorld { interface0 })
+        }
+    }
+    impl MyWorld {
+        /// Convenience wrapper around [`MyWorldPre::new`] and
+        /// [`MyWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<MyWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            MyWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::simple_lists::Host<Data = T> + 'static,
+            U: Send + foo::foo::simple_lists::Host<Data = T>,
+        {
+            foo::foo::simple_lists::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod simple_lists {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn simple_list1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn simple_list2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn simple_list3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn simple_list4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                inst.func_wrap_concurrent(
+                    "simple-list1",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::simple_list1(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "simple-list2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::simple_list2(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::Vec<u32>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::Vec<u32>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "simple-list3",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::simple_list3(host, arg0, arg1);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                (
+                                                    wasmtime::component::__internal::Vec<u32>,
+                                                    wasmtime::component::__internal::Vec<u32>,
+                                                ),
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        (
+                                                            wasmtime::component::__internal::Vec<u32>,
+                                                            wasmtime::component::__internal::Vec<u32>,
+                                                        ),
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "simple-list4",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::simple_list4(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                wasmtime::component::__internal::Vec<
+                                                    wasmtime::component::__internal::Vec<u32>,
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        wasmtime::component::__internal::Vec<
+                                                            wasmtime::component::__internal::Vec<u32>,
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn simple_list1(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::simple_list1(store, l)
+                }
+                fn simple_list2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            u32,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::simple_list2(store)
+                }
+                fn simple_list3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::simple_list3(store, a, b)
+                }
+                fn simple_list4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::simple_list4(store, l)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_lists {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    simple_list1: wasmtime::component::Func,
+                    simple_list2: wasmtime::component::Func,
+                    simple_list3: wasmtime::component::Func,
+                    simple_list4: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    simple_list1: wasmtime::component::ComponentExportIndex,
+                    simple_list2: wasmtime::component::ComponentExportIndex,
+                    simple_list3: wasmtime::component::ComponentExportIndex,
+                    simple_list4: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/simple-lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-lists`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/simple-lists` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let simple_list1 = lookup("simple-list1")?;
+                        let simple_list2 = lookup("simple-list2")?;
+                        let simple_list3 = lookup("simple-list3")?;
+                        let simple_list4 = lookup("simple-list4")?;
+                        Ok(GuestIndices {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let simple_list1 = *_instance
+                            .get_typed_func::<
+                                (&[u32],),
+                                (),
+                            >(&mut store, &self.simple_list1)?
+                            .func();
+                        let simple_list2 = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >(&mut store, &self.simple_list2)?
+                            .func();
+                        let simple_list3 = *_instance
+                            .get_typed_func::<
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >(&mut store, &self.simple_list3)?
+                            .func();
+                        let simple_list4 = *_instance
+                            .get_typed_func::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >(&mut store, &self.simple_list4)?
+                            .func();
+                        Ok(Guest {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_simple_list1<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u32>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::Vec<u32>,),
+                                (),
+                            >::new_unchecked(self.simple_list1)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_simple_list2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_simple_list3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<u32>,
+                        arg1: wasmtime::component::__internal::Vec<u32>,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<u32>,
+                                    wasmtime::component::__internal::Vec<u32>,
+                                ),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_simple_list4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -223,19 +223,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -241,19 +241,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap(
@@ -299,19 +303,23 @@ pub mod foo {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -249,19 +249,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -316,19 +320,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -1,0 +1,440 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `wasi`.
+///
+/// This structure is created through [`WasiPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Wasi`] as well.
+pub struct WasiPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: WasiIndices,
+}
+impl<T> Clone for WasiPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> WasiPre<_T> {
+    /// Creates a new copy of `WasiPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WasiIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Wasi`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Wasi>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `wasi`.
+///
+/// This is an implementation detail of [`WasiPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Wasi`] as well.
+#[derive(Clone)]
+pub struct WasiIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `wasi`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Wasi::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WasiPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WasiPre::instantiate_async`] to
+///   create a [`Wasi`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Wasi::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`WasiIndices::new_instance`] followed
+///   by [`WasiIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Wasi {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl WasiIndices {
+        /// Creates a new copy of `WasiIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(WasiIndices {})
+        }
+        /// Creates a new instance of [`WasiIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Wasi`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Wasi`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(WasiIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Wasi`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Wasi> {
+            let _instance = instance;
+            Ok(Wasi {})
+        }
+    }
+    impl Wasi {
+        /// Convenience wrapper around [`WasiPre::new`] and
+        /// [`WasiPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Wasi>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            WasiPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`WasiIndices::new_instance`] and
+        /// [`WasiIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Wasi> {
+            let indices = WasiIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::wasi_filesystem::Host<Data = T>
+                + foo::foo::wall_clock::Host + 'static,
+            U: Send + foo::foo::wasi_filesystem::Host<Data = T>
+                + foo::foo::wall_clock::Host,
+        {
+            foo::foo::wasi_filesystem::add_to_linker(linker, get)?;
+            foo::foo::wall_clock::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod wasi_filesystem {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DescriptorStat {}
+            impl core::fmt::Debug for DescriptorStat {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DescriptorStat").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < DescriptorStat as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < DescriptorStat as wasmtime::component::ComponentType
+                    >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            #[repr(u8)]
+            pub enum Errno {
+                #[component(name = "e")]
+                E,
+            }
+            impl Errno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Errno::E => "e",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Errno::E => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Errno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Errno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Errno {}
+            const _: () = {
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn create_directory_at(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), Errno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn stat(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<DescriptorStat, Errno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                inst.func_wrap_concurrent(
+                    "create-directory-at",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::create_directory_at(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<(), Errno>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<(), Errno>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "stat",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::stat(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (Result<DescriptorStat, Errno>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (Result<DescriptorStat, Errno>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn create_directory_at(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), Errno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::create_directory_at(store)
+                }
+                fn stat(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<DescriptorStat, Errno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::stat(store)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod wall_clock {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/wall-clock")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -249,19 +249,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -342,19 +346,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -246,19 +246,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -1,0 +1,535 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::anon::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::anon::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::anon::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::anon::Host<Data = T> + 'static,
+            U: Send + foo::foo::anon::Host<Data = T>,
+        {
+            foo::foo::anon::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_anon(&self) -> &exports::foo::foo::anon::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod anon {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            #[repr(u8)]
+            pub enum Error {
+                #[component(name = "success")]
+                Success,
+                #[component(name = "failure")]
+                Failure,
+            }
+            impl Error {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        Error::Success => "success",
+                        Error::Failure => "failure",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        Error::Success => "",
+                        Error::Failure => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Error")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn option_test(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<
+                            Option<wasmtime::component::__internal::String>,
+                            Error,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                inst.func_wrap_concurrent(
+                    "option-test",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_test(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                Result<
+                                                    Option<wasmtime::component::__internal::String>,
+                                                    Error,
+                                                >,
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        Result<
+                                                            Option<wasmtime::component::__internal::String>,
+                                                            Error,
+                                                        >,
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn option_test(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<
+                            Option<wasmtime::component::__internal::String>,
+                            Error,
+                        > + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_test(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod anon {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                #[repr(u8)]
+                pub enum Error {
+                    #[component(name = "success")]
+                    Success,
+                    #[component(name = "failure")]
+                    Failure,
+                }
+                impl Error {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            Error::Success => "success",
+                            Error::Failure => "failure",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            Error::Success => "",
+                            Error::Failure => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Error")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for Error {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for Error {}
+                const _: () = {
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Error as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    option_test: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    option_test: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/anon")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("no exported instance named `foo:foo/anon`")
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/anon")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("no exported instance named `foo:foo/anon`")
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/anon` does \
+                    not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let option_test = lookup("option-test")?;
+                        Ok(GuestIndices { option_test })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let option_test = *_instance
+                            .get_typed_func::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >(&mut store, &self.option_test)?
+                            .func();
+                        Ok(Guest { option_test })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_option_test<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            Result<
+                                Option<wasmtime::component::__internal::String>,
+                                Error,
+                            >,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    Result<
+                                        Option<wasmtime::component::__internal::String>,
+                                        Error,
+                                    >,
+                                ),
+                            >::new_unchecked(self.option_test)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -246,19 +246,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -170,7 +170,10 @@ const _: () = {
         pub fn call_y<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
-        ) -> wasmtime::Result<()> {
+        ) -> wasmtime::Result<()>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
             };

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -1,0 +1,190 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    y: wasmtime::component::ComponentExportIndex,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    y: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let y = _component
+                .export_index(None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
+                .1;
+            Ok(TheWorldIndices { y })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let y = _instance
+                .get_export(&mut store, None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
+            Ok(TheWorldIndices { y })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let y = *_instance.get_typed_func::<(), ()>(&mut store, &self.y)?.func();
+            Ok(TheWorld { y })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub async fn call_y<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+        where
+            <S as wasmtime::AsContext>::Data: Send + 'static,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+            };
+            let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
+            Ok(promise)
+        }
+    }
+};

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -250,7 +250,10 @@ pub mod exports {
             pub fn call_y<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
-            ) -> wasmtime::Result<()> {
+            ) -> wasmtime::Result<()>
+            where
+                <S as wasmtime::AsContext>::Data: Send,
+            {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
                 };

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -1,0 +1,271 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::the_name::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::the_name::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::the_name::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::the_name::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn the_name(&self) -> &exports::the_name::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod the_name {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::{anyhow, Box};
+        pub struct Guest {
+            y: wasmtime::component::Func,
+        }
+        #[derive(Clone)]
+        pub struct GuestIndices {
+            y: wasmtime::component::ComponentExportIndex,
+        }
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
+            pub fn new(
+                component: &wasmtime::component::Component,
+            ) -> wasmtime::Result<GuestIndices> {
+                let (_, instance) = component
+                    .export_index(None, "the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `the-name`")
+                    })?;
+                Self::_new(|name| {
+                    component.export_index(Some(&instance), name).map(|p| p.1)
+                })
+            }
+            /// This constructor is similar to [`GuestIndices::new`] except that it
+            /// performs string lookups after instantiation time.
+            pub fn new_instance(
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance_export = instance
+                    .get_export(&mut store, None, "the-name")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `the-name`")
+                    })?;
+                Self::_new(|name| {
+                    instance.get_export(&mut store, Some(&instance_export), name)
+                })
+            }
+            fn _new(
+                mut lookup: impl FnMut(
+                    &str,
+                ) -> Option<wasmtime::component::ComponentExportIndex>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let mut lookup = move |name| {
+                    lookup(name)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "instance export `the-name` does \
+            not have export `{name}`"
+                            )
+                        })
+                };
+                let _ = &mut lookup;
+                let y = lookup("y")?;
+                Ok(GuestIndices { y })
+            }
+            pub fn load(
+                &self,
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<Guest> {
+                let mut store = store.as_context_mut();
+                let _ = &mut store;
+                let _instance = instance;
+                let y = *_instance.get_typed_func::<(), ()>(&mut store, &self.y)?.func();
+                Ok(Guest { y })
+            }
+        }
+        impl Guest {
+            pub async fn call_y<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+            ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+            where
+                <S as wasmtime::AsContext>::Data: Send + 'static,
+            {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
+                };
+                let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
+                Ok(promise)
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -176,19 +176,20 @@ pub mod imports {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<T, G: for<'a> GetHost<&'a mut T, T, Host: Host>>(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()> {
         let mut inst = linker.instance("imports")?;
         inst.func_wrap(

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -184,19 +184,23 @@ pub mod imports {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -1,0 +1,274 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(TheWorldIndices {})
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(TheWorldIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            Ok(TheWorld {})
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + imports::Host<Data = T> + 'static,
+            U: Send + imports::Host<Data = T>,
+        {
+            imports::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+#[allow(clippy::all)]
+pub mod imports {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::{anyhow, Box};
+    pub trait Host {
+        type Data;
+        fn y(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> () + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized;
+    }
+    pub trait GetHost<
+        T,
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+        type Host: Host<Data = D> + Send;
+    }
+    impl<F, T, D, O> GetHost<T, D> for F
+    where
+        F: Fn(T) -> O + Send + Sync + Copy + 'static,
+        O: Host<Data = D> + Send,
+    {
+        type Host = O;
+    }
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+    >(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: G,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send + 'static,
+    {
+        let mut inst = linker.instance("imports")?;
+        inst.func_wrap_concurrent(
+            "y",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = caller;
+                let r = <G::Host as Host>::y(host);
+                Box::pin(async move {
+                    let fun = r.await;
+                    Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                        let r = fun(caller);
+                        Ok(r)
+                    })
+                        as Box<
+                            dyn FnOnce(
+                                wasmtime::StoreContextMut<'_, T>,
+                            ) -> wasmtime::Result<()> + Send + Sync,
+                        >
+                })
+                    as ::std::pin::Pin<
+                        Box<
+                            dyn ::std::future::Future<
+                                Output = Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >,
+                            > + Send + Sync + 'static,
+                        >,
+                    >
+            },
+        )?;
+        Ok(())
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host<Data = T> + Send,
+        T: Send + 'static,
+    {
+        add_to_linker_get_host(linker, get)
+    }
+    impl<_T: Host> Host for &mut _T {
+        type Data = _T::Data;
+        fn y(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> () + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized,
+        {
+            <_T as Host>::y(store)
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/smoke_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_tracing_async.rs
@@ -184,19 +184,23 @@ pub mod imports {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -1,0 +1,595 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::strings::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::strings::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new(_component)?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::strings::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::strings::Host<Data = T> + 'static,
+            U: Send + foo::foo::strings::Host<Data = T>,
+        {
+            foo::foo::strings::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod strings {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub trait Host {
+                type Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::String,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn b(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn c(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                inst.func_wrap_concurrent(
+                    "a",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::a(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "b",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::b(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::String,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::String,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "c",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::c(host, arg0, arg1);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (wasmtime::component::__internal::String,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (wasmtime::component::__internal::String,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: wasmtime::component::__internal::String,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a(store, x)
+                }
+                fn b(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::b(store)
+                }
+                fn c(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::c(store, a, b)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod strings {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    a: wasmtime::component::Func,
+                    b: wasmtime::component::Func,
+                    c: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    a: wasmtime::component::ComponentExportIndex,
+                    b: wasmtime::component::ComponentExportIndex,
+                    c: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/strings")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/strings`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/strings")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/strings`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/strings` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let a = lookup("a")?;
+                        let b = lookup("b")?;
+                        let c = lookup("c")?;
+                        Ok(GuestIndices { a, b, c })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let a = *_instance
+                            .get_typed_func::<(&str,), ()>(&mut store, &self.a)?
+                            .func();
+                        let b = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >(&mut store, &self.b)?
+                            .func();
+                        let c = *_instance
+                            .get_typed_func::<
+                                (&str, &str),
+                                (wasmtime::component::__internal::String,),
+                            >(&mut store, &self.c)?
+                            .func();
+                        Ok(Guest { a, b, c })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::String,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::__internal::String,),
+                                (),
+                            >::new_unchecked(self.a)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_b<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::String,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.b)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_c<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::String,
+                        arg1: wasmtime::component::__internal::String,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            wasmtime::component::__internal::String,
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::String,
+                                ),
+                                (wasmtime::component::__internal::String,),
+                            >::new_unchecked(self.c)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0, arg1))
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -63,7 +63,7 @@ impl LinkOptions {
 }
 pub enum Baz {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-pub trait HostBaz {
+pub trait HostBaz: Sized {
     async fn foo(&mut self, self_: wasmtime::component::Resource<Baz>) -> ();
     async fn drop(
         &mut self,
@@ -201,10 +201,11 @@ pub trait TheWorldImports: Send + HostBaz {
 }
 pub trait TheWorldImportsGetHost<
     T,
->: Fn(T) -> <Self as TheWorldImportsGetHost<T>>::Host + Send + Sync + Copy + 'static {
+    D,
+>: Fn(T) -> <Self as TheWorldImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
     type Host: TheWorldImports;
 }
-impl<F, T, O> TheWorldImportsGetHost<T> for F
+impl<F, T, D, O> TheWorldImportsGetHost<T, D> for F
 where
     F: Fn(T) -> O + Send + Sync + Copy + 'static,
     O: TheWorldImports,
@@ -282,10 +283,13 @@ const _: () = {
             let indices = TheWorldIndices::new_instance(&mut store, instance)?;
             indices.load(store, instance)
         }
-        pub fn add_to_linker_imports_get_host<T>(
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> TheWorldImportsGetHost<&'a mut T, T, Host: TheWorldImports>,
+        >(
             linker: &mut wasmtime::component::Linker<T>,
             options: &LinkOptions,
-            host_getter: impl for<'a> TheWorldImportsGetHost<&'a mut T>,
+            host_getter: G,
         ) -> wasmtime::Result<()>
         where
             T: Send,
@@ -410,7 +414,7 @@ pub mod foo {
             }
             pub enum Bar {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostBar {
+            pub trait HostBar: Sized {
                 async fn foo(&mut self, self_: wasmtime::component::Resource<Bar>) -> ();
                 async fn drop(
                     &mut self,
@@ -432,25 +436,29 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostBar {
+            pub trait Host: Send + HostBar + Sized {
                 async fn foo(&mut self) -> ();
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
                 options: &LinkOptions,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -1,0 +1,690 @@
+/// Link-time configurations.
+#[derive(Clone, Debug, Default)]
+pub struct LinkOptions {
+    experimental_interface: bool,
+    experimental_interface_function: bool,
+    experimental_interface_resource: bool,
+    experimental_interface_resource_method: bool,
+    experimental_world: bool,
+    experimental_world_function_import: bool,
+    experimental_world_interface_import: bool,
+    experimental_world_resource: bool,
+    experimental_world_resource_method: bool,
+}
+impl LinkOptions {
+    /// Enable members marked as `@unstable(feature = experimental-interface)`
+    pub fn experimental_interface(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-function)`
+    pub fn experimental_interface_function(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface_function = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-resource)`
+    pub fn experimental_interface_resource(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface_resource = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-resource-method)`
+    pub fn experimental_interface_resource_method(
+        &mut self,
+        enabled: bool,
+    ) -> &mut Self {
+        self.experimental_interface_resource_method = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world)`
+    pub fn experimental_world(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-function-import)`
+    pub fn experimental_world_function_import(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_function_import = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-interface-import)`
+    pub fn experimental_world_interface_import(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_interface_import = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-resource)`
+    pub fn experimental_world_resource(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_resource = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-resource-method)`
+    pub fn experimental_world_resource_method(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_resource_method = enabled;
+        self
+    }
+}
+pub enum Baz {}
+pub trait HostBaz: Sized {
+    type BazData;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::BazData>,
+        self_: wasmtime::component::Resource<Baz>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::BazData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+    fn drop(&mut self, rep: wasmtime::component::Resource<Baz>) -> wasmtime::Result<()>;
+}
+impl<_T: HostBaz> HostBaz for &mut _T {
+    type BazData = _T::BazData;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::BazData>,
+        self_: wasmtime::component::Resource<Baz>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::BazData>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as HostBaz>::foo(store, self_)
+    }
+    fn drop(&mut self, rep: wasmtime::component::Resource<Baz>) -> wasmtime::Result<()> {
+        HostBaz::drop(*self, rep)
+    }
+}
+impl std::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+    fn from(src: LinkOptions) -> Self {
+        (&src).into()
+    }
+}
+impl std::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+    fn from(src: &LinkOptions) -> Self {
+        let mut dest = Self::default();
+        dest.experimental_interface(src.experimental_interface);
+        dest.experimental_interface_function(src.experimental_interface_function);
+        dest.experimental_interface_resource(src.experimental_interface_resource);
+        dest.experimental_interface_resource_method(
+            src.experimental_interface_resource_method,
+        );
+        dest
+    }
+}
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`TheWorldIndices::new_instance`] followed
+///   by [`TheWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {}
+pub trait TheWorldImports: HostBaz {
+    type Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized;
+}
+pub trait TheWorldImportsGetHost<
+    T,
+    D,
+>: Fn(T) -> <Self as TheWorldImportsGetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+    type Host: TheWorldImports<BazData = D, Data = D>;
+}
+impl<F, T, D, O> TheWorldImportsGetHost<T, D> for F
+where
+    F: Fn(T) -> O + Send + Sync + Copy + 'static,
+    O: TheWorldImports<BazData = D, Data = D>,
+{
+    type Host = O;
+}
+impl<_T: TheWorldImports> TheWorldImports for &mut _T {
+    type Data = _T::Data;
+    fn foo(
+        store: wasmtime::StoreContextMut<'_, Self::Data>,
+    ) -> impl ::std::future::Future<
+        Output = impl FnOnce(
+            wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> () + Send + Sync + 'static,
+    > + Send + Sync + 'static
+    where
+        Self: Sized,
+    {
+        <_T as TheWorldImports>::foo(store)
+    }
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(TheWorldIndices {})
+        }
+        /// Creates a new instance of [`TheWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`TheWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`TheWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(TheWorldIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _instance = instance;
+            Ok(TheWorld {})
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new_instance`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker_imports_get_host<
+            T,
+            G: for<'a> TheWorldImportsGetHost<
+                    &'a mut T,
+                    T,
+                    Host: TheWorldImports<BazData = T, Data = T>,
+                >,
+        >(
+            linker: &mut wasmtime::component::Linker<T>,
+            options: &LinkOptions,
+            host_getter: G,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + 'static,
+        {
+            let mut linker = linker.root();
+            if options.experimental_world {
+                if options.experimental_world_resource {
+                    linker
+                        .resource(
+                            "baz",
+                            wasmtime::component::ResourceType::host::<Baz>(),
+                            move |mut store, rep| -> wasmtime::Result<()> {
+                                HostBaz::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                            },
+                        )?;
+                }
+                if options.experimental_world_function_import {
+                    linker
+                        .func_wrap_concurrent(
+                            "foo",
+                            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                                let host = caller;
+                                let r = <G::Host as TheWorldImports>::foo(host);
+                                Box::pin(async move {
+                                    let fun = r.await;
+                                    Box::new(move |
+                                        mut caller: wasmtime::StoreContextMut<'_, T>|
+                                    {
+                                        let r = fun(caller);
+                                        Ok(r)
+                                    })
+                                        as Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >
+                                })
+                                    as ::std::pin::Pin<
+                                        Box<
+                                            dyn ::std::future::Future<
+                                                Output = Box<
+                                                    dyn FnOnce(
+                                                        wasmtime::StoreContextMut<'_, T>,
+                                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                                >,
+                                            > + Send + Sync + 'static,
+                                        >,
+                                    >
+                            },
+                        )?;
+                }
+                if options.experimental_world_resource_method {
+                    linker
+                        .func_wrap_concurrent(
+                            "[method]baz.foo",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (arg0,): (wasmtime::component::Resource<Baz>,)|
+                            {
+                                let host = caller;
+                                let r = <G::Host as HostBaz>::foo(host, arg0);
+                                Box::pin(async move {
+                                    let fun = r.await;
+                                    Box::new(move |
+                                        mut caller: wasmtime::StoreContextMut<'_, T>|
+                                    {
+                                        let r = fun(caller);
+                                        Ok(r)
+                                    })
+                                        as Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >
+                                })
+                                    as ::std::pin::Pin<
+                                        Box<
+                                            dyn ::std::future::Future<
+                                                Output = Box<
+                                                    dyn FnOnce(
+                                                        wasmtime::StoreContextMut<'_, T>,
+                                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                                >,
+                                            > + Send + Sync + 'static,
+                                        >,
+                                    >
+                            },
+                        )?;
+                }
+            }
+            Ok(())
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            options: &LinkOptions,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::the_interface::Host<BarData = T, Data = T>
+                + TheWorldImports<BazData = T, Data = T> + 'static,
+            U: Send + foo::foo::the_interface::Host<BarData = T, Data = T>
+                + TheWorldImports<BazData = T, Data = T>,
+        {
+            if options.experimental_world {
+                Self::add_to_linker_imports_get_host(linker, options, get)?;
+                if options.experimental_world_interface_import {
+                    foo::foo::the_interface::add_to_linker(
+                        linker,
+                        &options.into(),
+                        get,
+                    )?;
+                }
+            }
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod the_interface {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            /// Link-time configurations.
+            #[derive(Clone, Debug, Default)]
+            pub struct LinkOptions {
+                experimental_interface: bool,
+                experimental_interface_function: bool,
+                experimental_interface_resource: bool,
+                experimental_interface_resource_method: bool,
+            }
+            impl LinkOptions {
+                /// Enable members marked as `@unstable(feature = experimental-interface)`
+                pub fn experimental_interface(&mut self, enabled: bool) -> &mut Self {
+                    self.experimental_interface = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-function)`
+                pub fn experimental_interface_function(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_function = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-resource)`
+                pub fn experimental_interface_resource(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_resource = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-resource-method)`
+                pub fn experimental_interface_resource_method(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_resource_method = enabled;
+                    self
+                }
+            }
+            pub enum Bar {}
+            pub trait HostBar: Sized {
+                type BarData;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostBar> HostBar for &mut _T {
+                type BarData = _T::BarData;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::BarData>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::BarData>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as HostBar>::foo(store, self_)
+                }
+                fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()> {
+                    HostBar::drop(*self, rep)
+                }
+            }
+            pub trait Host: HostBar + Sized {
+                type Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<BarData = D, Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<BarData = D, Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<
+                        &'a mut T,
+                        T,
+                        Host: Host<BarData = T, Data = T> + Send,
+                    >,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                if options.experimental_interface {
+                    let mut inst = linker.instance("foo:foo/the-interface")?;
+                    if options.experimental_interface_resource {
+                        inst.resource(
+                            "bar",
+                            wasmtime::component::ResourceType::host::<Bar>(),
+                            move |mut store, rep| -> wasmtime::Result<()> {
+                                HostBar::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                            },
+                        )?;
+                    }
+                    if options.experimental_interface_function {
+                        inst.func_wrap_concurrent(
+                            "foo",
+                            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                                let host = caller;
+                                let r = <G::Host as Host>::foo(host);
+                                Box::pin(async move {
+                                    let fun = r.await;
+                                    Box::new(move |
+                                        mut caller: wasmtime::StoreContextMut<'_, T>|
+                                    {
+                                        let r = fun(caller);
+                                        Ok(r)
+                                    })
+                                        as Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >
+                                })
+                                    as ::std::pin::Pin<
+                                        Box<
+                                            dyn ::std::future::Future<
+                                                Output = Box<
+                                                    dyn FnOnce(
+                                                        wasmtime::StoreContextMut<'_, T>,
+                                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                                >,
+                                            > + Send + Sync + 'static,
+                                        >,
+                                    >
+                            },
+                        )?;
+                    }
+                    if options.experimental_interface_resource_method {
+                        inst.func_wrap_concurrent(
+                            "[method]bar.foo",
+                            move |
+                                mut caller: wasmtime::StoreContextMut<'_, T>,
+                                (arg0,): (wasmtime::component::Resource<Bar>,)|
+                            {
+                                let host = caller;
+                                let r = <G::Host as HostBar>::foo(host, arg0);
+                                Box::pin(async move {
+                                    let fun = r.await;
+                                    Box::new(move |
+                                        mut caller: wasmtime::StoreContextMut<'_, T>|
+                                    {
+                                        let r = fun(caller);
+                                        Ok(r)
+                                    })
+                                        as Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >
+                                })
+                                    as ::std::pin::Pin<
+                                        Box<
+                                            dyn ::std::future::Future<
+                                                Output = Box<
+                                                    dyn FnOnce(
+                                                        wasmtime::StoreContextMut<'_, T>,
+                                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                                >,
+                                            > + Send + Sync + 'static,
+                                        >,
+                                    >
+                            },
+                        )?;
+                    }
+                }
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<BarData = T, Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, options, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn foo(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::foo(store)
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -206,19 +206,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap(

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -214,19 +214,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -1,0 +1,306 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `nope`.
+///
+/// This structure is created through [`NopePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Nope`] as well.
+pub struct NopePre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: NopeIndices,
+}
+impl<T> Clone for NopePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> NopePre<_T> {
+    /// Creates a new copy of `NopePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = NopeIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Nope`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Nope>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `nope`.
+///
+/// This is an implementation detail of [`NopePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Nope`] as well.
+#[derive(Clone)]
+pub struct NopeIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `nope`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Nope::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`NopePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`NopePre::instantiate_async`] to
+///   create a [`Nope`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Nope::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`NopeIndices::new_instance`] followed
+///   by [`NopeIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Nope {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl NopeIndices {
+        /// Creates a new copy of `NopeIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(NopeIndices {})
+        }
+        /// Creates a new instance of [`NopeIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Nope`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Nope`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(NopeIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Nope`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Nope> {
+            let _instance = instance;
+            Ok(Nope {})
+        }
+    }
+    impl Nope {
+        /// Convenience wrapper around [`NopePre::new`] and
+        /// [`NopePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Nope>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            NopePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`NopeIndices::new_instance`] and
+        /// [`NopeIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Nope> {
+            let indices = NopeIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::a::Host<Data = T> + 'static,
+            U: Send + foo::foo::a::Host<Data = T>,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum Error {
+                #[component(name = "other")]
+                Other(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Error::Other(e) => {
+                            f.debug_tuple("Error::Other").field(e).finish()
+                        }
+                    }
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl std::error::Error for Error {}
+            const _: () = {
+                assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn g(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), Error> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap_concurrent(
+                    "g",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::g(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<(), Error>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<(), Error>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn g(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), Error> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::g(store)
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
@@ -214,19 +214,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -196,19 +196,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap(
@@ -250,19 +254,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap(
@@ -304,19 +312,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap(
@@ -360,19 +372,20 @@ pub mod d {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<T, G: for<'a> GetHost<&'a mut T, T, Host: Host>>(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()> {
         let mut inst = linker.instance("d")?;
         inst.func_wrap(

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -266,19 +270,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -327,19 +335,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -390,19 +402,23 @@ pub mod d {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -1,0 +1,607 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `d`.
+///
+/// This structure is created through [`DPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`D`] as well.
+pub struct DPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: DIndices,
+}
+impl<T> Clone for DPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> DPre<_T> {
+    /// Creates a new copy of `DPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = DIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`D`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<D>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `d`.
+///
+/// This is an implementation detail of [`DPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`D`] as well.
+#[derive(Clone)]
+pub struct DIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `d`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`D::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`DPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`DPre::instantiate_async`] to
+///   create a [`D`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`D::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`DIndices::new_instance`] followed
+///   by [`DIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct D {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl DIndices {
+        /// Creates a new copy of `DIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            Ok(DIndices {})
+        }
+        /// Creates a new instance of [`DIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`D`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`D`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            Ok(DIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`D`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<D> {
+            let _instance = instance;
+            Ok(D {})
+        }
+    }
+    impl D {
+        /// Convenience wrapper around [`DPre::new`] and
+        /// [`DPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<D>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            DPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`DIndices::new_instance`] and
+        /// [`DIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<D> {
+            let indices = DIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::a::Host<Data = T> + foo::foo::b::Host<Data = T>
+                + foo::foo::c::Host<Data = T> + d::Host<Data = T> + 'static,
+            U: Send + foo::foo::a::Host<Data = T> + foo::foo::b::Host<Data = T>
+                + foo::foo::c::Host<Data = T> + d::Host<Data = T>,
+        {
+            foo::foo::a::add_to_linker(linker, get)?;
+            foo::foo::b::add_to_linker(linker, get)?;
+            foo::foo::c::add_to_linker(linker, get)?;
+            d::add_to_linker(linker, get)?;
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Foo {}
+            impl core::fmt::Debug for Foo {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Foo").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap_concurrent(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a(store)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod b {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type Foo = super::super::super::foo::foo::a::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                inst.func_wrap_concurrent(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a(store)
+                }
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod c {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type Foo = super::super::super::foo::foo::b::Foo;
+            const _: () = {
+                assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                inst.func_wrap_concurrent(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::a(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn a(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Foo + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::a(store)
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod d {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::{anyhow, Box};
+    pub type Foo = super::foo::foo::c::Foo;
+    const _: () = {
+        assert!(0 == < Foo as wasmtime::component::ComponentType >::SIZE32);
+        assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub trait Host {
+        type Data;
+        fn b(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> Foo + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized;
+    }
+    pub trait GetHost<
+        T,
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+        type Host: Host<Data = D> + Send;
+    }
+    impl<F, T, D, O> GetHost<T, D> for F
+    where
+        F: Fn(T) -> O + Send + Sync + Copy + 'static,
+        O: Host<Data = D> + Send,
+    {
+        type Host = O;
+    }
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+    >(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: G,
+    ) -> wasmtime::Result<()>
+    where
+        T: Send + 'static,
+    {
+        let mut inst = linker.instance("d")?;
+        inst.func_wrap_concurrent(
+            "b",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = caller;
+                let r = <G::Host as Host>::b(host);
+                Box::pin(async move {
+                    let fun = r.await;
+                    Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                        let r = fun(caller);
+                        Ok((r,))
+                    })
+                        as Box<
+                            dyn FnOnce(
+                                wasmtime::StoreContextMut<'_, T>,
+                            ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                        >
+                })
+                    as ::std::pin::Pin<
+                        Box<
+                            dyn ::std::future::Future<
+                                Output = Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Foo,)> + Send + Sync,
+                                >,
+                            > + Send + Sync + 'static,
+                        >,
+                    >
+            },
+        )?;
+        Ok(())
+    }
+    pub fn add_to_linker<T, U>(
+        linker: &mut wasmtime::component::Linker<T>,
+        get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+    ) -> wasmtime::Result<()>
+    where
+        U: Host<Data = T> + Send,
+        T: Send + 'static,
+    {
+        add_to_linker_get_host(linker, get)
+    }
+    impl<_T: Host> Host for &mut _T {
+        type Data = _T::Data;
+        fn b(
+            store: wasmtime::StoreContextMut<'_, Self::Data>,
+        ) -> impl ::std::future::Future<
+            Output = impl FnOnce(
+                wasmtime::StoreContextMut<'_, Self::Data>,
+            ) -> Foo + Send + Sync + 'static,
+        > + Send + Sync + 'static
+        where
+            Self: Sized,
+        {
+            <_T as Host>::b(store)
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
@@ -205,19 +205,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -279,19 +283,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -353,19 +361,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,
@@ -429,19 +441,23 @@ pub mod d {
     }
     pub trait GetHost<
         T,
-    >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+        D,
+    >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
         type Host: Host + Send;
     }
-    impl<F, T, O> GetHost<T> for F
+    impl<F, T, D, O> GetHost<T, D> for F
     where
         F: Fn(T) -> O + Send + Sync + Copy + 'static,
         O: Host + Send,
     {
         type Host = O;
     }
-    pub fn add_to_linker_get_host<T>(
+    pub fn add_to_linker_get_host<
+        T,
+        G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+    >(
         linker: &mut wasmtime::component::Linker<T>,
-        host_getter: impl for<'a> GetHost<&'a mut T>,
+        host_getter: G,
     ) -> wasmtime::Result<()>
     where
         T: Send,

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -532,19 +532,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap(
@@ -1613,7 +1617,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: E1,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (E1,),
@@ -1627,7 +1634,10 @@ pub mod exports {
                     pub fn call_e1_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<E1> {
+                    ) -> wasmtime::Result<E1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1642,7 +1652,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &V1,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&V1,),
@@ -1656,7 +1669,10 @@ pub mod exports {
                     pub fn call_v1_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<V1> {
+                    ) -> wasmtime::Result<V1>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1671,7 +1687,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: bool,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (bool,),
@@ -1685,7 +1704,10 @@ pub mod exports {
                     pub fn call_bool_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<bool> {
+                    ) -> wasmtime::Result<bool>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1705,7 +1727,10 @@ pub mod exports {
                         arg3: Option<E1>,
                         arg4: Option<f32>,
                         arg5: Option<Option<bool>>,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
@@ -1739,7 +1764,10 @@ pub mod exports {
                             Option<f32>,
                             Option<Option<bool>>,
                         ),
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1770,7 +1798,10 @@ pub mod exports {
                         arg5: Casts6,
                     ) -> wasmtime::Result<
                         (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
@@ -1794,7 +1825,10 @@ pub mod exports {
                         arg3: Result<(), ()>,
                         arg4: Result<u32, &V1>,
                         arg5: Result<&str, &[u8]>,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
@@ -1831,7 +1865,10 @@ pub mod exports {
                                 wasmtime::component::__internal::Vec<u8>,
                             >,
                         ),
-                    > {
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1857,7 +1894,10 @@ pub mod exports {
                     pub fn call_return_result_sugar<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<i32, MyErrno>> {
+                    ) -> wasmtime::Result<Result<i32, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1871,7 +1911,10 @@ pub mod exports {
                     pub fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<(), MyErrno>> {
+                    ) -> wasmtime::Result<Result<(), MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1885,7 +1928,10 @@ pub mod exports {
                     pub fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<MyErrno, MyErrno>> {
+                    ) -> wasmtime::Result<Result<MyErrno, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1899,7 +1945,10 @@ pub mod exports {
                     pub fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<(i32, u32), MyErrno>> {
+                    ) -> wasmtime::Result<Result<(i32, u32), MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1913,7 +1962,10 @@ pub mod exports {
                     pub fn call_return_option_sugar<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Option<i32>> {
+                    ) -> wasmtime::Result<Option<i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1927,7 +1979,10 @@ pub mod exports {
                     pub fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Option<MyErrno>> {
+                    ) -> wasmtime::Result<Option<MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1941,7 +1996,10 @@ pub mod exports {
                     pub fn call_result_simple<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<u32, i32>> {
+                    ) -> wasmtime::Result<Result<u32, i32>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1956,7 +2014,10 @@ pub mod exports {
                         &self,
                         mut store: S,
                         arg0: &IsClone,
-                    ) -> wasmtime::Result<()> {
+                    ) -> wasmtime::Result<()>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (&IsClone,),
@@ -1970,7 +2031,10 @@ pub mod exports {
                     pub fn call_is_clone_return<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<IsClone> {
+                    ) -> wasmtime::Result<IsClone>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1984,7 +2048,10 @@ pub mod exports {
                     pub fn call_return_named_option<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Option<u8>> {
+                    ) -> wasmtime::Result<Option<u8>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
@@ -1998,7 +2065,10 @@ pub mod exports {
                     pub fn call_return_named_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<Result<u8, MyErrno>> {
+                    ) -> wasmtime::Result<Result<u8, MyErrno>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send,
+                    {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -540,19 +540,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -1,0 +1,3070 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `my-world`.
+///
+/// This structure is created through [`MyWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`MyWorld`] as well.
+pub struct MyWorldPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: MyWorldIndices,
+}
+impl<T> Clone for MyWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = MyWorldIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`MyWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<MyWorld>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `my-world`.
+///
+/// This is an implementation detail of [`MyWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`MyWorld`] as well.
+#[derive(Clone)]
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::variants::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `my-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`MyWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`MyWorldPre::instantiate_async`] to
+///   create a [`MyWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`MyWorld::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`MyWorldIndices::new_instance`] followed
+///   by [`MyWorldIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct MyWorld {
+    interface0: exports::foo::foo::variants::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new(_component)?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Creates a new instance of [`MyWorldIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`MyWorld`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`MyWorld`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::foo::foo::variants::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(MyWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`MyWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(MyWorld { interface0 })
+        }
+    }
+    impl MyWorld {
+        /// Convenience wrapper around [`MyWorldPre::new`] and
+        /// [`MyWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<MyWorld>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            MyWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`MyWorldIndices::new_instance`] and
+        /// [`MyWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::variants::Host<Data = T> + 'static,
+            U: Send + foo::foo::variants::Host<Data = T>,
+        {
+            foo::foo::variants::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub fn foo_foo_variants(&self) -> &exports::foo::foo::variants::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod variants {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            #[repr(u8)]
+            pub enum E1 {
+                #[component(name = "a")]
+                A,
+            }
+            impl core::fmt::Debug for E1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        E1::A => f.debug_tuple("E1::A").finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum V1 {
+                #[component(name = "a")]
+                A,
+                #[component(name = "c")]
+                C(E1),
+                #[component(name = "d")]
+                D(wasmtime::component::__internal::String),
+                #[component(name = "e")]
+                E(Empty),
+                #[component(name = "f")]
+                F,
+                #[component(name = "g")]
+                G(u32),
+            }
+            impl core::fmt::Debug for V1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V1::A => f.debug_tuple("V1::A").finish(),
+                        V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                        V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                        V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                        V1::F => f.debug_tuple("V1::F").finish(),
+                        V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts1 {
+                #[component(name = "a")]
+                A(i32),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts1 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                        Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts2 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(f32),
+            }
+            impl core::fmt::Debug for Casts2 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                        Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts3 {
+                #[component(name = "a")]
+                A(f64),
+                #[component(name = "b")]
+                B(u64),
+            }
+            impl core::fmt::Debug for Casts3 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                        Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts4 {
+                #[component(name = "a")]
+                A(u32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts4 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                        Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts5 {
+                #[component(name = "a")]
+                A(f32),
+                #[component(name = "b")]
+                B(i64),
+            }
+            impl core::fmt::Debug for Casts5 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                        Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum Casts6 {
+                #[component(name = "a")]
+                A((f32, u32)),
+                #[component(name = "b")]
+                B((u32, u32)),
+            }
+            impl core::fmt::Debug for Casts6 {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                        Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(enum)]
+            #[derive(Clone, Copy, Eq, PartialEq)]
+            #[repr(u8)]
+            pub enum MyErrno {
+                #[component(name = "bad1")]
+                Bad1,
+                #[component(name = "bad2")]
+                Bad2,
+            }
+            impl MyErrno {
+                pub fn name(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "bad1",
+                        MyErrno::Bad2 => "bad2",
+                    }
+                }
+                pub fn message(&self) -> &'static str {
+                    match self {
+                        MyErrno::Bad1 => "",
+                        MyErrno::Bad2 => "",
+                    }
+                }
+            }
+            impl core::fmt::Debug for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("MyErrno")
+                        .field("code", &(*self as i32))
+                        .field("name", &self.name())
+                        .field("message", &self.message())
+                        .finish()
+                }
+            }
+            impl core::fmt::Display for MyErrno {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{} (error {})", self.name(), * self as i32)
+                }
+            }
+            impl std::error::Error for MyErrno {}
+            const _: () = {
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct IsClone {
+                #[component(name = "v1")]
+                pub v1: V1,
+            }
+            impl core::fmt::Debug for IsClone {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                }
+            }
+            const _: () = {
+                assert!(12 == < IsClone as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {
+                type Data;
+                fn e1_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: E1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn e1_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> E1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn v1_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: V1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn v1_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> V1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn bool_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: bool,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn bool_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> bool + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn option_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn option_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn casts(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Casts1,
+                            Casts2,
+                            Casts3,
+                            Casts4,
+                            Casts5,
+                            Casts6,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_result_sugar(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<i32, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_result_sugar2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_result_sugar3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<MyErrno, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_result_sugar4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(i32, u32), MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_option_sugar(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<i32> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_option_sugar2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn result_simple(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<u32, i32> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn is_clone_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: IsClone,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn is_clone_return(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> IsClone + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_named_option(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<u8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+                fn return_named_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<u8, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized;
+            }
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host<Data = D> + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host<Data = D> + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host<Data = T> + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                inst.func_wrap_concurrent(
+                    "e1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::e1_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "e1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::e1_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(E1,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(E1,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "v1-arg",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (V1,)| {
+                        let host = caller;
+                        let r = <G::Host as Host>::v1_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "v1-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::v1_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(V1,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(V1,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bool-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (bool,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::bool_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bool-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::bool_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(bool,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(bool,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_arg(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::option_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                (
+                                                    Option<bool>,
+                                                    Option<()>,
+                                                    Option<u32>,
+                                                    Option<E1>,
+                                                    Option<f32>,
+                                                    Option<Option<bool>>,
+                                                ),
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        (
+                                                            Option<bool>,
+                                                            Option<()>,
+                                                            Option<u32>,
+                                                            Option<E1>,
+                                                            Option<f32>,
+                                                            Option<Option<bool>>,
+                                                        ),
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "casts",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::casts(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        ): (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        )|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_arg(
+                            host,
+                            arg0,
+                            arg1,
+                            arg2,
+                            arg3,
+                            arg4,
+                            arg5,
+                        );
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (
+                                                (
+                                                    Result<(), ()>,
+                                                    Result<(), E1>,
+                                                    Result<E1, ()>,
+                                                    Result<(), ()>,
+                                                    Result<u32, V1>,
+                                                    Result<
+                                                        wasmtime::component::__internal::String,
+                                                        wasmtime::component::__internal::Vec<u8>,
+                                                    >,
+                                                ),
+                                            ),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (
+                                                        (
+                                                            Result<(), ()>,
+                                                            Result<(), E1>,
+                                                            Result<E1, ()>,
+                                                            Result<(), ()>,
+                                                            Result<u32, V1>,
+                                                            Result<
+                                                                wasmtime::component::__internal::String,
+                                                                wasmtime::component::__internal::Vec<u8>,
+                                                            >,
+                                                        ),
+                                                    ),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-result-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_result_sugar(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<i32, MyErrno>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<i32, MyErrno>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-result-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_result_sugar2(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<(), MyErrno>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<(), MyErrno>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-result-sugar3",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_result_sugar3(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (Result<MyErrno, MyErrno>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (Result<MyErrno, MyErrno>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-result-sugar4",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_result_sugar4(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<
+                                            (Result<(i32, u32), MyErrno>,),
+                                        > + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<
+                                                    (Result<(i32, u32), MyErrno>,),
+                                                > + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-option-sugar",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_option_sugar(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Option<i32>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Option<i32>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-option-sugar2",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_option_sugar2(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Option<MyErrno>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Option<MyErrno>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-simple",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::result_simple(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<u32, i32>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<u32, i32>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "is-clone-arg",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (IsClone,)|
+                    {
+                        let host = caller;
+                        let r = <G::Host as Host>::is_clone_arg(host, arg0);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok(r)
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<()> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<()> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "is-clone-return",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::is_clone_return(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(IsClone,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(IsClone,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-named-option",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_named_option(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Option<u8>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Option<u8>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "return-named-result",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = caller;
+                        let r = <G::Host as Host>::return_named_result(host);
+                        Box::pin(async move {
+                            let fun = r.await;
+                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
+                                let r = fun(caller);
+                                Ok((r,))
+                            })
+                                as Box<
+                                    dyn FnOnce(
+                                        wasmtime::StoreContextMut<'_, T>,
+                                    ) -> wasmtime::Result<(Result<u8, MyErrno>,)> + Send + Sync,
+                                >
+                        })
+                            as ::std::pin::Pin<
+                                Box<
+                                    dyn ::std::future::Future<
+                                        Output = Box<
+                                            dyn FnOnce(
+                                                wasmtime::StoreContextMut<'_, T>,
+                                            ) -> wasmtime::Result<(Result<u8, MyErrno>,)> + Send + Sync,
+                                        >,
+                                    > + Send + Sync + 'static,
+                                >,
+                            >
+                    },
+                )?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host<Data = T> + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host> Host for &mut _T {
+                type Data = _T::Data;
+                fn e1_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: E1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::e1_arg(store, x)
+                }
+                fn e1_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> E1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::e1_result(store)
+                }
+                fn v1_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: V1,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::v1_arg(store, x)
+                }
+                fn v1_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> V1 + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::v1_result(store)
+                }
+                fn bool_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    x: bool,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bool_arg(store, x)
+                }
+                fn bool_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> bool + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::bool_result(store)
+                }
+                fn option_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_arg(store, a, b, c, d, e, g)
+                }
+                fn option_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Option<bool>,
+                            Option<()>,
+                            Option<u32>,
+                            Option<E1>,
+                            Option<f32>,
+                            Option<Option<bool>>,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::option_result(store)
+                }
+                fn casts(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Casts1,
+                            Casts2,
+                            Casts3,
+                            Casts4,
+                            Casts5,
+                            Casts6,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::casts(store, a, b, c, d, e, f)
+                }
+                fn result_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_arg(store, a, b, c, d, e, f)
+                }
+                fn result_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> (
+                            Result<(), ()>,
+                            Result<(), E1>,
+                            Result<E1, ()>,
+                            Result<(), ()>,
+                            Result<u32, V1>,
+                            Result<
+                                wasmtime::component::__internal::String,
+                                wasmtime::component::__internal::Vec<u8>,
+                            >,
+                        ) + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_result(store)
+                }
+                fn return_result_sugar(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<i32, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_result_sugar(store)
+                }
+                fn return_result_sugar2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(), MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_result_sugar2(store)
+                }
+                fn return_result_sugar3(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<MyErrno, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_result_sugar3(store)
+                }
+                fn return_result_sugar4(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<(i32, u32), MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_result_sugar4(store)
+                }
+                fn return_option_sugar(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<i32> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_option_sugar(store)
+                }
+                fn return_option_sugar2(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_option_sugar2(store)
+                }
+                fn result_simple(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<u32, i32> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::result_simple(store)
+                }
+                fn is_clone_arg(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                    a: IsClone,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> () + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::is_clone_arg(store, a)
+                }
+                fn is_clone_return(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> IsClone + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::is_clone_return(store)
+                }
+                fn return_named_option(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Option<u8> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_named_option(store)
+                }
+                fn return_named_result(
+                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                ) -> impl ::std::future::Future<
+                    Output = impl FnOnce(
+                        wasmtime::StoreContextMut<'_, Self::Data>,
+                    ) -> Result<u8, MyErrno> + Send + Sync + 'static,
+                > + Send + Sync + 'static
+                where
+                    Self: Sized,
+                {
+                    <_T as Host>::return_named_result(store)
+                }
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod variants {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                #[repr(u8)]
+                pub enum E1 {
+                    #[component(name = "a")]
+                    A,
+                }
+                impl core::fmt::Debug for E1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            E1::A => f.debug_tuple("E1::A").finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(1 == < E1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone)]
+                pub enum V1 {
+                    #[component(name = "a")]
+                    A,
+                    #[component(name = "c")]
+                    C(E1),
+                    #[component(name = "d")]
+                    D(wasmtime::component::__internal::String),
+                    #[component(name = "e")]
+                    E(Empty),
+                    #[component(name = "f")]
+                    F,
+                    #[component(name = "g")]
+                    G(u32),
+                }
+                impl core::fmt::Debug for V1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            V1::A => f.debug_tuple("V1::A").finish(),
+                            V1::C(e) => f.debug_tuple("V1::C").field(e).finish(),
+                            V1::D(e) => f.debug_tuple("V1::D").field(e).finish(),
+                            V1::E(e) => f.debug_tuple("V1::E").field(e).finish(),
+                            V1::F => f.debug_tuple("V1::F").finish(),
+                            V1::G(e) => f.debug_tuple("V1::G").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(12 == < V1 as wasmtime::component::ComponentType >::SIZE32);
+                    assert!(4 == < V1 as wasmtime::component::ComponentType >::ALIGN32);
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts1 {
+                    #[component(name = "a")]
+                    A(i32),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts1 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts1::A(e) => f.debug_tuple("Casts1::A").field(e).finish(),
+                            Casts1::B(e) => f.debug_tuple("Casts1::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Casts1 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts1 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts2 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(f32),
+                }
+                impl core::fmt::Debug for Casts2 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts2::A(e) => f.debug_tuple("Casts2::A").field(e).finish(),
+                            Casts2::B(e) => f.debug_tuple("Casts2::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts2 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts2 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts3 {
+                    #[component(name = "a")]
+                    A(f64),
+                    #[component(name = "b")]
+                    B(u64),
+                }
+                impl core::fmt::Debug for Casts3 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts3::A(e) => f.debug_tuple("Casts3::A").field(e).finish(),
+                            Casts3::B(e) => f.debug_tuple("Casts3::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts3 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts3 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts4 {
+                    #[component(name = "a")]
+                    A(u32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts4 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts4::A(e) => f.debug_tuple("Casts4::A").field(e).finish(),
+                            Casts4::B(e) => f.debug_tuple("Casts4::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts4 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts4 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts5 {
+                    #[component(name = "a")]
+                    A(f32),
+                    #[component(name = "b")]
+                    B(i64),
+                }
+                impl core::fmt::Debug for Casts5 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts5::A(e) => f.debug_tuple("Casts5::A").field(e).finish(),
+                            Casts5::B(e) => f.debug_tuple("Casts5::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        16 == < Casts5 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        8 == < Casts5 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(variant)]
+                #[derive(Clone, Copy)]
+                pub enum Casts6 {
+                    #[component(name = "a")]
+                    A((f32, u32)),
+                    #[component(name = "b")]
+                    B((u32, u32)),
+                }
+                impl core::fmt::Debug for Casts6 {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        match self {
+                            Casts6::A(e) => f.debug_tuple("Casts6::A").field(e).finish(),
+                            Casts6::B(e) => f.debug_tuple("Casts6::B").field(e).finish(),
+                        }
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < Casts6 as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Casts6 as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(enum)]
+                #[derive(Clone, Copy, Eq, PartialEq)]
+                #[repr(u8)]
+                pub enum MyErrno {
+                    #[component(name = "bad1")]
+                    Bad1,
+                    #[component(name = "bad2")]
+                    Bad2,
+                }
+                impl MyErrno {
+                    pub fn name(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "bad1",
+                            MyErrno::Bad2 => "bad2",
+                        }
+                    }
+                    pub fn message(&self) -> &'static str {
+                        match self {
+                            MyErrno::Bad1 => "",
+                            MyErrno::Bad2 => "",
+                        }
+                    }
+                }
+                impl core::fmt::Debug for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("MyErrno")
+                            .field("code", &(*self as i32))
+                            .field("name", &self.name())
+                            .field("message", &self.message())
+                            .finish()
+                    }
+                }
+                impl core::fmt::Display for MyErrno {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        write!(f, "{} (error {})", self.name(), * self as i32)
+                    }
+                }
+                impl std::error::Error for MyErrno {}
+                const _: () = {
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct IsClone {
+                    #[component(name = "v1")]
+                    pub v1: V1,
+                }
+                impl core::fmt::Debug for IsClone {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("IsClone").field("v1", &self.v1).finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        12 == < IsClone as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    e1_arg: wasmtime::component::Func,
+                    e1_result: wasmtime::component::Func,
+                    v1_arg: wasmtime::component::Func,
+                    v1_result: wasmtime::component::Func,
+                    bool_arg: wasmtime::component::Func,
+                    bool_result: wasmtime::component::Func,
+                    option_arg: wasmtime::component::Func,
+                    option_result: wasmtime::component::Func,
+                    casts: wasmtime::component::Func,
+                    result_arg: wasmtime::component::Func,
+                    result_result: wasmtime::component::Func,
+                    return_result_sugar: wasmtime::component::Func,
+                    return_result_sugar2: wasmtime::component::Func,
+                    return_result_sugar3: wasmtime::component::Func,
+                    return_result_sugar4: wasmtime::component::Func,
+                    return_option_sugar: wasmtime::component::Func,
+                    return_option_sugar2: wasmtime::component::Func,
+                    result_simple: wasmtime::component::Func,
+                    is_clone_arg: wasmtime::component::Func,
+                    is_clone_return: wasmtime::component::Func,
+                    return_named_option: wasmtime::component::Func,
+                    return_named_result: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    e1_arg: wasmtime::component::ComponentExportIndex,
+                    e1_result: wasmtime::component::ComponentExportIndex,
+                    v1_arg: wasmtime::component::ComponentExportIndex,
+                    v1_result: wasmtime::component::ComponentExportIndex,
+                    bool_arg: wasmtime::component::ComponentExportIndex,
+                    bool_result: wasmtime::component::ComponentExportIndex,
+                    option_arg: wasmtime::component::ComponentExportIndex,
+                    option_result: wasmtime::component::ComponentExportIndex,
+                    casts: wasmtime::component::ComponentExportIndex,
+                    result_arg: wasmtime::component::ComponentExportIndex,
+                    result_result: wasmtime::component::ComponentExportIndex,
+                    return_result_sugar: wasmtime::component::ComponentExportIndex,
+                    return_result_sugar2: wasmtime::component::ComponentExportIndex,
+                    return_result_sugar3: wasmtime::component::ComponentExportIndex,
+                    return_result_sugar4: wasmtime::component::ComponentExportIndex,
+                    return_option_sugar: wasmtime::component::ComponentExportIndex,
+                    return_option_sugar2: wasmtime::component::ComponentExportIndex,
+                    result_simple: wasmtime::component::ComponentExportIndex,
+                    is_clone_arg: wasmtime::component::ComponentExportIndex,
+                    is_clone_return: wasmtime::component::ComponentExportIndex,
+                    return_named_option: wasmtime::component::ComponentExportIndex,
+                    return_named_result: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "foo:foo/variants")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/variants`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(&mut store, None, "foo:foo/variants")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/variants`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/variants` does \
+                    not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let e1_arg = lookup("e1-arg")?;
+                        let e1_result = lookup("e1-result")?;
+                        let v1_arg = lookup("v1-arg")?;
+                        let v1_result = lookup("v1-result")?;
+                        let bool_arg = lookup("bool-arg")?;
+                        let bool_result = lookup("bool-result")?;
+                        let option_arg = lookup("option-arg")?;
+                        let option_result = lookup("option-result")?;
+                        let casts = lookup("casts")?;
+                        let result_arg = lookup("result-arg")?;
+                        let result_result = lookup("result-result")?;
+                        let return_result_sugar = lookup("return-result-sugar")?;
+                        let return_result_sugar2 = lookup("return-result-sugar2")?;
+                        let return_result_sugar3 = lookup("return-result-sugar3")?;
+                        let return_result_sugar4 = lookup("return-result-sugar4")?;
+                        let return_option_sugar = lookup("return-option-sugar")?;
+                        let return_option_sugar2 = lookup("return-option-sugar2")?;
+                        let result_simple = lookup("result-simple")?;
+                        let is_clone_arg = lookup("is-clone-arg")?;
+                        let is_clone_return = lookup("is-clone-return")?;
+                        let return_named_option = lookup("return-named-option")?;
+                        let return_named_result = lookup("return-named-result")?;
+                        Ok(GuestIndices {
+                            e1_arg,
+                            e1_result,
+                            v1_arg,
+                            v1_result,
+                            bool_arg,
+                            bool_result,
+                            option_arg,
+                            option_result,
+                            casts,
+                            result_arg,
+                            result_result,
+                            return_result_sugar,
+                            return_result_sugar2,
+                            return_result_sugar3,
+                            return_result_sugar4,
+                            return_option_sugar,
+                            return_option_sugar2,
+                            result_simple,
+                            is_clone_arg,
+                            is_clone_return,
+                            return_named_option,
+                            return_named_result,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        let e1_arg = *_instance
+                            .get_typed_func::<(E1,), ()>(&mut store, &self.e1_arg)?
+                            .func();
+                        let e1_result = *_instance
+                            .get_typed_func::<(), (E1,)>(&mut store, &self.e1_result)?
+                            .func();
+                        let v1_arg = *_instance
+                            .get_typed_func::<(&V1,), ()>(&mut store, &self.v1_arg)?
+                            .func();
+                        let v1_result = *_instance
+                            .get_typed_func::<(), (V1,)>(&mut store, &self.v1_result)?
+                            .func();
+                        let bool_arg = *_instance
+                            .get_typed_func::<(bool,), ()>(&mut store, &self.bool_arg)?
+                            .func();
+                        let bool_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (bool,),
+                            >(&mut store, &self.bool_result)?
+                            .func();
+                        let option_arg = *_instance
+                            .get_typed_func::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >(&mut store, &self.option_arg)?
+                            .func();
+                        let option_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >(&mut store, &self.option_result)?
+                            .func();
+                        let casts = *_instance
+                            .get_typed_func::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >(&mut store, &self.casts)?
+                            .func();
+                        let result_arg = *_instance
+                            .get_typed_func::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, &V1>,
+                                    Result<&str, &[u8]>,
+                                ),
+                                (),
+                            >(&mut store, &self.result_arg)?
+                            .func();
+                        let result_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >(&mut store, &self.result_result)?
+                            .func();
+                        let return_result_sugar = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >(&mut store, &self.return_result_sugar)?
+                            .func();
+                        let return_result_sugar2 = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >(&mut store, &self.return_result_sugar2)?
+                            .func();
+                        let return_result_sugar3 = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >(&mut store, &self.return_result_sugar3)?
+                            .func();
+                        let return_result_sugar4 = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >(&mut store, &self.return_result_sugar4)?
+                            .func();
+                        let return_option_sugar = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Option<i32>,),
+                            >(&mut store, &self.return_option_sugar)?
+                            .func();
+                        let return_option_sugar2 = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Option<MyErrno>,),
+                            >(&mut store, &self.return_option_sugar2)?
+                            .func();
+                        let result_simple = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<u32, i32>,),
+                            >(&mut store, &self.result_simple)?
+                            .func();
+                        let is_clone_arg = *_instance
+                            .get_typed_func::<
+                                (&IsClone,),
+                                (),
+                            >(&mut store, &self.is_clone_arg)?
+                            .func();
+                        let is_clone_return = *_instance
+                            .get_typed_func::<
+                                (),
+                                (IsClone,),
+                            >(&mut store, &self.is_clone_return)?
+                            .func();
+                        let return_named_option = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Option<u8>,),
+                            >(&mut store, &self.return_named_option)?
+                            .func();
+                        let return_named_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >(&mut store, &self.return_named_result)?
+                            .func();
+                        Ok(Guest {
+                            e1_arg,
+                            e1_result,
+                            v1_arg,
+                            v1_result,
+                            bool_arg,
+                            bool_result,
+                            option_arg,
+                            option_result,
+                            casts,
+                            result_arg,
+                            result_result,
+                            return_result_sugar,
+                            return_result_sugar2,
+                            return_result_sugar3,
+                            return_result_sugar4,
+                            return_option_sugar,
+                            return_option_sugar2,
+                            result_simple,
+                            is_clone_arg,
+                            is_clone_return,
+                            return_named_option,
+                            return_named_result,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub async fn call_e1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: E1,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (E1,),
+                                (),
+                            >::new_unchecked(self.e1_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_e1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<E1>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (E1,),
+                            >::new_unchecked(self.e1_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_v1_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: V1,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (V1,),
+                                (),
+                            >::new_unchecked(self.v1_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_v1_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<V1>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (V1,),
+                            >::new_unchecked(self.v1_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_bool_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: bool,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (bool,),
+                                (),
+                            >::new_unchecked(self.bool_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_bool_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<bool>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (bool,),
+                            >::new_unchecked(self.bool_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_option_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Option<bool>,
+                        arg1: Option<()>,
+                        arg2: Option<u32>,
+                        arg3: Option<E1>,
+                        arg4: Option<f32>,
+                        arg5: Option<Option<bool>>,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Option<bool>,
+                                    Option<()>,
+                                    Option<u32>,
+                                    Option<E1>,
+                                    Option<f32>,
+                                    Option<Option<bool>>,
+                                ),
+                                (),
+                            >::new_unchecked(self.option_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_option_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            (
+                                Option<bool>,
+                                Option<()>,
+                                Option<u32>,
+                                Option<E1>,
+                                Option<f32>,
+                                Option<Option<bool>>,
+                            ),
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Option<bool>,
+                                        Option<()>,
+                                        Option<u32>,
+                                        Option<E1>,
+                                        Option<f32>,
+                                        Option<Option<bool>>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.option_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_casts<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Casts1,
+                        arg1: Casts2,
+                        arg2: Casts3,
+                        arg3: Casts4,
+                        arg4: Casts5,
+                        arg5: Casts6,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
+                                ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
+                            >::new_unchecked(self.casts)
+                        };
+                        let promise = callee
+                            .call_concurrent(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_result_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Result<(), ()>,
+                        arg1: Result<(), E1>,
+                        arg2: Result<E1, ()>,
+                        arg3: Result<(), ()>,
+                        arg4: Result<u32, V1>,
+                        arg5: Result<
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::Vec<u8>,
+                        >,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    Result<(), ()>,
+                                    Result<(), E1>,
+                                    Result<E1, ()>,
+                                    Result<(), ()>,
+                                    Result<u32, V1>,
+                                    Result<
+                                        wasmtime::component::__internal::String,
+                                        wasmtime::component::__internal::Vec<u8>,
+                                    >,
+                                ),
+                                (),
+                            >::new_unchecked(self.result_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(
+                                store.as_context_mut(),
+                                (arg0, arg1, arg2, arg3, arg4, arg5),
+                            )
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_result_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<
+                            (
+                                Result<(), ()>,
+                                Result<(), E1>,
+                                Result<E1, ()>,
+                                Result<(), ()>,
+                                Result<u32, V1>,
+                                Result<
+                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u8>,
+                                >,
+                            ),
+                        >,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (
+                                    (
+                                        Result<(), ()>,
+                                        Result<(), E1>,
+                                        Result<E1, ()>,
+                                        Result<(), ()>,
+                                        Result<u32, V1>,
+                                        Result<
+                                            wasmtime::component::__internal::String,
+                                            wasmtime::component::__internal::Vec<u8>,
+                                        >,
+                                    ),
+                                ),
+                            >::new_unchecked(self.result_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_result_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<Result<i32, MyErrno>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<i32, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_result_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<Result<(), MyErrno>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_result_sugar3<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<Result<MyErrno, MyErrno>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<MyErrno, MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar3)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_result_sugar4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<Result<(i32, u32), MyErrno>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<(i32, u32), MyErrno>,),
+                            >::new_unchecked(self.return_result_sugar4)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_option_sugar<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Option<i32>>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<i32>,),
+                            >::new_unchecked(self.return_option_sugar)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_option_sugar2<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Option<MyErrno>>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<MyErrno>,),
+                            >::new_unchecked(self.return_option_sugar2)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_result_simple<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Result<u32, i32>>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u32, i32>,),
+                            >::new_unchecked(self.result_simple)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_is_clone_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: IsClone,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (IsClone,),
+                                (),
+                            >::new_unchecked(self.is_clone_arg)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), (arg0,))
+                            .await?;
+                        Ok(promise)
+                    }
+                    pub async fn call_is_clone_return<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<IsClone>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (IsClone,),
+                            >::new_unchecked(self.is_clone_return)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_named_option<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<wasmtime::component::Promise<Option<u8>>>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Option<u8>,),
+                            >::new_unchecked(self.return_named_option)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                    pub async fn call_return_named_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> wasmtime::Result<
+                        wasmtime::component::Promise<Result<u8, MyErrno>>,
+                    >
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Result<u8, MyErrno>,),
+                            >::new_unchecked(self.return_named_result)
+                        };
+                        let promise = callee
+                            .call_concurrent(store.as_context_mut(), ())
+                            .await?;
+                        Ok(promise.map(|(v,)| v))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -540,19 +540,23 @@ pub mod foo {
             }
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/wat_concurrent.rs
+++ b/crates/component-macro/tests/expanded/wat_concurrent.rs
@@ -1,0 +1,271 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `example`.
+///
+/// This structure is created through [`ExamplePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Example`] as well.
+pub struct ExamplePre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: ExampleIndices,
+}
+impl<T> Clone for ExamplePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> ExamplePre<_T> {
+    /// Creates a new copy of `ExamplePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ExampleIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Example`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Example>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `example`.
+///
+/// This is an implementation detail of [`ExamplePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Example`] as well.
+#[derive(Clone)]
+pub struct ExampleIndices {
+    interface0: exports::same::name::this_name_is_duplicated::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `example`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Example::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ExamplePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ExamplePre::instantiate_async`] to
+///   create a [`Example`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Example::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`ExampleIndices::new_instance`] followed
+///   by [`ExampleIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Example {
+    interface0: exports::same::name::this_name_is_duplicated::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl ExampleIndices {
+        /// Creates a new copy of `ExampleIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new(
+                _component,
+            )?;
+            Ok(ExampleIndices { interface0 })
+        }
+        /// Creates a new instance of [`ExampleIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Example`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Example`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new_instance(
+                &mut store,
+                _instance,
+            )?;
+            Ok(ExampleIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Example`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(Example { interface0 })
+        }
+    }
+    impl Example {
+        /// Convenience wrapper around [`ExamplePre::new`] and
+        /// [`ExamplePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Example>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            ExamplePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`ExampleIndices::new_instance`] and
+        /// [`ExampleIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let indices = ExampleIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn same_name_this_name_is_duplicated(
+            &self,
+        ) -> &exports::same::name::this_name_is_duplicated::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    pub mod same {
+        pub mod name {
+            #[allow(clippy::all)]
+            pub mod this_name_is_duplicated {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type ThisNameIsDuplicated = wasmtime::component::ResourceAny;
+                pub struct GuestThisNameIsDuplicated<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {}
+                #[derive(Clone)]
+                pub struct GuestIndices {}
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new(
+                        component: &wasmtime::component::Component,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let (_, instance) = component
+                            .export_index(None, "same:name/this-name-is-duplicated")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `same:name/this-name-is-duplicated`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            component.export_index(Some(&instance), name).map(|p| p.1)
+                        })
+                    }
+                    /// This constructor is similar to [`GuestIndices::new`] except that it
+                    /// performs string lookups after instantiation time.
+                    pub fn new_instance(
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance_export = instance
+                            .get_export(
+                                &mut store,
+                                None,
+                                "same:name/this-name-is-duplicated",
+                            )
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `same:name/this-name-is-duplicated`"
+                                )
+                            })?;
+                        Self::_new(|name| {
+                            instance.get_export(&mut store, Some(&instance_export), name)
+                        })
+                    }
+                    fn _new(
+                        mut lookup: impl FnMut(
+                            &str,
+                        ) -> Option<wasmtime::component::ComponentExportIndex>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let mut lookup = move |name| {
+                            lookup(name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `same:name/this-name-is-duplicated` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        Ok(GuestIndices {})
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let _instance = instance;
+                        Ok(Guest {})
+                    }
+                }
+                impl Guest {}
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -207,7 +207,10 @@ const _: () = {
         pub fn call_f<S: wasmtime::AsContextMut>(
             &self,
             mut store: S,
-        ) -> wasmtime::Result<(T, U, R)> {
+        ) -> wasmtime::Result<(T, U, R)>
+        where
+            <S as wasmtime::AsContext>::Data: Send,
+        {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
             };
@@ -231,19 +234,23 @@ pub mod foo {
             pub trait Host {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()> {
                 let mut inst = linker.instance("foo:foo/i")?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -242,19 +242,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -1,0 +1,280 @@
+pub type U = foo::foo::i::T;
+const _: () = {
+    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
+    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
+};
+pub type T = u32;
+const _: () = {
+    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
+    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
+};
+#[derive(wasmtime::component::ComponentType)]
+#[derive(wasmtime::component::Lift)]
+#[derive(wasmtime::component::Lower)]
+#[component(record)]
+#[derive(Clone, Copy)]
+pub struct R {}
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("R").finish()
+    }
+}
+const _: () = {
+    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
+    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
+};
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `foo`.
+///
+/// This structure is created through [`FooPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: FooIndices,
+}
+impl<T> Clone for FooPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = FooIndices::new(instance_pre.component())?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Foo`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Foo>
+    where
+        _T: Send + 'static,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `foo`.
+///
+/// This is an implementation detail of [`FooPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Foo`] as well.
+#[derive(Clone)]
+pub struct FooIndices {
+    f: wasmtime::component::ComponentExportIndex,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `foo`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Foo::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`FooPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Foo::new`].
+///
+/// * You can also access the guts of instantiation through
+///   [`FooIndices::new_instance`] followed
+///   by [`FooIndices::load`] to crate an instance of this
+///   type.
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Foo {
+    f: wasmtime::component::Func,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new(
+            component: &wasmtime::component::Component,
+        ) -> wasmtime::Result<Self> {
+            let _component = component;
+            let f = _component
+                .export_index(None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
+                .1;
+            Ok(FooIndices { f })
+        }
+        /// Creates a new instance of [`FooIndices`] from an
+        /// instantiated component.
+        ///
+        /// This method of creating a [`Foo`] will perform string
+        /// lookups for all exports when this method is called. This
+        /// will only succeed if the provided instance matches the
+        /// requirements of [`Foo`].
+        pub fn new_instance(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Self> {
+            let _instance = instance;
+            let f = _instance
+                .get_export(&mut store, None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
+            Ok(FooIndices { f })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Foo`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let _instance = instance;
+            let f = *_instance
+                .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
+                .func();
+            Ok(Foo { f })
+        }
+    }
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            mut store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Foo>
+        where
+            _T: Send + 'static,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            FooPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`FooIndices::new_instance`] and
+        /// [`FooIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new_instance(&mut store, instance)?;
+            indices.load(store, instance)
+        }
+        pub fn add_to_linker<T, U>(
+            linker: &mut wasmtime::component::Linker<T>,
+            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+        ) -> wasmtime::Result<()>
+        where
+            T: Send + foo::foo::i::Host + 'static,
+            U: Send + foo::foo::i::Host,
+        {
+            foo::foo::i::add_to_linker(linker, get)?;
+            Ok(())
+        }
+        pub async fn call_f<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> wasmtime::Result<wasmtime::component::Promise<(T, U, R)>>
+        where
+            <S as wasmtime::AsContext>::Data: Send + 'static,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
+            };
+            let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
+            Ok(promise.map(|(v,)| v))
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod i {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type T = u16;
+            const _: () = {
+                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
+                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            pub trait Host {}
+            pub trait GetHost<
+                T,
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
+                type Host: Host + Send;
+            }
+            impl<F, T, D, O> GetHost<T, D> for F
+            where
+                F: Fn(T) -> O + Send + Sync + Copy + 'static,
+                O: Host + Send,
+            {
+                type Host = O;
+            }
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: G,
+            ) -> wasmtime::Result<()>
+            where
+                T: Send + 'static,
+            {
+                let mut inst = linker.instance("foo:foo/i")?;
+                Ok(())
+            }
+            pub fn add_to_linker<T, U>(
+                linker: &mut wasmtime::component::Linker<T>,
+                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            ) -> wasmtime::Result<()>
+            where
+                U: Host + Send,
+                T: Send + 'static,
+            {
+                add_to_linker_get_host(linker, get)
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {}
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -250,19 +250,23 @@ pub mod foo {
             pub trait Host: Send {}
             pub trait GetHost<
                 T,
-            >: Fn(T) -> <Self as GetHost<T>>::Host + Send + Sync + Copy + 'static {
+                D,
+            >: Fn(T) -> <Self as GetHost<T, D>>::Host + Send + Sync + Copy + 'static {
                 type Host: Host + Send;
             }
-            impl<F, T, O> GetHost<T> for F
+            impl<F, T, D, O> GetHost<T, D> for F
             where
                 F: Fn(T) -> O + Send + Sync + Copy + 'static,
                 O: Host + Send,
             {
                 type Host = O;
             }
-            pub fn add_to_linker_get_host<T>(
+            pub fn add_to_linker_get_host<
+                T,
+                G: for<'a> GetHost<&'a mut T, T, Host: Host + Send>,
+            >(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: impl for<'a> GetHost<&'a mut T>,
+                host_getter: G,
             ) -> wasmtime::Result<()>
             where
                 T: Send,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -62,6 +62,7 @@ semver = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
 bitflags = { workspace = true }
+futures = { workspace = true, features = ["alloc"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true
@@ -371,3 +372,13 @@ custom-native-signals = []
 # performance hit, even when not profiling, so it's disabled by default at
 # compile time.
 profile-pulley = ['pulley', 'profiling', 'pulley-interpreter/profile']
+
+# Enables support for the Component Model Async ABI, along with `future`,
+# `stream`, and `error-context` types.
+component-model-async = [
+  "async",
+  "component-model",
+  "std",
+  "wasmtime-component-macro?/component-model-async",
+  "dep:futures"
+]

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1,0 +1,74 @@
+use {
+    crate::AsContextMut,
+    anyhow::Result,
+    futures::{stream::FuturesUnordered, FutureExt},
+    std::{boxed::Box, future::Future, pin::Pin},
+};
+
+pub use futures_and_streams::{ErrorContext, FutureReader, StreamReader};
+
+mod futures_and_streams;
+
+/// Represents the result of a concurrent operation.
+///
+/// This is similar to a [`std::future::Future`] except that it represents an
+/// operation which requires exclusive access to a store in order to make
+/// progress -- without monopolizing that store for the lifetime of the
+/// operation.
+pub struct Promise<T>(Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>>);
+
+impl<T: 'static> Promise<T> {
+    /// Map the result of this `Promise` from one value to another.
+    pub fn map<U>(self, fun: impl FnOnce(T) -> U + Send + Sync + 'static) -> Promise<U> {
+        Promise(Box::pin(self.0.map(fun)))
+    }
+
+    /// Convert this `Promise` to a future which may be `await`ed for its
+    /// result.
+    ///
+    /// The returned future will require exclusive use of the store until it
+    /// completes.  If you need to await more than one `Promise` concurrently,
+    /// use [`PromisesUnordered`].
+    pub async fn get<U: Send>(self, store: impl AsContextMut<Data = U>) -> Result<T> {
+        _ = store;
+        todo!()
+    }
+
+    /// Convert this `Promise` to a future which may be `await`ed for its
+    /// result.
+    ///
+    /// Unlike [`Self::get`], this does _not_ take a store parameter, meaning
+    /// the returned future will not make progress until and unless the event
+    /// loop for the store it came from is polled.  Thus, this method should
+    /// only be used from within host functions and not from top-level embedder
+    /// code.
+    pub fn into_future(self) -> Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> {
+        self.0
+    }
+}
+
+/// Represents a collection of zero or more concurrent operations.
+///
+/// Similar to [`futures::stream::FuturesUnordered`], this type supports
+/// `await`ing more than one [`Promise`]s concurrently.
+pub struct PromisesUnordered<T>(
+    FuturesUnordered<Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>>>,
+);
+
+impl<T: 'static> PromisesUnordered<T> {
+    /// Create a new `PromisesUnordered` with no entries.
+    pub fn new() -> Self {
+        Self(FuturesUnordered::new())
+    }
+
+    /// Add the specified [`Promise`] to this collection.
+    pub fn push(&mut self, promise: Promise<T>) {
+        self.0.push(promise.0)
+    }
+
+    /// Get the next result from this collection, if any.
+    pub async fn next<U: Send>(&mut self, store: impl AsContextMut<Data = U>) -> Result<Option<T>> {
+        _ = store;
+        todo!()
+    }
+}

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1,0 +1,14 @@
+use std::marker::PhantomData;
+
+/// Represents the readable end of a Component Model `future`.
+pub struct FutureReader<T> {
+    _phantom: PhantomData<T>,
+}
+
+/// Represents the readable end of a Component Model `stream`.
+pub struct StreamReader<T> {
+    _phantom: PhantomData<T>,
+}
+
+/// Represents a Component Model `error-context`.
+pub struct ErrorContext {}

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -101,6 +101,8 @@
 #![allow(rustdoc::redundant_explicit_links)]
 
 mod component;
+#[cfg(feature = "component-model-async")]
+pub(crate) mod concurrent;
 mod func;
 mod instance;
 mod linker;
@@ -112,6 +114,8 @@ mod store;
 pub mod types;
 mod values;
 pub use self::component::{Component, ComponentExportIndex};
+#[cfg(feature = "component-model-async")]
+pub use self::concurrent::{ErrorContext, FutureReader, Promise, PromisesUnordered, StreamReader};
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -20,3 +20,4 @@ indexmap = { workspace = true }
 
 [features]
 std = []
+component-model-async = ['std']

--- a/crates/wit-bindgen/src/types.rs
+++ b/crates/wit-bindgen/src/types.rs
@@ -148,21 +148,18 @@ impl Types {
                 info = self.type_info(resolve, ty);
                 info.has_list = true;
             }
-            TypeDefKind::Type(ty) => {
-                info = self.type_info(resolve, ty);
-            }
-            TypeDefKind::Option(ty) => {
+            TypeDefKind::Type(ty) | TypeDefKind::Option(ty) => {
                 info = self.type_info(resolve, ty);
             }
             TypeDefKind::Result(r) => {
                 info = self.optional_type_info(resolve, r.ok.as_ref());
                 info |= self.optional_type_info(resolve, r.err.as_ref());
             }
-            TypeDefKind::Future(_) => todo!(),
-            TypeDefKind::Stream(_) => todo!(),
-            TypeDefKind::ErrorContext => todo!(),
+            TypeDefKind::Future(ty) | TypeDefKind::Stream(ty) => {
+                info = self.optional_type_info(resolve, ty.as_ref());
+            }
             TypeDefKind::Handle(_) => info.has_handle = true,
-            TypeDefKind::Resource => {}
+            TypeDefKind::Resource | TypeDefKind::ErrorContext => {}
             TypeDefKind::Unknown => unreachable!(),
         }
         self.type_info.insert(ty, info);

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1380,50 +1380,32 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-encoder]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasm-encoder]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-metadata]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasm-metadata]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-wave]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmparser]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmparser]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmprinter]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1578,14 +1560,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wast]]
-version = "223.0.0"
-when = "2025-01-08"
+version = "224.0.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wat]]
-version = "1.223.0"
-when = "2025-01-08"
+version = "1.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1810,14 +1792,14 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wit-bindgen]]
-version = "0.37.0"
-when = "2025-01-10"
+version = "0.38.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-core]]
-version = "0.37.0"
-when = "2025-01-10"
+version = "0.38.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1827,39 +1809,33 @@ when = "2025-01-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen-rt]]
+version = "0.38.0"
+when = "2025-01-22"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-rust]]
-version = "0.37.0"
-when = "2025-01-10"
+version = "0.38.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rust-macro]]
-version = "0.37.0"
-when = "2025-01-10"
+version = "0.38.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-component]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-component]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-parser]]
-version = "0.220.0"
-when = "2024-11-12"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wit-parser]]
-version = "0.223.0"
-when = "2025-01-08"
+version = "0.224.0"
+when = "2025-01-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
I've split this out of #9582 to make review easier.

This patch adds async/stream/future/error-context support to the host binding generator, along with placeholder type and function definitions in the `wasmtime` crate which the generated bindings can refer to.  See https://github.com/dicej/rfcs/blob/component-async/accepted/component-model-async.md#componentbindgen-updates for the design and rationale.

Note that I've added temporary `[patch.crates-io]` overrides in Cargo.toml until https://github.com/bytecodealliance/wit-bindgen/pull/1130 and https://github.com/bytecodealliance/wasm-tools/pull/1978 have been released.

Also note that we emit a `T: 'static` bound for `AsContextMut<Data = T>` when generating bindings with `concurrent_imports: true`.  This is only because `rustc` insists that the closure we're passing to
`LinkerInstance::func_wrap_concurrent` captures the lifetime of `T` despite my best efforts to convince it otherwise.  Alex and I suspect this is a limitation in the compiler, and I asked about it on the rust-lang Zulip, but we haven't been able to determine a workaround so far.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
