### PR TITLE
Winch: fix atomic and/or/xor bug

### DIFF
--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -221,6 +221,17 @@ impl WasmValType {
             | WasmValType::V128 => *self,
         }
     }
+
+    /// Attempt to build a `WasmValType` with the passed number of bits.
+    ///
+    /// Panics if the number of bits doesn't map to a WASM int type.
+    pub fn int_from_bits(bits: u8) -> Self {
+        match bits {
+            32 => Self::I32,
+            64 => Self::I64,
+            size => panic!("invaid int bits for WasmValType: {size}"),
+        }
+    }
 }
 
 /// WebAssembly reference type -- equivalent of `wasmparser`'s RefType

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x74
+;;       jne     0x82
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x57
-;;   69: movzwl  %ax, %eax
+;;       jne     0x65
+;;   77: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   72: ud2
-;;   74: ud2
+;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,17 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x44
-;;   55: movzbl  %al, %eax
+;;       jne     0x52
+;;   63: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,22 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6c
+;;       jne     0x7a
 ;;   42: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x53
-;;   64: addq    $0x10, %rsp
+;;       jne     0x61
+;;   72: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
-;;   6c: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x77
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,21 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x77
+;;       jne     0x79
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x59
-;;   6b: movzwq  %ax, %rax
+;;       jne     0x5b
+;;   6d: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
 ;;   77: ud2
+;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x6e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6e
+;;       jne     0x70
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x55
-;;   66: addq    $0x10, %rsp
+;;       jne     0x57
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
 ;;   6e: ud2
+;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,15 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x46
-;;   57: movzbq  %al, %rax
+;;       jne     0x48
+;;   59: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6f
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x71
+;;       jne     0x73
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       andq    %rax, %r11
+;;       andq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x58
-;;   69: addq    $0x10, %rsp
+;;       jne     0x5a
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6f: ud2
 ;;   71: ud2
+;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x74
+;;       jne     0x82
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x57
-;;   69: movzwl  %ax, %eax
+;;       jne     0x65
+;;   77: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   72: ud2
-;;   74: ud2
+;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,17 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x44
-;;   55: movzbl  %al, %eax
+;;       jne     0x52
+;;   63: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,22 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6c
+;;       jne     0x7a
 ;;   42: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x53
-;;   64: addq    $0x10, %rsp
+;;       jne     0x61
+;;   72: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
-;;   6c: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x77
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,21 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x77
+;;       jne     0x79
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x59
-;;   6b: movzwq  %ax, %rax
+;;       jne     0x5b
+;;   6d: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
 ;;   77: ud2
+;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x6e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6e
+;;       jne     0x70
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x55
-;;   66: addq    $0x10, %rsp
+;;       jne     0x57
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
 ;;   6e: ud2
+;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,15 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x46
-;;   57: movzbq  %al, %rax
+;;       jne     0x48
+;;   59: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6f
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x71
+;;       jne     0x73
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       orq     %rax, %r11
+;;       orq     %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x58
-;;   69: addq    $0x10, %rsp
+;;       jne     0x5a
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6f: ud2
 ;;   71: ud2
+;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x74
+;;       jne     0x82
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x57
-;;   69: movzwl  %ax, %eax
+;;       jne     0x65
+;;   77: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   72: ud2
-;;   74: ud2
+;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,17 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x44
-;;   55: movzbl  %al, %eax
+;;       jne     0x52
+;;   63: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,22 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6c
+;;       jne     0x7a
 ;;   42: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x53
-;;   64: addq    $0x10, %rsp
+;;       jne     0x61
+;;   72: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6a: ud2
-;;   6c: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x77
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,19 +21,21 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x77
+;;       jne     0x79
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x59
-;;   6b: movzwq  %ax, %rax
+;;       jne     0x5b
+;;   6d: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
 ;;   77: ud2
+;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x6e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x6e
+;;       jne     0x70
 ;;   44: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x55
-;;   66: addq    $0x10, %rsp
+;;       jne     0x57
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
 ;;   6e: ud2
+;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,15 @@
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x46
-;;   57: movzbq  %al, %rax
+;;       jne     0x48
+;;   59: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6f
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,18 +21,20 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x71
+;;       jne     0x73
 ;;   46: movl    $0, %ecx
 ;;       movq    0x58(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rax
+;;       popq    %rcx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
-;;       xorq    %rax, %r11
+;;       xorq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x58
-;;   69: addq    $0x10, %rsp
+;;       jne     0x5a
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6f: ud2
 ;;   71: ud2
+;;   73: ud2

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -909,8 +909,8 @@ impl Masm for MacroAssembler {
 
     fn atomic_rmw(
         &mut self,
+        _context: &mut CodeGenContext<Emission>,
         _addr: Self::Address,
-        _operand: WritableReg,
         _size: OperandSize,
         _op: RmwOp,
         _flags: MemFlags,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1407,8 +1407,8 @@ pub(crate) trait MacroAssembler {
     /// The value *before* the operation was performed is written back to the `operand` register.
     fn atomic_rmw(
         &mut self,
+        context: &mut CodeGenContext<Emission>,
         addr: Self::Address,
-        operand: WritableReg,
         size: OperandSize,
         op: RmwOp,
         flags: MemFlags,


### PR DESCRIPTION
This PR fixes atomic `and`/`or`/`xor`. The issue was that I was using the operand as a destination for the `AtomicRmwSeq`, but it is a macro-instruction, and the operand ended up being overwritten. This was caught when I enabled the `atomic.wast` spec tests in https://github.com/bytecodealliance/wasmtime/pull/10039#issuecomment-2603318507.

Investigating into the issue I realized that `AtomicRmwSeq` also had requirement for one of it's registers, but that didn't show up initially, because I got lucky, and the value was popped in the right register every time I tested.

The fix is to pop-push the operand to compute the address, and then pass the codegen context to masm to allocate the registers.
