### PR TITLE
Add Pulley support to wasmtime_test macro

### DIFF
--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -15,6 +15,15 @@
 //! }
 //! ```
 //!
+//! To use just one specific compiler strategy:
+//!
+//! ```rust
+//! #[wasmtime_test(strategies(only(Winch)))]
+//! fn my_test(config: &mut Config) -> Result<()> {
+//!     Ok(())
+//! }
+//! ```
+//!
 //! To explicitly indicate that a wasm features is needed
 //! ```
 //! #[wasmtime_test(wasm_features(gc))]
@@ -59,6 +68,21 @@ impl TestConfig {
                         Ok(())
                     } else if meta.path.is_ident("CraneliftPulley") {
                         self.strategies.retain(|s| *s != Compiler::CraneliftPulley);
+                        Ok(())
+                    } else {
+                        Err(meta.error("Unknown strategy"))
+                    }
+                })
+            } else if meta.path.is_ident("only") {
+                meta.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("Winch") {
+                        self.strategies.retain(|s| *s == Compiler::Winch);
+                        Ok(())
+                    } else if meta.path.is_ident("CraneliftNative") {
+                        self.strategies.retain(|s| *s == Compiler::CraneliftNative);
+                        Ok(())
+                    } else if meta.path.is_ident("CraneliftPulley") {
+                        self.strategies.retain(|s| *s == Compiler::CraneliftPulley);
                         Ok(())
                     } else {
                         Err(meta.error("Unknown strategy"))
@@ -200,7 +224,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
     let mut tests = if test_config.strategies == [Compiler::Winch] {
         vec![quote! {
             // This prevents dead code warning when the macro is invoked as:
-            //     #[wasmtime_test(strategies(not(CraneliftNative))]
+            //     #[wasmtime_test(strategies(only(Winch))]
             // Given that Winch only fully supports x86_64.
             #[allow(dead_code)]
             #func

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -57,6 +57,9 @@ impl TestConfig {
                     } else if meta.path.is_ident("CraneliftNative") {
                         self.strategies.retain(|s| *s != Compiler::CraneliftNative);
                         Ok(())
+                    } else if meta.path.is_ident("CraneliftPulley") {
+                        self.strategies.retain(|s| *s != Compiler::CraneliftPulley);
+                        Ok(())
                     } else {
                         Err(meta.error("Unknown strategy"))
                     }
@@ -97,7 +100,11 @@ impl TestConfig {
 impl Default for TestConfig {
     fn default() -> Self {
         Self {
-            strategies: vec![Compiler::CraneliftNative, Compiler::Winch],
+            strategies: vec![
+                Compiler::CraneliftNative,
+                Compiler::Winch,
+                Compiler::CraneliftPulley,
+            ],
             flags: Default::default(),
             test_attribute: None,
         }

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -54,7 +54,7 @@ impl TestConfig {
                     if meta.path.is_ident("Winch") {
                         self.strategies.retain(|s| *s != Compiler::Winch);
                         Ok(())
-                    } else if meta.path.is_ident("Cranelift") {
+                    } else if meta.path.is_ident("CraneliftNative") {
                         self.strategies.retain(|s| *s != Compiler::CraneliftNative);
                         Ok(())
                     } else {
@@ -193,7 +193,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
     let mut tests = if test_config.strategies == [Compiler::Winch] {
         vec![quote! {
             // This prevents dead code warning when the macro is invoked as:
-            //     #[wasmtime_test(strategies(not(Cranelift))]
+            //     #[wasmtime_test(strategies(not(CraneliftNative))]
             // Given that Winch only fully supports x86_64.
             #[allow(dead_code)]
             #func

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -259,7 +259,7 @@ fn get_fuel_clamps_at_zero(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(CraneliftNative)))]
+#[wasmtime_test(strategies(only(Winch)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_stack_alignment(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -259,7 +259,7 @@ fn get_fuel_clamps_at_zero(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(Cranelift)))]
+#[wasmtime_test(strategies(not(CraneliftNative)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_stack_alignment(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);

--- a/tests/all/winch_engine_features.rs
+++ b/tests/all/winch_engine_features.rs
@@ -1,7 +1,7 @@
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
-#[wasmtime_test(strategies(not(CraneliftNative)))]
+#[wasmtime_test(strategies(only(Winch)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_table_lazy_init(config: &mut Config) -> Result<()> {
     config.table_lazy_init(false);
@@ -21,7 +21,7 @@ fn ensure_compatibility_between_winch_and_table_lazy_init(config: &mut Config) -
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(CraneliftNative)))]
+#[wasmtime_test(strategies(only(Winch)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_signals_based_traps(config: &mut Config) -> Result<()> {
     config.signals_based_traps(false);
@@ -43,7 +43,7 @@ fn ensure_compatibility_between_winch_and_signals_based_traps(config: &mut Confi
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(CraneliftNative)))]
+#[wasmtime_test(strategies(only(Winch)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_generate_native_debuginfo(
     config: &mut Config,

--- a/tests/all/winch_engine_features.rs
+++ b/tests/all/winch_engine_features.rs
@@ -1,7 +1,7 @@
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
-#[wasmtime_test(strategies(not(Cranelift)))]
+#[wasmtime_test(strategies(not(CraneliftNative)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_table_lazy_init(config: &mut Config) -> Result<()> {
     config.table_lazy_init(false);
@@ -21,7 +21,7 @@ fn ensure_compatibility_between_winch_and_table_lazy_init(config: &mut Config) -
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(Cranelift)))]
+#[wasmtime_test(strategies(not(CraneliftNative)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_signals_based_traps(config: &mut Config) -> Result<()> {
     config.signals_based_traps(false);
@@ -43,7 +43,7 @@ fn ensure_compatibility_between_winch_and_signals_based_traps(config: &mut Confi
     Ok(())
 }
 
-#[wasmtime_test(strategies(not(Cranelift)))]
+#[wasmtime_test(strategies(not(CraneliftNative)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_compatibility_between_winch_and_generate_native_debuginfo(
     config: &mut Config,


### PR DESCRIPTION
This PR updates the `#[wasmtime_test]` macro to add support for Pulley.

This was one of the last remaining items in the Pulley TODO List #9747, I figured I'd try to knock it out.

I've renamed the `Cranelift` compilation strategy to `CraneliftNative` in order to disambiguate it from `CraneliftPulley` and to directly match the symbol in the `Compiler` enum.

`CraneliftPulley` is now included by default in the compilation strategies used by `#[wasmtime_test]`.

In order to support the tests that are targeting Winch specifically, I've added an `only(...)` specifier. So instead of `#[wasmtime_test(strategies(not(Cranelift)))]` it would be `#[wasmtime_test(strategies(only(Winch)))]`.

Now that the `wrap_and_typed_i31ref` test was running multiple times with different strategies, the `static HITS` counter was leaking state into the other test and causing things to fail. I moved the counter into the Store to get rid of the static variable.