### PR TITLE
winch: Tighten the definition of `ExtendKind`

### DIFF
--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -35,8 +35,6 @@ pub(crate) enum CodeGenError {
     /// implies a compiler bug.
     #[error("Winch internal error: {0}")]
     Internal(InternalError),
-    #[error("Unsupported extend kind")]
-    UnsupportedExtendKind,
 }
 
 /// An internal error.
@@ -189,9 +187,5 @@ impl CodeGenError {
 
     pub(crate) const fn unimplemented_masm_instruction() -> Self {
         Self::UnimplementedMasmInstruction
-    }
-
-    pub(crate) const fn unsupported_extend_kind() -> Self {
-        Self::UnsupportedExtendKind
     }
 }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     codegen::BlockSig,
     isa::reg::{writable, Reg},
     masm::{
-        ExtendKind, Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm,
-        RmwOp, SPOffset, ShiftKind, TrapCode, UNTRUSTED_FLAGS,
+        Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm, RmwOp, SPOffset,
+        ShiftKind, TrapCode, UnsignedExtend, UNTRUSTED_FLAGS,
     },
     stack::TypedReg,
 };
@@ -1373,14 +1373,8 @@ where
         arg: &MemArg,
         op: RmwOp,
         size: OperandSize,
-        extend: Option<ExtendKind>,
+        extend: Option<UnsignedExtend>,
     ) -> Result<()> {
-        // Only unsigned extends are supported for atomic operations.
-        match extend {
-            Some(kind) if kind.signed() => bail!(CodeGenError::unsupported_extend_kind()),
-            _ => (),
-        }
-
         let operand = self.context.pop_to_reg(self.masm, None).unwrap();
         if let Some(addr) = self.emit_compute_heap_address_align_checked(arg, size)? {
             let src = self.masm.address_at_reg(addr, 0)?;

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -2,7 +2,8 @@
 use super::{address::Address, regs};
 use crate::aarch64::regs::zero;
 use crate::masm::{
-    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind, TruncKind,
+    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind, SignedExtend,
+    TruncKind,
 };
 use crate::CallingConvention;
 use crate::{
@@ -440,8 +441,16 @@ impl Assembler {
         // we therefore sign-extend the operand.
         // see: https://github.com/bytecodealliance/wasmtime/issues/9766
         let size = if size == OperandSize::S32 && kind == DivKind::Signed {
-            self.extend(divisor, writable!(divisor), ExtendKind::I64Extend32S);
-            self.extend(dividend, writable!(dividend), ExtendKind::I64Extend32S);
+            self.extend(
+                divisor,
+                writable!(divisor),
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            );
+            self.extend(
+                dividend,
+                writable!(dividend),
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            );
             OperandSize::S64
         } else {
             size
@@ -471,8 +480,16 @@ impl Assembler {
         // we therefore sign-extend the operand.
         // see: https://github.com/bytecodealliance/wasmtime/issues/9766
         let size = if size == OperandSize::S32 && kind.is_signed() {
-            self.extend(divisor, writable!(divisor), ExtendKind::I64Extend32S);
-            self.extend(dividend, writable!(dividend), ExtendKind::I64Extend32S);
+            self.extend(
+                divisor,
+                writable!(divisor),
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            );
+            self.extend(
+                dividend,
+                writable!(dividend),
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            );
             OperandSize::S64
         } else {
             size

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -15,6 +15,7 @@ use crate::{
         CalleeKind, DivKind, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I, IntCmpKind,
         LoadKind, MacroAssembler as Masm, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind,
         RmwOp, RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot, TrapCode, TruncKind,
+        UnsignedExtend,
     },
     stack::TypedReg,
 };
@@ -909,7 +910,7 @@ impl Masm for MacroAssembler {
         _size: OperandSize,
         _op: RmwOp,
         _flags: MemFlags,
-        _extend: Option<ExtendKind>,
+        _extend: Option<UnsignedExtend>,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -4,7 +4,7 @@ use crate::{
     isa::{reg::Reg, CallingConvention},
     masm::{
         DivKind, ExtendKind, IntCmpKind, MulWideKind, OperandSize, RemKind, RoundingMode,
-        ShiftKind, VectorExtendKind,
+        ShiftKind, SignedExtend, UnsignedExtend, VectorExtendKind,
     },
     reg::writable,
     x64::regs::scratch,
@@ -147,11 +147,20 @@ impl From<ShiftKind> for CraneliftShiftKind {
 impl From<ExtendKind> for ExtMode {
     fn from(value: ExtendKind) -> Self {
         match value {
-            ExtendKind::I64Extend32U | ExtendKind::I64Extend32S => ExtMode::LQ,
-            ExtendKind::I32Extend8S | ExtendKind::I32Extend8U => ExtMode::BL,
-            ExtendKind::I32Extend16S | ExtendKind::I32Extend16U => ExtMode::WL,
-            ExtendKind::I64Extend8S | ExtendKind::I64Extend8U => ExtMode::BQ,
-            ExtendKind::I64Extend16S | ExtendKind::I64Extend16U => ExtMode::WQ,
+            ExtendKind::Signed(s) => match s {
+                SignedExtend::I32Extend8S => ExtMode::BL,
+                SignedExtend::I32Extend16S => ExtMode::WL,
+                SignedExtend::I64Extend8S => ExtMode::BQ,
+                SignedExtend::I64Extend16S => ExtMode::WQ,
+                SignedExtend::I64Extend32S => ExtMode::LQ,
+            },
+            ExtendKind::Unsigned(u) => match u {
+                UnsignedExtend::I32Extend8U => ExtMode::BL,
+                UnsignedExtend::I32Extend16U => ExtMode::WL,
+                UnsignedExtend::I64Extend8U => ExtMode::BQ,
+                UnsignedExtend::I64Extend16U => ExtMode::WQ,
+                UnsignedExtend::I64Extend32U => ExtMode::LQ,
+            },
         }
     }
 }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1436,8 +1436,7 @@ impl Masm for MacroAssembler {
         if let Some(extend) = extend {
             // We don't need to zero-extend from 32 to 64bits.
             if !(extend.from_bits() == 32 && extend.to_bits() == 64) {
-                self.asm
-                    .movzx_rr(operand.to_reg(), operand, ExtendKind::Unsigned(extend));
+                self.asm.movzx_rr(operand.to_reg(), operand, extend.into());
             }
         }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -9,7 +9,8 @@ use anyhow::{anyhow, bail, Result};
 use crate::masm::{
     DivKind, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I, IntCmpKind, LoadKind,
     MacroAssembler as Masm, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp,
-    RoundingMode, ShiftKind, SplatKind, TrapCode, TruncKind, TRUSTED_FLAGS, UNTRUSTED_FLAGS,
+    RoundingMode, ShiftKind, SplatKind, TrapCode, TruncKind, UnsignedExtend, TRUSTED_FLAGS,
+    UNTRUSTED_FLAGS,
 };
 use crate::{
     abi::{self, align_to, calculate_frame_adjustment, LocalSlot},
@@ -1122,7 +1123,11 @@ impl Masm for MacroAssembler {
     ) -> Result<()> {
         // Need to convert unsigned uint32 to uint64 for conversion instruction sequence.
         if let OperandSize::S32 = src_size {
-            self.extend(writable!(src), src, ExtendKind::I64Extend32U)?;
+            self.extend(
+                writable!(src),
+                src,
+                ExtendKind::Unsigned(UnsignedExtend::I64Extend32U),
+            )?;
         }
 
         self.asm
@@ -1398,7 +1403,7 @@ impl Masm for MacroAssembler {
         size: OperandSize,
         op: RmwOp,
         flags: MemFlags,
-        extend: Option<ExtendKind>,
+        extend: Option<UnsignedExtend>,
     ) -> Result<()> {
         match op {
             RmwOp::Add => {
@@ -1431,7 +1436,8 @@ impl Masm for MacroAssembler {
         if let Some(extend) = extend {
             // We don't need to zero-extend from 32 to 64bits.
             if !(extend.from_bits() == 32 && extend.to_bits() == 64) {
-                self.asm.movzx_rr(operand.to_reg(), operand, extend);
+                self.asm
+                    .movzx_rr(operand.to_reg(), operand, ExtendKind::Unsigned(extend));
             }
         }
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -217,6 +217,12 @@ pub(crate) enum UnsignedExtend {
     I64Extend32U,
 }
 
+impl From<UnsignedExtend> for ExtendKind {
+    fn from(value: UnsignedExtend) -> Self {
+        ExtendKind::Unsigned(value)
+    }
+}
+
 impl UnsignedExtend {
     pub fn from_bits(&self) -> u8 {
         match self {
@@ -246,6 +252,12 @@ pub(crate) enum SignedExtend {
     I64Extend16S,
     /// 32 to 64 bit signed extend.
     I64Extend32S,
+}
+
+impl From<SignedExtend> for ExtendKind {
+    fn from(value: SignedExtend) -> Self {
+        ExtendKind::Signed(value)
+    }
 }
 
 impl SignedExtend {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1250,77 +1250,49 @@ where
 
     fn visit_i64_extend_i32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I64Extend32S.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend_i32_u(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Unsigned(UnsignedExtend::I64Extend32U),
-            )?;
+            masm.extend(writable!(reg), reg, UnsignedExtend::I64Extend32U.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i32_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I32Extend8S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I32Extend8S.into())?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i32_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I32Extend16S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I32Extend16S.into())?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i64_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I64Extend8S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I64Extend8S.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I64Extend16S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I64Extend16S.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(
-                writable!(reg),
-                reg,
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
-            )?;
+            masm.extend(writable!(reg), reg, SignedExtend::I64Extend32S.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
@@ -2020,7 +1992,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I32Extend8S)),
+            LoadKind::ScalarExtend(SignedExtend::I32Extend8S.into()),
             MemOpKind::Normal,
         )
     }
@@ -2029,7 +2001,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend8U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I32Extend8U.into()),
             MemOpKind::Normal,
         )
     }
@@ -2038,7 +2010,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I32Extend16S)),
+            LoadKind::ScalarExtend(SignedExtend::I32Extend16S.into()),
             MemOpKind::Normal,
         )
     }
@@ -2047,7 +2019,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend16U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I32Extend16U.into()),
             MemOpKind::Normal,
         )
     }
@@ -2068,7 +2040,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend8S)),
+            LoadKind::ScalarExtend(SignedExtend::I64Extend8S.into()),
             MemOpKind::Normal,
         )
     }
@@ -2077,7 +2049,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend8U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend8U.into()),
             MemOpKind::Normal,
         )
     }
