### PR TITLE
Enable warnings if `coredump` is disabled

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -161,6 +161,7 @@ pub struct Config {
     pub(crate) memory_guaranteed_dense_image_size: u64,
     pub(crate) force_memory_init_memfd: bool,
     pub(crate) wmemcheck: bool,
+    #[cfg(feature = "coredump")]
     pub(crate) coredump_on_trap: bool,
     pub(crate) macos_use_mach_ports: bool,
     pub(crate) detect_host_feature: Option<fn(&str) -> Option<bool>>,
@@ -265,6 +266,7 @@ impl Config {
             memory_guaranteed_dense_image_size: 16 << 20,
             force_memory_init_memfd: false,
             wmemcheck: false,
+            #[cfg(feature = "coredump")]
             coredump_on_trap: false,
             macos_use_mach_ports: !cfg!(miri),
             #[cfg(feature = "std")]

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -292,7 +292,6 @@
         not(feature = "gc-null"),
         not(feature = "cranelift"),
         not(feature = "pooling-allocator"),
-        not(feature = "coredump"),
         not(feature = "runtime"),
         not(feature = "component-model"),
         not(feature = "threads"),

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -264,6 +264,7 @@ impl Global {
     /// Even if the same underlying global definition is added to the
     /// `StoreData` multiple times and becomes multiple `wasmtime::Global`s,
     /// this hash key will be consistent across all of these globals.
+    #[cfg(feature = "coredump")]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         store[self.0].definition.as_ptr() as usize
     }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -605,6 +605,7 @@ impl Instance {
     /// Returns both exported and non-exported globals.
     ///
     /// Gives access to the full globals space.
+    #[cfg(feature = "coredump")]
     pub(crate) fn all_globals<'a>(
         &'a self,
         store: &'a mut StoreOpaque,
@@ -625,6 +626,7 @@ impl Instance {
     /// Returns both exported and non-exported memories.
     ///
     /// Gives access to the full memories space.
+    #[cfg(feature = "coredump")]
     pub(crate) fn all_memories<'a>(
         &'a self,
         store: &'a mut StoreOpaque,

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -659,6 +659,7 @@ impl Memory {
     /// Even if the same underlying memory definition is added to the
     /// `StoreData` multiple times and becomes multiple `wasmtime::Memory`s,
     /// this hash key will be consistent across all of these memories.
+    #[cfg(feature = "coredump")]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         store[self.0].definition.as_ptr() as usize
     }

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -85,6 +85,7 @@ impl ModuleRegistry {
     }
 
     /// Gets an iterator over all modules in the registry.
+    #[cfg(feature = "coredump")]
     pub fn all_modules(&self) -> impl Iterator<Item = &'_ Module> + '_ {
         self.loaded_code
             .values()


### PR DESCRIPTION
Continuation of work in #10131

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
