### PR TITLE
winch(fuzzing): Enable `threads`

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -597,7 +597,6 @@ impl WasmtimeConfig {
                 config.simd_enabled = false;
                 config.relaxed_simd_enabled = false;
                 config.gc_enabled = false;
-                config.threads_enabled = false;
                 config.tail_call_enabled = false;
                 config.reference_types_enabled = false;
 


### PR DESCRIPTION
As of https://github.com/bytecodealliance/wasmtime/issues/9734, Winch supports the Threads proposal for x64.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
