### PR TITLE
Add a note about quadratic behavior in `Config::native_unwind_info`

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -524,6 +524,12 @@ impl Config {
     /// - When targeting Windows, since the Windows ABI requires it.
     /// - By default.
     ///
+    /// Note that systems loading many modules may wish to disable this
+    /// configuration option instead of leaving it on-by-default. Some platforms
+    /// exhibit quadratic behavior when registering/unregistering unwinding
+    /// information which can greatly slow down the module loading/unloading
+    /// process.
+    ///
     /// [`WasmBacktrace`]: crate::WasmBacktrace
     pub fn native_unwind_info(&mut self, enable: bool) -> &mut Self {
         self.native_unwind_info = Some(enable);


### PR DESCRIPTION
While I don't think this would have solved #10084 because it's not really anywhere you'd look once having such a problem I figure it's not harmful to mention this in the docs at least.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
