### PR TITLE
Winch: refactor heap address computation

### DIFF
--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
@@ -10,34 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x80
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x82
-;;   44: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x74
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x65
-;;   77: movzwl  %ax, %eax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x57
+;;   69: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   80: ud2
-;;   82: ud2
+;;   72: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
@@ -10,29 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x52
-;;   63: movzbl  %al, %eax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x44
+;;   55: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
@@ -10,33 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x6a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x7a
-;;   42: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6c
+;;   42: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x61
-;;   72: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x53
+;;   64: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   6a: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
@@ -10,32 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x75
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x79
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x77
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5b
-;;   6d: movzwq  %ax, %rax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x59
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   75: ud2
 ;;   77: ud2
-;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x70
-;;   44: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6e
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x57
-;;   68: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x55
+;;   66: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6c: ud2
 ;;   6e: ud2
-;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
@@ -10,27 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x63
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x48
-;;   59: movzbq  %al, %rax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x46
+;;   57: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   63: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x73
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andq    $7, %rdx
+;;       cmpq    $0, %rdx
+;;       jne     0x71
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movq    (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movq    (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
-;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5a
-;;   6b: addq    $0x10, %rsp
+;;       lock cmpxchgq %r11, (%rbx)
+;;       jne     0x58
+;;   69: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6f: ud2
 ;;   71: ud2
-;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
@@ -10,35 +10,27 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x82
+;;       ja      0x66
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x539, %eax
-;;       movl    $0x2a, %ecx
-;;       movl    $0, %edx
-;;       andw    $1, %dx
-;;       cmpw    $0, %dx
-;;       jne     0x84
-;;   49: movl    $0, %edx
+;;       movl    $0x539, %ecx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
+;;       jne     0x68
+;;   3f: movl    $0x539, %ecx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       subq    $4, %rsp
-;;       movl    %ecx, (%rsp)
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rsp), %eax
-;;       addq    $4, %rsp
-;;       lock cmpxchgw %cx, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %eax
+;;       lock cmpxchgw %cx, (%rdx)
 ;;       movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   82: ud2
-;;   84: ud2
+;;   66: ud2
+;;   68: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
@@ -10,30 +10,22 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x52
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x539, %eax
-;;       movl    $0x2a, %ecx
-;;       movl    $0, %edx
+;;       movl    $0x539, %ecx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       subq    $4, %rsp
-;;       movl    %ecx, (%rsp)
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rsp), %eax
-;;       addq    $4, %rsp
-;;       lock cmpxchgb %cl, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %eax
+;;       lock cmpxchgb %cl, (%rdx)
 ;;       movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   52: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
@@ -10,34 +10,26 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7c
+;;       ja      0x60
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x539, %eax
-;;       movl    $0x2a, %ecx
-;;       movl    $0, %edx
-;;       andl    $3, %edx
-;;       cmpl    $0, %edx
-;;       jne     0x7e
-;;   47: movl    $0, %edx
+;;       movl    $0x539, %ecx
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x62
+;;   3d: movl    $0x539, %ecx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       subq    $4, %rsp
-;;       movl    %ecx, (%rsp)
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rsp), %eax
-;;       addq    $4, %rsp
-;;       lock cmpxchgl %ecx, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %eax
+;;       lock cmpxchgl %ecx, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7c: ud2
-;;   7e: ud2
+;;   60: ud2
+;;   62: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
@@ -10,31 +10,27 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6f
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x539, %rax
-;;       movq    $0x2a, %rcx
-;;       movl    $0, %edx
-;;       andw    $1, %dx
-;;       cmpw    $0, %dx
-;;       jne     0x71
-;;   4d: movl    $0, %edx
+;;       movq    $0x539, %rcx
+;;       andw    $1, %cx
+;;       cmpw    $0, %cx
+;;       jne     0x6f
+;;   41: movq    $0x539, %rcx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       pushq   %rcx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       popq    %rax
-;;       lock cmpxchgw %cx, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %eax
+;;       lock cmpxchgw %cx, (%rdx)
 ;;       movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6d: ud2
 ;;   6f: ud2
