### PR TITLE
[29.0.x]: Fix a missing increment in p1-to-p2 adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,7 +1504,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2135,7 +2135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3196,7 +3196,8 @@ dependencies = [
  "libc",
  "sha2",
  "url",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.14.0+wasi-0.2.3",
  "wasi-nn",
  "wit-bindgen",
 ]
@@ -3663,6 +3664,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.0+wasi-0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
+dependencies = [
+ "wit-bindgen-rt 0.37.0",
+]
+
+[[package]]
 name = "wasi-common"
 version = "29.0.0"
 dependencies = [
@@ -3708,7 +3718,7 @@ dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
  "object",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-encoder 0.221.2",
  "wit-bindgen-rust-macro",
 ]
@@ -4969,7 +4979,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c966692b6d8c4bb3c1aee3313e0930f44457a5763cfffb666f814506124e4691"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.35.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -4989,6 +4999,15 @@ name = "wit-bindgen-rt"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d5562e971a823cf5a550a9d69cb7144e9b4969a810043127175517a4e1865"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
 dependencies = [
  "bitflags 2.6.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
  "sha2",
  "url",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasi 0.14.0+wasi-0.2.3",
+ "wasi 0.13.3+wasi-0.2.2",
  "wasi-nn",
  "wit-bindgen",
 ]
@@ -3665,11 +3665,11 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.14.0+wasi-0.2.3"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
- "wit-bindgen-rt 0.37.0",
+ "wit-bindgen-rt 0.33.0",
 ]
 
 [[package]]
@@ -4996,18 +4996,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.35.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605d5562e971a823cf5a550a9d69cb7144e9b4969a810043127175517a4e1865"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.37.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
+checksum = "605d5562e971a823cf5a550a9d69cb7144e9b4969a810043127175517a4e1865"
 dependencies = [
  "bitflags 2.6.0",
 ]

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,4 +21,4 @@ futures = { workspace = true, default-features = false, features = ['alloc'] }
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = "0.21.0"
-wasip2 = { version = "0.14.0", package = 'wasi' }
+wasip2 = { version = "0.13.0", package = 'wasi' }

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,3 +21,4 @@ futures = { workspace = true, default-features = false, features = ['alloc'] }
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = "0.21.0"
+wasip2 = { version = "0.14.0", package = 'wasi' }

--- a/crates/test-programs/src/bin/cli_multiple_preopens.rs
+++ b/crates/test-programs/src/bin/cli_multiple_preopens.rs
@@ -1,0 +1,29 @@
+use std::str;
+
+fn main() {
+    dbg!(wasip2::filesystem::preopens::get_directories());
+    unsafe {
+        let p3 = wasi::fd_prestat_get(3).unwrap();
+        let p4 = wasi::fd_prestat_get(4).unwrap();
+        let p5 = wasi::fd_prestat_get(5).unwrap();
+        assert_eq!(wasi::fd_prestat_get(6).err().unwrap(), wasi::ERRNO_BADF);
+
+        assert_eq!(p3.u.dir.pr_name_len, 2);
+        assert_eq!(p4.u.dir.pr_name_len, 2);
+        assert_eq!(p5.u.dir.pr_name_len, 2);
+
+        let mut buf = [0; 100];
+
+        wasi::fd_prestat_dir_name(3, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/a");
+        wasi::fd_prestat_dir_name(4, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/b");
+        wasi::fd_prestat_dir_name(5, buf.as_mut_ptr(), buf.len()).unwrap();
+        assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/c");
+        assert_eq!(
+            wasi::fd_prestat_dir_name(6, buf.as_mut_ptr(), buf.len()),
+            Err(wasi::ERRNO_BADF),
+        );
+    }
+    // ..
+}

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -404,6 +404,7 @@ impl ImportAlloc {
             ImportAlloc::GetPreopenPath { cur, nth, alloc } => {
                 if align == 1 {
                     let real_alloc = *nth == *cur;
+                    *cur += 1;
                     if real_alloc {
                         alloc.alloc(align, size)
                     } else {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4465,6 +4465,12 @@ user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-06-03"
 end = "2025-12-05"
 
+[[trusted.wasi]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-07-22"
+end = "2026-01-21"
+
 [[trusted.wasm-bindgen]]
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -489,6 +489,14 @@ start = "2022-11-21"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-math]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-01-20"
+end = "2026-01-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmtime-runtime]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -142,6 +142,9 @@ audit-as-crates-io = true
 [policy.wasmtime-jit-icache-coherence]
 audit-as-crates-io = true
 
+[policy.wasmtime-math]
+audit-as-crates-io = true
+
 [policy.wasmtime-slab]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1140,6 +1140,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasi]]
+version = "0.14.0+wasi-0.2.3"
+when = "2025-01-10"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.wasi-common]]
 version = "27.0.0"
 when = "2024-11-20"
@@ -1626,6 +1633,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-bindgen-rt]]
 version = "0.35.0"
 when = "2024-11-13"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-bindgen-rt]]
+version = "0.37.0"
+when = "2025-01-10"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1141,11 +1141,11 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi]]
-version = "0.14.0+wasi-0.2.3"
-when = "2025-01-10"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
+version = "0.13.3+wasi-0.2.2"
+when = "2024-10-08"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
 version = "27.0.0"
@@ -1631,14 +1631,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rt]]
-version = "0.35.0"
-when = "2024-11-13"
+version = "0.33.0"
+when = "2024-09-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rt]]
-version = "0.37.0"
-when = "2025-01-10"
+version = "0.35.0"
+when = "2024-11-13"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -257,6 +257,14 @@ audited_as = "26.0.1"
 version = "29.0.0"
 audited_as = "27.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "30.0.0"
+audited_as = "28.0.0"
+
+[[unpublished.wasmtime-math]]
+version = "30.0.0"
+audited_as = "29.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -1296,6 +1304,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "27.0.0"
 when = "2024-11-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-math]]
+version = "29.0.0"
+when = "2025-01-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2059,6 +2059,18 @@ after empty
         ])?;
         Ok(())
     }
+
+    #[test]
+    fn cli_multiple_preopens() -> Result<()> {
+        run_wasmtime(&[
+            "run",
+            "--dir=/::/a",
+            "--dir=/::/b",
+            "--dir=/::/c",
+            CLI_MULTIPLE_PREOPENS_COMPONENT,
+        ])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
Backport of #10064 to the 29.0.x release branch to get a new official release of the adapter binaries. Additionally backports https://github.com/bytecodealliance/wasmtime/pull/10059 to get CI passing.