### PR TITLE
Add test for opening miscellaneous devices on UNIX-alikes.

### DIFF
--- a/crates/test-programs/src/bin/preview1_device_read.rs
+++ b/crates/test-programs/src/bin/preview1_device_read.rs
@@ -1,0 +1,16 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+
+/// Assert that we can read from "miscellanous" devices such as /dev/zero on UNIX-alikes (assuming
+/// /dev is passed as a preopen).
+fn main() {
+    let mut device = OpenOptions::new()
+        .read(true)
+        .open("zero")
+        .expect("/dev/zero should be found and openable");
+    let mut buffer = [1, 1];
+    device
+        .read_exact(&mut buffer)
+        .expect("/dev/zero should be readable");
+    assert_eq!(buffer, [0, 0]);
+}

--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -34,10 +34,9 @@ async fn run(path: &str, inherit_stdio: bool) -> Result<()> {
                 .stdout(Box::new(stdout.clone()))
                 .stderr(Box::new(stderr.clone()));
         }
-        builder.arg(name)?.arg(".")?;
+        builder.arg(name)?.arg("/dev")?;
         println!("preopen: {workspace:?}");
-        let preopen_dir =
-            cap_std::fs::Dir::open_ambient_dir(workspace.path(), cap_std::ambient_authority())?;
+        let preopen_dir = cap_std::fs::Dir::open_ambient_dir("/dev", cap_std::ambient_authority())?;
         builder.preopened_dir(preopen_dir, ".")?;
         for (var, val) in test_programs_artifacts::wasi_tests_environment() {
             builder.env(var, val)?;
@@ -291,4 +290,9 @@ async fn preview1_file_write() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview1_path_open_lots() {
     run(PREVIEW1_PATH_OPEN_LOTS, true).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(not(unix), ignore)]
+async fn preview1_device_read() {
+    run(PREVIEW1_DEVICE_READ, true).await.unwrap()
 }

--- a/crates/wasi-common/tests/all/sync.rs
+++ b/crates/wasi-common/tests/all/sync.rs
@@ -26,10 +26,9 @@ fn run(path: &str, inherit_stdio: bool) -> Result<()> {
                 .stdout(Box::new(stdout.clone()))
                 .stderr(Box::new(stderr.clone()));
         }
-        builder.arg(name)?.arg(".")?;
+        builder.arg(name)?.arg("/dev")?;
         println!("preopen: {workspace:?}");
-        let preopen_dir =
-            cap_std::fs::Dir::open_ambient_dir(workspace.path(), cap_std::ambient_authority())?;
+        let preopen_dir = cap_std::fs::Dir::open_ambient_dir("/dev", cap_std::ambient_authority())?;
         builder.preopened_dir(preopen_dir, ".")?;
         for (var, val) in test_programs_artifacts::wasi_tests_environment() {
             builder.env(var, val)?;
@@ -280,4 +279,9 @@ fn preview1_file_write() {
 #[test_log::test]
 fn preview1_path_open_lots() {
     run(PREVIEW1_PATH_OPEN_LOTS, true).unwrap()
+}
+#[test_log::test]
+#[cfg_attr(not(unix), ignore)]
+fn preview1_device_read() {
+    run(PREVIEW1_DEVICE_READ, true).unwrap()
 }

--- a/crates/wasi/tests/all/async_.rs
+++ b/crates/wasi/tests/all/async_.rs
@@ -399,3 +399,8 @@ async fn preview2_file_read_write() {
         .await
         .unwrap()
 }
+// #[test_log::test(tokio::test(flavor = "multi_thread"))]
+// #[cfg_attr(not(unix), ignore)]
+// async fn preview1_device_read() {
+//     run(PREVIEW1_DEVICE_READ_COMPONENT, false).await.unwrap()
+// }

--- a/crates/wasi/tests/all/sync.rs
+++ b/crates/wasi/tests/all/sync.rs
@@ -333,3 +333,8 @@ fn preview2_adapter_badfd() {
 fn preview2_file_read_write() {
     run(PREVIEW2_FILE_READ_WRITE_COMPONENT, false).unwrap()
 }
+// #[test_log::test]
+// #[cfg_attr(not(unix), ignore)]
+// fn preview1_device_read() {
+//     run(PREVIEW1_DEVICE_READ_COMPONENT, false).unwrap()
+// }


### PR DESCRIPTION
Fixes #514, but CI is grumpy and I have questions.

Both the sync and async variants run by `cargo test -p wasi-common preview1_device_read` work and are valid.

However, `foreach_preview1!(assert_test_exists)` fails its assertions when I run `ci/run-tests.sh` unless I repeat my tests in `wasi` (commented out here) as well as `wasi-common`. Is that the intent? I'm not sure what value such repetition has for this test. Perhaps I'm adding tests in the wrong place altogether. I welcome any illumination! (@alexcrichton?)

```
error[E0432]: unresolved import `self::preview1_device_read`
  --> crates/wasi/tests/all/main.rs:86:13
   |
86 |         use self::$name as _;
   |             ^^^^^^^^^^^^^^^^ no `preview1_device_read` in `async_`
   |
  ::: crates/wasi/tests/all/async_.rs:30:1
   |
30 | foreach_preview1!(assert_test_exists);
   | -------------------------------------
   | |
   | help: a similar name exists in the module: `PREVIEW1_DEVICE_READ`
   | in this macro invocation
   |
   = note: this error originates in the macro `assert_test_exists` which comes from the expansion of the macro `foreach_preview1` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0432]: unresolved import `self::preview1_device_read`
  --> crates/wasi/tests/all/main.rs:86:13
   |
86 |         use self::$name as _;
   |             ^^^^^^^^^^^^^^^^ no `preview1_device_read` in `preview1`
   |
  ::: crates/wasi/tests/all/preview1.rs:28:1
   |
28 | foreach_preview1!(assert_test_exists);
   | -------------------------------------
   | |
   | help: a similar name exists in the module: `PREVIEW1_DEVICE_READ`
   | in this macro invocation
   |
   = note: this error originates in the macro `assert_test_exists` which comes from the expansion of the macro `foreach_preview1` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0432]: unresolved import `self::preview1_device_read`
  --> crates/wasi/tests/all/main.rs:86:13
   |
86 |         use self::$name as _;
   |             ^^^^^^^^^^^^^^^^ no `preview1_device_read` in `sync`
   |
  ::: crates/wasi/tests/all/sync.rs:32:1
   |
32 | foreach_preview1!(assert_test_exists);
   | -------------------------------------
   | |
   | help: a similar name exists in the module: `PREVIEW1_DEVICE_READ`
   | in this macro invocation
   |
   = note: this error originates in the macro `assert_test_exists` which comes from the expansion of the macro `foreach_preview1` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Note that I've hard-coded a "/dev" preopen into the test harnesses temporarily. Once I'm sure I'm adding to the right set of tests, I'll refactor to pass it only for this new one.