### PR TITLE
Disable Winch fuzzing on non-x86_64 architectures

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -574,6 +574,9 @@ impl WasmtimeConfig {
                 // don't want to make the same fuzz input DNA generate different test
                 // cases on different targets.
                 if cfg!(not(target_arch = "x86_64")) {
+                    log::warn!(
+                        "want to compile with Winch but host architecture does not support it"
+                    );
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
