### PR TITLE
Support platforms without 64-bit atomics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -570,6 +570,10 @@ jobs:
           apt_packages: gcc-powerpc64le-linux-gnu
           env:
             CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER: powerpc64le-linux-gnu-gcc
+        # A no_std target without 64-bit atomics
+        - target: riscv32imac-unknown-none-elf
+          os: ubuntu-latest
+          test: cargo check -p wasmtime --no-default-features --features runtime,gc,component-model
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:
     - uses: actions/checkout@v4

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -40,6 +40,7 @@ macro_rules! foreach_builtin_function {
             // Invoked when fuel has run out while executing a function.
             out_of_gas(vmctx: vmctx) -> bool;
             // Invoked when we reach a new epoch.
+            #[cfg(target_has_atomic = "64")]
             new_epoch(vmctx: vmctx) -> u64;
             // Invoked before malloc returns.
             #[cfg(feature = "wmemcheck")]

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -223,12 +223,13 @@ impl StoreId {
             // Note the usage of `Relaxed` ordering here which should be ok
             // since we're only looking for atomicity on this counter and this
             // otherwise isn't used to synchronize memory stored anywhere else.
-            static NEXT_ID: AtomicId = AtomicId::new(0);
+            static NEXT_ID: AtomicU64 = AtomicU64::new(0);
             let id = NEXT_ID.fetch_add(1, Relaxed);
             if id > OVERFLOW_THRESHOLD {
                 NEXT_ID.store(OVERFLOW_THRESHOLD, Relaxed);
                 panic!("store id allocator overflow");
             }
+            id
         };
 
         // When 64-bit atomics are not allowed use a `RwLock<u64>`. This is
@@ -249,7 +250,7 @@ impl StoreId {
             ret
         };
 
-        StoreId(NonZeroU64::new(u64::from(id) + 1).unwrap())
+        StoreId(NonZeroU64::new(id + 1).unwrap())
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -178,6 +178,7 @@ pub unsafe trait VMStore {
     /// Callback invoked whenever an instance observes a new epoch
     /// number. Cannot fail; cooperative epoch-based yielding is
     /// completely semantically transparent. Returns the new deadline.
+    #[cfg(target_has_atomic = "64")]
     fn new_epoch(&mut self) -> Result<u64, Error>;
 
     /// Callback invoked whenever an instance needs to trigger a GC.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -22,6 +22,7 @@ use core::alloc::Layout;
 use core::any::Any;
 use core::ops::Range;
 use core::ptr::NonNull;
+#[cfg(target_has_atomic = "64")]
 use core::sync::atomic::AtomicU64;
 use core::{mem, ptr};
 use sptr::Strict;
@@ -571,6 +572,7 @@ impl Instance {
     }
 
     /// Return a pointer to the global epoch counter used by this instance.
+    #[cfg(target_has_atomic = "64")]
     pub fn epoch_ptr(&mut self) -> NonNull<Option<VmPtr<AtomicU64>>> {
         unsafe { self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_epoch_ptr()) }
     }
@@ -596,11 +598,13 @@ impl Instance {
             let store = store.as_mut();
             self.runtime_limits()
                 .write(Some(store.vmruntime_limits().into()));
+            #[cfg(target_has_atomic = "64")]
             self.epoch_ptr()
                 .write(Some(NonNull::from(store.engine().epoch_counter()).into()));
             self.set_gc_heap(store.gc_store_mut().ok());
         } else {
             self.runtime_limits().write(None);
+            #[cfg(target_has_atomic = "64")]
             self.epoch_ptr().write(None);
             self.set_gc_heap(None);
         }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1074,6 +1074,7 @@ fn out_of_gas(store: &mut dyn VMStore, _instance: &mut Instance) -> Result<()> {
 }
 
 // Hook for when an instance observes that the epoch has changed.
+#[cfg(target_has_atomic = "64")]
 fn new_epoch(store: &mut dyn VMStore, _instance: &mut Instance) -> Result<NextEpoch> {
     store.new_epoch().map(NextEpoch)
 }

--- a/crates/wasmtime/src/runtime/vm/provenance.rs
+++ b/crates/wasmtime/src/runtime/vm/provenance.rs
@@ -46,7 +46,7 @@ use core::fmt;
 use core::marker;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicU64, AtomicUsize};
+use core::sync::atomic::AtomicUsize;
 use wasmtime_environ::VMSharedTypeIndex;
 
 /// A pointer that is used by compiled code, or in other words is accessed
@@ -213,7 +213,8 @@ unsafe impl VmSafe for i64 {}
 unsafe impl VmSafe for i128 {}
 unsafe impl VmSafe for isize {}
 unsafe impl VmSafe for AtomicUsize {}