@@ -2086,7 +2058,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend16U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend16U.into()),
             MemOpKind::Normal,
         )
     }
@@ -2095,7 +2067,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend16S)),
+            LoadKind::ScalarExtend(SignedExtend::I64Extend16S.into()),
             MemOpKind::Normal,
         )
     }
@@ -2104,7 +2076,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend32U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend32U.into()),
             MemOpKind::Normal,
         )
     }
@@ -2113,7 +2085,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend32S)),
+            LoadKind::ScalarExtend(SignedExtend::I64Extend32S.into()),
             MemOpKind::Normal,
         )
     }
@@ -2275,7 +2247,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend8U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I32Extend8U.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2284,7 +2256,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend16U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I32Extend16U.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2302,7 +2274,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend8U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend8U.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2311,7 +2283,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend16U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend16U.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2320,7 +2292,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend32U)),
+            LoadKind::ScalarExtend(UnsignedExtend::I64Extend32U.into()),
             MemOpKind::Atomic,
         )
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -9,10 +9,9 @@ use crate::codegen::{
     control_index, Callee, CodeGen, CodeGenError, ControlStackFrame, Emission, FnCall,
 };
 use crate::masm::{
-    DivKind, ExtendKind, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
-    MemMoveDirection, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode,
-    SPOffset, ShiftKind, SignedExtend, SplatKind, SplatLoadKind, TruncKind, UnsignedExtend,
-    VectorExtendKind,
+    DivKind, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler, MemMoveDirection,
+    MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
+    SignedExtend, SplatKind, SplatLoadKind, TruncKind, UnsignedExtend, VectorExtendKind,
 };
 
 use crate::reg::{writable, Reg};

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -11,7 +11,8 @@ use crate::codegen::{
 use crate::masm::{
     DivKind, ExtendKind, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
     MemMoveDirection, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode,
-    SPOffset, ShiftKind, SplatKind, SplatLoadKind, TruncKind, VectorExtendKind,
+    SPOffset, ShiftKind, SignedExtend, SplatKind, SplatLoadKind, TruncKind, UnsignedExtend,
+    VectorExtendKind,
 };
 
 use crate::reg::{writable, Reg};
@@ -1249,49 +1250,77 @@ where
 
     fn visit_i64_extend_i32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            )?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend_i32_u(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32U)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Unsigned(UnsignedExtend::I64Extend32U),
