### PR TITLE
pulley: Execute a wasm module under miri

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,6 +218,8 @@ jobs:
             echo run-dwarf=true >> $GITHUB_OUTPUT
           elif grep -q 'prtest:platform-checks' commits.log; then
             echo platform-checks=true >> $GITHUB_OUTPUT
+          elif grep -q 'prtest:miri' commits.log; then
+            echo test-miri=true >> $GITHUB_OUTPUT
           fi
           if grep -q crates.c-api names.log; then
             echo test-capi=true >> $GITHUB_OUTPUT
@@ -1035,12 +1037,15 @@ jobs:
           - "wasmtime-cli"
           - "wasmtime-environ --all-features"
           - "pulley-interpreter --all-features"
+        include:
+          - script: ./ci/miri-provenance-test.sh
     needs: determine
     if: needs.determine.outputs.test-miri && github.repository == 'bytecodealliance/wasmtime'
     name: Miri
     runs-on: ubuntu-latest
     env:
       CARGO_NEXTEST_VERSION: 0.9.67
+      MIRIFLAGS: -Zmiri-permissive-provenance
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1057,8 +1062,9 @@ jobs:
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-nextest --version ${{ env.CARGO_NEXTEST_VERSION }} cargo-nextest --locked
     - run: |
         cargo miri nextest run -j4 --no-fail-fast -p ${{ matrix.crate }}
-      env:
-        MIRIFLAGS: -Zmiri-strict-provenance
+      if: ${{ matrix.crate }}
+    - run: ${{ matrix.script }}
+      if: ${{ matrix.script }}
 
     # common logic to cancel the entire run if this job fails
     - uses: ./.github/actions/cancel-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1032,12 +1032,11 @@ jobs:
   miri:
     strategy:
       matrix:
-        crate:
-          - "wasmtime --features pulley"
-          - "wasmtime-cli"
-          - "wasmtime-environ --all-features"
-          - "pulley-interpreter --all-features"
         include:
+          - crate: "wasmtime --features pulley"
+          - crate: "wasmtime-cli"
+          - crate: "wasmtime-environ --all-features"
+          - crate: "pulley-interpreter --all-features"
           - script: ./ci/miri-provenance-test.sh
     needs: determine
     if: needs.determine.outputs.test-miri && github.repository == 'bytecodealliance/wasmtime'

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ examples/.cache
 *.smt2
 cranelift/isle/veri/veri_engine/test_output
 crates/explorer/node_modules
