### PR TITLE
Winch: Even tighter Extends

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     codegen::BlockSig,
     isa::reg::{writable, Reg},
     masm::{
-        Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm, RmwOp, SPOffset,
-        ShiftKind, TrapCode, UnsignedExtend, UNTRUSTED_FLAGS,
+        Extend, Imm, IntCmpKind, LoadKind, MacroAssembler, MemOpKind, OperandSize, RegImm, RmwOp,
+        SPOffset, ShiftKind, TrapCode, Zero, UNTRUSTED_FLAGS,
     },
     stack::TypedReg,
 };
@@ -1368,7 +1368,7 @@ where
         arg: &MemArg,
         op: RmwOp,
         size: OperandSize,
-        extend: Option<UnsignedExtend>,
+        extend: Option<Extend<Zero>>,
     ) -> Result<()> {
         let operand = self.context.pop_to_reg(self.masm, None).unwrap();
         if let Some(addr) = self.emit_compute_heap_address_align_checked(arg, size)? {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -2,8 +2,8 @@
 use super::{address::Address, regs};
 use crate::aarch64::regs::zero;
 use crate::masm::{
-    DivKind, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind, SignedExtend,
-    TruncKind,
+    DivKind, Extend, ExtendKind, FloatCmpKind, IntCmpKind, RemKind, RoundingMode, ShiftKind,
+    Signed, TruncKind,
 };
 use crate::CallingConvention;
 use crate::{
@@ -444,12 +444,12 @@ impl Assembler {
             self.extend(
                 divisor,
                 writable!(divisor),
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
+                ExtendKind::Signed(Extend::<Signed>::I64Extend32),
             );
             self.extend(
                 dividend,
                 writable!(dividend),
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
+                ExtendKind::Signed(Extend::<Signed>::I64Extend32),
             );
             OperandSize::S64
         } else {
@@ -483,12 +483,12 @@ impl Assembler {
             self.extend(
                 divisor,
                 writable!(divisor),
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
+                ExtendKind::Signed(Extend::<Signed>::I64Extend32),
             );
             self.extend(
                 dividend,
                 writable!(dividend),
-                ExtendKind::Signed(SignedExtend::I64Extend32S),
+                ExtendKind::Signed(Extend::<Signed>::I64Extend32),
             );
             OperandSize::S64
         } else {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -12,10 +12,10 @@ use crate::{
         CallingConvention,
     },
     masm::{
-        CalleeKind, DivKind, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I, IntCmpKind,
-        LoadKind, MacroAssembler as Masm, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind,
-        RmwOp, RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot, TrapCode, TruncKind,
-        UnsignedExtend,
+        CalleeKind, DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I,
+        IntCmpKind, LoadKind, MacroAssembler as Masm, MemOpKind, MulWideKind, OperandSize, RegImm,
+        RemKind, RmwOp, RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot, TrapCode,
+        TruncKind, Zero,
     },
     stack::TypedReg,
 };
@@ -914,7 +914,7 @@ impl Masm for MacroAssembler {
         _size: OperandSize,
         _op: RmwOp,
         _flags: MemFlags,
-        _extend: Option<UnsignedExtend>,
+        _extend: Option<Extend<Zero>>,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -240,7 +240,7 @@ impl From<Extend<Zero>> for ExtendKind {
 }
 
 impl<T: ExtendType> Extend<T> {
-    pub fn src_size(&self) -> OperandSize {
+    pub fn from_size(&self) -> OperandSize {
         match self {
             Extend::I32Extend8 | Extend::I64Extend8 => OperandSize::S8,
             Extend::I32Extend16 | Extend::I64Extend16 => OperandSize::S16,
@@ -249,7 +249,7 @@ impl<T: ExtendType> Extend<T> {
         }
     }
 
-    pub fn dst_size(&self) -> OperandSize {
+    pub fn to_size(&self) -> OperandSize {
         match self {
             Extend::I32Extend8 | Extend::I32Extend16 => OperandSize::S32,
             Extend::I64Extend8 | Extend::I64Extend16 | Extend::I64Extend32 => OperandSize::S64,
@@ -258,11 +258,11 @@ impl<T: ExtendType> Extend<T> {
     }
 
     pub fn from_bits(&self) -> u8 {
-        self.src_size().num_bits()
+        self.from_size().num_bits()
     }
 
     pub fn to_bits(&self) -> u8 {
-        self.dst_size().num_bits()
+        self.to_size().num_bits()
     }
 }
 
@@ -434,8 +434,8 @@ impl LoadKind {
 
     fn operand_size_for_scalar(extend_kind: &ExtendKind) -> OperandSize {
         match extend_kind {
-            ExtendKind::Signed(s) => s.src_size(),
-            ExtendKind::Unsigned(u) => u.src_size(),
+            ExtendKind::Signed(s) => s.from_size(),
+            ExtendKind::Unsigned(u) => u.from_size(),
         }
     }
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -392,11 +392,11 @@ impl ExtractLaneKind {
     }
 }
 
-impl From<ExtractLaneKind> for ExtendKind {
+impl From<ExtractLaneKind> for SignedExtend {
     fn from(value: ExtractLaneKind) -> Self {
         match value {
-            ExtractLaneKind::I8x16S => Self::Signed(SignedExtend::I32Extend8S),
-            ExtractLaneKind::I16x8S => Self::Signed(SignedExtend::I32Extend16S),
+            ExtractLaneKind::I8x16S => SignedExtend::I32Extend8S,
+            ExtractLaneKind::I16x8S => SignedExtend::I32Extend16S,
             _ => unimplemented!(),
         }
     }
@@ -519,6 +519,23 @@ impl OperandSize {
             8 => S64,
             16 => S128,
             _ => panic!("Invalid bytes {bytes} for OperandSize"),
+        }
+    }
+
+    pub fn unsigned_extend_to(&self, to: Self) -> Option<UnsignedExtend> {
+        match to {
+            OperandSize::S32 => match self {
+                OperandSize::S8 => Some(UnsignedExtend::I32Extend8U),
+                OperandSize::S16 => Some(UnsignedExtend::I32Extend16U),
+                _ => None,
+            },
+            OperandSize::S64 => match self {
+                OperandSize::S8 => Some(UnsignedExtend::I64Extend8U),
+                OperandSize::S16 => Some(UnsignedExtend::I64Extend16U),
+                OperandSize::S32 => Some(UnsignedExtend::I64Extend32U),
+                _ => None,
+            },
+            _ => None,
         }
     }
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -9,9 +9,9 @@ use crate::codegen::{
     control_index, Callee, CodeGen, CodeGenError, ControlStackFrame, Emission, FnCall,
 };
 use crate::masm::{
-    DivKind, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler, MemMoveDirection,
-    MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
-    SignedExtend, SplatKind, SplatLoadKind, TruncKind, UnsignedExtend, VectorExtendKind,
+    DivKind, Extend, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
+    MemMoveDirection, MemOpKind, MulWideKind, OperandSize, RegImm, RemKind, RmwOp, RoundingMode,
+    SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind, TruncKind, VectorExtendKind, Zero,
 };
 
 use crate::reg::{writable, Reg};
@@ -1250,49 +1250,49 @@ where
 
     fn visit_i64_extend_i32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I64Extend32S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I64Extend32.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend_i32_u(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, UnsignedExtend::I64Extend32U.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Zero>::I64Extend32.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i32_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I32Extend8S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I32Extend8.into())?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i32_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I32Extend16S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I32Extend16.into())?;
             Ok(TypedReg::i32(reg))
         })
     }
 
     fn visit_i64_extend8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I64Extend8S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I64Extend8.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I64Extend16S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I64Extend16.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
 
     fn visit_i64_extend32_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, &mut |masm, reg| {
-            masm.extend(writable!(reg), reg, SignedExtend::I64Extend32S.into())?;
+            masm.extend(writable!(reg), reg, Extend::<Signed>::I64Extend32.into())?;
             Ok(TypedReg::i64(reg))
         })
     }
@@ -1997,7 +1997,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(SignedExtend::I32Extend8S.into()),
+            LoadKind::ScalarExtend(Extend::<Signed>::I32Extend8.into()),
             MemOpKind::Normal,
         )
     }
@@ -2006,7 +2006,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(UnsignedExtend::I32Extend8U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I32Extend8.into()),
             MemOpKind::Normal,
         )
     }
@@ -2015,7 +2015,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(SignedExtend::I32Extend16S.into()),
+            LoadKind::ScalarExtend(Extend::<Signed>::I32Extend16.into()),
             MemOpKind::Normal,
         )
     }
