### PR TITLE
pulley: Run more functions in the miri provenance test

### DIFF
--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -20,7 +20,7 @@ impl Interpreter {
     /// Creates a new interpreter ready to interpret code.
     pub fn new(engine: &Engine) -> Interpreter {
         let ret = Interpreter {
-            pulley: Box::new(Vm::with_stack(vec![0; engine.config().max_wasm_stack])),
+            pulley: Box::new(Vm::with_stack(engine.config().max_wasm_stack)),
         };
         engine.profiler().register_interpreter(&ret);
         ret

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -1138,7 +1138,7 @@ impl Interpreter<'_> {
 
 #[test]
 fn simple_push_pop() {
-    let mut state = MachineState::with_stack(vec![0; 16]);
+    let mut state = MachineState::with_stack(16);
     let pc = ExecutingPc::default();
     unsafe {
         let mut bytecode = [0; 10];

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -125,10 +125,13 @@ fn pulley_provenance_test() -> Result<()> {
     });
     let instance = Instance::new(&mut store, &module, &[host_wrap.into(), host_new.into()])?;
 
-    let func = instance
-        .get_typed_func::<(), (i32, i32, i32)>(&mut store, "call-wasm")
-        .unwrap();
-    let results = func.call(&mut store, ())?;
-    assert_eq!(results, (1, 2, 3));
+    for func in ["call-wasm", "call-native-wrap", "call-native-new"] {
+        let func = instance
+            .get_typed_func::<(), (i32, i32, i32)>(&mut store, func)
+            .unwrap();
+        let results = func.call(&mut store, ())?;
+        assert_eq!(results, (1, 2, 3));
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This commit executes a few more functions in Pulley which uncovered a bug where the pulley stack was not properly aligned on the host. This commit refactors things to ensure that the stack is 16-byte aligned on the host. While here the stack is additionally updated to be allocated as uninitialized to avoid paying the initialization cost on each Pulley interpreter being created.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