+            )?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i32_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I32Extend8S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I32Extend8S),
+            )?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i32_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I32Extend16S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I32Extend16S),
+            )?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i64_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend8S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I64Extend8S),
+            )?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend16S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I64Extend16S),
+            )?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, ExtendKind::I64Extend32S)?;
+            masm.extend(
+                writable!(reg),
+                reg,
+                ExtendKind::Signed(SignedExtend::I64Extend32S),
+            )?;
             Ok(TypedReg::i64(reg))
         })
     }
@@ -1991,7 +2020,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend8S),
+            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I32Extend8S)),
             MemOpKind::Normal,
         )
     }
@@ -2000,7 +2029,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend8U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend8U)),
             MemOpKind::Normal,
         )
     }
@@ -2009,7 +2038,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend16S),
+            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I32Extend16S)),
             MemOpKind::Normal,
         )
     }
@@ -2018,7 +2047,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend16U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend16U)),
             MemOpKind::Normal,
         )
     }
@@ -2039,7 +2068,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend8S),
+            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend8S)),
             MemOpKind::Normal,
         )
     }
@@ -2048,7 +2077,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend8U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend8U)),
             MemOpKind::Normal,
         )
     }
@@ -2057,7 +2086,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend16U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend16U)),
             MemOpKind::Normal,
         )
     }
