### PR TITLE
Fix sync'ing the "wat" feature of the C API

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -57,5 +57,6 @@ gc-null = ["wasmtime/gc-null"]
 cranelift = ['wasmtime/cranelift']
 winch = ['wasmtime/winch']
 debug-builtins = ['wasmtime/debug-builtins']
+wat = ['dep:wat', 'wasmtime/wat']
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/build.rs
+++ b/crates/c-api/build.rs
@@ -20,6 +20,7 @@ const FEATURES: &[&str] = &[
     "CRANELIFT",
     "WINCH",
     "DEBUG_BUILTINS",
+    "WAT",
 ];
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST


### PR DESCRIPTION
This was forgotten in a few location so this fixes up things to ensure all the feature locations mention "wat" correctly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
