### PR TITLE
IR documentation improvements and improve debug assert

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -230,7 +230,12 @@ fn lower_to_amode(ctx: &mut Lower<Inst>, spec: InsnInput, offset: i32) -> Amode 
     // We now either have an add that we must materialize, or some other input; as well as the
     // final offset.
     if let Some(add) = matches_input(ctx, spec, Opcode::Iadd) {
-        debug_assert_eq!(ctx.output_ty(add, 0), types::I64);
+        let output_ty = ctx.output_ty(add, 0);
+        debug_assert_eq!(
+            output_ty,
+            types::I64,
+            "Address width of 64 expected, got {output_ty}"
+        );
         let add_inputs = &[
             InsnInput {
                 insn: add,

--- a/cranelift/docs/ir.md
+++ b/cranelift/docs/ir.md
@@ -37,24 +37,24 @@ float average(const float *array, size_t count)
 }
 ```
 
-Here is the same function compiled into Cranelift IR:
+Here is the same function compiled into Cranelift IR (with 64 bit pointers):
 
 ```
 test verifier
 
-function %average(i32, i32) -> f32 system_v {
+function %average(i64, i64) -> f32 system_v {
     ss0 = explicit_slot 8         ; Stack slot for `sum`.
 
-block1(v0: i32, v1: i32):
+block1(v0: i64, v1: i64):
     v2 = f64const 0x0.0
     stack_store v2, ss0
     brif v1, block2, block5                  ; Handle count == 0.
 
 block2:
-    v3 = iconst.i32 0
+    v3 = iconst.i64 0
     jump block3(v3)
 
-block3(v4: i32):
+block3(v4: i64):
     v5 = imul_imm v4, 4
     v6 = iadd v0, v5
     v7 = load.f32 v6              ; array[i]


### PR DESCRIPTION
Improvements discussed in #10118, fyi @cfallin.

Changes are two-fold, commits are split out.


In 681c8c8fb5e286afb58b97f84cd23b0b0af70d54 adds a message to the debug assert stating the reason why the assert failed. Other asserts with string were capitalised, I tried to match it, reads like:
```
assertion `left == right` failed: Address width of 64 expected, got i32
  left: types::I32
 right: types::I64
```
Technically the type assignment and print isn't necessary, but I found it reads more clear than left and right only, though the fmt made it a multi-line :/ 

In c5f31de428e5f7bb0ea84a64a7e228c9ea9e7574 the size of the first and second argument is changed to 64 bits, as well as the `v3` and `v4`, which hold the offset into the array, I also added one sentence above it pointing at the pointer size is assumed to be 64 bits for the conversion of the function to IR. I did the changes manually, confirmed the changes do not trigger the debug assert and verified the created symbol does work to calculate an average.


Meta suggestion: The PR template contains:
> Our development process is documented in the Wasmtime book:
> https://docs.wasmtime.dev/contributing-development-process.html

That should really be linked in [CONTRIBUTING.md](https://github.com/bytecodealliance/wasmtime/blob/main/CONTRIBUTING.md) as well, because I ended up looking at the commit history to figure out the commit message preference, only to discover that it'll be squashed anyway :D 