### PR TITLE
More Pulley Provenance Tests

### DIFF
--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -214,6 +214,25 @@ where
             .map(|i| K::new(i))
             .map_err(|i| K::new(i))
     }
+
+    /// Analog of `get_raw` except that a raw pointer is returned rather than a
+    /// mutable reference.
+    ///
+    /// The default accessors of items in [`PrimaryMap`] will invalidate all
+    /// previous borrows obtained from the map according to miri. This function
+    /// can be used to acquire a pointer and then subsequently acquire a second
+    /// pointer later on without invalidating the first one. In other words
+    /// this is only here to help borrow two elements simultaneously with miri.
+    pub fn get_raw_mut(&mut self, k: K) -> Option<*mut V> {
+        if k.index() < self.elems.len() {
+            // SAFETY: the `add` function requires that the index is in-bounds
+            // with respect to the allocation which is satisfied here due to
+            // the bounds-check above.
+            unsafe { Some(self.elems.as_mut_ptr().add(k.index())) }
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1082,7 +1082,9 @@ impl Instance {
 
     /// Get a locally-defined memory.
     pub fn get_defined_memory(&mut self, index: DefinedMemoryIndex) -> *mut Memory {
-        &raw mut self.memories[index].1
+        // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
+        // `*mut A`, which should be a safe operation to do.
+        unsafe { &raw mut (*self.memories.get_raw_mut(index).unwrap()).1 }
     }
 
     /// Do a `memory.copy`
@@ -1302,20 +1304,26 @@ impl Instance {
             }
         }
 
-        &raw mut self.tables[idx].1
+        // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
+        // `*mut A`, which should be a safe operation to do.
+        unsafe { &raw mut (*self.tables.get_raw_mut(idx).unwrap()).1 }
     }
 
     /// Get a table by index regardless of whether it is locally-defined or an
     /// imported, foreign table.
     pub(crate) fn get_table(&mut self, table_index: TableIndex) -> *mut Table {
-        self.with_defined_table_index_and_instance(table_index, |idx, instance| {
-            &raw mut instance.tables[idx].1
+        self.with_defined_table_index_and_instance(table_index, |idx, instance| unsafe {
+            // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
+            // `*mut A`, which should be a safe operation to do.
+            &raw mut (*instance.tables.get_raw_mut(idx).unwrap()).1
         })
     }
 
     /// Get a locally-defined table.
     pub(crate) fn get_defined_table(&mut self, index: DefinedTableIndex) -> *mut Table {
-        &raw mut self.tables[index].1
+        // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
+        // `*mut A`, which should be a safe operation to do.
+        unsafe { &raw mut (*self.tables.get_raw_mut(index).unwrap()).1 }
     }
 
     pub(crate) fn with_defined_table_index_and_instance<R>(

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -144,28 +144,31 @@ fn pulley_provenance_test() -> Result<()> {
     let funcref = instance.get_func(&mut store, "call-wasm").unwrap();
     for func in ["call_ref-wasm", "return_call_ref-wasm"] {
         println!("testing func {func:?}");
-        let func = instance
-            .get_typed_func::<Func, (i32, i32, i32)>(&mut store, func)
-            .unwrap();
+        let func = instance.get_typed_func::<Func, (i32, i32, i32)>(&mut store, func)?;
         let results = func.call(&mut store, funcref)?;
         assert_eq!(results, (1, 2, 3));
     }
 
     let trap = instance
-        .get_typed_func::<(), ()>(&mut store, "unreachable")
-        .unwrap()
+        .get_typed_func::<(), ()>(&mut store, "unreachable")?
         .call(&mut store, ())
         .unwrap_err()
         .downcast::<Trap>()?;
     assert_eq!(trap, Trap::UnreachableCodeReached);
 
     let trap = instance
-        .get_typed_func::<(), i32>(&mut store, "divide-by-zero")
-        .unwrap()
+        .get_typed_func::<(), i32>(&mut store, "divide-by-zero")?
         .call(&mut store, ())
         .unwrap_err()
         .downcast::<Trap>()?;
     assert_eq!(trap, Trap::IntegerDivisionByZero);
+
+    instance
+        .get_typed_func::<(), ()>(&mut store, "memory-intrinsics")?
+        .call(&mut store, ())?;
+    instance
+        .get_typed_func::<(), ()>(&mut store, "table-intrinsics")?
+        .call(&mut store, ())?;
 
     Ok(())
 }

--- a/tests/all/pulley_provenance_test.wat
+++ b/tests/all/pulley_provenance_test.wat
@@ -49,4 +49,38 @@
     i32.const 100
     i32.const 0
     i32.div_s)
+
+  (memory 1)
+  (func (export "memory-intrinsics")
+    (drop (i32.load (i32.const 0)))
+    (i32.store (i32.const 0) (i32.const 0))
+    (drop (memory.grow (i32.const 1)))
+    (drop (i32.load (i32.const 0)))
+    (i32.store (i32.const 0) (i32.const 0))
+    (drop (memory.size))
+
+    (memory.copy (i32.const 0) (i32.const 1) (i32.const 10))
+    (memory.init $d (i32.const 0) (i32.const 1) (i32.const 3))
+    (memory.fill (i32.const 0) (i32.const 10) (i32.const 10))
+
+    (data.drop $d)
+  )
+  (data $d "abcd")
+
+  (table 1 funcref)
+  (func (export "table-intrinsics")
+    (drop (table.get (i32.const 0)))
+    (table.set (i32.const 0) (table.get (i32.const 0)))
+
+    (drop (table.grow (ref.null func) (i32.const 100)))
+
+    (drop (table.get (i32.const 1)))
+    (table.set (i32.const 1) (table.get (i32.const 1)))
+
+    (table.copy (i32.const 0) (i32.const 1) (i32.const 10))
+    (table.init $e (i32.const 0) (i32.const 1) (i32.const 3))
+    (table.fill (i32.const 0) (ref.func $empty) (i32.const 10))
+  )
+  (elem $e func $empty $empty $empty $empty)
+  (func $empty)
 )


### PR DESCRIPTION
In the spirit of covering more libcalls and exercising more wasm this adds execution of table/memory intrinsics. This helped uncover some stacked-borrows unsoundness in how our `table.copy` intrinsic is implemented which was fixed with a new carefully typed method on `PrimaryMap`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
