### PR TITLE
Use `VmSafe` trait in `VMComponentContext`

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -92,10 +92,10 @@ impl HostFunc {
     }
 
     pub fn lowering(&self) -> VMLowering {
-        let data = &*self.func as *const (dyn Any + Send + Sync) as *mut u8;
+        let data = NonNull::from(&*self.func).cast();
         VMLowering {
             callee: self.entrypoint,
-            data,
+            data: data.into(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
-use crate::runtime::vm::HostResultHasUnwindSentinel;
+use crate::runtime::vm::{HostResultHasUnwindSentinel, VmSafe};
 use core::cell::Cell;
 use core::convert::Infallible;
 use core::ptr::NonNull;
@@ -42,6 +42,10 @@ macro_rules! define_builtins {
                 ) $( -> signature!(@ty $result))?,
             )*
         }
+
+        // SAFETY: the above structure is repr(C) and only contains `VmSafe`
+        // fields.
+        unsafe impl VmSafe for VMComponentBuiltins {}
 
         impl VMComponentBuiltins {
             pub const INIT: VMComponentBuiltins = VMComponentBuiltins {


### PR DESCRIPTION
An additional extension of #10043 to migrate components to `VmSafe` as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
