### PR TITLE
wasmtime-wasi: Fix spurious wake-ups in `blocking_` of `InputStream` and `OutputStream`

### DIFF
--- a/crates/wasi-io/src/streams.rs
+++ b/crates/wasi-io/src/streams.rs
@@ -33,6 +33,11 @@ pub trait InputStream: Pollable {
     /// Similar to `read`, except that it blocks until at least one byte can be
     /// read.
     async fn blocking_read(&mut self, size: usize) -> StreamResult<Bytes> {
+        if size == 0 {
+            self.ready().await;
+            return self.read(size);
+        }
+
         let mut i = 0;
         loop {
             // This `ready` call may return prematurely due to `io::ErrorKind::WouldBlock`.


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
issue #9667 

The `InputStream::ready` can be prematurely triggered by `io::ErrorKind::WouldBlock`. This PR ensure that `blocking_` functions return a valid non-empty result.