### PR TITLE
 Make it easier to reuse fuzzing configuration on the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ dependencies = [
  "wasmparser",
  "wasmprinter",
  "wasmtime",
+ "wasmtime-cli-flags",
  "wasmtime-wast",
  "wasmtime-wast-util",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,6 +445,7 @@ wmemcheck = ["wasmtime/wmemcheck"]
 trace-log = ["wasmtime/trace-log"]
 memory-protection-keys = ["wasmtime-cli-flags/memory-protection-keys"]
 profile-pulley = ["wasmtime/profile-pulley"]
+component-model-async = ["wasmtime-cli-flags/component-model-async", "component-model"]
 
 # This feature, when enabled, will statically compile out all logging statements
 # throughout Wasmtime and its dependencies.

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -25,6 +25,7 @@ humantime = { workspace = true }
 async = ["wasmtime/async"]
 pooling-allocator = ["wasmtime/pooling-allocator"]
 component-model = ["wasmtime/component-model"]
+component-model-async = ["wasmtime/component-model-async"]
 cache = ["wasmtime/cache"]
 parallel-compilation = ["wasmtime/parallel-compilation", "dep:rayon"]
 logging = ["dep:file-per-thread-logger", "dep:tracing-subscriber"]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -931,7 +931,7 @@ impl CommonOptions {
             ("component-model", component_model, wasm_component_model)
             ("component-model", component_model_more_flags, wasm_component_model_more_flags)
             ("component-model", component_model_multiple_returns, wasm_component_model_multiple_returns)
-            ("component-model", component_model_async, wasm_component_model_async)
+            ("component-model-async", component_model_async, wasm_component_model_async)
             ("threads", threads, wasm_threads)
             ("gc", gc, wasm_gc)
             ("gc", reference_types, wasm_reference_types)

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -811,11 +811,7 @@ impl CommonOptions {
                     }
                     match_feature! {
                         ["memory-protection-keys" : self.opts.pooling_memory_protection_keys]
-                        enable => cfg.memory_protection_keys(if enable {
-                            wasmtime::MpkEnabled::Enable
-                        } else {
-                            wasmtime::MpkEnabled::Disable
-                        }),
+                        enable => cfg.memory_protection_keys(enable),
                         _ => err,
                     }
                     match_feature! {

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -26,8 +26,9 @@ target-lexicon = { workspace = true }
 tempfile = "3.3.0"
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasmtime = { workspace = true, features = ['default', 'winch', 'gc', 'memory-protection-keys', 'pulley'] }
+wasmtime-cli-flags = { workspace = true, features = ['gc', 'memory-protection-keys', 'pulley'] }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
+wasmtime = { workspace = true, features = ['default', 'winch'] }
 wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
 wasm-mutate = { workspace = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -26,7 +26,6 @@ target-lexicon = { workspace = true }
 tempfile = "3.3.0"
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasmtime-cli-flags = { workspace = true, features = ['gc', 'memory-protection-keys', 'pulley'] }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
 wasmtime = { workspace = true, features = ['default', 'winch'] }
 wasm-encoder = { workspace = true }
@@ -36,6 +35,21 @@ wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
 wasmi = "0.39.1"
 futures = { workspace = true }
 wasmtime-wast-util = { path = '../wast-util' }
+
+[dependencies.wasmtime-cli-flags]
+workspace = true
+features = [
+  'async',
+  'component-model',
+  'cranelift',
+  'gc',
+  'gc-drc',
+  'gc-null',
+  'memory-protection-keys',
+  'pooling-allocator',
+  'pulley',
+  'threads',
+]
 
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled
 # binary for MinGW which is built on our CI. It does have one for Windows-msvc,

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -41,6 +41,7 @@ workspace = true
 features = [
   'async',
   'component-model',
+  'component-model-async',
   'cranelift',
   'gc',
   'gc-drc',

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -18,15 +18,16 @@ pub enum CodegenSettings {
 
 impl CodegenSettings {
     /// Configure Wasmtime with these codegen settings.
-    pub fn configure(&self, config: &mut wasmtime::Config) {
+    pub fn configure(&self, config: &mut wasmtime_cli_flags::CommonOptions) {
         match self {
             CodegenSettings::Native => {}
             CodegenSettings::Target { target, flags } => {
-                config.target(target).unwrap();
+                config.target = Some(target.to_string());
                 for (key, value) in flags {
-                    unsafe {
-                        config.cranelift_flag_set(key, value);
-                    }
+                    config
+                        .codegen
+                        .cranelift
+                        .push((key.clone(), Some(value.clone())));
                 }
             }
         }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -322,9 +322,10 @@ impl Config {
             }
 
             if self.wasmtime.force_jump_veneers {
-                cfg.codegen
-                    .cranelift
-                    .push(("wasmtime_linkopt_force_jump_veneer".to_string(), None));
+                cfg.codegen.cranelift.push((
+                    "wasmtime_linkopt_force_jump_veneer".to_string(),
+                    Some("true".to_string()),
+                ));
             }
 
             if let Some(pad) = self.wasmtime.padding_between_functions {

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -249,46 +249,44 @@ impl Config {
     /// Converts this to a `wasmtime::Config` object
     pub fn to_wasmtime(&self) -> wasmtime::Config {
         crate::init_fuzzing();
-        log::debug!("creating wasmtime config with {:#?}", self.wasmtime);
 
-        let mut cfg = wasmtime::Config::new();
-        cfg.parallel_compilation(false)
-            .wasm_bulk_memory(true)
-            .wasm_reference_types(self.module_config.config.reference_types_enabled)
-            .wasm_multi_value(self.module_config.config.multi_value_enabled)
-            .wasm_multi_memory(self.module_config.config.max_memories > 1)
-            .wasm_simd(self.module_config.config.simd_enabled)
-            .wasm_memory64(self.module_config.config.memory64_enabled)
-            .wasm_tail_call(self.module_config.config.tail_call_enabled)
-            .wasm_custom_page_sizes(self.module_config.config.custom_page_sizes_enabled)
-            .wasm_threads(self.module_config.config.threads_enabled)
-            .wasm_function_references(self.module_config.function_references_enabled)
-            .wasm_gc(self.module_config.config.gc_enabled)
-            .wasm_custom_page_sizes(self.module_config.config.custom_page_sizes_enabled)
-            .wasm_wide_arithmetic(self.module_config.config.wide_arithmetic_enabled)
-            .wasm_extended_const(self.module_config.config.extended_const_enabled)
-            .wasm_component_model_more_flags(self.module_config.component_model_more_flags)
-            .wasm_component_model_async(self.module_config.component_model_async)
-            .native_unwind_info(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info)
-            .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)
-            .cranelift_opt_level(self.wasmtime.opt_level.to_wasmtime())
-            .cranelift_regalloc_algorithm(self.wasmtime.regalloc_algorithm.to_wasmtime())
-            .consume_fuel(self.wasmtime.consume_fuel)
-            .epoch_interruption(self.wasmtime.epoch_interruption)
-            .memory_guaranteed_dense_image_size(std::cmp::min(
-                // Clamp this at 16MiB so we don't get huge in-memory
-                // images during fuzzing.
-                16 << 20,
-                self.wasmtime.memory_guaranteed_dense_image_size,
-            ))
-            .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
-            .generate_address_map(self.wasmtime.generate_address_map)
-            .signals_based_traps(self.wasmtime.signals_based_traps)
-            .async_stack_zeroing(self.wasmtime.async_stack_zeroing);
-
+        let mut cfg = wasmtime_cli_flags::CommonOptions::default();
+        cfg.codegen.native_unwind_info =
+            Some(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info);
+        cfg.codegen.parallel_compilation = Some(false);
+        cfg.debug.address_map = Some(self.wasmtime.generate_address_map);
+        cfg.opts.opt_level = Some(self.wasmtime.opt_level.to_wasmtime());
+        cfg.opts.regalloc_algorithm = Some(self.wasmtime.regalloc_algorithm.to_wasmtime());
+        cfg.opts.signals_based_traps = Some(self.wasmtime.signals_based_traps);
+        cfg.opts.memory_guaranteed_dense_image_size = Some(std::cmp::min(
+            // Clamp this at 16MiB so we don't get huge in-memory
+            // images during fuzzing.
+            16 << 20,
+            self.wasmtime.memory_guaranteed_dense_image_size,
+        ));
+        cfg.wasm.async_stack_zeroing = Some(self.wasmtime.async_stack_zeroing);
+        cfg.wasm.bulk_memory = Some(true);
+        cfg.wasm.component_model_async = Some(self.module_config.component_model_async);
+        cfg.wasm.component_model_more_flags = Some(self.module_config.component_model_more_flags);
+        cfg.wasm.custom_page_sizes = Some(self.module_config.config.custom_page_sizes_enabled);
+        cfg.wasm.epoch_interruption = Some(self.wasmtime.epoch_interruption);
+        cfg.wasm.extended_const = Some(self.module_config.config.extended_const_enabled);
+        cfg.wasm.fuel = self.wasmtime.consume_fuel.then(|| u64::MAX);
+        cfg.wasm.function_references = Some(self.module_config.function_references_enabled);
+        cfg.wasm.gc = Some(self.module_config.config.gc_enabled);
+        cfg.wasm.memory64 = Some(self.module_config.config.memory64_enabled);
+        cfg.wasm.multi_memory = Some(self.module_config.config.max_memories > 1);
+        cfg.wasm.multi_value = Some(self.module_config.config.multi_value_enabled);
+        cfg.wasm.nan_canonicalization = Some(self.wasmtime.canonicalize_nans);
+        cfg.wasm.reference_types = Some(self.module_config.config.reference_types_enabled);
+        cfg.wasm.simd = Some(self.module_config.config.simd_enabled);
+        cfg.wasm.tail_call = Some(self.module_config.config.tail_call_enabled);
+        cfg.wasm.threads = Some(self.module_config.config.threads_enabled);
+        cfg.wasm.wide_arithmetic = Some(self.module_config.config.wide_arithmetic_enabled);
         if !self.module_config.config.simd_enabled {
-            cfg.wasm_relaxed_simd(false);
+            cfg.wasm.relaxed_simd = Some(false);
         }
+        cfg.codegen.collector = Some(self.wasmtime.collector.to_wasmtime());
 
         let compiler_strategy = &self.wasmtime.compiler_strategy;
         let cranelift_strategy = match compiler_strategy {
@@ -296,7 +294,6 @@ impl Config {
             CompilerStrategy::Winch => false,
         };
         self.wasmtime.compiler_strategy.configure(&mut cfg);
-        cfg.collector(self.wasmtime.collector.to_wasmtime());
 
         self.wasmtime.codegen.configure(&mut cfg);
 
@@ -313,7 +310,7 @@ impl Config {
             // If the wasm-smith-generated module use nan canonicalization then we
             // don't need to enable it, but if it doesn't enable it already then we
             // enable this codegen option.
-            cfg.cranelift_nan_canonicalization(!self.module_config.config.canonicalize_nans);
+            cfg.wasm.nan_canonicalization = Some(!self.module_config.config.canonicalize_nans);
 
             // Enabling the verifier will at-least-double compilation time, which
             // with a 20-30x slowdown in fuzzing can cause issues related to
@@ -321,31 +318,29 @@ impl Config {
             // functions then disable the verifier when fuzzing to try to lessen the
             // impact of timeouts.
             if self.module_config.config.max_funcs > 10 {
-                cfg.cranelift_debug_verifier(false);
+                cfg.codegen.cranelift_debug_verifier = Some(false);
             }
 
             if self.wasmtime.force_jump_veneers {
-                unsafe {
-                    cfg.cranelift_flag_set("wasmtime_linkopt_force_jump_veneer", "true");
-                }
+                cfg.codegen
+                    .cranelift
+                    .push(("wasmtime_linkopt_force_jump_veneer".to_string(), None));
             }
 
             if let Some(pad) = self.wasmtime.padding_between_functions {
-                unsafe {
-                    cfg.cranelift_flag_set(
-                        "wasmtime_linkopt_padding_between_functions",
-                        &pad.to_string(),
-                    );
-                }
+                cfg.codegen.cranelift.push((
+                    "wasmtime_linkopt_padding_between_functions".to_string(),
+                    Some(pad.to_string()),
+                ));
             }
 
-            cfg.cranelift_pcc(pcc);
+            cfg.codegen.pcc = Some(pcc);
 
             // Eager init is currently only supported on Cranelift, not Winch.
-            cfg.table_lazy_init(self.wasmtime.table_lazy_init);
+            cfg.opts.table_lazy_init = Some(self.wasmtime.table_lazy_init);
         }
 
-        self.wasmtime.async_config.configure(&mut cfg);
+        self.wasmtime.strategy.configure(&mut cfg);
 
         // Vary the memory configuration, but only if threads are not enabled.
         // When the threads proposal is enabled we might generate shared memory,
@@ -357,7 +352,7 @@ impl Config {
         // - shared memories are required to be aligned which means that the
         //   `CustomUnaligned` variant isn't actually safe to use with a shared
         //   memory.
-        if !self.module_config.config.threads_enabled {
+        let host_memory = if !self.module_config.config.threads_enabled {
             // If PCC is enabled, force other options to be compatible: PCC is currently only
             // supported when bounds checks are elided.
             let memory_config = if pcc {
@@ -376,17 +371,33 @@ impl Config {
 
             match &memory_config {
                 MemoryConfig::Normal(memory_config) => {
-                    memory_config.apply_to(&mut cfg);
+                    memory_config.configure(&mut cfg);
+                    None
                 }
                 MemoryConfig::CustomUnaligned => {
-                    cfg.with_host_memory(Arc::new(UnalignedMemoryCreator))
-                        .memory_reservation(0)
-                        .memory_guard_size(0)
-                        .memory_reservation_for_growth(0)
-                        .guard_before_linear_memory(false)
-                        .memory_init_cow(false);
+                    cfg.opts.memory_reservation = Some(0);
+                    cfg.opts.memory_guard_size = Some(0);
+                    cfg.opts.memory_reservation_for_growth = Some(0);
+                    cfg.opts.guard_before_linear_memory = Some(false);
+                    cfg.opts.memory_init_cow = Some(false);
+                    log::debug!("a custom unaligned host memory will be in use");
+                    Some(Arc::new(UnalignedMemoryCreator))
                 }
             }
+        } else {
+            None
+        };
+
+        log::debug!("creating wasmtime config with CLI options:\n{cfg}");
+        let mut cfg = cfg.config(None).expect("failed to create wasmtime::Config");
+
+        if let Some(host_memory) = host_memory {
+            cfg.with_host_memory(host_memory);
+        }
+
+        if self.wasmtime.async_config != AsyncConfig::Disabled {
+            log::debug!("async config in used {:?}", self.wasmtime.async_config);
+            self.wasmtime.async_config.configure(&mut cfg);
         }
 
         return cfg;
@@ -800,19 +811,17 @@ pub enum CompilerStrategy {
 
 impl CompilerStrategy {
     /// Configures `config` to use this compilation strategy
-    pub fn configure(&self, config: &mut wasmtime::Config) {
+    pub fn configure(&self, config: &mut wasmtime_cli_flags::CommonOptions) {
         match self {
             CompilerStrategy::CraneliftNative => {
-                config.strategy(wasmtime::Strategy::Cranelift);
+                config.codegen.compiler = Some(wasmtime::Strategy::Cranelift);
             }
             CompilerStrategy::Winch => {
-                config.strategy(wasmtime::Strategy::Winch);
+                config.codegen.compiler = Some(wasmtime::Strategy::Winch);
             }
             CompilerStrategy::CraneliftPulley => {
-                config
-                    .strategy(wasmtime::Strategy::Cranelift)
-                    .target("pulley64")
-                    .unwrap();
+                config.codegen.compiler = Some(wasmtime::Strategy::Cranelift);
+                config.target = Some("pulley64".to_string());
             }
         }
     }

--- a/crates/fuzzing/src/generators/instance_allocation_strategy.rs
+++ b/crates/fuzzing/src/generators/instance_allocation_strategy.rs
@@ -12,11 +12,12 @@ pub enum InstanceAllocationStrategy {
 
 impl InstanceAllocationStrategy {
     /// Convert this generated strategy a Wasmtime strategy.
-    pub fn to_wasmtime(&self) -> wasmtime::InstanceAllocationStrategy {
+    pub fn configure(&self, cfg: &mut wasmtime_cli_flags::CommonOptions) {
         match self {
-            InstanceAllocationStrategy::OnDemand => wasmtime::InstanceAllocationStrategy::OnDemand,
+            InstanceAllocationStrategy::OnDemand => {}
             InstanceAllocationStrategy::Pooling(pooling) => {
-                wasmtime::InstanceAllocationStrategy::Pooling(pooling.to_wasmtime())
+                cfg.opts.pooling_allocator = Some(true);
+                pooling.configure(cfg);
             }
         }
     }

--- a/crates/fuzzing/src/generators/memory.rs
+++ b/crates/fuzzing/src/generators/memory.rs
@@ -191,29 +191,19 @@ fn interesting_virtual_memory_size(
 }
 
 impl NormalMemoryConfig {
-    /// Apply this memory configuration to the given `wasmtime::Config`.
-    pub fn apply_to(&self, config: &mut wasmtime::Config) {
-        if let Some(n) = self.memory_reservation {
-            config.memory_reservation(n);
-        }
-        if let Some(n) = self.memory_guard_size {
-            config.memory_guard_size(n);
-        }
-        if let Some(n) = self.memory_reservation_for_growth {
-            config.memory_reservation_for_growth(n);
-        }
-
-        config
-            .guard_before_linear_memory(self.guard_before_linear_memory)
-            .memory_init_cow(self.memory_init_cow);
+    /// Apply this memory configuration to the given config.
+    pub fn configure(&self, cfg: &mut wasmtime_cli_flags::CommonOptions) {
+        cfg.opts.memory_reservation = self.memory_reservation;
+        cfg.opts.memory_guard_size = self.memory_guard_size;
+        cfg.opts.memory_reservation_for_growth = self.memory_reservation_for_growth;
+        cfg.opts.guard_before_linear_memory = Some(self.guard_before_linear_memory);
+        cfg.opts.memory_init_cow = Some(self.memory_init_cow);
 
         if let Some(enable) = self.cranelift_enable_heap_access_spectre_mitigations {
-            unsafe {
-                config.cranelift_flag_set(
-                    "enable_heap_access_spectre_mitigation",
-                    &enable.to_string(),
-                );
-            }
+            cfg.codegen.cranelift.push((
+                "enable_heap_access_spectre_mitigation".to_string(),
+                Some(enable.to_string()),
+            ));
         }
     }
 }

--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -38,38 +38,34 @@ pub struct PoolingAllocationConfig {
 
 impl PoolingAllocationConfig {
     /// Convert the generated limits to Wasmtime limits.
-    pub fn to_wasmtime(&self) -> wasmtime::PoolingAllocationConfig {
-        let mut cfg = wasmtime::PoolingAllocationConfig::default();
+    pub fn configure(&self, cfg: &mut wasmtime_cli_flags::CommonOptions) {
+        cfg.opts.pooling_total_component_instances = Some(self.total_component_instances);
+        cfg.opts.pooling_total_core_instances = Some(self.total_core_instances);
+        cfg.opts.pooling_total_memories = Some(self.total_memories);
+        cfg.opts.pooling_total_tables = Some(self.total_tables);
+        cfg.opts.pooling_total_stacks = Some(self.total_stacks);
 
-        cfg.total_component_instances(self.total_component_instances);
-        cfg.total_core_instances(self.total_core_instances);
-        cfg.total_memories(self.total_memories);
-        cfg.total_tables(self.total_tables);
-        cfg.total_stacks(self.total_stacks);
+        cfg.opts.pooling_max_memory_size = Some(self.max_memory_size);
+        cfg.opts.pooling_table_elements = Some(self.table_elements);
 
-        cfg.max_memory_size(self.max_memory_size);
-        cfg.table_elements(self.table_elements);
+        cfg.opts.pooling_max_component_instance_size = Some(self.component_instance_size);
+        cfg.opts.pooling_max_memories_per_component = Some(self.max_memories_per_component);
+        cfg.opts.pooling_max_tables_per_component = Some(self.max_tables_per_component);
 
-        cfg.max_component_instance_size(self.component_instance_size);
-        cfg.max_memories_per_component(self.max_memories_per_component);
-        cfg.max_tables_per_component(self.max_tables_per_component);
+        cfg.opts.pooling_max_core_instance_size = Some(self.core_instance_size);
+        cfg.opts.pooling_max_memories_per_module = Some(self.max_memories_per_module);
+        cfg.opts.pooling_max_tables_per_module = Some(self.max_tables_per_module);
 
-        cfg.max_core_instance_size(self.core_instance_size);
-        cfg.max_memories_per_module(self.max_memories_per_module);
-        cfg.max_tables_per_module(self.max_tables_per_module);
+        cfg.opts.pooling_table_keep_resident = Some(self.table_keep_resident);
+        cfg.opts.pooling_memory_keep_resident = Some(self.linear_memory_keep_resident);
 
-        cfg.table_keep_resident(self.table_keep_resident);
-        cfg.linear_memory_keep_resident(self.linear_memory_keep_resident);
+        cfg.opts.pooling_decommit_batch_size = Some(self.decommit_batch_size);
+        cfg.opts.pooling_max_unused_warm_slots = Some(self.max_unused_warm_slots);
 
-        cfg.decommit_batch_size(self.decommit_batch_size);
-        cfg.max_unused_warm_slots(self.max_unused_warm_slots);
+        cfg.opts.pooling_async_stack_keep_resident = Some(self.async_stack_keep_resident);
 
-        cfg.async_stack_keep_resident(self.async_stack_keep_resident);
-
-        cfg.memory_protection_keys(self.memory_protection_keys);
-        cfg.max_memory_protection_keys(self.max_memory_protection_keys);
-
-        cfg
+        cfg.opts.pooling_memory_protection_keys = Some(self.memory_protection_keys);
+        cfg.opts.pooling_max_memory_protection_keys = Some(self.max_memory_protection_keys);
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -31,8 +31,6 @@ use wasmtime_fiber::RuntimeFiberStackCreator;
 
 #[cfg(feature = "runtime")]
 pub use crate::runtime::code_memory::CustomCodeMemory;
-#[cfg(feature = "pooling-allocator")]
-pub use crate::runtime::vm::MpkEnabled;
 #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
 pub use wasmtime_environ::CacheStore;
 
@@ -2850,6 +2848,18 @@ pub enum WasmBacktraceDetails {
     /// Support for backtrace details is conditional on the
     /// `WASMTIME_BACKTRACE_DETAILS` environment variable.
     Environment,
+}
+
+/// Describe the tri-state configuration of memory protection keys (MPK).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum MpkEnabled {
+    /// Use MPK if supported by the current system; fall back to guard regions
+    /// otherwise.
+    Auto,
+    /// Use MPK or fail if not supported.
+    Enable,
+    /// Do not use MPK.
+    Disable,
 }
 
 /// Configuration options used with [`InstanceAllocationStrategy::Pooling`] to

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -77,7 +77,6 @@ pub use crate::runtime::vm::memory::{
     Memory, MemoryBase, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
 };
 pub use crate::runtime::vm::mmap_vec::MmapVec;
-pub use crate::runtime::vm::mpk::MpkEnabled;
 pub use crate::runtime::vm::provenance::*;
 pub use crate::runtime::vm::store_box::*;
 #[cfg(feature = "std")]

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -49,9 +49,10 @@ use super::{
 use crate::prelude::*;
 use crate::runtime::vm::{
     instance::Instance,
-    mpk::{self, MpkEnabled, ProtectionKey, ProtectionMask},
+    mpk::{self, ProtectionKey, ProtectionMask},
     CompiledModuleId, Memory, Table,
 };
+use crate::MpkEnabled;
 use std::borrow::Cow;
 use std::fmt::Display;
 use std::sync::{Mutex, MutexGuard};

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -57,11 +57,12 @@ use super::{
 use crate::prelude::*;
 use crate::runtime::vm::{
     mmap::AlignedLength, CompiledModuleId, InstanceAllocationRequest, InstanceLimits, Memory,
-    MemoryBase, MemoryImageSlot, Mmap, MmapOffset, MpkEnabled, PoolingInstanceAllocatorConfig,
+    MemoryBase, MemoryImageSlot, Mmap, MmapOffset, PoolingInstanceAllocatorConfig,
 };
 use crate::{
     runtime::vm::mpk::{self, ProtectionKey, ProtectionMask},
     vm::HostAlignedByteCount,
+    MpkEnabled,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};

--- a/crates/wasmtime/src/runtime/vm/mpk/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/mod.rs
@@ -45,15 +45,3 @@ cfg_if::cfg_if! {
         pub use disabled::{allow, current_mask, is_supported, keys, ProtectionKey, ProtectionMask};
     }
 }
-
-/// Describe the tri-state configuration of memory protection keys (MPK).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum MpkEnabled {
-    /// Use MPK if supported by the current system; fall back to guard regions
-    /// otherwise.
-    Auto,
-    /// Use MPK or fail if not supported.
-    Enable,
-    /// Do not use MPK.
-    Disable,
-}


### PR DESCRIPTION


During fuzzing we emit a debug log of configured options to assist with
reproducing fuzz test cases outside of the fuzzing harness. Mapping
options the fuzzer is using though to CLI flags, for example, is a bit
of an art though and not obvious. Just today we've got a fuzz bug and I
couldn't figure out how to reproduce on the CLI and it turns out the
issue was that I was forgetting a flag that was being configured in
response to another flag. I got a bit fed up with constantly trying to
map one to the other, so I've decided to fix things.

This commit adds a `Display for CommonOptions` implementation to the
`wasmtime-cli-flags` crate. This is built on the same macro-construction
infrastructure of all our flags making it a relatively low one-time-cost
to implement this. Each option value now implements not only parsing but
printing as well.

Next the `wasmtime-fuzzing` crate was updated to create a
`CommonOptions` first which is then in turn used to create a
`wasmtime::Config`. This provides a layer to insert a log statement with
to emit all configuration options in a form that can be easily
copy/pasted to the CLI to reproduce.

Overall after doing this I was able to quickly reproduce the bug in
question (yay!). The CLI flag logging is pretty verbose right now since
the fuzzing infrastructure sets many settings redundantly to their
defaults, but reducing flags to a minimum is expected to be relatively
easy compared to otherwise trying to extract the options.

