### PR TITLE
add component-model-async/lower.wast test

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -280,10 +280,6 @@ impl<'a> TrampolineCompiler<'a> {
             async_,
         } = *options;
 
-        if async_ {
-            todo!()
-        }
-
         // vmctx: *mut VMComponentContext
         host_sig.params.push(ir::AbiParam::new(pointer_type));
         callee_args.push(vmctx);
@@ -348,6 +344,14 @@ impl<'a> TrampolineCompiler<'a> {
             self.builder
                 .ins()
                 .iconst(ir::types::I8, i64::from(string_encoding as u8)),
+        );
+
+        // async_: bool
+        host_sig.params.push(ir::AbiParam::new(ir::types::I8));
+        callee_args.push(
+            self.builder
+                .ins()
+                .iconst(ir::types::I8, if async_ { 1 } else { 0 }),
         );
 
         // storage: *mut ValRaw

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -94,6 +94,7 @@ pub struct ComponentInstance {
 ///   option for the canonical ABI options.
 /// * `string_encoding` - this is the configured string encoding for the
 ///   canonical ABI this lowering corresponds to.
+/// * `async_` - whether the caller is using the async ABI.
 /// * `args_and_results` - pointer to stack-allocated space in the caller where
 ///   all the arguments are stored as well as where the results will be written
 ///   to. The size and initialized bytes of this depends on the core wasm type
@@ -117,6 +118,7 @@ pub type VMLoweringCallee = extern "C" fn(
     opt_memory: *mut VMMemoryDefinition,
     opt_realloc: *mut VMFuncRef,
     string_encoding: u8,
+    async_: u8,
     args_and_results: NonNull<mem::MaybeUninit<ValRaw>>,
     nargs_and_results: usize,
 ) -> bool;

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -379,7 +379,7 @@ impl InterpreterRef<'_> {
             use wasmtime_environ::component::ComponentBuiltinFunctionIndex;
 
             if id == const { HostCall::ComponentLowerImport.index() } {
-                call!(@host VMLoweringCallee(nonnull, nonnull, u32, nonnull, ptr, ptr, u8, nonnull, size) -> bool);
+                call!(@host VMLoweringCallee(nonnull, nonnull, u32, nonnull, ptr, ptr, u8, u8, nonnull, size) -> bool);
             }
 
             macro_rules! component {

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -96,6 +96,9 @@ pub fn link_component_spectest<T>(linker: &mut component::Linker<T>) -> Result<(
     let engine = linker.engine().clone();
     linker
         .root()
+        .func_wrap("host-echo-u32", |_, v: (u32,)| Ok(v))?;
+    linker
+        .root()
         .func_wrap("host-return-two", |_, _: ()| Ok((2u32,)))?;
     let mut i = linker.instance("host")?;
     i.func_wrap("return-three", |_, _: ()| Ok((3u32,)))?;

--- a/tests/misc_testsuite/component-model-async/lower.wast
+++ b/tests/misc_testsuite/component-model-async/lower.wast
@@ -1,0 +1,13 @@
+;;! component_model_async = true
+
+;; async lower
+(component
+  (import "host-echo-u32" (func $foo (param "p1" u32) (result u32)))
+  (core module $libc (memory (export "memory") 1))
+  (core instance $libc (instantiate $libc))
+  (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
+  (core module $m
+    (func (import "" "foo") (param i32 i32) (result i32))
+  )
+  (core instance $i (instantiate $m (with "" (instance (export "foo" (func $foo))))))
+)


### PR DESCRIPTION
This is another piece of #9582 which I'm splitting out to make review easier.

This test includes a minimal component which lowers an import with the `async` option.

The rest of the changes fill in some TODOs to make the test pass.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
