### PR TITLE
Wasmtime: fix `PartialEq` implementation for `RegisteredType`

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -70,6 +70,14 @@ struct EngineInner {
     compatible_with_native_host: OnceLock<Result<(), String>>,
 }
 
+impl core::fmt::Debug for Engine {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Engine")
+            .field(&Arc::as_ptr(&self.inner))
+            .finish()
+    }
+}
+
 impl Default for Engine {
     fn default() -> Engine {
         Engine::new(&Config::default()).unwrap()

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -263,11 +263,11 @@ impl core::ops::Deref for RegisteredType {
 
 impl PartialEq for RegisteredType {
     fn eq(&self, other: &Self) -> bool {
-        let eq = Arc::ptr_eq(&self.entry.0, &other.entry.0);
+        let eq = self.index == other.index && Engine::same(&self.engine, &other.engine);
 
         if cfg!(debug_assertions) {
             if eq {
-                assert!(Engine::same(&self.engine, &other.engine));
+                assert!(Arc::ptr_eq(&self.entry.0, &other.entry.0));
                 assert_eq!(self.ty, other.ty);
             } else {
                 assert!(self.ty != other.ty || !Engine::same(&self.engine, &other.engine));
@@ -365,6 +365,9 @@ impl RegisteredType {
         ty: Arc<WasmSubType>,
         layout: Option<GcLayout>,
     ) -> Self {
+        log::trace!(
+            "RegisteredType::from_parts({engine:?}, {entry:?}, {index:?}, {ty:?}, {layout:?})"
+        );
         debug_assert!(entry.0.registrations.load(Acquire) != 0);
         RegisteredType {
             engine,

--- a/tests/all/arrays.rs
+++ b/tests/all/arrays.rs
@@ -1,15 +1,5 @@
+use super::gc_store;
 use wasmtime::*;
-
-fn gc_store() -> Result<Store<()>> {
-    let _ = env_logger::try_init();
-
-    let mut config = Config::new();
-    config.wasm_function_references(true);
-    config.wasm_gc(true);
-
-    let engine = Engine::new(&config)?;
-    Ok(Store::new(&engine, ()))
-}
 
 #[test]
 fn array_new_empty() -> Result<()> {

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -106,3 +106,14 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
 
     config
 }
+
+pub(crate) fn gc_store() -> wasmtime::Result<wasmtime::Store<()>> {
+    let _ = env_logger::try_init();
+
+    let mut config = wasmtime::Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = wasmtime::Engine::new(&config)?;
+    Ok(wasmtime::Store::new(&engine, ()))
+}


### PR DESCRIPTION
We were incorrectly checking whether they were in the same rec group (i.e. whether the two `RegisteredType`s had the same `RecGroupEntry`) rather than whether they were actually the same type or not, even if they were in the same rec group.

This fixes one of two issues reported in #9714

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
