### PR TITLE
Attempt to speed up windows runners

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -65,3 +65,8 @@ runs:
     - name: Install the WASI target
       shell: bash
       run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
+
+    - name: Move Windows target directory
+      shell: bash
+      run: echo 'CARGO_TARGET_DIR=${{ runner.temp }}/target' >> "$GITHUB_ENV"
+      if: runner.os == 'Windows'


### PR DESCRIPTION
I read somewhere on the internet that `C:\` may be slow for I/O. Let's try moving the Rust target directory to somewhere else and see if it has any affect on performance

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
