### PR TITLE
Add audit for `wasmtime-math`

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -489,6 +489,14 @@ start = "2022-11-21"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-math]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-01-20"
+end = "2026-01-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmtime-runtime]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -142,6 +142,9 @@ audit-as-crates-io = true
 [policy.wasmtime-jit-icache-coherence]
 audit-as-crates-io = true
 
+[policy.wasmtime-math]
+audit-as-crates-io = true
+
 [policy.wasmtime-slab]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -385,6 +385,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-math]]
+version = "30.0.0"
+audited_as = "29.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -1484,6 +1488,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "28.0.0"
 when = "2024-12-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-math]]
+version = "29.0.0"
+when = "2025-01-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
I noticed that CI is failing given that an audit and policy for `wasmtime-math` is missing.

`wasmtime-math` was introduced in
https://github.com/bytecodealliance/wasmtime/pull/9808/files.

I followed a similar approach to what it's used for all the other `wasmtime-*` crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