-;;   71: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
@@ -10,30 +10,26 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x68
+;;       ja      0x66
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x539, %rax
-;;       movq    $0x2a, %rcx
-;;       movl    $0, %edx
-;;       andl    $3, %edx
-;;       cmpl    $0, %edx
-;;       jne     0x6a
-;;   4b: movl    $0, %edx
+;;       movq    $0x539, %rcx
+;;       andl    $3, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x68
+;;   3f: movq    $0x539, %rcx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       pushq   %rcx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       popq    %rax
-;;       lock cmpxchgl %ecx, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %eax
+;;       lock cmpxchgl %ecx, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   66: ud2
 ;;   68: ud2
-;;   6a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
@@ -10,26 +10,22 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5b
+;;       ja      0x57
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x539, %rax
-;;       movq    $0x2a, %rcx
-;;       movl    $0, %edx
+;;       movq    $0x539, %rcx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       pushq   %rcx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       popq    %rax
-;;       lock cmpxchgb %cl, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %eax
+;;       lock cmpxchgb %cl, (%rdx)
 ;;       movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5b: ud2
+;;   57: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
@@ -10,30 +10,26 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6b
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x539, %rax
-;;       movq    $0x2a, %rcx
-;;       movl    $0, %edx
-;;       andq    $7, %rdx
-;;       cmpq    $0, %rdx
-;;       jne     0x6d
-;;   4d: movl    $0, %edx
+;;       movq    $0x539, %rcx
+;;       andq    $7, %rcx
+;;       cmpq    $0, %rcx
+;;       jne     0x6b
+;;   41: movq    $0x539, %rcx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rbx
-;;       addq    %rdx, %rbx
-;;       pushq   %rcx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       popq    %rax
-;;       lock cmpxchgq %rcx, (%rbx)
+;;       movq    (%r11), %rdx
+;;       addq    %rcx, %rdx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %eax
+;;       lock cmpxchgq %rcx, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   69: ud2
 ;;   6b: ud2
-;;   6d: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
@@ -10,34 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x80
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x82
-;;   44: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x74
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x65
-;;   77: movzwl  %ax, %eax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x57
+;;   69: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   80: ud2
-;;   82: ud2
+;;   72: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
@@ -10,29 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x52
-;;   63: movzbl  %al, %eax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x44
+;;   55: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
@@ -10,33 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x6a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x7a
-;;   42: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6c
+;;   42: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x61
-;;   72: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x53
+;;   64: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   6a: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
@@ -10,32 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x75
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x79
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x77
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5b
-;;   6d: movzwq  %ax, %rax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x59
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   75: ud2
 ;;   77: ud2
-;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x70
-;;   44: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6e
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x57
-;;   68: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x55
+;;   66: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6c: ud2
 ;;   6e: ud2
