### PR TITLE
wasmtime-wit-bindgen: use core instead of std in all emitted code

### DIFF
--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -41,5 +41,4 @@ similar = { workspace = true }
 
 [features]
 async = []
-std = ['wasmtime-wit-bindgen/std']
-component-model-async = ['std', 'async', 'wasmtime-wit-bindgen/component-model-async']
+component-model-async = ['async', 'wasmtime-wit-bindgen/component-model-async']

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -199,7 +199,7 @@ pub mod foo {
                 fn take_char(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: char,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -209,7 +209,7 @@ pub mod foo {
                 /// A function that returns a character
                 fn return_char(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> char + Send + Sync + 'static,
@@ -261,9 +261,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -291,9 +291,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(char,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -322,7 +322,7 @@ pub mod foo {
                 fn take_char(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: char,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -335,7 +335,7 @@ pub mod foo {
                 /// A function that returns a character
                 fn return_char(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> char + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -231,7 +231,7 @@ pub mod foo {
                 type Data;
                 fn kebab_case(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -241,7 +241,7 @@ pub mod foo {
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: LudicrousSpeed,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -250,7 +250,7 @@ pub mod foo {
                     Self: Sized;
                 fn function_with_dashes(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -259,7 +259,7 @@ pub mod foo {
                     Self: Sized;
                 fn function_with_no_weird_characters(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -268,7 +268,7 @@ pub mod foo {
                     Self: Sized;
                 fn apple(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -277,7 +277,7 @@ pub mod foo {
                     Self: Sized;
                 fn apple_pear(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -286,7 +286,7 @@ pub mod foo {
                     Self: Sized;
                 fn apple_pear_grape(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -295,7 +295,7 @@ pub mod foo {
                     Self: Sized;
                 fn a0(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -309,7 +309,7 @@ pub mod foo {
                 /// apple-PEAR-grape: func()
                 fn is_xml(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -318,7 +318,7 @@ pub mod foo {
                     Self: Sized;
                 fn explicit(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -327,7 +327,7 @@ pub mod foo {
                     Self: Sized;
                 fn explicit_kebab(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -337,7 +337,7 @@ pub mod foo {
                 /// Identifiers with the same name as keywords are quoted.
                 fn bool(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -386,9 +386,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -419,9 +419,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -449,9 +449,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -481,9 +481,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -511,9 +511,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -541,9 +541,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -571,9 +571,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -601,9 +601,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -631,9 +631,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -661,9 +661,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -691,9 +691,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -721,9 +721,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -750,7 +750,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn kebab_case(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -763,7 +763,7 @@ pub mod foo {
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: LudicrousSpeed,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -775,7 +775,7 @@ pub mod foo {
                 }
                 fn function_with_dashes(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -787,7 +787,7 @@ pub mod foo {
                 }
                 fn function_with_no_weird_characters(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -799,7 +799,7 @@ pub mod foo {
                 }
                 fn apple(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -811,7 +811,7 @@ pub mod foo {
                 }
                 fn apple_pear(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -823,7 +823,7 @@ pub mod foo {
                 }
                 fn apple_pear_grape(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -835,7 +835,7 @@ pub mod foo {
                 }
                 fn a0(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -852,7 +852,7 @@ pub mod foo {
                 /// apple-PEAR-grape: func()
                 fn is_xml(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -864,7 +864,7 @@ pub mod foo {
                 }
                 fn explicit(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -876,7 +876,7 @@ pub mod foo {
                 }
                 fn explicit_kebab(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -889,7 +889,7 @@ pub mod foo {
                 /// Identifiers with the same name as keywords are quoted.
                 fn bool(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -207,7 +207,7 @@ pub mod a {
                 type Data;
                 fn f(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> LiveType + Send + Sync + 'static,
@@ -256,9 +256,9 @@ pub mod a {
                                     ) -> wasmtime::Result<(LiveType,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -285,7 +285,7 @@ pub mod a {
                 type Data = _T::Data;
                 fn f(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> LiveType + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -99,7 +99,7 @@ pub trait FooImports {
     type Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -124,7 +124,7 @@ impl<_T: FooImports> FooImports for &mut _T {
     type Data = _T::Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -230,9 +230,9 @@ const _: () = {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -312,7 +312,7 @@ pub mod foo {
                 fn roundtrip_flag1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag1 + Send + Sync + 'static,
@@ -322,7 +322,7 @@ pub mod foo {
                 fn roundtrip_flag2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag2,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag2 + Send + Sync + 'static,
@@ -332,7 +332,7 @@ pub mod foo {
                 fn roundtrip_flag4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag4,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag4 + Send + Sync + 'static,
@@ -342,7 +342,7 @@ pub mod foo {
                 fn roundtrip_flag8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag8 + Send + Sync + 'static,
@@ -352,7 +352,7 @@ pub mod foo {
                 fn roundtrip_flag16(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag16 + Send + Sync + 'static,
@@ -362,7 +362,7 @@ pub mod foo {
                 fn roundtrip_flag32(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag32 + Send + Sync + 'static,
@@ -372,7 +372,7 @@ pub mod foo {
                 fn roundtrip_flag64(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag64 + Send + Sync + 'static,
@@ -424,9 +424,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag1,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -457,9 +457,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag2,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -490,9 +490,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag4,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -523,9 +523,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag8,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -556,9 +556,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag16,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -589,9 +589,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -622,9 +622,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Flag64,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -652,7 +652,7 @@ pub mod foo {
                 fn roundtrip_flag1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag1 + Send + Sync + 'static,
@@ -665,7 +665,7 @@ pub mod foo {
                 fn roundtrip_flag2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag2,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag2 + Send + Sync + 'static,
@@ -678,7 +678,7 @@ pub mod foo {
                 fn roundtrip_flag4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag4,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag4 + Send + Sync + 'static,
@@ -691,7 +691,7 @@ pub mod foo {
                 fn roundtrip_flag8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag8 + Send + Sync + 'static,
@@ -704,7 +704,7 @@ pub mod foo {
                 fn roundtrip_flag16(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag16 + Send + Sync + 'static,
@@ -717,7 +717,7 @@ pub mod foo {
                 fn roundtrip_flag32(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag32 + Send + Sync + 'static,
@@ -730,7 +730,7 @@ pub mod foo {
                 fn roundtrip_flag64(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Flag64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Flag64 + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -198,7 +198,7 @@ pub mod foo {
                 fn f32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: f32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -208,7 +208,7 @@ pub mod foo {
                 fn f64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: f64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -217,7 +217,7 @@ pub mod foo {
                     Self: Sized;
                 fn f32_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> f32 + Send + Sync + 'static,
@@ -226,7 +226,7 @@ pub mod foo {
                     Self: Sized;
                 fn f64_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> f64 + Send + Sync + 'static,
@@ -275,9 +275,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -305,9 +305,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -335,9 +335,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(f32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -365,9 +365,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(f64,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -395,7 +395,7 @@ pub mod foo {
                 fn f32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: f32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -408,7 +408,7 @@ pub mod foo {
                 fn f64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: f64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -420,7 +420,7 @@ pub mod foo {
                 }
                 fn f32_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> f32 + Send + Sync + 'static,
@@ -432,7 +432,7 @@ pub mod foo {
                 }
                 fn f64_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> f64 + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -99,7 +99,7 @@ pub trait Host_Imports {
     type Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -124,7 +124,7 @@ impl<_T: Host_Imports> Host_Imports for &mut _T {
     type Data = _T::Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -230,9 +230,9 @@ const _: () = {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -198,7 +198,7 @@ pub mod foo {
                 fn a1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -208,7 +208,7 @@ pub mod foo {
                 fn a2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -218,7 +218,7 @@ pub mod foo {
                 fn a3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -228,7 +228,7 @@ pub mod foo {
                 fn a4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -238,7 +238,7 @@ pub mod foo {
                 fn a5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -248,7 +248,7 @@ pub mod foo {
                 fn a6(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -258,7 +258,7 @@ pub mod foo {
                 fn a7(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -268,7 +268,7 @@ pub mod foo {
                 fn a8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -285,7 +285,7 @@ pub mod foo {
                     p6: i32,
                     p7: u64,
                     p8: i64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -294,7 +294,7 @@ pub mod foo {
                     Self: Sized;
                 fn r1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u8 + Send + Sync + 'static,
@@ -303,7 +303,7 @@ pub mod foo {
                     Self: Sized;
                 fn r2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i8 + Send + Sync + 'static,
@@ -312,7 +312,7 @@ pub mod foo {
                     Self: Sized;
                 fn r3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u16 + Send + Sync + 'static,
@@ -321,7 +321,7 @@ pub mod foo {
                     Self: Sized;
                 fn r4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i16 + Send + Sync + 'static,
@@ -330,7 +330,7 @@ pub mod foo {
                     Self: Sized;
                 fn r5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -339,7 +339,7 @@ pub mod foo {
                     Self: Sized;
                 fn r6(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i32 + Send + Sync + 'static,
@@ -348,7 +348,7 @@ pub mod foo {
                     Self: Sized;
                 fn r7(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u64 + Send + Sync + 'static,
@@ -357,7 +357,7 @@ pub mod foo {
                     Self: Sized;
                 fn r8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i64 + Send + Sync + 'static,
@@ -366,7 +366,7 @@ pub mod foo {
                     Self: Sized;
                 fn pair_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (i64, u8) + Send + Sync + 'static,
@@ -415,9 +415,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -445,9 +445,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -475,9 +475,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -505,9 +505,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -535,9 +535,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -565,9 +565,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -595,9 +595,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -625,9 +625,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -677,9 +677,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -707,9 +707,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u8,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -737,9 +737,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(i8,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -767,9 +767,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u16,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -797,9 +797,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(i16,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -827,9 +827,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -857,9 +857,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(i32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -887,9 +887,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u64,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -917,9 +917,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(i64,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -947,9 +947,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<((i64, u8),)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -977,7 +977,7 @@ pub mod foo {
                 fn a1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -990,7 +990,7 @@ pub mod foo {
                 fn a2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i8,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1003,7 +1003,7 @@ pub mod foo {
                 fn a3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1016,7 +1016,7 @@ pub mod foo {
                 fn a4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i16,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1029,7 +1029,7 @@ pub mod foo {
                 fn a5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1042,7 +1042,7 @@ pub mod foo {
                 fn a6(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1055,7 +1055,7 @@ pub mod foo {
                 fn a7(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: u64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1068,7 +1068,7 @@ pub mod foo {
                 fn a8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: i64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1088,7 +1088,7 @@ pub mod foo {
                     p6: i32,
                     p7: u64,
                     p8: i64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1100,7 +1100,7 @@ pub mod foo {
                 }
                 fn r1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u8 + Send + Sync + 'static,
@@ -1112,7 +1112,7 @@ pub mod foo {
                 }
                 fn r2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i8 + Send + Sync + 'static,
@@ -1124,7 +1124,7 @@ pub mod foo {
                 }
                 fn r3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u16 + Send + Sync + 'static,
@@ -1136,7 +1136,7 @@ pub mod foo {
                 }
                 fn r4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i16 + Send + Sync + 'static,
@@ -1148,7 +1148,7 @@ pub mod foo {
                 }
                 fn r5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -1160,7 +1160,7 @@ pub mod foo {
                 }
                 fn r6(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i32 + Send + Sync + 'static,
@@ -1172,7 +1172,7 @@ pub mod foo {
                 }
                 fn r7(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u64 + Send + Sync + 'static,
@@ -1184,7 +1184,7 @@ pub mod foo {
                 }
                 fn r8(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i64 + Send + Sync + 'static,
@@ -1196,7 +1196,7 @@ pub mod foo {
                 }
                 fn pair_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (i64, u8) + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -378,7 +378,7 @@ pub mod foo {
                 fn list_u8_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u8>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -388,7 +388,7 @@ pub mod foo {
                 fn list_u16_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u16>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -398,7 +398,7 @@ pub mod foo {
                 fn list_u32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -408,7 +408,7 @@ pub mod foo {
                 fn list_u64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -418,7 +418,7 @@ pub mod foo {
                 fn list_s8_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i8>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -428,7 +428,7 @@ pub mod foo {
                 fn list_s16_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i16>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -438,7 +438,7 @@ pub mod foo {
                 fn list_s32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -448,7 +448,7 @@ pub mod foo {
                 fn list_s64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -458,7 +458,7 @@ pub mod foo {
                 fn list_f32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<f32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -468,7 +468,7 @@ pub mod foo {
                 fn list_f64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<f64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -477,7 +477,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_u8_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
@@ -486,7 +486,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_u16_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -497,7 +497,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_u32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -508,7 +508,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_u64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -519,7 +519,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_s8_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
@@ -528,7 +528,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_s16_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -539,7 +539,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_s32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -550,7 +550,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_s64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -561,7 +561,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_f32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -572,7 +572,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_f64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -584,7 +584,7 @@ pub mod foo {
                 fn tuple_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -598,7 +598,7 @@ pub mod foo {
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -607,7 +607,7 @@ pub mod foo {
                     Self: Sized;
                 fn string_list_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -621,7 +621,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -635,7 +635,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -647,7 +647,7 @@ pub mod foo {
                 fn record_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -659,7 +659,7 @@ pub mod foo {
                 fn record_list_reverse(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -671,7 +671,7 @@ pub mod foo {
                 fn variant_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -683,7 +683,7 @@ pub mod foo {
                 fn load_store_everything(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: LoadStoreAllSizes,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> LoadStoreAllSizes + Send + Sync + 'static,
@@ -735,9 +735,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -768,9 +768,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -801,9 +801,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -834,9 +834,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -867,9 +867,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -900,9 +900,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -933,9 +933,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -966,9 +966,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -999,9 +999,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1032,9 +1032,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1064,9 +1064,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1098,9 +1098,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1132,9 +1132,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1166,9 +1166,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1200,9 +1200,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1234,9 +1234,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1268,9 +1268,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1302,9 +1302,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1336,9 +1336,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1370,9 +1370,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1407,9 +1407,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1448,9 +1448,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1484,9 +1484,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1535,9 +1535,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1586,9 +1586,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1627,9 +1627,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1664,9 +1664,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1701,9 +1701,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1736,9 +1736,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(LoadStoreAllSizes,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1766,7 +1766,7 @@ pub mod foo {
                 fn list_u8_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u8>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1779,7 +1779,7 @@ pub mod foo {
                 fn list_u16_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u16>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1792,7 +1792,7 @@ pub mod foo {
                 fn list_u32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1805,7 +1805,7 @@ pub mod foo {
                 fn list_u64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<u64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1818,7 +1818,7 @@ pub mod foo {
                 fn list_s8_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i8>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1831,7 +1831,7 @@ pub mod foo {
                 fn list_s16_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i16>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1844,7 +1844,7 @@ pub mod foo {
                 fn list_s32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1857,7 +1857,7 @@ pub mod foo {
                 fn list_s64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<i64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1870,7 +1870,7 @@ pub mod foo {
                 fn list_f32_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<f32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1883,7 +1883,7 @@ pub mod foo {
                 fn list_f64_param(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<f64>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1895,7 +1895,7 @@ pub mod foo {
                 }
                 fn list_u8_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
@@ -1907,7 +1907,7 @@ pub mod foo {
                 }
                 fn list_u16_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1921,7 +1921,7 @@ pub mod foo {
                 }
                 fn list_u32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1935,7 +1935,7 @@ pub mod foo {
                 }
                 fn list_u64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1949,7 +1949,7 @@ pub mod foo {
                 }
                 fn list_s8_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
@@ -1961,7 +1961,7 @@ pub mod foo {
                 }
                 fn list_s16_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1975,7 +1975,7 @@ pub mod foo {
                 }
                 fn list_s32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1989,7 +1989,7 @@ pub mod foo {
                 }
                 fn list_s64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2003,7 +2003,7 @@ pub mod foo {
                 }
                 fn list_f32_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2017,7 +2017,7 @@ pub mod foo {
                 }
                 fn list_f64_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2032,7 +2032,7 @@ pub mod foo {
                 fn tuple_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2049,7 +2049,7 @@ pub mod foo {
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -2061,7 +2061,7 @@ pub mod foo {
                 }
                 fn string_list_ret(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2078,7 +2078,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2095,7 +2095,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2110,7 +2110,7 @@ pub mod foo {
                 fn record_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2125,7 +2125,7 @@ pub mod foo {
                 fn record_list_reverse(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2140,7 +2140,7 @@ pub mod foo {
                 fn variant_list(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -2155,7 +2155,7 @@ pub mod foo {
                 fn load_store_everything(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: LoadStoreAllSizes,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> LoadStoreAllSizes + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -294,7 +294,7 @@ pub mod foo {
                     a14: u64,
                     a15: u64,
                     a16: u64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -304,7 +304,7 @@ pub mod foo {
                 fn big_argument(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: BigStruct,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -408,9 +408,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -441,9 +441,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -486,7 +486,7 @@ pub mod foo {
                     a14: u64,
                     a15: u64,
                     a16: u64,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -517,7 +517,7 @@ pub mod foo {
                 fn big_argument(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: BigStruct,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/multi-return_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multi-return_concurrent.rs
@@ -199,7 +199,7 @@ pub mod foo {
                 type Data;
                 fn mra(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -208,7 +208,7 @@ pub mod foo {
                     Self: Sized;
                 fn mrb(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -217,7 +217,7 @@ pub mod foo {
                     Self: Sized;
                 fn mrc(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -226,7 +226,7 @@ pub mod foo {
                     Self: Sized;
                 fn mrd(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -235,7 +235,7 @@ pub mod foo {
                     Self: Sized;
                 fn mre(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, f32) + Send + Sync + 'static,
@@ -284,9 +284,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -314,9 +314,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -344,9 +344,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -374,9 +374,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -404,9 +404,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32, f32)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -433,7 +433,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn mra(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -445,7 +445,7 @@ pub mod foo {
                 }
                 fn mrb(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -457,7 +457,7 @@ pub mod foo {
                 }
                 fn mrc(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -469,7 +469,7 @@ pub mod foo {
                 }
                 fn mrd(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -481,7 +481,7 @@ pub mod foo {
                 }
                 fn mre(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, f32) + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -216,7 +216,7 @@ pub mod my {
                 type Data;
                 fn x(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -265,9 +265,9 @@ pub mod my {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -294,7 +294,7 @@ pub mod my {
                 type Data = _T::Data;
                 fn x(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -316,7 +316,7 @@ pub mod my {
                 type Data;
                 fn x(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -365,9 +365,9 @@ pub mod my {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -394,7 +394,7 @@ pub mod my {
                 type Data = _T::Data;
                 fn x(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -344,7 +344,7 @@ pub mod foo {
                 fn tuple_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (char, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -353,7 +353,7 @@ pub mod foo {
                     Self: Sized;
                 fn tuple_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (char, u32) + Send + Sync + 'static,
@@ -363,7 +363,7 @@ pub mod foo {
                 fn empty_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Empty,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -372,7 +372,7 @@ pub mod foo {
                     Self: Sized;
                 fn empty_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Empty + Send + Sync + 'static,
@@ -382,7 +382,7 @@ pub mod foo {
                 fn scalar_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Scalars,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -391,7 +391,7 @@ pub mod foo {
                     Self: Sized;
                 fn scalar_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Scalars + Send + Sync + 'static,
@@ -401,7 +401,7 @@ pub mod foo {
                 fn flags_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: ReallyFlags,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -410,7 +410,7 @@ pub mod foo {
                     Self: Sized;
                 fn flags_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> ReallyFlags + Send + Sync + 'static,
@@ -420,7 +420,7 @@ pub mod foo {
                 fn aggregate_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Aggregates,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -429,7 +429,7 @@ pub mod foo {
                     Self: Sized;
                 fn aggregate_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Aggregates + Send + Sync + 'static,
@@ -439,7 +439,7 @@ pub mod foo {
                 fn typedef_inout(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     e: TupleTypedef2,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i32 + Send + Sync + 'static,
@@ -491,9 +491,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -521,9 +521,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<((char, u32),)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -554,9 +554,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -584,9 +584,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Empty,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -617,9 +617,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -647,9 +647,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Scalars,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -680,9 +680,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -710,9 +710,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(ReallyFlags,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -743,9 +743,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -773,9 +773,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Aggregates,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -806,9 +806,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(i32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -836,7 +836,7 @@ pub mod foo {
                 fn tuple_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (char, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -848,7 +848,7 @@ pub mod foo {
                 }
                 fn tuple_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (char, u32) + Send + Sync + 'static,
@@ -861,7 +861,7 @@ pub mod foo {
                 fn empty_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Empty,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -873,7 +873,7 @@ pub mod foo {
                 }
                 fn empty_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Empty + Send + Sync + 'static,
@@ -886,7 +886,7 @@ pub mod foo {
                 fn scalar_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Scalars,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -898,7 +898,7 @@ pub mod foo {
                 }
                 fn scalar_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Scalars + Send + Sync + 'static,
@@ -911,7 +911,7 @@ pub mod foo {
                 fn flags_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: ReallyFlags,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -923,7 +923,7 @@ pub mod foo {
                 }
                 fn flags_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> ReallyFlags + Send + Sync + 'static,
@@ -936,7 +936,7 @@ pub mod foo {
                 fn aggregate_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Aggregates,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -948,7 +948,7 @@ pub mod foo {
                 }
                 fn aggregate_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Aggregates + Send + Sync + 'static,
@@ -961,7 +961,7 @@ pub mod foo {
                 fn typedef_inout(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     e: TupleTypedef2,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> i32 + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -238,7 +238,7 @@ pub mod foo {
                 type Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Thing + Send + Sync + 'static,
@@ -287,9 +287,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Thing,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -316,7 +316,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Thing + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -3,7 +3,7 @@ pub trait HostWorldResource: Sized {
     type WorldResourceData;
     fn new(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
@@ -13,7 +13,7 @@ pub trait HostWorldResource: Sized {
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         self_: wasmtime::component::Resource<WorldResource>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> () + Send + Sync + 'static,
@@ -22,7 +22,7 @@ pub trait HostWorldResource: Sized {
         Self: Sized;
     fn static_foo(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> () + Send + Sync + 'static,
@@ -38,7 +38,7 @@ impl<_T: HostWorldResource> HostWorldResource for &mut _T {
     type WorldResourceData = _T::WorldResourceData;
     fn new(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
@@ -51,7 +51,7 @@ impl<_T: HostWorldResource> HostWorldResource for &mut _T {
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         self_: wasmtime::component::Resource<WorldResource>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> () + Send + Sync + 'static,
@@ -63,7 +63,7 @@ impl<_T: HostWorldResource> HostWorldResource for &mut _T {
     }
     fn static_foo(
         store: wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::WorldResourceData>,
         ) -> () + Send + Sync + 'static,
@@ -187,7 +187,7 @@ pub trait TheWorldImports: HostWorldResource {
     type Data;
     fn some_world_func(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
@@ -212,7 +212,7 @@ impl<_T: TheWorldImports> TheWorldImports for &mut _T {
     type Data = _T::Data;
     fn some_world_func(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> wasmtime::component::Resource<WorldResource> + Send + Sync + 'static,
@@ -369,9 +369,9 @@ const _: () = {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -405,9 +405,9 @@ const _: () = {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -436,9 +436,9 @@ const _: () = {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -469,9 +469,9 @@ const _: () = {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -549,7 +549,7 @@ pub mod foo {
                 type BarData;
                 fn new(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
@@ -558,7 +558,7 @@ pub mod foo {
                     Self: Sized;
                 fn static_a(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> u32 + Send + Sync + 'static,
@@ -568,7 +568,7 @@ pub mod foo {
                 fn method_a(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
                     self_: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> u32 + Send + Sync + 'static,
@@ -584,7 +584,7 @@ pub mod foo {
                 type BarData = _T::BarData;
                 fn new(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
@@ -596,7 +596,7 @@ pub mod foo {
                 }
                 fn static_a(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> u32 + Send + Sync + 'static,
@@ -609,7 +609,7 @@ pub mod foo {
                 fn method_a(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
                     self_: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> u32 + Send + Sync + 'static,
@@ -686,7 +686,7 @@ pub mod foo {
                 fn bar_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -696,7 +696,7 @@ pub mod foo {
                 fn bar_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -705,7 +705,7 @@ pub mod foo {
                     Self: Sized;
                 fn bar_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
@@ -715,7 +715,7 @@ pub mod foo {
                 fn tuple_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -725,7 +725,7 @@ pub mod foo {
                 fn tuple_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -734,7 +734,7 @@ pub mod foo {
                     Self: Sized;
                 fn tuple_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -747,7 +747,7 @@ pub mod foo {
                 fn option_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -757,7 +757,7 @@ pub mod foo {
                 fn option_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -766,7 +766,7 @@ pub mod foo {
                     Self: Sized;
                 fn option_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<
@@ -778,7 +778,7 @@ pub mod foo {
                 fn result_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -788,7 +788,7 @@ pub mod foo {
                 fn result_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -797,7 +797,7 @@ pub mod foo {
                     Self: Sized;
                 fn result_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<
@@ -812,7 +812,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -824,7 +824,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -833,7 +833,7 @@ pub mod foo {
                     Self: Sized;
                 fn list_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -845,7 +845,7 @@ pub mod foo {
                 fn record_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: NestedOwn,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -855,7 +855,7 @@ pub mod foo {
                 fn record_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: NestedBorrow,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -864,7 +864,7 @@ pub mod foo {
                     Self: Sized;
                 fn record_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> NestedOwn + Send + Sync + 'static,
@@ -874,7 +874,7 @@ pub mod foo {
                 fn func_with_handle_typedef(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: SomeHandle,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -939,9 +939,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -971,9 +971,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1004,9 +1004,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1037,9 +1037,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1070,9 +1070,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1102,9 +1102,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1137,9 +1137,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1170,9 +1170,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1202,9 +1202,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1237,9 +1237,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1270,9 +1270,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1302,9 +1302,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1337,9 +1337,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1370,9 +1370,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1402,9 +1402,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1443,9 +1443,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1482,9 +1482,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1518,9 +1518,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1557,9 +1557,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1590,9 +1590,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1620,9 +1620,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(NestedOwn,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1653,9 +1653,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1683,7 +1683,7 @@ pub mod foo {
                 fn bar_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1696,7 +1696,7 @@ pub mod foo {
                 fn bar_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1708,7 +1708,7 @@ pub mod foo {
                 }
                 fn bar_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::Resource<Bar> + Send + Sync + 'static,
@@ -1721,7 +1721,7 @@ pub mod foo {
                 fn tuple_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1734,7 +1734,7 @@ pub mod foo {
                 fn tuple_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1746,7 +1746,7 @@ pub mod foo {
                 }
                 fn tuple_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -1762,7 +1762,7 @@ pub mod foo {
                 fn option_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1775,7 +1775,7 @@ pub mod foo {
                 fn option_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1787,7 +1787,7 @@ pub mod foo {
                 }
                 fn option_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<
@@ -1802,7 +1802,7 @@ pub mod foo {
                 fn result_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1815,7 +1815,7 @@ pub mod foo {
                 fn result_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1827,7 +1827,7 @@ pub mod foo {
                 }
                 fn result_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<
@@ -1845,7 +1845,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1860,7 +1860,7 @@ pub mod foo {
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1872,7 +1872,7 @@ pub mod foo {
                 }
                 fn list_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -1887,7 +1887,7 @@ pub mod foo {
                 fn record_own_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: NestedOwn,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1900,7 +1900,7 @@ pub mod foo {
                 fn record_borrow_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: NestedBorrow,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1912,7 +1912,7 @@ pub mod foo {
                 }
                 fn record_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> NestedOwn + Send + Sync + 'static,
@@ -1925,7 +1925,7 @@ pub mod foo {
                 fn func_with_handle_typedef(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: SomeHandle,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -2102,7 +2102,7 @@ pub mod foo {
                 type Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::Resource<A> + Send + Sync + 'static,
@@ -2153,9 +2153,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -2184,7 +2184,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::Resource<A> + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -292,7 +292,7 @@ pub mod http_fetch {
         fn fetch_request(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
             request: Request,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> Response + Send + Sync + 'static,
@@ -341,9 +341,9 @@ pub mod http_fetch {
                             ) -> wasmtime::Result<(Response,)> + Send + Sync,
                         >
                 })
-                    as ::std::pin::Pin<
+                    as ::core::pin::Pin<
                         Box<
-                            dyn ::std::future::Future<
+                            dyn ::core::future::Future<
                                 Output = Box<
                                     dyn FnOnce(
                                         wasmtime::StoreContextMut<'_, T>,
@@ -371,7 +371,7 @@ pub mod http_fetch {
         fn fetch_request(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
             request: Request,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> Response + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -197,7 +197,7 @@ pub mod foo {
                 type Data;
                 fn f1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -207,7 +207,7 @@ pub mod foo {
                 fn f2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -218,7 +218,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: u32,
                     b: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -227,7 +227,7 @@ pub mod foo {
                     Self: Sized;
                 fn f4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -236,7 +236,7 @@ pub mod foo {
                     Self: Sized;
                 fn f5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, u32) + Send + Sync + 'static,
@@ -248,7 +248,7 @@ pub mod foo {
                     a: u32,
                     b: u32,
                     c: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, u32, u32) + Send + Sync + 'static,
@@ -297,9 +297,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -327,9 +327,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -360,9 +360,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -390,9 +390,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(u32,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -420,9 +420,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<((u32, u32),)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -453,9 +453,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<((u32, u32, u32),)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -482,7 +482,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn f1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -495,7 +495,7 @@ pub mod foo {
                 fn f2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -509,7 +509,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: u32,
                     b: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -521,7 +521,7 @@ pub mod foo {
                 }
                 fn f4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> u32 + Send + Sync + 'static,
@@ -533,7 +533,7 @@ pub mod foo {
                 }
                 fn f5(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, u32) + Send + Sync + 'static,
@@ -548,7 +548,7 @@ pub mod foo {
                     a: u32,
                     b: u32,
                     c: u32,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (u32, u32, u32) + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -200,7 +200,7 @@ pub mod foo {
                 fn simple_list1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     l: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -209,7 +209,7 @@ pub mod foo {
                     Self: Sized;
                 fn simple_list2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -222,7 +222,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: wasmtime::component::__internal::Vec<u32>,
                     b: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -237,7 +237,7 @@ pub mod foo {
                     l: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::Vec<u32>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -291,9 +291,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -323,9 +323,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -371,9 +371,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -423,9 +423,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -459,7 +459,7 @@ pub mod foo {
                 fn simple_list1(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     l: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -471,7 +471,7 @@ pub mod foo {
                 }
                 fn simple_list2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<
@@ -487,7 +487,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: wasmtime::component::__internal::Vec<u32>,
                     b: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -505,7 +505,7 @@ pub mod foo {
                     l: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::Vec<u32>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::Vec<

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -230,7 +230,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Errno {}
+            impl core::error::Error for Errno {}
             const _: () = {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -237,7 +237,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Errno {}
+            impl core::error::Error for Errno {}
             const _: () = {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -239,7 +239,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Errno {}
+            impl core::error::Error for Errno {}
             const _: () = {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
@@ -248,7 +248,7 @@ pub mod foo {
                 type Data;
                 fn create_directory_at(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), Errno> + Send + Sync + 'static,
@@ -257,7 +257,7 @@ pub mod foo {
                     Self: Sized;
                 fn stat(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<DescriptorStat, Errno> + Send + Sync + 'static,
@@ -306,9 +306,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<(), Errno>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -338,9 +338,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -369,7 +369,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn create_directory_at(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), Errno> + Send + Sync + 'static,
@@ -381,7 +381,7 @@ pub mod foo {
                 }
                 fn stat(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<DescriptorStat, Errno> + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -237,7 +237,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Errno {}
+            impl core::error::Error for Errno {}
             const _: () = {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -226,7 +226,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
@@ -339,7 +339,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for Error {}
+                impl core::error::Error for Error {}
                 const _: () = {
                     assert!(
                         1 == < Error as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -233,7 +233,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
@@ -353,7 +353,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for Error {}
+                impl core::error::Error for Error {}
                 const _: () = {
                     assert!(
                         1 == < Error as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -233,7 +233,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
@@ -242,7 +242,7 @@ pub mod foo {
                 type Data;
                 fn option_test(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<
@@ -301,9 +301,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -337,7 +337,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn option_test(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<
@@ -407,7 +407,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for Error {}
+                impl core::error::Error for Error {}
                 const _: () = {
                     assert!(
                         1 == < Error as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -233,7 +233,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
@@ -366,7 +366,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for Error {}
+                impl core::error::Error for Error {}
                 const _: () = {
                     assert!(
                         1 == < Error as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -182,7 +182,7 @@ pub mod imports {
         type Data;
         fn y(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> () + Send + Sync + 'static,
@@ -231,9 +231,9 @@ pub mod imports {
                             ) -> wasmtime::Result<()> + Send + Sync,
                         >
                 })
-                    as ::std::pin::Pin<
+                    as ::core::pin::Pin<
                         Box<
-                            dyn ::std::future::Future<
+                            dyn ::core::future::Future<
                                 Output = Box<
                                     dyn FnOnce(
                                         wasmtime::StoreContextMut<'_, T>,
@@ -260,7 +260,7 @@ pub mod imports {
         type Data = _T::Data;
         fn y(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> () + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -198,7 +198,7 @@ pub mod foo {
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::String,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -207,7 +207,7 @@ pub mod foo {
                     Self: Sized;
                 fn b(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
@@ -218,7 +218,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: wasmtime::component::__internal::String,
                     b: wasmtime::component::__internal::String,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
@@ -270,9 +270,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -302,9 +302,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -345,9 +345,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -377,7 +377,7 @@ pub mod foo {
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: wasmtime::component::__internal::String,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -389,7 +389,7 @@ pub mod foo {
                 }
                 fn b(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::String + Send + Sync + 'static,
@@ -403,7 +403,7 @@ pub mod foo {
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: wasmtime::component::__internal::String,
                     b: wasmtime::component::__internal::String,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> wasmtime::component::__internal::String + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/unstable-features.rs
+++ b/crates/component-macro/tests/expanded/unstable-features.rs
@@ -74,12 +74,12 @@ impl<_T: HostBaz + ?Sized> HostBaz for &mut _T {
         HostBaz::drop(*self, rep)
     }
 }
-impl std::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: LinkOptions) -> Self {
         (&src).into()
     }
 }
-impl std::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: &LinkOptions) -> Self {
         let mut dest = Self::default();
         dest.experimental_interface(src.experimental_interface);

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -81,12 +81,12 @@ impl<_T: HostBaz + ?Sized + Send> HostBaz for &mut _T {
         HostBaz::drop(*self, rep).await
     }
 }
-impl std::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: LinkOptions) -> Self {
         (&src).into()
     }
 }
-impl std::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: &LinkOptions) -> Self {
         let mut dest = Self::default();
         dest.experimental_interface(src.experimental_interface);

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -67,7 +67,7 @@ pub trait HostBaz: Sized {
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::BazData>,
         self_: wasmtime::component::Resource<Baz>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::BazData>,
         ) -> () + Send + Sync + 'static,
@@ -81,7 +81,7 @@ impl<_T: HostBaz> HostBaz for &mut _T {
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::BazData>,
         self_: wasmtime::component::Resource<Baz>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::BazData>,
         ) -> () + Send + Sync + 'static,
@@ -95,12 +95,12 @@ impl<_T: HostBaz> HostBaz for &mut _T {
         HostBaz::drop(*self, rep)
     }
 }
-impl std::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: LinkOptions) -> Self {
         (&src).into()
     }
 }
-impl std::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: &LinkOptions) -> Self {
         let mut dest = Self::default();
         dest.experimental_interface(src.experimental_interface);
@@ -213,7 +213,7 @@ pub trait TheWorldImports: HostBaz {
     type Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -238,7 +238,7 @@ impl<_T: TheWorldImports> TheWorldImports for &mut _T {
     type Data = _T::Data;
     fn foo(
         store: wasmtime::StoreContextMut<'_, Self::Data>,
-    ) -> impl ::std::future::Future<
+    ) -> impl ::core::future::Future<
         Output = impl FnOnce(
             wasmtime::StoreContextMut<'_, Self::Data>,
         ) -> () + Send + Sync + 'static,
@@ -366,9 +366,9 @@ const _: () = {
                                             ) -> wasmtime::Result<()> + Send + Sync,
                                         >
                                 })
-                                    as ::std::pin::Pin<
+                                    as ::core::pin::Pin<
                                         Box<
-                                            dyn ::std::future::Future<
+                                            dyn ::core::future::Future<
                                                 Output = Box<
                                                     dyn FnOnce(
                                                         wasmtime::StoreContextMut<'_, T>,
@@ -404,9 +404,9 @@ const _: () = {
                                             ) -> wasmtime::Result<()> + Send + Sync,
                                         >
                                 })
-                                    as ::std::pin::Pin<
+                                    as ::core::pin::Pin<
                                         Box<
-                                            dyn ::std::future::Future<
+                                            dyn ::core::future::Future<
                                                 Output = Box<
                                                     dyn FnOnce(
                                                         wasmtime::StoreContextMut<'_, T>,
@@ -497,7 +497,7 @@ pub mod foo {
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
                     self_: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> () + Send + Sync + 'static,
@@ -514,7 +514,7 @@ pub mod foo {
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::BarData>,
                     self_: wasmtime::component::Resource<Bar>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::BarData>,
                     ) -> () + Send + Sync + 'static,
@@ -535,7 +535,7 @@ pub mod foo {
                 type Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -605,9 +605,9 @@ pub mod foo {
                                             ) -> wasmtime::Result<()> + Send + Sync,
                                         >
                                 })
-                                    as ::std::pin::Pin<
+                                    as ::core::pin::Pin<
                                         Box<
-                                            dyn ::std::future::Future<
+                                            dyn ::core::future::Future<
                                                 Output = Box<
                                                     dyn FnOnce(
                                                         wasmtime::StoreContextMut<'_, T>,
@@ -642,9 +642,9 @@ pub mod foo {
                                             ) -> wasmtime::Result<()> + Send + Sync,
                                         >
                                 })
-                                    as ::std::pin::Pin<
+                                    as ::core::pin::Pin<
                                         Box<
-                                            dyn ::std::future::Future<
+                                            dyn ::core::future::Future<
                                                 Output = Box<
                                                     dyn FnOnce(
                                                         wasmtime::StoreContextMut<'_, T>,
@@ -674,7 +674,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn foo(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
@@ -81,12 +81,12 @@ impl<_T: HostBaz + ?Sized + Send> HostBaz for &mut _T {
         HostBaz::drop(*self, rep).await
     }
 }
-impl std::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: LinkOptions) -> Self {
         (&src).into()
     }
 }
-impl std::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
     fn from(src: &LinkOptions) -> Self {
         let mut dest = Self::default();
         dest.experimental_interface(src.experimental_interface);

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -196,7 +196,7 @@ pub mod foo {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -203,7 +203,7 @@ pub mod foo {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -203,7 +203,7 @@ pub mod foo {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
@@ -212,7 +212,7 @@ pub mod foo {
                 type Data;
                 fn g(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), Error> + Send + Sync + 'static,
@@ -261,9 +261,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<(), Error>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -290,7 +290,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn g(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), Error> + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_tracing_async.rs
@@ -203,7 +203,7 @@ pub mod foo {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for Error {}
+            impl core::error::Error for Error {}
             const _: () = {
                 assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -204,7 +204,7 @@ pub mod foo {
                 type Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -253,9 +253,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Foo,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -282,7 +282,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -307,7 +307,7 @@ pub mod foo {
                 type Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -356,9 +356,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Foo,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -385,7 +385,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -410,7 +410,7 @@ pub mod foo {
                 type Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -459,9 +459,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Foo,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -488,7 +488,7 @@ pub mod foo {
                 type Data = _T::Data;
                 fn a(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Foo + Send + Sync + 'static,
@@ -515,7 +515,7 @@ pub mod d {
         type Data;
         fn b(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> Foo + Send + Sync + 'static,
@@ -564,9 +564,9 @@ pub mod d {
                             ) -> wasmtime::Result<(Foo,)> + Send + Sync,
                         >
                 })
-                    as ::std::pin::Pin<
+                    as ::core::pin::Pin<
                         Box<
-                            dyn ::std::future::Future<
+                            dyn ::core::future::Future<
                                 Output = Box<
                                     dyn FnOnce(
                                         wasmtime::StoreContextMut<'_, T>,
@@ -593,7 +593,7 @@ pub mod d {
         type Data = _T::Data;
         fn b(
             store: wasmtime::StoreContextMut<'_, Self::Data>,
-        ) -> impl ::std::future::Future<
+        ) -> impl ::core::future::Future<
             Output = impl FnOnce(
                 wasmtime::StoreContextMut<'_, Self::Data>,
             ) -> Foo + Send + Sync + 'static,

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -435,7 +435,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for MyErrno {}
+            impl core::error::Error for MyErrno {}
             const _: () = {
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
@@ -1243,7 +1243,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for MyErrno {}
+                impl core::error::Error for MyErrno {}
                 const _: () = {
                     assert!(
                         1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -442,7 +442,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for MyErrno {}
+            impl core::error::Error for MyErrno {}
             const _: () = {
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
@@ -1302,7 +1302,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for MyErrno {}
+                impl core::error::Error for MyErrno {}
                 const _: () = {
                     assert!(
                         1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -442,7 +442,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for MyErrno {}
+            impl core::error::Error for MyErrno {}
             const _: () = {
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
@@ -470,7 +470,7 @@ pub mod foo {
                 fn e1_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: E1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -479,7 +479,7 @@ pub mod foo {
                     Self: Sized;
                 fn e1_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> E1 + Send + Sync + 'static,
@@ -489,7 +489,7 @@ pub mod foo {
                 fn v1_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: V1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -498,7 +498,7 @@ pub mod foo {
                     Self: Sized;
                 fn v1_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> V1 + Send + Sync + 'static,
@@ -508,7 +508,7 @@ pub mod foo {
                 fn bool_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: bool,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -517,7 +517,7 @@ pub mod foo {
                     Self: Sized;
                 fn bool_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> bool + Send + Sync + 'static,
@@ -532,7 +532,7 @@ pub mod foo {
                     d: Option<E1>,
                     e: Option<f32>,
                     g: Option<Option<bool>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -541,7 +541,7 @@ pub mod foo {
                     Self: Sized;
                 fn option_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -563,7 +563,7 @@ pub mod foo {
                     d: Casts4,
                     e: Casts5,
                     f: Casts6,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -588,7 +588,7 @@ pub mod foo {
                         wasmtime::component::__internal::String,
                         wasmtime::component::__internal::Vec<u8>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -597,7 +597,7 @@ pub mod foo {
                     Self: Sized;
                 fn result_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -616,7 +616,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_result_sugar(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<i32, MyErrno> + Send + Sync + 'static,
@@ -625,7 +625,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_result_sugar2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), MyErrno> + Send + Sync + 'static,
@@ -634,7 +634,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_result_sugar3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<MyErrno, MyErrno> + Send + Sync + 'static,
@@ -643,7 +643,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_result_sugar4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(i32, u32), MyErrno> + Send + Sync + 'static,
@@ -652,7 +652,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_option_sugar(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<i32> + Send + Sync + 'static,
@@ -661,7 +661,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_option_sugar2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<MyErrno> + Send + Sync + 'static,
@@ -670,7 +670,7 @@ pub mod foo {
                     Self: Sized;
                 fn result_simple(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<u32, i32> + Send + Sync + 'static,
@@ -680,7 +680,7 @@ pub mod foo {
                 fn is_clone_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: IsClone,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -689,7 +689,7 @@ pub mod foo {
                     Self: Sized;
                 fn is_clone_return(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> IsClone + Send + Sync + 'static,
@@ -698,7 +698,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_named_option(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<u8> + Send + Sync + 'static,
@@ -707,7 +707,7 @@ pub mod foo {
                     Self: Sized;
                 fn return_named_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<u8, MyErrno> + Send + Sync + 'static,
@@ -756,9 +756,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -786,9 +786,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(E1,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -816,9 +816,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -846,9 +846,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(V1,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -879,9 +879,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -909,9 +909,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(bool,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -964,9 +964,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1005,9 +1005,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1066,9 +1066,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1126,9 +1126,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1170,9 +1170,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1214,9 +1214,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<i32, MyErrno>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1244,9 +1244,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<(), MyErrno>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1276,9 +1276,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1310,9 +1310,9 @@ pub mod foo {
                                         > + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1342,9 +1342,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Option<i32>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1372,9 +1372,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Option<MyErrno>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1402,9 +1402,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<u32, i32>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1435,9 +1435,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<()> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1465,9 +1465,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(IsClone,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1495,9 +1495,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Option<u8>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1525,9 +1525,9 @@ pub mod foo {
                                     ) -> wasmtime::Result<(Result<u8, MyErrno>,)> + Send + Sync,
                                 >
                         })
-                            as ::std::pin::Pin<
+                            as ::core::pin::Pin<
                                 Box<
-                                    dyn ::std::future::Future<
+                                    dyn ::core::future::Future<
                                         Output = Box<
                                             dyn FnOnce(
                                                 wasmtime::StoreContextMut<'_, T>,
@@ -1555,7 +1555,7 @@ pub mod foo {
                 fn e1_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: E1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1567,7 +1567,7 @@ pub mod foo {
                 }
                 fn e1_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> E1 + Send + Sync + 'static,
@@ -1580,7 +1580,7 @@ pub mod foo {
                 fn v1_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: V1,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1592,7 +1592,7 @@ pub mod foo {
                 }
                 fn v1_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> V1 + Send + Sync + 'static,
@@ -1605,7 +1605,7 @@ pub mod foo {
                 fn bool_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     x: bool,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1617,7 +1617,7 @@ pub mod foo {
                 }
                 fn bool_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> bool + Send + Sync + 'static,
@@ -1635,7 +1635,7 @@ pub mod foo {
                     d: Option<E1>,
                     e: Option<f32>,
                     g: Option<Option<bool>>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1647,7 +1647,7 @@ pub mod foo {
                 }
                 fn option_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -1672,7 +1672,7 @@ pub mod foo {
                     d: Casts4,
                     e: Casts5,
                     f: Casts6,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -1700,7 +1700,7 @@ pub mod foo {
                         wasmtime::component::__internal::String,
                         wasmtime::component::__internal::Vec<u8>,
                     >,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1712,7 +1712,7 @@ pub mod foo {
                 }
                 fn result_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> (
@@ -1734,7 +1734,7 @@ pub mod foo {
                 }
                 fn return_result_sugar(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<i32, MyErrno> + Send + Sync + 'static,
@@ -1746,7 +1746,7 @@ pub mod foo {
                 }
                 fn return_result_sugar2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(), MyErrno> + Send + Sync + 'static,
@@ -1758,7 +1758,7 @@ pub mod foo {
                 }
                 fn return_result_sugar3(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<MyErrno, MyErrno> + Send + Sync + 'static,
@@ -1770,7 +1770,7 @@ pub mod foo {
                 }
                 fn return_result_sugar4(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<(i32, u32), MyErrno> + Send + Sync + 'static,
@@ -1782,7 +1782,7 @@ pub mod foo {
                 }
                 fn return_option_sugar(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<i32> + Send + Sync + 'static,
@@ -1794,7 +1794,7 @@ pub mod foo {
                 }
                 fn return_option_sugar2(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<MyErrno> + Send + Sync + 'static,
@@ -1806,7 +1806,7 @@ pub mod foo {
                 }
                 fn result_simple(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<u32, i32> + Send + Sync + 'static,
@@ -1819,7 +1819,7 @@ pub mod foo {
                 fn is_clone_arg(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
                     a: IsClone,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> () + Send + Sync + 'static,
@@ -1831,7 +1831,7 @@ pub mod foo {
                 }
                 fn is_clone_return(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> IsClone + Send + Sync + 'static,
@@ -1843,7 +1843,7 @@ pub mod foo {
                 }
                 fn return_named_option(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Option<u8> + Send + Sync + 'static,
@@ -1855,7 +1855,7 @@ pub mod foo {
                 }
                 fn return_named_result(
                     store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::std::future::Future<
+                ) -> impl ::core::future::Future<
                     Output = impl FnOnce(
                         wasmtime::StoreContextMut<'_, Self::Data>,
                     ) -> Result<u8, MyErrno> + Send + Sync + 'static,
@@ -2186,7 +2186,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for MyErrno {}
+                impl core::error::Error for MyErrno {}
                 const _: () = {
                     assert!(
                         1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -442,7 +442,7 @@ pub mod foo {
                     write!(f, "{} (error {})", self.name(), * self as i32)
                 }
             }
-            impl std::error::Error for MyErrno {}
+            impl core::error::Error for MyErrno {}
             const _: () = {
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32);
                 assert!(1 == < MyErrno as wasmtime::component::ComponentType >::ALIGN32);
@@ -1626,7 +1626,7 @@ pub mod exports {
                         write!(f, "{} (error {})", self.name(), * self as i32)
                     }
                 }
-                impl std::error::Error for MyErrno {}
+                impl core::error::Error for MyErrno {}
                 const _: () = {
                     assert!(
                         1 == < MyErrno as wasmtime::component::ComponentType >::SIZE32

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -315,7 +315,6 @@ addr2line = ["dep:addr2line", "dep:gimli", "std"]
 # This will be automatically enabled if necessary.
 std = [
   'postcard/use-std',
-  'wasmtime-component-macro?/std',
   'wasmtime-environ/std',
   'object/std',
   'once_cell',

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -19,5 +19,4 @@ wit-parser = { workspace = true }
 indexmap = { workspace = true }
 
 [features]
-std = []
-component-model-async = ['std']
+component-model-async = []

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -2132,11 +2132,9 @@ impl<'a> InterfaceGenerator<'a> {
                 self.push_str("}\n");
                 self.push_str("}\n");
 
-                if cfg!(feature = "std") {
-                    self.push_str("impl std::error::Error for ");
-                    self.push_str(&name);
-                    self.push_str("{}\n");
-                }
+                self.push_str("impl core::error::Error for ");
+                self.push_str(&name);
+                self.push_str("{}\n");
             }
             self.assert_type(id, &name);
         }
@@ -2319,14 +2317,12 @@ impl<'a> InterfaceGenerator<'a> {
                 self.push_str("}\n");
                 self.push_str("}\n");
 
-                if cfg!(feature = "std") {
-                    self.push_str("impl");
-                    self.print_generics(lt);
-                    self.push_str(" std::error::Error for ");
-                    self.push_str(&name);
-                    self.print_generics(lt);
-                    self.push_str(" {}\n");
-                }
+                self.push_str("impl");
+                self.print_generics(lt);
+                self.push_str(" core::error::Error for ");
+                self.push_str(&name);
+                self.print_generics(lt);
+                self.push_str(" {}\n");
             }
 
             self.assert_type(id, &name);
@@ -2499,11 +2495,9 @@ impl<'a> InterfaceGenerator<'a> {
             self.push_str("}\n");
             self.push_str("}\n");
             self.push_str("\n");
-            if cfg!(feature = "std") {
-                self.push_str("impl std::error::Error for ");
-                self.push_str(&name);
-                self.push_str("{}\n");
-            }
+            self.push_str("impl core::error::Error for ");
+            self.push_str(&name);
+            self.push_str("{}\n");
         } else {
             self.print_rust_enum_debug(
                 id,
@@ -3144,7 +3138,7 @@ impl<'a> InterfaceGenerator<'a> {
                 uwriteln!(
                     self.src,
                     "        }}) as {box_fn}
-                         }}) as ::std::pin::Pin<Box<dyn ::std::future::Future<Output = {box_fn}> \
+                         }}) as ::core::pin::Pin<Box<dyn ::core::future::Future<Output = {box_fn}> \
                                + Send + Sync + 'static>>
                     "
                 );
@@ -3182,7 +3176,7 @@ impl<'a> InterfaceGenerator<'a> {
         self.push_str(" -> ");
 
         if let CallStyle::Concurrent = &style {
-            uwrite!(self.src, "impl ::std::future::Future<Output = impl FnOnce(wasmtime::StoreContextMut<'_, Self::{data}>) -> ");
+            uwrite!(self.src, "impl ::core::future::Future<Output = impl FnOnce(wasmtime::StoreContextMut<'_, Self::{data}>) -> ");
         }
 
         if !self.generator.opts.trappable_imports.can_trap(func) {
@@ -3588,13 +3582,13 @@ impl LinkOptionsBuilder {
         uwriteln!(
             src,
             "
-            impl std::convert::From<LinkOptions> for {path}::LinkOptions {{
+            impl core::convert::From<LinkOptions> for {path}::LinkOptions {{
                 fn from(src: LinkOptions) -> Self {{
                     (&src).into()
                 }}
             }}
 
-            impl std::convert::From<&LinkOptions> for {path}::LinkOptions {{
+            impl core::convert::From<&LinkOptions> for {path}::LinkOptions {{
                 fn from(src: &LinkOptions) -> Self {{
                     let mut dest = Self::default();
         "


### PR DESCRIPTION
Improve compatibility with #![no_std] builds by substituting all uses of `std::` for `core::` in wasmtime-wit-bindgen output.

The one use of the `std` cargo feature in this crate was to gate emitting `impl std::error::Error for ...`, now that Error is in core we can unconditionally emit an `impl core::error::Error for ...`, and eliminate the `std` cargo feature in the `wasmtime-wit-bindgen` and `wasmtime-component-macro` crates.