@@ -2024,7 +2024,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(UnsignedExtend::I32Extend16U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I32Extend16.into()),
             MemOpKind::Normal,
         )
     }
@@ -2045,7 +2045,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(SignedExtend::I64Extend8S.into()),
+            LoadKind::ScalarExtend(Extend::<Signed>::I64Extend8.into()),
             MemOpKind::Normal,
         )
     }
@@ -2054,7 +2054,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend8U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend8.into()),
             MemOpKind::Normal,
         )
     }
@@ -2063,7 +2063,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend16U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend16.into()),
             MemOpKind::Normal,
         )
     }
@@ -2072,7 +2072,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(SignedExtend::I64Extend16S.into()),
+            LoadKind::ScalarExtend(Extend::<Signed>::I64Extend16.into()),
             MemOpKind::Normal,
         )
     }
@@ -2081,7 +2081,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend32U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend32.into()),
             MemOpKind::Normal,
         )
     }
@@ -2090,7 +2090,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(SignedExtend::I64Extend32S.into()),
+            LoadKind::ScalarExtend(Extend::<Signed>::I64Extend32.into()),
             MemOpKind::Normal,
         )
     }
@@ -2252,7 +2252,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(UnsignedExtend::I32Extend8U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I32Extend8.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2261,7 +2261,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I32,
-            LoadKind::ScalarExtend(UnsignedExtend::I32Extend16U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I32Extend16.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2279,7 +2279,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend8U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend8.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2288,7 +2288,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend16U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend16.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2297,7 +2297,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::I64,
-            LoadKind::ScalarExtend(UnsignedExtend::I64Extend32U.into()),
+            LoadKind::ScalarExtend(Extend::<Zero>::I64Extend32.into()),
             MemOpKind::Atomic,
         )
     }
