### PR TITLE
Try using ARM64 runners from GitHub

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -16,6 +16,7 @@ const GENERIC_BUCKETS = 3;
 const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
 const ubuntu = 'ubuntu-24.04';
+const ubuntu_arm = 'ubuntu-24.04-arm';
 const windows = 'windows-2022';
 const macos = 'macos-14';
 
@@ -95,12 +96,8 @@ const FULL_MATRIX = [
     "filter": "mingw-x64"
   },
   {
-    "os": ubuntu,
+    "os": ubuntu_arm,
     "target": "aarch64-unknown-linux-gnu",
-    "gcc_package": "gcc-aarch64-linux-gnu",
-    "gcc": "aarch64-linux-gnu-gcc",
-    "qemu": "qemu-aarch64 -L /usr/aarch64-linux-gnu",
-    "qemu_target": "aarch64-linux-user",
     "name": "Test Linux arm64",
     "filter": "linux-arm64",
     "isa": "aarch64",


### PR DESCRIPTION
Let's see if we can run our aarch64 tests natively instead of through QEMU emulation...

prtest:linux-arm64

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