@@ -2066,7 +2095,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend16S),
+            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend16S)),
             MemOpKind::Normal,
         )
     }
@@ -2075,7 +2104,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend32U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend32U)),
             MemOpKind::Normal,
         )
     }
@@ -2084,7 +2113,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend32S),
+            LoadKind::ScalarExtend(ExtendKind::Signed(SignedExtend::I64Extend32S)),
             MemOpKind::Normal,
         )
     }
@@ -2246,7 +2275,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend8U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend8U)),
             MemOpKind::Atomic,
         )
     }
@@ -2255,7 +2284,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(ExtendKind::I32Extend16U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I32Extend16U)),
             MemOpKind::Atomic,
         )
     }
@@ -2273,7 +2302,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend8U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend8U)),
             MemOpKind::Atomic,
         )
     }
@@ -2282,7 +2311,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend16U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend16U)),
             MemOpKind::Atomic,
         )
     }
@@ -2291,7 +2320,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(ExtendKind::I64Extend32U),
+            LoadKind::ScalarExtend(ExtendKind::Unsigned(UnsignedExtend::I64Extend32U)),
             MemOpKind::Atomic,
         )
     }
@@ -2338,7 +2367,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
 
@@ -2347,7 +2376,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2360,7 +2389,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2369,7 +2398,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2378,7 +2407,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 
@@ -2391,7 +2420,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
     fn visit_i32_atomic_rmw16_sub_u(&mut self, arg: MemArg) -> Self::Output {
@@ -2399,7 +2428,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2412,7 +2441,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2421,7 +2450,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2430,7 +2459,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 
@@ -2443,7 +2472,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
 
@@ -2452,7 +2481,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2465,7 +2494,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2474,7 +2503,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2483,7 +2512,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 
@@ -2496,7 +2525,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
 
@@ -2505,7 +2534,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2518,7 +2547,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2527,7 +2556,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2536,7 +2565,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 
@@ -2549,7 +2578,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
 
@@ -2558,7 +2587,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2571,7 +2600,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2580,7 +2609,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2589,7 +2618,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 
@@ -2602,7 +2631,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S8,
-            Some(ExtendKind::I32Extend8U),
+            Some(UnsignedExtend::I32Extend8U),
         )
     }
 
@@ -2611,7 +2640,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S16,
-            Some(ExtendKind::I32Extend16U),
+            Some(UnsignedExtend::I32Extend16U),
         )
     }
 
@@ -2624,7 +2653,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S8,
-            Some(ExtendKind::I64Extend8U),
+            Some(UnsignedExtend::I64Extend8U),
         )
     }
 
@@ -2633,7 +2662,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S16,
-            Some(ExtendKind::I64Extend16U),
+            Some(UnsignedExtend::I64Extend16U),
         )
     }
 
@@ -2642,7 +2671,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S32,
-            Some(ExtendKind::I64Extend32U),
+            Some(UnsignedExtend::I64Extend32U),
         )
     }
 


### PR DESCRIPTION
Some instructions, like the atomic ones, part of the threads proposal, we want to ensure through the type system that only supported extend kinds are passed, that way the emission layer can ignore the extend kind validation at runtime.

This commit divides the existing `ExtendKind` enum into the signed and unsigned variants, making the definition more amenable to atomic operations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
