### PR TITLE
Fuzzing: Keep AVX flags enabled for Winch

### DIFF
--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -31,6 +31,15 @@ impl CodegenSettings {
             }
         }
     }
+
+    /// Returns the flags used for codegen.
+    pub(crate) fn flags(&self) -> &[(String, String)] {
+        if let Self::Target { flags, .. } = self {
+            flags
+        } else {
+            &[]
+        }
+    }
 }
 
 impl<'a> Arbitrary<'a> for CodegenSettings {

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -386,21 +386,6 @@ impl Config {
             }
         }
 
-        if self.wasmtime.compiler_strategy == CompilerStrategy::Winch
-            && self.module_config.config.simd_enabled
-        {
-            // Keep AVX and AVX2 matching host support. Otherwise SIMD fuzzing
-            // breaks because there is no support for SIMD without AVX and AVX2.
-            unsafe {
-                if std::is_x86_feature_detected!("avx") {
-                    cfg.cranelift_flag_enable("has_avx");
-                }
-                if std::is_x86_feature_detected!("avx2") {
-                    cfg.cranelift_flag_enable("has_avx2");
-                }
-            }
-        }
-
         return cfg;
     }
 
@@ -698,6 +683,17 @@ impl WasmtimeConfig {
         self.make_internally_consistent();
 
         Ok(())
+    }
+
+    /// Returns the codegen flag value, if any, for `name`.
+    pub(crate) fn codegen_flag(&self, name: &str) -> Option<&str> {
+        self.codegen.flags().iter().find_map(|(n, value)| {
+            if n == name {
+                Some(value.as_str())
+            } else {
+                None
+            }
+        })
     }
 
     /// Helper to switch `MemoryConfig::CustomUnaligned` to

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -386,7 +386,9 @@ impl Config {
             }
         }
 
-        if self.wasmtime.compiler_strategy == CompilerStrategy::Winch {
+        if self.wasmtime.compiler_strategy == CompilerStrategy::Winch
+            && self.module_config.config.simd_enabled
+        {
             // Keep AVX and AVX2 matching host support. Otherwise SIMD fuzzing
             // breaks because there is no support for SIMD without AVX and AVX2.
             unsafe {

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -386,6 +386,19 @@ impl Config {
             }
         }
 
+        if self.wasmtime.compiler_strategy == CompilerStrategy::Winch {
+            // Keep AVX and AVX2 matching host support. Otherwise SIMD fuzzing
+            // breaks because there is no support for SIMD without AVX and AVX2.
+            unsafe {
+                if std::is_x86_feature_detected!("avx") {
+                    cfg.cranelift_flag_enable("has_avx");
+                }
+                if std::is_x86_feature_detected!("avx2") {
+                    cfg.cranelift_flag_enable("has_avx2");
+                }
+            }
+        }
+
         return cfg;
     }
 

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -685,6 +685,9 @@ pub fn wast_test(mut fuzz_config: generators::Config, test: generators::WastTest
                 .codegen_flag("has_avx2")
                 .is_some_and(|value| value == "false"))
     {
+        log::warn!(
+            "Skipping Wast test because Winch doesn't support SIMD tests with AVX or AVX2 disabled"
+        );
         return;
     }
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Winch relies on AVX and AVX2 CPU features for implementing SIMD instructions on x64. The fuzzer sometimes disables these flags in Cranelift but the SIMD Wast tests are marked as supported if the Rust standard library says the current CPU has AVX and AVX2 support. So when the fuzzer disables these flags, the test is still marked as supported and then fails with an error saying AVX or AVX2 is required when the test is executed.