### PR TITLE
async/stream/future plumbing for wasmtime-environ

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -94,6 +94,103 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::AlwaysTrap => {
                 self.translate_always_trap();
             }
+            Trampoline::TaskBackpressure { instance } => {
+                _ = instance;
+                todo!()
+            }
+            Trampoline::TaskReturn => todo!(),
+            Trampoline::TaskWait {
+                instance,
+                async_,
+                memory,
+            } => {
+                _ = (instance, async_, memory);
+                todo!()
+            }
+            Trampoline::TaskPoll {
+                instance,
+                async_,
+                memory,
+            } => {
+                _ = (instance, async_, memory);
+                todo!()
+            }
+            Trampoline::TaskYield { async_ } => {
+                _ = async_;
+                todo!()
+            }
+            Trampoline::SubtaskDrop { instance } => {
+                _ = instance;
+                todo!()
+            }
+            Trampoline::StreamNew { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::StreamRead { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::StreamWrite { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::StreamCancelRead { ty, async_ } => {
+                _ = (ty, async_);
+                todo!()
+            }
+            Trampoline::StreamCancelWrite { ty, async_ } => {
+                _ = (ty, async_);
+                todo!()
+            }
+            Trampoline::StreamCloseReadable { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::StreamCloseWritable { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::FutureNew { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::FutureRead { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::FutureWrite { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::FutureCancelRead { ty, async_ } => {
+                _ = (ty, async_);
+                todo!()
+            }
+            Trampoline::FutureCancelWrite { ty, async_ } => {
+                _ = (ty, async_);
+                todo!()
+            }
+            Trampoline::FutureCloseReadable { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::FutureCloseWritable { ty } => {
+                _ = ty;
+                todo!()
+            }
+            Trampoline::ErrorContextNew { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::ErrorContextDebugMessage { ty, options } => {
+                _ = (ty, options);
+                todo!()
+            }
+            Trampoline::ErrorContextDrop { ty } => {
+                _ = ty;
+                todo!()
+            }
             Trampoline::ResourceNew(ty) => self.translate_resource_new(*ty),
             Trampoline::ResourceRep(ty) => self.translate_resource_rep(*ty),
             Trampoline::ResourceDrop(ty) => self.translate_resource_drop(*ty),
@@ -114,6 +211,26 @@ impl<'a> TrampolineCompiler<'a> {
                 self.translate_resource_libcall(host::resource_exit_call, |me, rets| {
                     me.raise_if_host_trapped(rets.pop().unwrap());
                 })
+            }
+            Trampoline::AsyncEnterCall => todo!(),
+            Trampoline::AsyncExitCall {
+                callback,
+                post_return,
+            } => {
+                _ = (callback, post_return);
+                todo!()
+            }
+            Trampoline::FutureTransfer => {
+                _ = host::future_transfer;
+                todo!()
+            }
+            Trampoline::StreamTransfer => {
+                _ = host::stream_transfer;
+                todo!()
+            }
+            Trampoline::ErrorContextTransfer => {
+                _ = host::error_context_transfer;
+                todo!()
             }
         }
     }
@@ -159,7 +276,13 @@ impl<'a> TrampolineCompiler<'a> {
             realloc,
             post_return,
             string_encoding,
+            callback: _,
+            async_,
         } = *options;
+
+        if async_ {
+            todo!()
+        }
 
         // vmctx: *mut VMComponentContext
         host_sig.params.push(ir::AbiParam::new(pointer_type));

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -147,6 +147,8 @@ impl Factc {
                     realloc: Some(dummy_def()),
                     // Lowering never allows `post-return`
                     post_return: None,
+                    async_: false,
+                    callback: None,
                 },
                 lift_options: AdapterOptions {
                     instance: RuntimeComponentInstanceIndex::from_u32(1),
@@ -159,6 +161,8 @@ impl Factc {
                     } else {
                         None
                     },
+                    async_: false,
+                    callback: None,
                 },
                 func: dummy_def(),
             });

--- a/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
+++ b/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
@@ -168,6 +168,10 @@ fn target(data: &[u8]) -> arbitrary::Result<()> {
                         realloc: Some(dummy_def()),
                         // Lowering never allows `post-return`
                         post_return: None,
+                        // Lowering never allows `callback`
+                        callback: None,
+                        // TODO: support async lowers
+                        async_: false,
                     },
                     lift_options: AdapterOptions {
                         instance: RuntimeComponentInstanceIndex::from_u32(1),
@@ -180,6 +184,9 @@ fn target(data: &[u8]) -> arbitrary::Result<()> {
                         } else {
                             None
                         },
+                        // TODO: support async lowers
+                        callback: None,
+                        async_: false,
                     },
                     func: dummy_def(),
                 });

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -83,6 +83,10 @@ macro_rules! foreach_builtin_component_function {
             resource_enter_call(vmctx: vmctx);
             resource_exit_call(vmctx: vmctx) -> bool;
 
+            future_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
+            stream_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
+            error_context_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
+
             trap(vmctx: vmctx, code: u8);
 
             utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8) -> bool;

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -157,8 +157,12 @@ pub struct AdapterOptions {
     pub memory64: bool,
     /// An optional definition of `realloc` to used.
     pub realloc: Option<dfg::CoreDef>,
+    /// The async callback function used by these options, if specified.
+    pub callback: Option<dfg::CoreDef>,
     /// An optional definition of a `post-return` to use.
     pub post_return: Option<dfg::CoreDef>,
+    /// Whether to use the async ABI for lifting or lowering.
+    pub async_: bool,
 }
 
 impl<'data> Translator<'_, 'data> {
@@ -227,7 +231,7 @@ impl<'data> Translator<'_, 'data> {
             // in-order here as well. (with an assert to double-check)
             for (adapter, name) in adapter_module.adapters.iter().zip(&names) {
                 let index = translation.module.exports[name];
-                let i = component.adapter_paritionings.push((module_id, index));
+                let i = component.adapter_partitionings.push((module_id, index));
                 assert_eq!(i, *adapter);
             }
 
@@ -300,6 +304,19 @@ fn fact_import_to_core_def(
         }
         fact::Import::ResourceEnterCall => simple_intrinsic(dfg::Trampoline::ResourceEnterCall),
         fact::Import::ResourceExitCall => simple_intrinsic(dfg::Trampoline::ResourceExitCall),
+        fact::Import::AsyncEnterCall => simple_intrinsic(dfg::Trampoline::AsyncEnterCall),
+        fact::Import::AsyncExitCall {
+            callback,
+            post_return,
+        } => simple_intrinsic(dfg::Trampoline::AsyncExitCall {
+            callback: callback.clone().map(|v| dfg.callbacks.push(v)),
+            post_return: post_return.clone().map(|v| dfg.post_returns.push(v)),
+        }),
+        fact::Import::FutureTransfer => simple_intrinsic(dfg::Trampoline::FutureTransfer),
+        fact::Import::StreamTransfer => simple_intrinsic(dfg::Trampoline::StreamTransfer),
+        fact::Import::ErrorContextTransfer => {
+            simple_intrinsic(dfg::Trampoline::ErrorContextTransfer)
+        }
     }
 }
 
@@ -361,6 +378,9 @@ impl PartitionAdapterModules {
             self.core_export(dfg, memory);
         }
         if let Some(def) = &options.realloc {
+            self.core_def(dfg, def);
+        }
+        if let Some(def) = &options.callback {
             self.core_def(dfg, def);
         }
         if let Some(def) = &options.post_return {

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -89,6 +89,36 @@ indices! {
     pub struct TypeResultIndex(u32);
     /// Index pointing to a list type in the component model.
     pub struct TypeListIndex(u32);
+    /// Index pointing to a future type in the component model.
+    pub struct TypeFutureIndex(u32);
+    /// Index pointing to a future table within a component.
+    ///
+    /// This is analogous to `TypeResourceTableIndex` in that it tracks
+    /// ownership of futures within each (sub)component instance.
+    pub struct TypeFutureTableIndex(u32);
+    /// Index pointing to a stream type in the component model.
+    pub struct TypeStreamIndex(u32);
+    /// Index pointing to a stream table within a component.
+    ///
+    /// This is analogous to `TypeResourceTableIndex` in that it tracks
+    /// ownership of stream within each (sub)component instance.
+    pub struct TypeStreamTableIndex(u32);
+
+    /// Index pointing to a error context table within a component.
+    ///
+    /// This is analogous to `TypeResourceTableIndex` in that it tracks
+    /// ownership of error contexts within each (sub)component instance.
+    pub struct TypeComponentLocalErrorContextTableIndex(u32);
+
+    /// Index pointing to a (component) globally tracked error context table entry
+    ///
+    /// Unlike [`TypeComponentLocalErrorContextTableIndex`], this index refers to
+    /// the global state table for error contexts at the level of the entire component,
+    /// not just a subcomponent.
+    pub struct TypeComponentGlobalErrorContextTableIndex(u32);
+
+    /// Index pointing to an interned `task.return` type within a component.
+    pub struct TypeTaskReturnIndex(u32);
 
     /// Index pointing to a resource table within a component.
     ///
@@ -186,6 +216,9 @@ indices! {
     /// Same as `RuntimeMemoryIndex` except for the `realloc` function.
     pub struct RuntimeReallocIndex(u32);
 
+    /// Same as `RuntimeMemoryIndex` except for the `callback` function.
+    pub struct RuntimeCallbackIndex(u32);
+
     /// Same as `RuntimeMemoryIndex` except for the `post-return` function.
     pub struct RuntimePostReturnIndex(u32);
 
@@ -194,7 +227,7 @@ indices! {
     ///
     /// This is used to point to various bits of metadata within a compiled
     /// component and is stored in the final compilation artifact. This does not
-    /// have a direct corresponance to any wasm definition.
+    /// have a direct correspondence to any wasm definition.
     pub struct TrampolineIndex(u32);
 
     /// An index into `Component::export_items` at the end of compilation.
@@ -237,8 +270,14 @@ pub struct ComponentTypes {
     pub(super) options: PrimaryMap<TypeOptionIndex, TypeOption>,
     pub(super) results: PrimaryMap<TypeResultIndex, TypeResult>,
     pub(super) resource_tables: PrimaryMap<TypeResourceTableIndex, TypeResourceTable>,
-
     pub(super) module_types: Option<ModuleTypes>,
+    pub(super) futures: PrimaryMap<TypeFutureIndex, TypeFuture>,
+    pub(super) future_tables: PrimaryMap<TypeFutureTableIndex, TypeFutureTable>,
+    pub(super) streams: PrimaryMap<TypeStreamIndex, TypeStream>,
+    pub(super) stream_tables: PrimaryMap<TypeStreamTableIndex, TypeStreamTable>,
+    pub(super) error_context_tables:
+        PrimaryMap<TypeComponentLocalErrorContextTableIndex, TypeErrorContextTable>,
+    pub(super) task_returns: PrimaryMap<TypeTaskReturnIndex, TypeTaskReturn>,
 }
 
 impl ComponentTypes {
@@ -261,7 +300,10 @@ impl ComponentTypes {
             | InterfaceType::Float32
             | InterfaceType::Char
             | InterfaceType::Own(_)
-            | InterfaceType::Borrow(_) => &CanonicalAbiInfo::SCALAR4,
+            | InterfaceType::Borrow(_)
+            | InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => &CanonicalAbiInfo::SCALAR4,
 
             InterfaceType::U64 | InterfaceType::S64 | InterfaceType::Float64 => {
                 &CanonicalAbiInfo::SCALAR8
@@ -320,6 +362,11 @@ impl_index! {
     impl Index<TypeResultIndex> for ComponentTypes { TypeResult => results }
     impl Index<TypeListIndex> for ComponentTypes { TypeList => lists }
     impl Index<TypeResourceTableIndex> for ComponentTypes { TypeResourceTable => resource_tables }
+    impl Index<TypeFutureIndex> for ComponentTypes { TypeFuture => futures }
+    impl Index<TypeStreamIndex> for ComponentTypes { TypeStream => streams }
+    impl Index<TypeFutureTableIndex> for ComponentTypes { TypeFutureTable => future_tables }
+    impl Index<TypeStreamTableIndex> for ComponentTypes { TypeStreamTable => stream_tables }
+    impl Index<TypeComponentLocalErrorContextTableIndex> for ComponentTypes { TypeErrorContextTable => error_context_tables }
 }
 
 // Additionally forward anything that can index `ModuleTypes` to `ModuleTypes`
@@ -430,6 +477,20 @@ pub struct TypeFunc {
     pub params: TypeTupleIndex,
     /// Results of the function represented as a tuple.
     pub results: TypeTupleIndex,
+    /// Expected core func type for memory32 `task.return` calls for this function.
+    pub task_return_type32: TypeTaskReturnIndex,
+    /// Expected core func type for memory64 `task.return` calls for this function.
+    pub task_return_type64: TypeTaskReturnIndex,
+}
+
+/// A core type representing the expected `task.return` signature for a
+/// component function.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeTaskReturn {
+    /// Core type parameters for the signature.
+    ///
+    /// Note that `task.return` never returns results.
+    pub params: Vec<FlatType>,
 }
 
 /// All possible interface types that values can have.
@@ -464,6 +525,9 @@ pub enum InterfaceType {
     Result(TypeResultIndex),
     Own(TypeResourceTableIndex),
     Borrow(TypeResourceTableIndex),
+    Future(TypeFutureTableIndex),
+    Stream(TypeStreamTableIndex),
+    ErrorContext(TypeComponentLocalErrorContextTableIndex),
 }
 
 impl From<&wasmparser::PrimitiveValType> for InterfaceType {
@@ -972,6 +1036,45 @@ pub struct TypeResult {
     pub info: VariantInfo,
 }
 
+/// Shape of a "future" interface type.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeFuture {
+    /// The `T` in `future<T>`
+    pub payload: Option<InterfaceType>,
+}
+
+/// Metadata about a future table added to a component.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeFutureTable {
+    /// The specific future type this table is used for.
+    pub ty: TypeFutureIndex,
+    /// The specific component instance this table is used for.
+    pub instance: RuntimeComponentInstanceIndex,
+}
+
+/// Shape of a "stream" interface type.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeStream {
+    /// The `T` in `stream<T>`
+    pub payload: Option<InterfaceType>,
+}
+
+/// Metadata about a stream table added to a component.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeStreamTable {
+    /// The specific stream type this table is used for.
+    pub ty: TypeStreamIndex,
+    /// The specific component instance this table is used for.
+    pub instance: RuntimeComponentInstanceIndex,
+}
+
+/// Metadata about a error context table added to a component.
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct TypeErrorContextTable {
+    /// The specific component instance this table is used for.
+    pub instance: RuntimeComponentInstanceIndex,
+}
+
 /// Metadata about a resource table added to a component.
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
 pub struct TypeResourceTable {
@@ -1049,7 +1152,7 @@ impl FlatTypes<'_> {
 // Note that this is intentionally duplicated here to keep the size to 1 byte
 // regardless to changes in the core wasm type system since this will only
 // ever use integers/floats for the foreseeable future.
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, Copy, Clone)]
 #[allow(missing_docs, reason = "self-describing variants")]
 pub enum FlatType {
     I32,

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -31,7 +31,7 @@ pub use resources::ResourcesBuilder;
 /// Some more information about this can be found in #4814
 const MAX_TYPE_DEPTH: u32 = 100;
 
-/// Structured used to build a [`ComponentTypes`] during translation.
+/// Structure used to build a [`ComponentTypes`] during translation.
 ///
 /// This contains tables to intern any component types found as well as
 /// managing building up core wasm [`ModuleTypes`] as well.
@@ -45,6 +45,12 @@ pub struct ComponentTypesBuilder {
     flags: HashMap<TypeFlags, TypeFlagsIndex>,
     options: HashMap<TypeOption, TypeOptionIndex>,
     results: HashMap<TypeResult, TypeResultIndex>,
+    futures: HashMap<TypeFuture, TypeFutureIndex>,
+    streams: HashMap<TypeStream, TypeStreamIndex>,
+    future_tables: HashMap<TypeFutureTable, TypeFutureTableIndex>,
+    stream_tables: HashMap<TypeStreamTable, TypeStreamTableIndex>,
+    error_context_tables: HashMap<TypeErrorContextTable, TypeComponentLocalErrorContextTableIndex>,
+    task_returns: HashMap<TypeTaskReturn, TypeTaskReturnIndex>,
 
     component_types: ComponentTypes,
     module_types: ModuleTypesBuilder,
@@ -70,15 +76,16 @@ where
 macro_rules! intern_and_fill_flat_types {
     ($me:ident, $name:ident, $val:ident) => {{
         if let Some(idx) = $me.$name.get(&$val) {
-            return *idx;
+            *idx
+        } else {
+            let idx = $me.component_types.$name.push($val.clone());
+            let mut info = TypeInformation::new();
+            info.$name($me, &$val);
+            let idx2 = $me.type_info.$name.push(info);
+            assert_eq!(idx, idx2);
+            $me.$name.insert($val, idx);
+            idx
         }
-        let idx = $me.component_types.$name.push($val.clone());
-        let mut info = TypeInformation::new();
-        info.$name($me, &$val);
-        let idx2 = $me.type_info.$name.push(info);
-        assert_eq!(idx, idx2);
-        $me.$name.insert($val, idx);
-        return idx;
     }};
 }
 
@@ -97,6 +104,12 @@ impl ComponentTypesBuilder {
             flags: HashMap::default(),
             options: HashMap::default(),
             results: HashMap::default(),
+            futures: HashMap::default(),
+            streams: HashMap::default(),
+            future_tables: HashMap::default(),
+            stream_tables: HashMap::default(),
+            error_context_tables: HashMap::default(),
+            task_returns: HashMap::default(),
             component_types: ComponentTypes::default(),
             type_info: TypeInformationCache::default(),
             resources: ResourcesBuilder::default(),
@@ -184,6 +197,24 @@ impl ComponentTypesBuilder {
         self.component_types.resource_tables.len()
     }
 
+    /// Returns the number of future tables allocated so far, or the maximum
+    /// `TypeFutureTableIndex`.
+    pub fn num_future_tables(&self) -> usize {
+        self.component_types.future_tables.len()
+    }
+
+    /// Returns the number of stream tables allocated so far, or the maximum
+    /// `TypeStreamTableIndex`.
+    pub fn num_stream_tables(&self) -> usize {
+        self.component_types.stream_tables.len()
+    }
+
+    /// Returns the number of error-context tables allocated so far, or the maximum
+    /// `TypeComponentLocalErrorContextTableIndex`.
+    pub fn num_error_context_tables(&self) -> usize {
+        self.component_types.error_context_tables.len()
+    }
+
     /// Returns a mutable reference to the underlying `ResourcesBuilder`.
     pub fn resources_mut(&mut self) -> &mut ResourcesBuilder {
         &mut self.resources
@@ -215,10 +246,24 @@ impl ComponentTypesBuilder {
             .iter()
             .map(|(_name, ty)| self.valtype(types, ty))
             .collect::<Result<_>>()?;
+        let params = self.new_tuple_type(params);
+        let results = self.new_tuple_type(results);
+        let (task_return_type32, task_return_type64) =
+            if let Some(types) = self.flat_types(&InterfaceType::Tuple(results)) {
+                (types.memory32.to_vec(), types.memory64.to_vec())
+            } else {
+                (vec![FlatType::I32], vec![FlatType::I64])
+            };
         let ty = TypeFunc {
             param_names,
-            params: self.new_tuple_type(params),
-            results: self.new_tuple_type(results),
+            params,
+            results,
+            task_return_type32: self.add_task_return_type(TypeTaskReturn {
+                params: task_return_type32,
+            }),
+            task_return_type64: self.add_task_return_type(TypeTaskReturn {
+                params: task_return_type64,
+            }),
         };
         Ok(self.add_func_type(ty))
     }
@@ -356,7 +401,8 @@ impl ComponentTypesBuilder {
         })
     }
 
-    fn defined_type(
+    /// Convert a wasmparser `ComponentDefinedTypeId` into Wasmtime's type representation.
+    pub fn defined_type(
         &mut self,
         types: TypesRef<'_>,
         id: ComponentDefinedTypeId,
@@ -380,9 +426,15 @@ impl ComponentTypesBuilder {
             ComponentDefinedType::Borrow(r) => {
                 InterfaceType::Borrow(self.resource_id(r.resource()))
             }
-            ComponentDefinedType::Future(_)
-            | ComponentDefinedType::Stream(_)
-            | ComponentDefinedType::ErrorContext => bail!("unsupported async type"),
+            ComponentDefinedType::Future(ty) => {
+                InterfaceType::Future(self.future_table_type(types, ty)?)
+            }
+            ComponentDefinedType::Stream(ty) => {
+                InterfaceType::Stream(self.stream_table_type(types, ty)?)
+            }
+            ComponentDefinedType::ErrorContext => {
+                InterfaceType::ErrorContext(self.error_context_table_type()?)
+            }
         };
         let info = self.type_information(&ret);
         if info.depth > MAX_TYPE_DEPTH {
@@ -516,6 +568,40 @@ impl ComponentTypesBuilder {
         Ok(self.add_result_type(TypeResult { ok, err, abi, info }))
     }
 
+    fn future_table_type(
+        &mut self,
+        types: TypesRef<'_>,
+        ty: &Option<ComponentValType>,
+    ) -> Result<TypeFutureTableIndex> {
+        let payload = ty.as_ref().map(|ty| self.valtype(types, ty)).transpose()?;
+        let ty = self.add_future_type(TypeFuture { payload });
+        Ok(self.add_future_table_type(TypeFutureTable {
+            ty,
+            instance: self.resources.get_current_instance().unwrap(),
+        }))
+    }
+
+    fn stream_table_type(
+        &mut self,
+        types: TypesRef<'_>,
+        ty: &Option<ComponentValType>,
+    ) -> Result<TypeStreamTableIndex> {
+        let payload = ty.as_ref().map(|ty| self.valtype(types, ty)).transpose()?;
+        let ty = self.add_stream_type(TypeStream { payload });
+        Ok(self.add_stream_table_type(TypeStreamTable {
+            ty,
+            instance: self.resources.get_current_instance().unwrap(),
+        }))
+    }
+
+    /// Retrieve Wasmtime's type representation of the `error-context` type from
+    /// the point of view of the current component instance.
+    pub fn error_context_table_type(&mut self) -> Result<TypeComponentLocalErrorContextTableIndex> {
+        Ok(self.add_error_context_table_type(TypeErrorContextTable {
+            instance: self.resources.get_current_instance().unwrap(),
+        }))
+    }
+
     fn list_type(&mut self, types: TypesRef<'_>, ty: &ComponentValType) -> Result<TypeListIndex> {
         assert_eq!(types.id(), self.module_types.validator_id());
         let element = self.valtype(types, ty)?;
@@ -568,9 +654,64 @@ impl ComponentTypesBuilder {
         intern_and_fill_flat_types!(self, results, ty)
     }
 
-    /// Interns a new type within this type information.
+    /// Interns a new list type within this type information.
     pub fn add_list_type(&mut self, ty: TypeList) -> TypeListIndex {
         intern_and_fill_flat_types!(self, lists, ty)
+    }
+
+    /// Interns a new future type within this type information.
+    pub fn add_future_type(&mut self, ty: TypeFuture) -> TypeFutureIndex {
+        intern(&mut self.futures, &mut self.component_types.futures, ty)
+    }
+
+    /// Interns a new future table type within this type information.
+    pub fn add_future_table_type(&mut self, ty: TypeFutureTable) -> TypeFutureTableIndex {
+        intern(
+            &mut self.future_tables,
+            &mut self.component_types.future_tables,
+            ty,
+        )
+    }
+
+    /// Interns a new stream type within this type information.
+    pub fn add_stream_type(&mut self, ty: TypeStream) -> TypeStreamIndex {
+        intern(&mut self.streams, &mut self.component_types.streams, ty)
+    }
+
+    /// Interns a new stream table type within this type information.
+    pub fn add_stream_table_type(&mut self, ty: TypeStreamTable) -> TypeStreamTableIndex {
+        intern(
+            &mut self.stream_tables,
+            &mut self.component_types.stream_tables,
+            ty,
+        )
+    }
+
+    /// Interns a new error context table type within this type information.
+    pub fn add_error_context_table_type(
+        &mut self,
+        ty: TypeErrorContextTable,
+    ) -> TypeComponentLocalErrorContextTableIndex {
+        intern(
+            &mut self.error_context_tables,
+            &mut self.component_types.error_context_tables,
+            ty,
+        )
+    }
+
+    /// Interns a new task return type within this type information.
+    pub fn add_task_return_type(&mut self, ty: TypeTaskReturn) -> TypeTaskReturnIndex {
+        intern(
+            &mut self.task_returns,
+            &mut self.component_types.task_returns,
+            ty,
+        )
+    }
+
+    /// Gets a previously interned task return type within this type
+    /// information, if any.
+    pub fn get_task_return_type(&self, ty: &TypeTaskReturn) -> Option<TypeTaskReturnIndex> {
+        self.task_returns.get(ty).copied()
     }
 
     /// Returns the canonical ABI information about the specified type.
@@ -603,7 +744,10 @@ impl ComponentTypesBuilder {
             | InterfaceType::U32
             | InterfaceType::S32
             | InterfaceType::Char
-            | InterfaceType::Own(_) => {
+            | InterfaceType::Own(_)
+            | InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => {
                 static INFO: TypeInformation = TypeInformation::primitive(FlatType::I32);
                 &INFO
             }

--- a/crates/environ/src/component/types_builder/resources.rs
+++ b/crates/environ/src/component/types_builder/resources.rs
@@ -231,4 +231,9 @@ impl ResourcesBuilder {
     pub fn set_current_instance(&mut self, instance: RuntimeComponentInstanceIndex) {
         self.current_instance = Some(instance);
     }
+
+    /// Retrieves the `current_instance` field.
+    pub fn get_current_instance(&self) -> Option<RuntimeComponentInstanceIndex> {
+        self.current_instance
+    }
 }

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -80,6 +80,19 @@ struct Compiler<'a, 'b> {
 }
 
 pub(super) fn compile(module: &mut Module<'_>, adapter: &AdapterData) {
+    match (adapter.lower.options.async_, adapter.lift.options.async_) {
+        (false, false) => {}
+        (true, true) => {
+            todo!()
+        }
+        (false, true) => {
+            todo!()
+        }
+        (true, false) => {
+            todo!()
+        }
+    }
+
     let lower_sig = module.types.signature(&adapter.lower, Context::Lower);
     let lift_sig = module.types.signature(&adapter.lift, Context::Lift);
     let ty = module
@@ -588,6 +601,12 @@ impl Compiler<'_, '_> {
 
             // TODO(#6696) - something nonzero, is 1 right?
             InterfaceType::Own(_) | InterfaceType::Borrow(_) => 1,
+
+            InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => {
+                todo!()
+            }
         };
 
         match self.fuel.checked_sub(cost) {
@@ -622,6 +641,11 @@ impl Compiler<'_, '_> {
                     InterfaceType::Result(t) => self.translate_result(*t, src, dst_ty, dst),
                     InterfaceType::Own(t) => self.translate_own(*t, src, dst_ty, dst),
                     InterfaceType::Borrow(t) => self.translate_borrow(*t, src, dst_ty, dst),
+                    InterfaceType::Future(_)
+                    | InterfaceType::Stream(_)
+                    | InterfaceType::ErrorContext(_) => {
+                        todo!()
+                    }
                 }
             }
 

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -88,6 +88,10 @@ pub enum Trap {
     /// would have violated the reentrance rules of the component model,
     /// triggering a trap instead.
     CannotEnterComponent,
+
+    /// Async-lifted export failed to produce a result by calling `task.return`
+    /// before returning `STATUS_DONE` and/or after all host tasks completed.
+    NoAsyncResult,
     // if adding a variant here be sure to update the `check!` macro below
 }
 
@@ -124,6 +128,7 @@ impl Trap {
             AllocationTooLarge
             CastFailure
             CannotEnterComponent
+            NoAsyncResult
         }
 
         None
@@ -154,6 +159,7 @@ impl fmt::Display for Trap {
             AllocationTooLarge => "allocation size too large",
             CastFailure => "cast failure",
             CannotEnterComponent => "cannot enter component instance",
+            NoAsyncResult => "async-lifted export failed to produce a result",
         };
         write!(f, "wasm trap: {desc}")
     }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -602,6 +602,7 @@ impl Component {
                 GlobalInitializer::LowerImport { .. }
                 | GlobalInitializer::ExtractMemory(_)
                 | GlobalInitializer::ExtractRealloc(_)
+                | GlobalInitializer::ExtractCallback(_)
                 | GlobalInitializer::ExtractPostReturn(_)
                 | GlobalInitializer::Resource(_) => {}
             }

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -2484,6 +2484,9 @@ pub fn desc(ty: &InterfaceType) -> &'static str {
         InterfaceType::Enum(_) => "enum",
         InterfaceType::Own(_) => "owned resource",
         InterfaceType::Borrow(_) => "borrowed resource",
+        InterfaceType::Future(_) => "future",
+        InterfaceType::Stream(_) => "stream",
+        InterfaceType::ErrorContext(_) => "error-context",
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -607,6 +607,11 @@ impl<'a> Instantiator<'a> {
                     self.extract_realloc(store.0, realloc)
                 }
 
+                GlobalInitializer::ExtractCallback(callback) => {
+                    _ = callback;
+                    todo!()
+                }
+
                 GlobalInitializer::ExtractPostReturn(post_return) => {
                     self.extract_post_return(store.0, post_return)
                 }

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -145,6 +145,9 @@ impl TypeChecker<'_> {
             (InterfaceType::String, _) => false,
             (InterfaceType::Char, InterfaceType::Char) => true,
             (InterfaceType::Char, _) => false,
+            (InterfaceType::Future(_), _)
+            | (InterfaceType::Stream(_), _)
+            | (InterfaceType::ErrorContext(_), _) => todo!(),
         }
     }
 
@@ -660,6 +663,9 @@ impl Type {
             InterfaceType::Flags(index) => Type::Flags(Flags::from(*index, instance)),
             InterfaceType::Own(index) => Type::Own(instance.resource_type(*index)),
             InterfaceType::Borrow(index) => Type::Borrow(instance.resource_type(*index)),
+            InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => todo!(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -198,6 +198,9 @@ impl Val {
 
                 Val::Flags(flags.into())
             }
+            InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => todo!(),
         })
     }
 
@@ -319,6 +322,9 @@ impl Val {
                 }
                 Val::Flags(flags.into())
             }
+            InterfaceType::Future(_)
+            | InterfaceType::Stream(_)
+            | InterfaceType::ErrorContext(_) => todo!(),
         })
     }
 
@@ -429,6 +435,9 @@ impl Val {
                 Ok(())
             }
             (InterfaceType::Flags(_), _) => unexpected(ty, self),
+            (InterfaceType::Future(_), _)
+            | (InterfaceType::Stream(_), _)
+            | (InterfaceType::ErrorContext(_), _) => todo!(),
         }
     }
 
@@ -564,6 +573,9 @@ impl Val {
                 Ok(())
             }
             (InterfaceType::Flags(_), _) => unexpected(ty, self),
+            (InterfaceType::Future(_), _)
+            | (InterfaceType::Stream(_), _)
+            | (InterfaceType::ErrorContext(_), _) => todo!(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -557,3 +557,33 @@ unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
 unsafe fn trap(_vmctx: *mut VMComponentContext, code: u8) -> Result<Infallible> {
     Err(wasmtime_environ::Trap::from_u8(code).unwrap().into())
 }
+
+unsafe fn future_transfer(
+    vmctx: *mut VMComponentContext,
+    src_idx: u32,
+    src_table: u32,
+    dst_table: u32,
+) -> Result<u32> {
+    _ = (vmctx, src_idx, src_table, dst_table);
+    todo!()
+}
+
+unsafe fn stream_transfer(
+    vmctx: *mut VMComponentContext,
+    src_idx: u32,
+    src_table: u32,
+    dst_table: u32,
+) -> Result<u32> {
+    _ = (vmctx, src_idx, src_table, dst_table);
+    todo!()
+}
+
+unsafe fn error_context_transfer(
+    vmctx: *mut VMComponentContext,
+    src_idx: u32,
+    src_table: u32,
+    dst_table: u32,
+) -> Result<u32> {
+    _ = (vmctx, src_idx, src_table, dst_table);
+    todo!()
+}

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -519,6 +519,7 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
                 LowerImport { .. }
                 | ExtractMemory(_)
                 | ExtractRealloc(_)
+                | ExtractCallback(_)
                 | ExtractPostReturn(_)
                 | Resource(_) => {}
             }


### PR DESCRIPTION
I've split this out of #9582 to make review easier.

This patch includes the plumbing needed to route
async/stream/future/error-context data from `wit-parser`, through the various layers of `wasmtime-environ`, and on to `wasmtime-cranelift` and `wasmtime`. The `wasmtime::runtime`, `wasmtime_environ::fact`, and `wasmtime_cranelift::compiler::component` modules only contain `todo!()` stubs to begin with; I'll flesh those out in later PRs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
