### PR TITLE
Enable warnings if `component-model` is disabled

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -356,7 +356,7 @@ reexport-wasmparser = []
 
 # Enables instances of the traits defined in the wasm-wave crate, which
 # provides a human-readable text format for component values.
-wave = ["dep:wasm-wave"]
+wave = ["dep:wasm-wave", 'component-model']
 
 # For platforms that Wasmtime does not have support for Wasmtime will disable
 # the use of virtual memory by default, for example allocating linear memories

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -292,7 +292,6 @@
         not(feature = "cranelift"),
         not(feature = "pooling-allocator"),
         not(feature = "runtime"),
-        not(feature = "component-model"),
         not(feature = "std"),
     ),
     allow(dead_code, unused_imports)

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
@@ -1,8 +1,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::memory::{validate_atomic_addr, LocalMemory, MmapMemory};
 use crate::runtime::vm::parking_spot::{ParkingSpot, Waiter};
-use crate::runtime::vm::vmcontext::VMMemoryDefinition;
-use crate::runtime::vm::{Memory, VMStore, WaitResult};
+use crate::runtime::vm::{Memory, VMMemoryDefinition, VMStore, WaitResult};
 use std::cell::RefCell;
 use std::ops::Range;
 use std::ptr::NonNull;


### PR DESCRIPTION
Continuation of work in #10131

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
