### PR TITLE
Fix a missing increment in p1-to-p2 adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2164,7 +2164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3227,7 +3227,8 @@ dependencies = [
  "libc",
  "sha2",
  "url",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.14.0+wasi-0.2.3",
  "wasi-nn",
  "wit-bindgen",
 ]
@@ -3694,6 +3695,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.0+wasi-0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasi-common"
 version = "30.0.0"
 dependencies = [
@@ -3739,7 +3749,7 @@ dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
  "object",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,3 +21,4 @@ futures = { workspace = true, default-features = false, features = ['alloc'] }
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = "0.21.0"
+wasip2 = { version = "0.14.0", package = 'wasi' }

--- a/crates/test-programs/src/bin/cli_multiple_preopens.rs
+++ b/crates/test-programs/src/bin/cli_multiple_preopens.rs
@@ -1,0 +1,29 @@
+use std::str;
+
+fn main() {
+    dbg!(wasip2::filesystem::preopens::get_directories());
+    unsafe {
+        let p3 = wasi::fd_prestat_get(3).unwrap();
+        let p4 = wasi::fd_prestat_get(4).unwrap();
+        let p5 = wasi::fd_prestat_get(5).unwrap();
+        assert_eq!(wasi::fd_prestat_get(6).err().unwrap(), wasi::ERRNO_BADF);
+
+        assert_eq!(p3.u.dir.pr_name_len, 2);
+        assert_eq!(p4.u.dir.pr_name_len, 2);
+        assert_eq!(p5.u.dir.pr_name_len, 2);
+
+        let mut buf = [0; 100];
+
+        wasi::fd_prestat_dir_name(3, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/a");
+        wasi::fd_prestat_dir_name(4, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/b");
+        wasi::fd_prestat_dir_name(5, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/c");
+        assert_eq!(
+            wasi::fd_prestat_dir_name(6, buf.as_mut_ptr(), buf.len()),
+            Err(wasi::ERRNO_BADF),
+        );
+    }
+    // ..
+}

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -404,6 +404,7 @@ impl ImportAlloc {
             ImportAlloc::GetPreopenPath { cur, nth, alloc } => {
                 if align == 1 {
                     let real_alloc = *nth == *cur;
+                    *cur += 1;
                     if real_alloc {
                         alloc.alloc(align, size)
                     } else {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4547,6 +4547,12 @@ user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-06-03"
 end = "2025-12-05"
 
+[[trusted.wasi]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-07-22"
+end = "2026-01-21"
+
 [[trusted.wasm-bindgen]]
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1324,6 +1324,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasi]]
+version = "0.14.0+wasi-0.2.3"
+when = "2025-01-10"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.wasi-common]]
 version = "28.0.0"
 when = "2024-12-20"

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2070,6 +2070,18 @@ after empty
         ])?;
         Ok(())
     }
+
+    #[test]
+    fn cli_multiple_preopens() -> Result<()> {
+        run_wasmtime(&[
+            "run",
+            "--dir=/::/a",
+            "--dir=/::/b",
+            "--dir=/::/c",
+            CLI_MULTIPLE_PREOPENS_COMPONENT,
+        ])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit fixes a bug in the WASIp1-to-WASIp2 adapter during `fd_prestat_dir_name` where an iterator variable was forgotten to be incremented. That means that getting the path for anything other than the first preopen didn't work correctly.

Closes #10058

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