-unsafe impl VmSafe for AtomicU64 {}
+#[cfg(target_has_atomic = "64")]
+unsafe impl VmSafe for core::sync::atomic::AtomicU64 {}
 
 // This is a small `u32` wrapper defined in `wasmtime-environ`, so impl the
 // vm-safe-ness here.

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -116,6 +116,7 @@ unsafe extern "C" {
     ///
     /// Returns false if `wasmtime_longjmp` was used to return to this function.
     /// Returns true if `wasmtime_longjmp` was not called and `callback` returned.
+    #[cfg(has_host_compiler_backend)]
     pub fn wasmtime_setjmp(
         jmp_buf: *mut *const u8,
         callback: extern "C" fn(*mut u8, *mut u8) -> bool,
@@ -133,6 +134,7 @@ unsafe extern "C" {
     ///
     /// This function may be invoked from the `wasmtime_trap_handler_t`
     /// configured by `wasmtime_init_traps`.
+    #[cfg(has_host_compiler_backend)]
     pub fn wasmtime_longjmp(jmp_buf: *const u8) -> !;
 
     /// Initializes trap-handling logic for this platform.

--- a/crates/wasmtime/src/runtime/vm/sys/custom/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/mod.rs
@@ -17,6 +17,7 @@ pub mod capi;
 #[cfg(has_virtual_memory)]
 pub mod mmap;
 pub mod traphandlers;
+#[cfg(has_host_compiler_backend)]
 pub mod unwind;
 #[cfg(has_virtual_memory)]
 pub mod vm;

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -1,13 +1,14 @@
 use crate::prelude::*;
-use crate::runtime::vm::VMContext;
-use core::mem;
-use core::ptr::NonNull;
+#[cfg(has_host_compiler_backend)]
+use crate::{mem, ptr::NonNull, runtime::vm::VMContext};
 
+#[cfg(has_host_compiler_backend)]
 pub use crate::runtime::vm::sys::capi::{self, wasmtime_longjmp};
 
 #[allow(missing_docs)]
 pub type SignalHandler = Box<dyn Fn() + Send + Sync>;
 
+#[cfg(has_host_compiler_backend)]
 pub unsafe fn wasmtime_setjmp(
     jmp_buf: *mut *const u8,
     callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
 #[cfg(has_host_compiler_backend)]
-use crate::{mem, ptr::NonNull, runtime::vm::VMContext};
+use crate::runtime::vm::VMContext;
+#[cfg(has_host_compiler_backend)]
+use core::{mem, ptr::NonNull};
 
 #[cfg(has_host_compiler_backend)]
 pub use crate::runtime::vm::sys::capi::{self, wasmtime_longjmp};

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -94,12 +94,15 @@ For explanations of what each tier means see below.
 | Target               | `armv7-unknown-linux-gnueabihf`   | full-time maintainer |
 | Target               | `i686-pc-windows-msvc`            | CI testing, full-time maintainer |
 | Target               | `i686-unknown-linux-gnu`          | full-time maintainer |
+| Target               | `powerpc64le-unknown-linux-gnu`   | CI testing, full-time maintainer |
+| Target               | `riscv32imac-unknown-none-elf`[^5]| CI testing, full-time maintainer |
 | Target               | `riscv64gc-unknown-linux-gnu`     | full-time maintainer        |
 | Target               | `wasm32-wasip1` [^3]              | Supported but not tested    |
 | Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-freebsd`          | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
+| Target               | `x86_64-unknown-none` [^5]        | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
 | Execution Backend    | Pulley                            | fuzzing                     |
@@ -138,6 +141,12 @@ Wasmtime-compiled-to-wasm can itself compile wasm but cannot execute wasm.
 linked, meaning that they are not suitable for "run on any linux distribution"
 style use cases. Wasmtime does not have static binary artifacts at this time and
 that will require building from source.
+
+[^5]: Rust targets that are `#![no_std]` don't support the entire feature set of
+Wasmtime. For example the `threads` Cargo feature requires the standard library.
+For more information see the [`no_std` documentation][nostd].
+
+[nostd]: ./stability-platform-support.md
 
 #### Unsupported features and platforms
 


### PR DESCRIPTION
This commit enables Wasmtime to build on platforms without 64-bit atomic instructions, such as Rust's `riscv32imac-unknown-none-elf` target. There are only two users of 64-bit atomics right now which are epochs and allocation of `StoreId`. This commit adds `#[cfg]` to epoch-related infrastructure in the runtime to turn that all of if 64-bit atomics aren't available. The thinking is that epochs more-or-less don't work without 64-bit atomics so it's easier to just remove them entirely.

Allocation of `StoreId` is trickier though because it's so core to Wasmtime and it basically can't be removed. I've opted to change the allocator to 32-bit indices instead of 64-bit indices. Note that `StoreId` requires unique IDs to be allocated for safety which means that while a 64-bit integer won't overflow for a few thousand years a 32-bit integer will overflow in a few hours from quickly creating stores. The rough hope though is that embeddings on platforms like this aren't churning through stores. Regardless if this condition is triggered it'll result in a panic rather than unsoundness, so we hopefully have at least that going for us.

Closes #8768

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
