### PR TITLE
Cut down on serde requirements in `wasmtime` crate

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -95,6 +95,7 @@ wasmtime_option_group! {
 
         /// Enable memory protection keys for the pooling allocator; this can
         /// optimize the size of memory slots.
+        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
         pub pooling_memory_protection_keys: Option<wasmtime::MpkEnabled>,
 
         /// Sets an upper limit on how many memory protection keys (MPK) Wasmtime

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -95,6 +95,7 @@ wasmtime_option_group! {
 
         /// Enable memory protection keys for the pooling allocator; this can
         /// optimize the size of memory slots.
+        #[serde(default)]
         #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
         pub pooling_memory_protection_keys: Option<wasmtime::MpkEnabled>,
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -5,7 +5,6 @@ use alloc::sync::Arc;
 use bitflags::Flags;
 use core::fmt;
 use core::str::FromStr;
-use serde_derive::{Deserialize, Serialize};
 #[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]
 use std::path::Path;
 use wasmparser::WasmFeatures;

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2607,7 +2607,7 @@ impl fmt::Debug for Config {
 ///
 /// This is used as an argument to the [`Config::strategy`] method.
 #[non_exhaustive]
-#[derive(PartialEq, Eq, Clone, Debug, Copy, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum Strategy {
     /// An indicator that the compilation strategy should be automatically
     /// selected.
@@ -2677,7 +2677,7 @@ impl Strategy {
 ///       additional objects. Reference counts are larger than mark bits and
 ///       free lists are larger than bump pointers, for example.
 #[non_exhaustive]
-#[derive(PartialEq, Eq, Clone, Debug, Copy, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum Collector {
     /// An indicator that the garbage collector should be automatically
     /// selected.
@@ -2777,7 +2777,7 @@ impl Collector {
 
 /// Possible optimization levels for the Cranelift codegen backend.
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OptLevel {
     /// No optimizations performed, minimizes compilation time by disabling most
     /// optimizations.
@@ -2791,7 +2791,7 @@ pub enum OptLevel {
 
 /// Possible register allocator algorithms for the Cranelift codegen backend.
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RegallocAlgorithm {
     /// Generates the fastest possible code, but may take longer.
     ///
@@ -2851,7 +2851,7 @@ pub enum WasmBacktraceDetails {
 }
 
 /// Describe the tri-state configuration of memory protection keys (MPK).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MpkEnabled {
     /// Use MPK if supported by the current system; fall back to guard regions
     /// otherwise.


### PR DESCRIPTION
Remove `derive(Deserialize, Serialize)` for some configuration-based enums to ideally give us more flexibility in the future as to what these are exactly called. I'm not sure of any internal users of these except for one use due to #9811 which can be switched to using an option-based parser to ensure the same syntax is accepted via `--config` and on the CLI with a flag.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
