### PR TITLE
winch: Refactor global address calculation

### DIFF
--- a/tests/misc_testsuite/winch/imported_globals_fuzzbug.wast
+++ b/tests/misc_testsuite/winch/imported_globals_fuzzbug.wast
@@ -1,0 +1,58 @@
+
+(module $a
+  (global (export "b") i32 (i32.const 0))
+)
+(register "a")
+
+(module $index
+  (import "a" "b" (global i32))
+  (func (export "start")
+    (local i32 i32 i32)
+    local.get 2
+    local.get 2
+    local.get 2
+    local.get 2
+    local.get 2
+    local.get 2
+    local.get 2
+    local.get 2
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    global.get 0
+    local.get 2
+    global.get 0
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+  )
+)
+
+(assert_return (invoke "start"))


### PR DESCRIPTION
This commit fixes a fuzz-bug. See the test case for details.

Prior to this commit, imported global addresses were calculated with register offset addressing, using the scratch register as the base. With imported globals, the caller must load the address into an allocatable register which implies that in presence of spills the scratch register would get clobbered, affecting the previously loaded imported global address.

This commit fixes the issue by returning an allocatable register, along with the offset and global type, which is expected to be freed by the caller after emitting the global load or store.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
