### PR TITLE
Disallow dead code/unused imports by default in `wasmtime` crate

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -281,7 +281,6 @@
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 // Allow broken links when the default features is disabled because most of our
 // documentation is written for the "one build" of the `main` branch which has
 // most features enabled. This will present warnings in stripped-down doc builds


### PR DESCRIPTION
This PR is a change to the crate attributes of the `wasmtime` crate. Quite some time ago when Wasmtime had far fewer crate features I added a directive to allow dead code and unused imports when the `default` feature was disabled. The original intention was to not worry too much about unused imports and dead code in every possible configuration of Wasmtime to ease the burden of dealing with unused imports or compile-time conditionally used code.

The primary consequence of this change though is that `cargo build` doesn't actually warn about dead code or unused imports in this repository during development. The reason for this is that the `default` feature is disabled by default and never actually enabled by any dependency inside the repository. Instead each crate, like `wasmtime-cli`, has its own `default` feature.

If I were to start from the problem of "I want dead code warnings by default in this repository" there's two possible fixes:

1. Change `wasmtime-cli`'s `default` feature to include `wasmtime/default`.
2. Remove this `#[allow]` directive.

While (1) would indeed work this is an attempt to get (2) working to see how bad the changes are necessary within the crate.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