+tests/all/pulley_provenance_test.cwasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,6 @@ dependencies = [
  "env_logger 0.11.5",
  "log",
  "object",
- "sptr",
  "termcolor",
  "wasmtime-math",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,9 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
+#
+# NB: once this is 1.84+ delete `pulley/build.rs` and the similar code in
+# `crate/wasmtime/build.rs`
 rust-version = "1.82.0"
 
 [workspace.lints.rust]

--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -15,5 +15,5 @@ cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-m
   -O signals-based-traps=n
 
 MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
-  cargo +nightly miri test --test all -- \
+  cargo miri test --test all -- \
     --ignored pulley_provenance_test "$@"

--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is a small script to assist in running the `pulley_provenance_test` test
+# located at `tests/all/pulley.rs`. The goal of this script is to use the native
+# host to compile the wasm module in question to avoid needing to run Cranelift
+# under MIRI. That enables much faster iteration on the test here.
+
+set -ex
+
+cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-model \
+  compile --target pulley64 ./tests/all/pulley_provenance_test.wat \
+  -o tests/all/pulley_provenance_test.cwasm \
+  -O memory-reservation=$((1 << 20)) \
+  -O memory-guard-size=0 \
+  -O signals-based-traps=n
+
+MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
+  cargo +nightly miri test --test all -- \
+    --ignored pulley_provenance_test "$@"

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -1,5 +1,10 @@
+use std::process::Command;
+use std::str;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+
+    enable_features_based_on_rustc_version();
 
     // NB: duplicating a workaround in the wasmtime-fiber build script.
     println!("cargo:rustc-check-cfg=cfg(asan)");
@@ -91,4 +96,27 @@ fn build_c_helpers() {
     println!("cargo:rerun-if-changed=src/runtime/vm/helpers.c");
     build.file("src/runtime/vm/helpers.c");
     build.compile("wasmtime-helpers");
+}
+
+fn enable_features_based_on_rustc_version() {
+    // Temporary check to see if the rustc version >= 1.84 in which case
+    // provenance-related pointer APIs are available. This is temporary because
+    // in the future the MSRV of this crate will be beyond 1.84 in which case
+    // this build script can be deleted.
+    let minor = rustc_minor_version().unwrap_or(0);
+    if minor >= 84 {
+        println!("cargo:rustc-cfg=has_provenance_apis");
+    }
+    println!("cargo:rustc-check-cfg=cfg(has_provenance_apis)");
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = std::env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
 }

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 arbitrary = { workspace = true, optional = true }
 cranelift-bitset = { workspace = true }
 log = { workspace = true }
-sptr = { workspace = true }
 wasmtime-math = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 

--- a/pulley/build.rs
+++ b/pulley/build.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+use std::str;
+
+fn main() {
+    // Temporary check to see if the rustc version >= 1.84 in which case
+    // provenance-related pointer APIs are available. This is temporary because
+    // in the future the MSRV of this crate will be beyond 1.84 in which case
+    // this build script can be deleted.
+    let minor = rustc_minor_version().unwrap_or(0);
+    if minor >= 84 {
+        println!("cargo:rustc-cfg=has_provenance_apis");
+    }
+    println!("cargo:rustc-check-cfg=cfg(has_provenance_apis)");
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = std::env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/tests/all/pulley_provenance_test.wat
+++ b/tests/all/pulley_provenance_test.wat
@@ -1,0 +1,21 @@
+;; This file is run as part of `pulley_provenance_test` in
+;; `tests/all/pulley.rs`. This is currently split out to be precompiled outside
+;; of miri and to have the compiled bytecode loaded directly into miri.
+(module
+  (import "" "host-wrap" (func $host-wrap (result i32 i32 i32)))
+  (import "" "host-new" (func $host-new (result i32 i32 i32)))
+  (func $some-wasm-func (result i32 i32 i32)
+    i32.const 1
+    i32.const 2
+    i32.const 3
+  )
+  (func (export "call-wasm") (result i32 i32 i32)
+    call $some-wasm-func
+  )
+  (func (export "call-native-wrap") (result i32 i32 i32)
+    call $host-wrap
+  )
+  (func (export "call-native-new") (result i32 i32 i32)
+    call $host-new
+  )
+)


### PR DESCRIPTION
This commit adds a test to CI and a script locally to execute which will run an entire wasm module under Pulley. The goal of this commit is to add The Test for miri execution of wasm. In general miri is too slow to run for the full test suite and even for this single test it takes a very long time to compile the one small module here. To help with this the module is precompiled on native for Pulley and then deserialized in miri itself, meaning that we skip miri execution of Cranelift entirely.

The goal of this commit is to eventually expand this test to cover lots of little and basic operations of wasm which touch VM state. For now it's just a simple smoke test that doesn't run much but it will be expanded over time. Making it much larger than now already turns up miri violations so I wanted to land an initial scaffold first before expanding later.

Getting this test to pass requires changing the `VmPtr<T>` introduced in #10043 to use a `NonZeroUsize` internally rather than `NonNull<T>`. This is because Pulley is only compatible with exposed provenance which means we need to actually expose the provenance of pointers.

Both Pulley and Wasmtime need to deal with exposed provenance APIs, but such APIs are not available in Wasmtime's current MSRV of 1.82. These APIs were instead introduced as stable in Rust 1.84. In lieu of waiting a few months because I'm impatient I've added a small build script to both crates to detect the rustc version and see whether provenance APIs are available. These build script modifications will no longer be necessary once our MSRV is 1.84+.

prtest:miri

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
