### PR TITLE
wasmtime-cli: support `run --invoke` for components using wave

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,6 +514,7 @@ compile = ["cranelift"]
 run = [
   "dep:wasmtime-wasi",
   "wasmtime/runtime",
+  "wasmtime/wave",
   "dep:listenfd",
   "dep:wasi-common",
   "dep:tokio",

--- a/crates/wasmtime/src/runtime/wave/core.rs
+++ b/crates/wasmtime/src/runtime/wave/core.rs
@@ -97,7 +97,7 @@ impl WasmValue for crate::Val {
         let val = f64::from_bits(*unwrap_val!(self, Self::F64, "f64"));
         canonicalize_nan64(val)
     }
-
+    #[allow(clippy::cast_possible_truncation)]
     fn unwrap_tuple(&self) -> Box<dyn Iterator<Item = Cow<Self>> + '_> {
         let v = unwrap_val!(self, Self::V128, "tuple").as_u128();
         let low = v as i64;

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -48,25 +48,30 @@ The `run` command accepts an optional `--invoke` argument, which is the name of
 an exported function of the module to run.
 
 ```sh
-$ wasmtime run --invoke "initialize()" foo.wasm
+$ wasmtime run --invoke 'initialize()' foo.wasm
 ```
 
-The exported function's name and exported function's parentheses must both be enclosed in one set of double quotes, i.e. `"initialize()"`. 
+The exported function's name and exported function's parentheses must both be enclosed in one set of single quotes, i.e. `'initialize()'`. 
 This treats the exported function as a single argument and prevents issues with shell interpretation.
 The presence of the parenthesis `()` signifies function invocation, as apposed to the function name just being referenced.
 This convention helps to distinguish function calls from other kinds of string arguments.
 
-**Note:** If your function takes a string argument, ensure that you use escaped double quotes inside the parentheses. For example:
+**Note:** If your function takes a string argument, ensure that you surround the string argument in double quotes. For example:
 
 ```sh
-$ wasmtime run --invoke "initialize(\"hello\")" foo.wasm
+$ wasmtime run --invoke 'initialize("hello")' foo.wasm
 ```
 
 Each individual argument within the parentheses must be separated by a comma:
 
 ```sh
-$ wasmtime run --invoke "initialize(\"Pi\", 3.14)" foo.wasm
-$ wasmtime run --invoke "add(1, 2)" foo.wasm
+$ wasmtime run --invoke 'initialize("Pi", 3.14)' foo.wasm
+$ wasmtime run --invoke 'add(1, 2)' foo.wasm
+```
+
+**Please note:** If you enclose your whole function call using double quotes, your string argument will require its double quotes to be escaped (escaping quotes is more complicated and harder to read and therefore not ideal). For example:
+```bash
+wasmtime run - invoke "initialize(\"hello\")" foo.wasm
 ```
 
 ## `serve`

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -27,11 +27,10 @@ module. This means that the module will be compiled to native code,
 instantiated, and then optionally have an export executed.
 
 The `wasmtime` CLI will automatically hook up any WASI-related imported
-functionality, but at this time if your module imports anything else it will
+functionality, but at this time, if your module imports anything else, it will
 fail instantiation.
 
-The `run` command takes one positional argument which is the name of the module
-to run:
+The `run` command takes one positional argument, which is the name of the module to run:
 
 ```sh
 $ wasmtime run foo.wasm
@@ -45,11 +44,29 @@ as well as the text format for WebAssembly (`*.wat`):
 $ wasmtime foo.wat
 ```
 
-The `run` command accepts an optional `invoke` argument which is the name of
+The `run` command accepts an optional `--invoke` argument, which is the name of
 an exported function of the module to run.
 
 ```sh
-$ wasmtime run foo.wasm --invoke initialize
+$ wasmtime run --invoke "initialize()" foo.wasm
+```
+
+The exported function's name and exported function's parentheses must both be enclosed in one set of double quotes, i.e. `"initialize()"`. 
+This treats the exported function as a single argument and prevents issues with shell interpretation.
+The presence of the parenthesis `()` signifies function invocation, as apposed to the function name just being referenced.
+This convention helps to distinguish function calls from other kinds of string arguments.
+
+**Note:** If your function takes a string argument, ensure that you use escaped double quotes inside the parentheses. For example:
+
+```sh
+$ wasmtime run --invoke "initialize(\"hello\")" foo.wasm
+```
+
+Each individual argument within the parentheses must be separated by a comma:
+
+```sh
+$ wasmtime run --invoke "initialize(\"Pi\", 3.14)" foo.wasm
+$ wasmtime run --invoke "add(1, 2)" foo.wasm
 ```
 
 ## `serve`

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -44,25 +44,31 @@ as well as the text format for WebAssembly (`*.wat`):
 $ wasmtime foo.wat
 ```
 
-The `run` command accepts an optional `--invoke` argument, which is the name of
-an exported function of the module to run.
+**Wasm Modules**
+
+A Wasm **module** exports raw functions directly. The `run` command accepts an optional `--invoke` argument, which is the name of an exported raw function (of the module) to run:
+
+```sh
+$ wasmtime run --invoke initialize foo.wasm
+```
+
+**Wasm Components**
+
+A Wasm **component** uses typed interfaces defined by [the component model](https://component-model.bytecodealliance.org/design/components.html). The `run` command also accepts the optional `--invoke` argument for calling an exported function of a **component**. However, the calling of an exported function of a component uses [WAVE](https://github.com/bytecodealliance/wasm-tools/tree/a56e8d3d2a0b754e0465c668f8e4b68bad97590f/crates/wasm-wave#readme)(a human-oriented text encoding of Wasm Component Model values). For example:
 
 ```sh
 $ wasmtime run --invoke 'initialize()' foo.wasm
 ```
 
-The exported function's name and exported function's parentheses must both be enclosed in one set of single quotes, i.e. `'initialize()'`. 
-This treats the exported function as a single argument and prevents issues with shell interpretation.
-The presence of the parenthesis `()` signifies function invocation, as apposed to the function name just being referenced.
-This convention helps to distinguish function calls from other kinds of string arguments.
+You will notice that (when using WAVE) the exported function's name and exported function's parentheses are both enclosed in one set of single quotes, i.e. `'initialize()'`. This treats the exported function as a single argument, prevents issues with shell interpretation and signifies function invocation (as apposed to the function name just being referenced). Using WAVE (when calling exported functions of Wasm components) helps to distinguish function calls from other kinds of string arguments. Below are some more examples:
 
-**Note:** If your function takes a string argument, ensure that you surround the string argument in double quotes. For example:
+If your function takes a string argument, you surround the string argument in double quotes:
 
 ```sh
 $ wasmtime run --invoke 'initialize("hello")' foo.wasm
 ```
 
-Each individual argument within the parentheses must be separated by a comma:
+And each individual argument within the parentheses is separated by a comma:
 
 ```sh
 $ wasmtime run --invoke 'initialize("Pi", 3.14)' foo.wasm

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -494,10 +494,6 @@ impl RunCommand {
             }
             #[cfg(feature = "component-model")]
             CliLinker::Component(linker) => {
-                if self.invoke.is_some() {
-                    bail!("using `--invoke` with components is not supported");
-                }
-
                 let component = main_target.unwrap_component();
 
                 let command = wasmtime_wasi::bindings::Command::instantiate_async(
@@ -506,19 +502,26 @@ impl RunCommand {
                     linker,
                 )
                 .await?;
-                let result = command
-                    .wasi_cli_run()
-                    .call_run(&mut *store)
-                    .await
-                    .context("failed to invoke `run` function")
-                    .map_err(|e| self.handle_core_dump(&mut *store, e));
 
-                // Translate the `Result<(),()>` produced by wasm into a feigned
-                // explicit exit here with status 1 if `Err(())` is returned.
-                result.and_then(|wasm_result| match wasm_result {
-                    Ok(()) => Ok(()),
-                    Err(()) => Err(wasmtime_wasi::I32Exit(1).into()),
-                })
+                if let Some(invoke) = &self.invoke {
+                    let untyped_call =
+                        wasmtime::component::wasm_wave::untyped::UntypedFuncCall::parse(&invoke)?;
+                    todo!("lookup '{}' in component", untyped_call.name());
+                } else {
+                    let result = command
+                        .wasi_cli_run()
+                        .call_run(&mut *store)
+                        .await
+                        .context("failed to invoke `run` function")
+                        .map_err(|e| self.handle_core_dump(&mut *store, e));
+
+                    // Translate the `Result<(),()>` produced by wasm into a feigned
+                    // explicit exit here with status 1 if `Err(())` is returned.
+                    result.and_then(|wasm_result| match wasm_result {
+                        Ok(()) => Ok(()),
+                        Err(()) => Err(wasmtime_wasi::I32Exit(1).into()),
+                    })
+                }
             }
         };
         finish_epoch_handler(store);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -542,30 +542,20 @@ impl RunCommand {
             Val,
         };
 
+        // Check if the invoke string is present
         let invoke: &String = self.invoke.as_ref().unwrap();
-
-        // Check if input is wrapped in double quotes
-        let lacks_quotes = !invoke.starts_with('"') && !invoke.ends_with('"');
-
-        // Check if parentheses are present and in the correct order ()
-        let lacks_parentheses = (invoke.contains('(') && invoke.contains(')'))
-            && (invoke.find('(').unwrap() < invoke.find(')').unwrap());
-
-        // Construct a properly formatted suggestion
-        let empty_argument_suggestion = format!(r#""{}()""#, invoke.trim_matches('"'));
-
-        // Construct a properly formatted suggestion for string arguments
-        let string_argument_suggestion = format!(r#""{}(\"hello\")""#, invoke.trim_matches('"'));
+        // Create raw version of invoke for error messages
+        let raw_invoke = format!("{invoke:?}");
 
         let untyped_call = UntypedFuncCall::parse(invoke).with_context(|| {
-            if lacks_quotes || lacks_parentheses {
+                let trimmed_invoke = invoke.trim_matches(['"', '\'']);
+                // Construct examples of valid function calls for error messages
+                let empty_args = format!("'{trimmed_invoke}()'");
+                let single_string_arg = format!("'{trimmed_invoke}(\"hello\")'");
+                let multiple_args = format!("'{trimmed_invoke}(\"Pi\", 3.14)'");
                 format!(
-                    "Failed to parse invoke '{invoke}': function calls must be enveloped in double quotes and must include parentheses (e.g., {empty_argument_suggestion}).\n
-                    String arguments must be enveloped in escaped double quotes (e.g., {string_argument_suggestion}).\n"
+                    "Failed to parse invoke '{raw_invoke}': function calls must include parentheses and must be enveloped in single quotes. For example, {empty_args}. String arguments must use double quotes {single_string_arg}, and commas must separate multiple arguments. For example, {multiple_args}.",
                 )
-            } else {
-                format!("Failed to parse invoke '{invoke}': invalid function call syntax")
-            }
         })?;
 
         let name = untyped_call.name();

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -544,17 +544,10 @@ impl RunCommand {
 
         // Check if the invoke string is present
         let invoke: &String = self.invoke.as_ref().unwrap();
-        // Create raw version of invoke for error messages
-        let raw_invoke = format!("{invoke:?}");
 
         let untyped_call = UntypedFuncCall::parse(invoke).with_context(|| {
-                let trimmed_invoke = invoke.trim_matches(['"', '\'']);
-                // Construct examples of valid function calls for error messages
-                let empty_args = format!("'{trimmed_invoke}()'");
-                let single_string_arg = format!("'{trimmed_invoke}(\"hello\")'");
-                let multiple_args = format!("'{trimmed_invoke}(\"Pi\", 3.14)'");
                 format!(
-                    "Failed to parse invoke '{raw_invoke}': function calls must include parentheses and must be enveloped in single quotes. For example, {empty_args}. String arguments must use double quotes {single_string_arg}, and commas must separate multiple arguments. For example, {multiple_args}.",
+                    "Failed to parse invoke '{invoke}': See https://docs.wasmtime.dev/cli-options.html#run for syntax",
                 )
         })?;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -494,46 +494,9 @@ impl RunCommand {
             }
             #[cfg(feature = "component-model")]
             CliLinker::Component(linker) => {
-                let component = main_target.unwrap_component();
-
-                if let Some(invoke) = &self.invoke {
-                    let untyped_call =
-                        wasmtime::component::wasm_wave::untyped::UntypedFuncCall::parse(&invoke)?;
-                    let name = untyped_call.name();
-                    let matches = component
-                        .exports_rec(None)
-                        .expect("at root")
-                        .filter(|(names, _, _)| {
-                            names.last().expect("always at least one name") == name
-                        })
-                        .collect::<Vec<_>>();
-                    match matches.len()  {
-                        0 => bail!("No export named `{name}` in component."),
-                        1 => {}
-                        _ => bail!("Multiple exports named `{name}`: {matches:?}. FIXME: support some way to disambiguate names"),
-                    };
-                    use wasmtime::component::types::ComponentItem;
-                    use wasmtime::component::wasm_wave::wasm::{DisplayFuncResults, WasmFunc};
-                    use wasmtime::component::Val;
-                    let (params, result_len, export) = match &matches[0] {
-                        (_names, ComponentItem::ComponentFunc(func), export) => {
-                            let param_types = WasmFunc::params(func).collect::<Vec<_>>();
-                            let params = untyped_call.to_wasm_params(&param_types)?;
-                            (params, func.results().len(), export)
-                        }
-                        (names, ty, _) => {
-                            bail!("Cannot invoke export {names:?}: expected ComponentFunc, got type {ty:?}");
-                        }
-                    };
-
-                    let instance = linker.instantiate_async(&mut *store, component).await?;
-                    let func = instance
-                        .get_func(&mut *store, export)
-                        .expect("found export index");
-                    let mut results = vec![Val::Bool(false); result_len];
-                    func.call_async(&mut *store, &params, &mut results).await?;
-                    println!("{}", DisplayFuncResults(&results));
-                    Ok(())
+                let component = main_module.unwrap_component();
+                if self.invoke.is_some() {
+                    self.invoke_component(&mut *store, component, linker).await
                 } else {
                     let command = wasmtime_wasi::bindings::Command::instantiate_async(
                         &mut *store,
@@ -561,6 +524,60 @@ impl RunCommand {
         finish_epoch_handler(store);
 
         result
+    }
+
+    #[cfg(feature = "component-model")]
+    async fn invoke_component(
+        &self,
+        store: &mut Store<Host>,
+        component: &wasmtime::component::Component,
+        linker: &mut wasmtime::component::Linker<Host>,
+    ) -> Result<()> {
+        use wasmtime::component::{
+            types::ComponentItem,
+            wasm_wave::{
+                untyped::UntypedFuncCall,
+                wasm::{DisplayFuncResults, WasmFunc},
+            },
+            Val,
+        };
+
+        let invoke = self.invoke.as_ref().unwrap();
+        let untyped_call = UntypedFuncCall::parse(invoke)?;
+        let name = untyped_call.name();
+        let matches = component
+            .exports_rec(None)
+            .expect("at root")
+            .filter(|(names, _, _)| names.last().expect("always at least one name") == name)
+            .collect::<Vec<_>>();
+        match matches.len()  {
+                        0 => bail!("No export named `{name}` in component."),
+                        1 => {}
+                        _ => bail!("Multiple exports named `{name}`: {matches:?}. FIXME: support some way to disambiguate names"),
+                    };
+        let (params, result_len, export) = match &matches[0] {
+            (_names, ComponentItem::ComponentFunc(func), export) => {
+                let param_types = WasmFunc::params(func).collect::<Vec<_>>();
+                let params = untyped_call.to_wasm_params(&param_types)?;
+                (params, func.results().len(), export)
+            }
+            (names, ty, _) => {
+                bail!("Cannot invoke export {names:?}: expected ComponentFunc, got type {ty:?}");
+            }
+        };
+
+        let instance = linker.instantiate_async(&mut *store, component).await?;
+
+        let func = instance
+            .get_func(&mut *store, export)
+            .expect("found export index");
+
+        let mut results = vec![Val::Bool(false); result_len];
+        func.call_async(&mut *store, &params, &mut results).await?;
+
+        println!("{}", DisplayFuncResults(&results));
+
+        Ok(())
     }
 
     async fn invoke_func(&self, store: &mut Store<Host>, func: Func) -> Result<()> {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -496,18 +496,52 @@ impl RunCommand {
             CliLinker::Component(linker) => {
                 let component = main_target.unwrap_component();
 
-                let command = wasmtime_wasi::bindings::Command::instantiate_async(
-                    &mut *store,
-                    component,
-                    linker,
-                )
-                .await?;
-
                 if let Some(invoke) = &self.invoke {
                     let untyped_call =
                         wasmtime::component::wasm_wave::untyped::UntypedFuncCall::parse(&invoke)?;
-                    todo!("lookup '{}' in component", untyped_call.name());
+                    let name = untyped_call.name();
+                    let matches = component
+                        .exports_rec(None)
+                        .expect("at root")
+                        .filter(|(names, _, _)| {
+                            names.last().expect("always at least one name") == name
+                        })
+                        .collect::<Vec<_>>();
+                    match matches.len()  {
+                        0 => bail!("No export named `{name}` in component."),
+                        1 => {}
+                        _ => bail!("Multiple exports named `{name}`: {matches:?}. FIXME: support some way to disambiguate names"),
+                    };
+                    use wasmtime::component::types::ComponentItem;
+                    use wasmtime::component::wasm_wave::wasm::{DisplayFuncResults, WasmFunc};
+                    use wasmtime::component::Val;
+                    let (params, result_len, export) = match &matches[0] {
+                        (_names, ComponentItem::ComponentFunc(func), export) => {
+                            let param_types = WasmFunc::params(func).collect::<Vec<_>>();
+                            let params = untyped_call.to_wasm_params(&param_types)?;
+                            (params, func.results().len(), export)
+                        }
+                        (names, ty, _) => {
+                            bail!("Cannot invoke export {names:?}: expected ComponentFunc, got type {ty:?}");
+                        }
+                    };
+
+                    let instance = linker.instantiate_async(&mut *store, component).await?;
+                    let func = instance
+                        .get_func(&mut *store, export)
+                        .expect("found export index");
+                    let mut results = vec![Val::Bool(false); result_len];
+                    func.call_async(&mut *store, &params, &mut results).await?;
+                    println!("{}", DisplayFuncResults(&results));
+                    Ok(())
                 } else {
+                    let command = wasmtime_wasi::bindings::Command::instantiate_async(
+                        &mut *store,
+                        component,
+                        linker,
+                    )
+                    .await?;
+
                     let result = command
                         .wasi_cli_run()
                         .call_run(&mut *store)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -543,7 +543,8 @@ impl RunCommand {
         };
 
         let invoke = self.invoke.as_ref().unwrap();
-        let untyped_call = UntypedFuncCall::parse(invoke)?;
+        let untyped_call = UntypedFuncCall::parse(invoke)
+            .with_context(|| format!("parsing invoke \"{invoke}\""))?;
         let name = untyped_call.name();
         let matches = component
             .exports_rec(None)
@@ -558,7 +559,9 @@ impl RunCommand {
         let (params, result_len, export) = match &matches[0] {
             (_names, ComponentItem::ComponentFunc(func), export) => {
                 let param_types = WasmFunc::params(func).collect::<Vec<_>>();
-                let params = untyped_call.to_wasm_params(&param_types)?;
+                let params = untyped_call.to_wasm_params(&param_types).with_context(|| {
+                    format!("while interpreting parameters in invoke \"{invoke}\"")
+                })?;
                 (params, func.results().len(), export)
             }
             (names, ty, _) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -494,7 +494,7 @@ impl RunCommand {
             }
             #[cfg(feature = "component-model")]
             CliLinker::Component(linker) => {
-                let component = main_module.unwrap_component();
+                let component = main_target.unwrap_component();
                 if self.invoke.is_some() {
                     self.invoke_component(&mut *store, component, linker).await
                 } else {
@@ -552,25 +552,32 @@ impl RunCommand {
         })?;
 
         let name = untyped_call.name();
-        let matches = component
-            .exports_rec(None)
-            .expect("at root")
-            .filter(|(names, _, _)| names.last().expect("always at least one name") == name)
-            .collect::<Vec<_>>();
+        let matches = Self::search_component(store.engine(), component.component_type(), name);
         match matches.len()  {
                         0 => bail!("No export named `{name}` in component."),
                         1 => {}
                         _ => bail!("Multiple exports named `{name}`: {matches:?}. FIXME: support some way to disambiguate names"),
                     };
         let (params, result_len, export) = match &matches[0] {
-            (_names, ComponentItem::ComponentFunc(func), export) => {
+            (names, ComponentItem::ComponentFunc(func)) => {
                 let param_types = WasmFunc::params(func).collect::<Vec<_>>();
                 let params = untyped_call.to_wasm_params(&param_types).with_context(|| {
                     format!("while interpreting parameters in invoke \"{invoke}\"")
                 })?;
-                (params, func.results().len(), export)
+                let mut export = None;
+                for name in names {
+                    let (_item, ix) = component
+                        .export_index(export.as_ref(), name)
+                        .expect("export exists");
+                    export = Some(ix);
+                }
+                (
+                    params,
+                    func.results().len(),
+                    export.expect("export has at least one name"),
+                )
             }
-            (names, ty, _) => {
+            (names, ty) => {
                 bail!("Cannot invoke export {names:?}: expected ComponentFunc, got type {ty:?}");
             }
         };
@@ -587,6 +594,45 @@ impl RunCommand {
         println!("{}", DisplayFuncResults(&results));
 
         Ok(())
+    }
+
+    #[cfg(feature = "component-model")]
+    fn search_component(
+        engine: &Engine,
+        component: wasmtime::component::types::Component,
+        name: &str,
+    ) -> Vec<(Vec<String>, wasmtime::component::types::ComponentItem)> {
+        use wasmtime::component::types::ComponentItem as CItem;
+        fn collect_exports(
+            engine: &Engine,
+            item: CItem,
+            basename: Vec<String>,
+        ) -> Vec<(Vec<String>, CItem)> {
+            match item {
+                CItem::Component(c) => c
+                    .exports(engine)
+                    .flat_map(move |(name, item)| {
+                        let mut names = basename.clone();
+                        names.push(name.to_string());
+                        collect_exports(engine, item, names)
+                    })
+                    .collect::<Vec<_>>(),
+                CItem::ComponentInstance(c) => c
+                    .exports(engine)
+                    .flat_map(move |(name, item)| {
+                        let mut names = basename.clone();
+                        names.push(name.to_string());
+                        collect_exports(engine, item, names)
+                    })
+                    .collect::<Vec<_>>(),
+                _ => vec![(basename, item)],
+            }
+        }
+
+        collect_exports(engine, CItem::Component(component), Vec::new())
+            .into_iter()
+            .filter(|(names, _item)| names.last().expect("at least one name") == name)
+            .collect()
     }
 
     async fn invoke_func(&self, store: &mut Store<Host>, func: Func) -> Result<()> {

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1119,14 +1119,7 @@ mod test_programs {
 
     #[test]
     fn cli_hello_stdout() -> Result<()> {
-        run_wasmtime(&[
-            "run",
-            "-Wcomponent-model",
-            CLI_HELLO_STDOUT_COMPONENT,
-            "gussie",
-            "sparky",
-            "willa",
-        ])?;
+        run_wasmtime(&["run", "-Wcomponent-model", CLI_HELLO_STDOUT_COMPONENT])?;
         Ok(())
     }
 
@@ -2119,6 +2112,23 @@ after empty
     #[tokio::test]
     async fn cli_serve_trap_before_set() -> Result<()> {
         cli_serve_guest_never_invoked_set(CLI_SERVE_TRAP_BEFORE_SET_COMPONENT).await
+    }
+
+    mod invoke {
+        use super::*;
+
+        #[test]
+        fn cli_hello_stdout() -> Result<()> {
+            println!("{CLI_HELLO_STDOUT_COMPONENT}");
+            run_wasmtime(&[
+                "run",
+                "-Wcomponent-model",
+                CLI_HELLO_STDOUT_COMPONENT,
+                "--invoke",
+                "run()",
+            ])?;
+            Ok(())
+        }
     }
 }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2120,13 +2120,16 @@ after empty
         #[test]
         fn cli_hello_stdout() -> Result<()> {
             println!("{CLI_HELLO_STDOUT_COMPONENT}");
-            run_wasmtime(&[
+            let output = run_wasmtime(&[
                 "run",
                 "-Wcomponent-model",
-                CLI_HELLO_STDOUT_COMPONENT,
                 "--invoke",
                 "run()",
+                CLI_HELLO_STDOUT_COMPONENT,
             ])?;
+            // First this component prints "hello, world", then the invoke
+            // result is printed as "ok".
+            assert_eq!(output, "hello, world\nok\n");
             Ok(())
         }
     }


### PR DESCRIPTION
This PR adds support for `wasmtime run --invoke <wave-function-call> component.wasm` to wasmtime-cli. In the existing invoke for modules, the user provides a bare function name, and only functions that do not take arguments are supported. For components, the argument to invoke is parsed into component vals using the existing wasm-wave parsing introduced in https://github.com/bytecodealliance/wasmtime/pull/8872.  We make some effort to provide useful error messages when   we can't parse the wave function call.