### PR TITLE
Configure fuel specified in `wasmtime wast`

### DIFF
--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -24,7 +24,10 @@ impl WastCommand {
         self.common.init_logging()?;
 
         let config = self.common.config(None)?;
-        let store = Store::new(&Engine::new(&config)?, ());
+        let mut store = Store::new(&Engine::new(&config)?, ());
+        if let Some(fuel) = self.common.wasm.fuel {
+            store.set_fuel(fuel)?;
+        }
         let mut wast_context = WastContext::new(store);
 
         wast_context


### PR DESCRIPTION
Otherwise if specified no fuel is injected and wasm execution always traps.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