@@ -2344,7 +2344,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
 
@@ -2353,7 +2353,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2366,7 +2366,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2375,7 +2375,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2384,7 +2384,7 @@ where
             &arg,
             RmwOp::Add,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 
@@ -2397,7 +2397,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
     fn visit_i32_atomic_rmw16_sub_u(&mut self, arg: MemArg) -> Self::Output {
@@ -2405,7 +2405,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2418,7 +2418,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2427,7 +2427,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2436,7 +2436,7 @@ where
             &arg,
             RmwOp::Sub,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 
@@ -2449,7 +2449,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
 
@@ -2458,7 +2458,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2471,7 +2471,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2480,7 +2480,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2489,7 +2489,7 @@ where
             &arg,
             RmwOp::Xchg,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 
@@ -2502,7 +2502,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
 
@@ -2511,7 +2511,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2524,7 +2524,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2533,7 +2533,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2542,7 +2542,7 @@ where
             &arg,
             RmwOp::And,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 
@@ -2555,7 +2555,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
 
@@ -2564,7 +2564,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2577,7 +2577,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2586,7 +2586,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2595,7 +2595,7 @@ where
             &arg,
             RmwOp::Or,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 
@@ -2608,7 +2608,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S8,
-            Some(UnsignedExtend::I32Extend8U),
+            Some(Extend::<Zero>::I32Extend8),
         )
     }
 
@@ -2617,7 +2617,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S16,
-            Some(UnsignedExtend::I32Extend16U),
+            Some(Extend::<Zero>::I32Extend16),
         )
     }
 
@@ -2630,7 +2630,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S8,
-            Some(UnsignedExtend::I64Extend8U),
+            Some(Extend::<Zero>::I64Extend8),
         )
     }
 
@@ -2639,7 +2639,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S16,
-            Some(UnsignedExtend::I64Extend16U),
+            Some(Extend::<Zero>::I64Extend16),
         )
     }
 
@@ -2648,7 +2648,7 @@ where
             &arg,
             RmwOp::Xor,
             OperandSize::S32,
-            Some(UnsignedExtend::I64Extend32U),
+            Some(Extend::<Zero>::I64Extend32),
         )
     }
 


### PR DESCRIPTION
Followup to https://github.com/bytecodealliance/wasmtime/pull/10053

This PR has two commit:

1) The first commit makes `mov*` instruct receive the adequate `Extend` operation. And it makes extend conversion  operation harder to misuse.
2) The second commit is **optional**. This is an alternative to `Signed/UnsignedExtend`, that merges the two into a `Extend<T>`, and factorizes common behaviour, avoiding repetition. The `T` is either `Signed` or `Zero`, with precautions in the design so that it's hard to misuse.
