### PR TITLE
docs: Update docs for `wasm_simd`

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -932,8 +932,10 @@ impl Config {
     /// as the `v128` type and all of its operators being in a module. Note that
     /// this does not enable the [relaxed simd proposal].
     ///
-    /// **Note**: On x86_64 platforms the base CPU feature requirement for SIMD
-    /// is SSE2.
+    /// **Note**
+    ///
+    /// On x86_64 platforms the base CPU feature requirement for SIMD
+    /// is SSE2 for the Cranelift compiler and AVX for the Winch compiler.
     ///
     /// This is `true` by default.
     ///


### PR DESCRIPTION
SIMD support in Winch is moving along, a considerable amount of instructions are already supported. This commits updates the documentation to refelct x64 CPU requirements

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