-;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
@@ -10,27 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x63
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x48
-;;   59: movzbq  %al, %rax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x46
+;;   57: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   63: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x73
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andq    $7, %rdx
+;;       cmpq    $0, %rdx
+;;       jne     0x71
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movq    (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movq    (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
-;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5a
-;;   6b: addq    $0x10, %rsp
+;;       lock cmpxchgq %r11, (%rbx)
+;;       jne     0x58
+;;   69: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6f: ud2
 ;;   71: ud2
-;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
@@ -10,34 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x80
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x82
-;;   44: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x74
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x65
-;;   77: movzwl  %ax, %eax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x57
+;;   69: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   80: ud2
-;;   82: ud2
+;;   72: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
@@ -10,29 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x5e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x52
-;;   63: movzbl  %al, %eax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x44
+;;   55: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
@@ -10,33 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x6a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movl    $0x2a, %eax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x7a
-;;   42: movl    $0, %ecx
+;;       movl    $0x2a, %ecx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6c
+;;   42: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       subq    $4, %rsp
-;;       movl    %eax, (%rsp)
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x61
-;;   72: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x53
+;;   64: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   6a: ud2
+;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
@@ -10,32 +10,30 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x75
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
-;;       jne     0x79
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andw    $1, %dx
+;;       cmpw    $0, %dx
+;;       jne     0x77
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzwq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzwq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5b
-;;   6d: movzwq  %ax, %rax
+;;       lock cmpxchgw %r11w, (%rbx)
+;;       jne     0x59
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   75: ud2
 ;;   77: ud2
-;;   79: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x6c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andl    $3, %ecx
-;;       cmpl    $0, %ecx
-;;       jne     0x70
-;;   44: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andl    $3, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x6e
+;;   44: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movl    (%rdx), %eax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movl    (%rbx), %eax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x57
-;;   68: addq    $0x10, %rsp
+;;       lock cmpxchgl %r11d, (%rbx)
+;;       jne     0x55
+;;   66: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6c: ud2
 ;;   6e: ud2
-;;   70: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
@@ -10,27 +10,25 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x63
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movzbq  (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movzbq  (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x48
-;;   59: movzbq  %al, %rax
+;;       lock cmpxchgb %r11b, (%rbx)
+;;       jne     0x46
+;;   57: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   63: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
@@ -10,31 +10,29 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x10(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    $0x2a, %rax
-;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x73
-;;   46: movl    $0, %ecx
+;;       movq    $0x2a, %rcx
+;;       movl    $0, %edx
+;;       andq    $7, %rdx
+;;       cmpq    $0, %rdx
+;;       jne     0x71
+;;   46: movl    $0, %edx
 ;;       movq    0x58(%r14), %r11
-;;       movq    (%r11), %rdx
-;;       addq    %rcx, %rdx
-;;       pushq   %rax
-;;       popq    %rcx
-;;       movq    (%rdx), %rax
+;;       movq    (%r11), %rbx
+;;       addq    %rdx, %rbx
+;;       movq    (%rbx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
-;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5a
-;;   6b: addq    $0x10, %rsp
+;;       lock cmpxchgq %r11, (%rbx)
+;;       jne     0x58
+;;   69: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6f: ud2
 ;;   71: ud2
-;;   73: ud2

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -910,7 +910,7 @@ impl Masm for MacroAssembler {
     fn atomic_rmw(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _addr: Self::Address,
+        _compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         _size: OperandSize,
         _op: RmwOp,
         _flags: MemFlags,
@@ -932,7 +932,7 @@ impl Masm for MacroAssembler {
     fn atomic_cas(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _addr: Self::Address,
+        _compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         _size: OperandSize,
         _flags: MemFlags,
         _extend: Option<Extend<Zero>>,

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1429,65 +1429,74 @@ impl Masm for MacroAssembler {
     fn atomic_rmw(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
+        compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         size: OperandSize,
         op: RmwOp,
         flags: MemFlags,
         extend: Option<Extend<Zero>>,
     ) -> Result<()> {
-        let res = match op {
-            RmwOp::Add => {
-                let operand = context.pop_to_reg(self, None)?;
-                self.asm
-                    .lock_xadd(addr, operand.reg, writable!(operand.reg), size, flags);
-                operand.reg
-            }
-            RmwOp::Sub => {
-                let operand = context.pop_to_reg(self, None)?;
-                self.asm.neg(operand.reg, writable!(operand.reg), size);
-                self.asm
-                    .lock_xadd(addr, operand.reg, writable!(operand.reg), size, flags);
-                operand.reg
-            }
-            RmwOp::Xchg => {
-                let operand = context.pop_to_reg(self, None)?;
-                self.asm
-                    .xchg(addr, operand.reg, writable!(operand.reg), size, flags);
-                operand.reg
-            }
-            RmwOp::And | RmwOp::Or | RmwOp::Xor => {
-                let op = match op {
-                    RmwOp::And => AtomicRmwSeqOp::And,
-                    RmwOp::Or => AtomicRmwSeqOp::Or,
-                    RmwOp::Xor => AtomicRmwSeqOp::Xor,
-                    _ => unreachable!(
-                        "invalid op for atomic_rmw_seq, should be one of `or`, `and` or `xor`"
-                    ),
-                };
-                let dst = context.reg(regs::rax(), self)?;
-                let operand = context.pop_to_reg(self, None)?;
+        // `atomic_rmw_seq` requires the rax register, reserve it now
+        if matches!(op, RmwOp::And | RmwOp::Or | RmwOp::Xor) {
+            context.reg(regs::rax(), self)?;
+        }
 
-                self.asm
-                    .atomic_rmw_seq(addr, operand.reg, writable!(dst), size, flags, op);
+        let operand = context.pop_to_reg(self, None)?;
 
-                context.free_reg(operand.reg);
-                dst
-            }
-        };
-
-        let dst_ty = match extend {
-            Some(ext) => {
-                // We don't need to zero-extend from 32 to 64bits.
-                if !(ext.from_bits() == 32 && ext.to_bits() == 64) {
-                    self.asm.movzx_rr(res, writable!(res), ext.into());
+        if let Some(addr) = compute_addr(self, context)? {
+            let src = self.address_at_reg(addr, 0)?;
+            let res = match op {
+                RmwOp::Add => {
+                    self.asm
+                        .lock_xadd(src, operand.reg, writable!(operand.reg), size, flags);
+                    operand.reg
                 }
+                RmwOp::Sub => {
+                    self.asm.neg(operand.reg, writable!(operand.reg), size);
+                    self.asm
+                        .lock_xadd(src, operand.reg, writable!(operand.reg), size, flags);
+                    operand.reg
+                }
+                RmwOp::Xchg => {
+                    self.asm
+                        .xchg(src, operand.reg, writable!(operand.reg), size, flags);
+                    operand.reg
+                }
+                RmwOp::And | RmwOp::Or | RmwOp::Xor => {
+                    let op = match op {
+                        RmwOp::And => AtomicRmwSeqOp::And,
+                        RmwOp::Or => AtomicRmwSeqOp::Or,
+                        RmwOp::Xor => AtomicRmwSeqOp::Xor,
+                        _ => unreachable!(
+                            "invalid op for atomic_rmw_seq, should be one of `or`, `and` or `xor`"
+                        ),
+                    };
 
-                WasmValType::int_from_bits(ext.to_bits())
-            }
-            None => WasmValType::int_from_bits(size.num_bits()),
-        };
+                    // we have already reserved rax is already reserved
+                    let dst = regs::rax();
 
-        context.stack.push(TypedReg::new(dst_ty, res).into());
+                    self.asm
+                        .atomic_rmw_seq(src, operand.reg, writable!(dst), size, flags, op);
+
+                    context.free_reg(operand.reg);
+                    dst
+                }
+            };
+
+            let dst_ty = match extend {
+                Some(ext) => {
+                    // We don't need to zero-extend from 32 to 64bits.
+                    if !(ext.from_bits() == 32 && ext.to_bits() == 64) {
+                        self.asm.movzx_rr(res, writable!(res), ext.into());
+                    }
+
+                    WasmValType::int_from_bits(ext.to_bits())
+                }
+                None => WasmValType::int_from_bits(size.num_bits()),
+            };
+
+            context.stack.push(TypedReg::new(dst_ty, res).into());
+            context.free_reg(addr);
+        }
 
         Ok(())
     }
@@ -1543,7 +1552,7 @@ impl Masm for MacroAssembler {
     fn atomic_cas(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
+        compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         size: OperandSize,
         flags: MemFlags,
         extend: Option<Extend<Zero>>,
@@ -1551,32 +1560,35 @@ impl Masm for MacroAssembler {
         // `cmpxchg` expects `expected` to be in the `*a*` register.
         // reserve rax for the expected argument.
         let rax = context.reg(regs::rax(), self)?;
+        if let Some(addr) = compute_addr(self, context)? {
+            let replacement = context.pop_to_reg(self, None)?;
+            let src = self.address_at_reg(addr, 0)?;
 
-        let replacement = context.pop_to_reg(self, None)?;
+            // mark `rax` as allocatable again.
+            context.free_reg(rax);
+            let expected = context.pop_to_reg(self, Some(regs::rax()))?;
 
-        // mark `rax` as allocatable again.
-        context.free_reg(rax);
-        let expected = context.pop_to_reg(self, Some(regs::rax()))?;
+            self.asm.cmpxchg(
+                src,
+                expected.reg,
+                replacement.reg,
+                writable!(expected.reg),
+                size,
+                flags,
+            );
 
-        self.asm.cmpxchg(
-            addr,
-            expected.reg,
-            replacement.reg,
-            writable!(expected.reg),
-            size,
-            flags,
-        );
-
-        if let Some(extend) = extend {
-            // We don't need to zero-extend from 32 to 64bits.
-            if !(extend.from_bits() == 32 && extend.to_bits() == 64) {
-                self.asm
-                    .movzx_rr(expected.reg.into(), writable!(expected.reg.into()), extend);
+            if let Some(extend) = extend {
+                // We don't need to zero-extend from 32 to 64bits.
+                if !(extend.from_bits() == 32 && extend.to_bits() == 64) {
+                    self.asm
+                        .movzx_rr(expected.reg.into(), writable!(expected.reg.into()), extend);
+                }
             }
-        }
 
-        context.stack.push(expected.into());
-        context.free_reg(replacement);
+            context.stack.push(expected.into());
+            context.free_reg(replacement);
+            context.free_reg(addr);
+        }
 
         Ok(())
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1412,7 +1412,7 @@ pub(crate) trait MacroAssembler {
     fn atomic_rmw(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
+        compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         size: OperandSize,
         op: RmwOp,
         flags: MemFlags,
@@ -1438,7 +1438,7 @@ pub(crate) trait MacroAssembler {
     fn atomic_cas(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
+        compute_addr: impl FnOnce(&mut Self, &mut CodeGenContext<Emission>) -> Result<Option<Reg>>,
         size: OperandSize,
         flags: MemFlags,
         extend: Option<Extend<Zero>>,


### PR DESCRIPTION
This PR factors out heap address computation from the `CodeGen` struct, so that it can be passed as a callback to masm. The reason for this refactor is that it avoid uncontidional spill on x64 for atomic operations that have specific requirement on some register.

This happens because the address for those instruction are under the operands, forcing us to pop those operands to registers, computing the address, and pushing the operands back on the stack. This danse made is almost certain that the required registers would be already allocated when needed, thus forcing a spill. By factring out address computation, we can pass it as a callback to the macro assembler, that can pop arguements in their natural order, reserving specific registers as necessary.


runnig a few benchs with sightglass (not all the testsuite is supported yet), there's no performance regression in doing so:
```
compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 19296541.11 ± 5094859.49 (confidence = 99%)

  refacto.so is 1.01x to 1.01x faster than main.so!

  [2361419777 2391240753.01 2441310853] main.so
  [2340893254 2371944211.90 2421142219] refacto.so

instantiation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  No difference in performance.

  [371434 422720.96 560161] main.so
  [341377 417196.75 494199] refacto.so

execution :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  No difference in performance.

  [905704442 928015775.03 981552142] main.so
  [905318861 932491387.89 998574294] refacto.so

-------------------------------------------------------------------------

instantiation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [103974 128183.43 181890] main.so
  [105307 131811.77 177160] refacto.so

compilation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [21460612 25083573.56 51889605] main.so
  [21764794 25410240.69 53043037] refacto.so

execution :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [108341768 110171123.02 119094004] main.so
  [107632268 109609358.98 114981054] refacto.so

-------------------------------------------------------------------------

execution :: cycles :: benchmarks/regex/benchmark.wasm

  Δ = 2168975.90 ± 1429157.42 (confidence = 99%)

  refacto.so is 1.00x to 1.02x faster than main.so!

  [230279362 234821937.90 252109774] main.so
  [229225690 232652962.00 243118560] refacto.so

instantiation :: cycles :: benchmarks/regex/benchmark.wasm

  No difference in performance.

  [310116 341486.65 583080] main.so
  [298291 337779.62 385882] refacto.so

compilation :: cycles :: benchmarks/regex/benchmark.wasm

  No difference in performance.

  [227528308 234328619.97 266022424] main.so
  [227071476 232270717.37 262020199] refacto.so
```

Those benches do not indicate improvement in performance, but that's probably because they don't rely on atomic operations. Looking at the generated asm in the `disas` tests, we can see that a good amount of insructions are shaved off: they correspond to the spills.
