### PR TITLE
winch(aarch64): Revisit the shadow stack pointer approach

### DIFF
--- a/tests/disas/winch/aarch64/br/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_br_if_cond.wat
@@ -10,11 +10,11 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br/as_br_value.wat
@@ -10,13 +10,13 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #9
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_if_cond.wat
@@ -15,13 +15,13 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #2
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_else.wat
+++ b/tests/disas/winch/aarch64/br/as_if_else.wat
@@ -15,8 +15,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -29,7 +29,7 @@
 ;;       b       #0x48
 ;;   40: mov     x16, #4
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_then.wat
+++ b/tests/disas/winch/aarch64/br/as_if_then.wat
@@ -15,8 +15,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -29,7 +29,7 @@
 ;;       mov     w0, w16
 ;;       b       #0x48
 ;;   44: ldur    w0, [x28]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_loop_first.wat
+++ b/tests/disas/winch/aarch64/br/as_loop_first.wat
@@ -11,13 +11,13 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #3
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/br_jump.wat
+++ b/tests/disas/winch/aarch64/br/br_jump.wat
@@ -18,24 +18,23 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w16, [x28, #4]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
 ;;       ldur    w16, [x28, #8]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       b       #0x38
-;;   54: add     sp, sp, #0x18
-;;       mov     x28, sp
+;;   50: add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
@@ -10,8 +10,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -24,7 +24,7 @@
 ;;       tst     w0, w0
 ;;       b.ne    #0x48
 ;;       b       #0x48
-;;   48: add     sp, sp, #0x10
-;;       mov     x28, sp
+;;   48: add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_value.wat
@@ -10,8 +10,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #2
@@ -21,7 +21,7 @@
 ;;       tst     w1, w1
 ;;       b.ne    #0x3c
 ;;       b       #0x3c
-;;   3c: add     sp, sp, #0x10
-;;       mov     x28, sp
+;;   3c: add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_if_cond.wat
@@ -16,8 +16,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -35,7 +35,7 @@
 ;;       b       #0x5c
 ;;   54: mov     x16, #3
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -31,7 +31,7 @@
 ;;   48: stur    w0, [x28, #4]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/large.wat
+++ b/tests/disas/winch/aarch64/br_table/large.wat
@@ -743,8 +743,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -25378,7 +25378,7 @@
 ;;       b       #0x180fc
 ;; 180f4: mov     x16, #1
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
+++ b/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
@@ -23,8 +23,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -56,7 +56,7 @@
 ;;       .byte   0xdc, 0xff, 0xff, 0xff
 ;;       mov     x16, #3
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/multi.wat
+++ b/tests/disas/winch/aarch64/call/multi.wat
@@ -15,24 +15,23 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x1
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
 ;;       stur    x0, [x28]
 ;;       mov     x16, #2
 ;;       mov     w0, w16
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x16, #1
 ;;       stur    w16, [x28]
 ;;       ldur    x1, [x28, #4]
 ;;       ldur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    w16, [x1]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -41,24 +40,22 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
-;;       sub     sp, sp, #0xc
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
 ;;       mov     x1, x9
 ;;       mov     x2, x9
 ;;       ldur    x0, [x28, #0xc]
 ;;       bl      #0
-;;   a0: add     sp, sp, #0xc
-;;       mov     x28, sp
+;;   a0: add     x28, x28, #0xc
 ;;       ldur    x9, [x28, #0xc]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/params.wat
+++ b/tests/disas/winch/aarch64/call/params.wat
@@ -42,8 +42,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -51,11 +51,11 @@
 ;;       ldur    w0, [x28, #4]
 ;;       ldur    w1, [x28]
 ;;       add     w1, w1, w0, uxtx
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     sp, sp, #0x24
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x24
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #0x24]
@@ -79,22 +79,20 @@
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
 ;;       bl      #0x160
-;;   a4: add     sp, sp, #0x24
-;;       mov     x28, sp
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;   a4: add     x28, x28, #0x24
+;;       add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       ldur    w2, [x28]
 ;;       add     w2, w2, w1, uxtx
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w2, [x28]
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #0x24]
@@ -117,23 +115,21 @@
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
 ;;       bl      #0x160
-;;  13c: add     sp, sp, #0x20
-;;       mov     x28, sp
-;;       add     sp, sp, #8
-;;       mov     x28, sp
+;;  134: add     x28, x28, #0x20
+;;       add     x28, x28, #8
 ;;       ldur    x9, [x28, #0x10]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;; 
+;;
 ;; wasm[0]::function[1]::add:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x28
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x20]
 ;;       stur    x1, [x28, #0x18]
 ;;       stur    w2, [x28, #0x14]
@@ -160,7 +156,7 @@
 ;;       ldur    w0, [x29, #0x20]
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x28
-;;       mov     x28, sp
+;;       add     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/recursive.wat
+++ b/tests/disas/winch/aarch64/call/recursive.wat
@@ -29,8 +29,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -41,44 +41,40 @@
 ;;       b.eq    #0x44
 ;;       b       #0x3c
 ;;   3c: ldur    w0, [x28, #4]
-;;       b       #0xd4
+;;       b       #0xc4
 ;;   44: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #1
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       bl      #0
-;;   70: add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;   70: add     x28, x28, #4
+;;       add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, #2
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       bl      #0
-;;   b4: add     sp, sp, #4
-;;       mov     x28, sp
+;;   ac: add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/reg_on_stack.wat
+++ b/tests/disas/winch/aarch64/call/reg_on_stack.wat
@@ -18,51 +18,47 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w16, [x28, #4]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       mov     x16, #1
 ;;       mov     w2, w16
 ;;       bl      #0
-;;   50: add     sp, sp, #4
-;;       mov     x28, sp
+;;   50: add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x14]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       mov     x16, #1
 ;;       mov     w2, w16
 ;;       bl      #0
-;;   7c: ldur    x9, [x28, #0x18]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;   78: ldur    x9, [x28, #0x18]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       ldur    w1, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       ldur    w0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       tst     w1, w1
-;;       b.eq    #0xbc
+;;       b.eq    #0xac
+;;       b       #0xa4
+;;   a4: add     x28, x28, #4
 ;;       b       #0xb0
-;;   b0: add     sp, sp, #4
-;;       mov     x28, sp
-;;       b       #0xc0
-;;   bc: .byte   0x1f, 0xc1, 0x00, 0x00
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;   ac: .byte   0x1f, 0xc1, 0x00, 0x00
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -20,14 +20,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x1, x9
 ;;       mov     x16, #0x14
@@ -35,26 +35,25 @@
 ;;       mov     x16, #0x50
 ;;       mov     w3, w16
 ;;       bl      #0x80
-;;   4c: add     sp, sp, #8
-;;       mov     x28, sp
+;;   4c: add     x28, x28, #8
 ;;       ldur    x9, [x28, #0x10]
 ;;       mov     x16, #2
 ;;       mov     w1, w16
 ;;       stur    w1, [x28, #4]
 ;;       ldur    w1, [x28, #4]
 ;;       add     w0, w0, w1, uxtx
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;; 
+;;
 ;; wasm[0]::function[1]::add:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -63,7 +62,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -34,8 +34,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -47,19 +47,21 @@
 ;;       b       #0x3c
 ;;   3c: mov     x16, #1
 ;;       mov     w0, w16
-;;       b       #0x250
+;;       b       #0x244
 ;;   48: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #2
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       mov     x2, x9
 ;;       ldur    x3, [x2, #0x50]
 ;;       cmp     x1, x3, uxtx
-;;       b.hs    #0x260
-;;   74: mov     x16, x1
+;;       sub     sp, x28, #4
+;;       b.hs    #0x254
+;;   78: mov     sp, x28
+;;       mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
 ;;       ldur    x2, [x2, #0x48]
@@ -69,61 +71,61 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xd4
-;;       b       #0xa4
-;;   a4: sub     sp, sp, #4
-;;       mov     x28, sp
+;;       b.ne    #0xd8
+;;       b       #0xac
+;;   ac: sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x0, x9
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x398
-;;   c4: add     sp, sp, #4
-;;       mov     x28, sp
+;;       bl      #0x38c
+;;   cc: add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xd8
-;;   d4: and     x0, x0, #0xfffffffffffffffe
-;;       cbz     x0, #0x264
-;;   dc: ldur    x16, [x9, #0x40]
+;;       b       #0xdc
+;;   d8: and     x0, x0, #0xfffffffffffffffe
+;;       sub     sp, x28, #4
+;;       cbz     x0, #0x258
+;;   e4: mov     sp, x28
+;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
-;;       b.ne    #0x268
-;;   f0: sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     sp, x28, #4
+;;       b.ne    #0x25c
+;;  100: mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
+;;       add     x28, x28, #8
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x5
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  128: add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;  138: add     x28, x28, #4
+;;       add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, #1
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       mov     x2, x9
 ;;       ldur    x3, [x2, #0x50]
 ;;       cmp     x1, x3, uxtx
-;;       b.hs    #0x26c
-;;  174: mov     x16, x1
+;;       b.hs    #0x260
+;;  17c: mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
 ;;       ldur    x2, [x2, #0x48]
@@ -134,57 +136,52 @@
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
 ;;       b.ne    #0x1e4
-;;       b       #0x1a4
-;;  1a4: sub     sp, sp, #4
-;;       mov     x28, sp
+;;       b       #0x1ac
+;;  1ac: sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     sp, sp, #0xc
-;;       mov     x28, sp
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28, #0xc]
-;;       bl      #0x398
-;;  1cc: add     sp, sp, #0xc
-;;       mov     x28, sp
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       bl      #0x38c
+;;  1d4: add     x28, x28, #0xc
+;;       add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x18]
 ;;       b       #0x1e8
 ;;  1e4: and     x0, x0, #0xfffffffffffffffe
-;;       cbz     x0, #0x270
+;;       cbz     x0, #0x264
 ;;  1ec: ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
-;;       b.ne    #0x274
-;;  200: sub     sp, sp, #8
-;;       mov     x28, sp
+;;       b.ne    #0x268
+;;  200: sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
+;;       add     x28, x28, #8
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
 ;;       mov     x0, x5
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       blr     x4
-;;  230: add     sp, sp, #4
-;;       mov     x28, sp
+;;  22c: add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
+;;  254: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  258: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  25c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  260: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  264: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  268: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  26c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  270: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  274: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -22,13 +22,13 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,23 +37,25 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w16, [x28, #4]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       mov     x2, x9
 ;;       ldur    x3, [x2, #0x50]
 ;;       cmp     x1, x3, uxtx
-;;       b.hs    #0x168
-;;   90: mov     x16, x1
+;;       sub     sp, x28, #4
+;;       b.hs    #0x170
+;;   94: mov     sp, x28
+;;       mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
 ;;       ldur    x2, [x2, #0x48]
@@ -63,50 +65,50 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xf0
-;;       b       #0xc0
-;;   c0: sub     sp, sp, #4
-;;       mov     x28, sp
+;;       b.ne    #0xf4
+;;       b       #0xc8
+;;   c8: sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x0, x9
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x378
-;;   e0: add     sp, sp, #4
-;;       mov     x28, sp
+;;       bl      #0x380
+;;   e8: add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xf4
-;;   f0: and     x0, x0, #0xfffffffffffffffe
-;;       cbz     x0, #0x16c
-;;   f8: ldur    x16, [x9, #0x40]
+;;       b       #0xf8
+;;   f4: and     x0, x0, #0xfffffffffffffffe
+;;       sub     sp, x28, #4
+;;       cbz     x0, #0x174
+;;  100: mov     sp, x28
+;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
-;;       b.ne    #0x170
-;;  10c: sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     sp, x28, #4
+;;       b.ne    #0x178
+;;  11c: mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
+;;       add     x28, x28, #8
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x5
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  144: add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;  154: add     x28, x28, #4
+;;       add     x28, x28, #4
 ;;       ldur    x9, [x28, #0x10]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  168: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  16c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  170: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  174: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  178: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       fabs    s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fabs    s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/const.wat
+++ b/tests/disas/winch/aarch64/f32_add/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fadd    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/locals.wat
+++ b/tests/disas/winch/aarch64/f32_add/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fadd    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/params.wat
+++ b/tests/disas/winch/aarch64/f32_add/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fadd    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       frintp  s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       frintp  s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       scvtf   s0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       scvtf   s0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       scvtf   s0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       scvtf   s0, w0
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       ucvtf   s0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       ucvtf   s0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w1, [x28, #4]
 ;;       ucvtf   s0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       ucvtf   s0, w1
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       scvtf   s0, x0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       scvtf   s0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       scvtf   s0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       scvtf   s0, x0
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x1, x16
 ;;       ucvtf   s0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x1, [x28]
 ;;       ucvtf   s0, x1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x1, [x28]
 ;;       ucvtf   s0, x1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x1, x16
 ;;       ucvtf   s0, x1
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -26,7 +26,7 @@
 ;;       ushr    v0.2s, v0.2s, #0x1f
 ;;       sli     v1.2s, v0.2s, #0x1f
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -41,7 +41,7 @@
 ;;       ushr    v0.2s, v0.2s, #0x1f
 ;;       sli     v1.2s, v0.2s, #0x1f
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       ushr    v0.2s, v0.2s, #0x1f
 ;;       sli     v1.2s, v0.2s, #0x1f
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/const.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcvt    s0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcvt    s0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/params.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcvt    s0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/const.wat
+++ b/tests/disas/winch/aarch64/f32_div/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fdiv    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/locals.wat
+++ b/tests/disas/winch/aarch64/f32_div/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fdiv    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/params.wat
+++ b/tests/disas/winch/aarch64/f32_div/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fdiv    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/const.wat
+++ b/tests/disas/winch/aarch64/f32_eq/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       frintm  s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       frintm  s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/const.wat
+++ b/tests/disas/winch/aarch64/f32_ge/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xc0000000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/const.wat
+++ b/tests/disas/winch/aarch64/f32_gt/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xc0000000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/const.wat
+++ b/tests/disas/winch/aarch64/f32_le/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xc0000000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/const.wat
+++ b/tests/disas/winch/aarch64/f32_lt/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xc0000000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/const.wat
+++ b/tests/disas/winch/aarch64/f32_max/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fmax    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/locals.wat
+++ b/tests/disas/winch/aarch64/f32_max/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmax    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/params.wat
+++ b/tests/disas/winch/aarch64/f32_max/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmax    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/const.wat
+++ b/tests/disas/winch/aarch64/f32_min/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fmin    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/locals.wat
+++ b/tests/disas/winch/aarch64/f32_min/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmin    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/params.wat
+++ b/tests/disas/winch/aarch64/f32_min/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmin    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/const.wat
+++ b/tests/disas/winch/aarch64/f32_mul/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fmul    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f32_mul/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmul    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/params.wat
+++ b/tests/disas/winch/aarch64/f32_mul/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fmul    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/const.wat
+++ b/tests/disas/winch/aarch64/f32_ne/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x40000000
@@ -24,7 +24,7 @@
 ;;       fmov    s1, w16
 ;;       fcmp    s0, s1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fcmp    s0, s1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       frintn  s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       frintn  s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       fneg    s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fneg    s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       fmov    s0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       fmov    s0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       fmov    s0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -23,7 +23,7 @@
 ;;       fmov    s0, w0
 ;;       mov     x16, #1
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       fmov    s0, w0
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #4
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0x3fa8, lsl #16
 ;;       fmov    s0, w16
 ;;       fsqrt   s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fsqrt   s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/const.wat
+++ b/tests/disas/winch/aarch64/f32_sub/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xcccd
@@ -25,7 +25,7 @@
 ;;       fmov    s1, w16
 ;;       fsub    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f32_sub/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fsub    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/params.wat
+++ b/tests/disas/winch/aarch64/f32_sub/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    s1, [x28, #4]
 ;;       fsub    s1, s1, s0
 ;;       fmov    s0, s1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     w16, #0xf5c3
 ;;       movk    w16, #0xbfa8, lsl #16
 ;;       fmov    s0, w16
 ;;       frintz  s0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       frintz  s0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       fabs    d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fabs    d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/const.wat
+++ b/tests/disas/winch/aarch64/f64_add/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fadd    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/locals.wat
+++ b/tests/disas/winch/aarch64/f64_add/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fadd    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/params.wat
+++ b/tests/disas/winch/aarch64/f64_add/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fadd    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       frintp  d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       frintp  d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       scvtf   d0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       scvtf   d0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       scvtf   d0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       scvtf   d0, w0
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #8
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       ucvtf   d0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       ucvtf   d0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w1, [x28, #4]
 ;;       ucvtf   d0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w1, w16
 ;;       ucvtf   d0, w1
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #8
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       scvtf   d0, x0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       scvtf   d0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       scvtf   d0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       scvtf   d0, x0
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #8
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x1, x16
 ;;       ucvtf   d0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x1, [x28]
 ;;       ucvtf   d0, x1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x1, [x28]
 ;;       ucvtf   d0, x1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x1, x16
 ;;       ucvtf   d0, x1
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #8
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -30,7 +30,7 @@
 ;;       ushr    d0, d0, #0x3f
 ;;       sli     d1, d0, #0x3f
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -46,7 +46,7 @@
 ;;       ushr    d0, d0, #0x3f
 ;;       sli     d1, d0, #0x3f
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       ushr    d0, d0, #0x3f
 ;;       sli     d1, d0, #0x3f
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/const.wat
+++ b/tests/disas/winch/aarch64/f64_div/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fdiv    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/locals.wat
+++ b/tests/disas/winch/aarch64/f64_div/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fdiv    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/params.wat
+++ b/tests/disas/winch/aarch64/f64_div/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fdiv    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/const.wat
+++ b/tests/disas/winch/aarch64/f64_eq/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       frintm  d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       frintm  d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/const.wat
+++ b/tests/disas/winch/aarch64/f64_ge/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x4000000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/const.wat
+++ b/tests/disas/winch/aarch64/f64_gt/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x4000000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/const.wat
+++ b/tests/disas/winch/aarch64/f64_le/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x4000000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/const.wat
+++ b/tests/disas/winch/aarch64/f64_lt/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x4000000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, mi
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/const.wat
+++ b/tests/disas/winch/aarch64/f64_max/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fmax    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/locals.wat
+++ b/tests/disas/winch/aarch64/f64_max/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmax    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/params.wat
+++ b/tests/disas/winch/aarch64/f64_max/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmax    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/const.wat
+++ b/tests/disas/winch/aarch64/f64_min/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fmin    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/locals.wat
+++ b/tests/disas/winch/aarch64/f64_min/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmin    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/params.wat
+++ b/tests/disas/winch/aarch64/f64_min/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmin    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/const.wat
+++ b/tests/disas/winch/aarch64/f64_mul/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fmul    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f64_mul/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmul    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/params.wat
+++ b/tests/disas/winch/aarch64/f64_mul/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fmul    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/const.wat
+++ b/tests/disas/winch/aarch64/f64_ne/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x4000000000000000
@@ -24,7 +24,7 @@
 ;;       fmov    d1, x16
 ;;       fcmp    d0, d1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fcmp    d0, d1
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       frintn  d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       frintn  d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       fneg    d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fneg    d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/const.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcvt    d0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcvt    d0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/params.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcvt    d0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       fmov    d0, x0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       fmov    d0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       fmov    d0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -23,7 +23,7 @@
 ;;       fmov    d0, x0
 ;;       mov     x16, #1
 ;;       mov     x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
@@ -14,20 +14,19 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       fmov    d0, x0
-;;       sub     sp, sp, #8
-;;       mov     x28, sp
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
-;;       add     sp, sp, #8
-;;       mov     x28, sp
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #8
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0x3ff5, lsl #48
 ;;       fmov    d0, x16
 ;;       fsqrt   d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fsqrt   d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/const.wat
+++ b/tests/disas/winch/aarch64/f64_sub/const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x999a
@@ -29,7 +29,7 @@
 ;;       fmov    d1, x16
 ;;       fsub    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f64_sub/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -45,7 +45,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fsub    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/params.wat
+++ b/tests/disas/winch/aarch64/f64_sub/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    d0, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    d1, [x28, #8]
 ;;       fsub    d1, d1, d0
 ;;       fmov    d0, d1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x851f
@@ -22,7 +22,7 @@
 ;;       movk    x16, #0xbff5, lsl #48
 ;;       fmov    d0, x16
 ;;       frintz  d0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       frintz  d0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/const.wat
+++ b/tests/disas/winch/aarch64/i32_add/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     w0, w16
 ;;       add     w0, w0, #0x14
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/locals.wat
+++ b/tests/disas/winch/aarch64/i32_add/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max.wat
+++ b/tests/disas/winch/aarch64/i32_add/max.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7fffffff
 ;;       mov     w0, w16
 ;;       add     w0, w0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_add/max_one.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x80000000
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       add     w0, w0, w16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_add/mixed.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       add     w0, w0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/params.wat
+++ b/tests/disas/winch/aarch64/i32_add/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/signed.wat
+++ b/tests/disas/winch/aarch64/i32_add/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       add     w0, w0, w16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       add     w0, w0, #0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/const.wat
+++ b/tests/disas/winch/aarch64/i32_and/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       and     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/locals.wat
+++ b/tests/disas/winch/aarch64/i32_and/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       and     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/params.wat
+++ b/tests/disas/winch/aarch64/i32_and/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       and     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/const.wat
+++ b/tests/disas/winch/aarch64/i32_clz/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     w0, w16
 ;;       clz     w0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_clz/locals.wat
@@ -16,8 +16,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -26,7 +26,7 @@
 ;;       mov     w0, w16
 ;;       stur    w0, [x28, #4]
 ;;       clz     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/params.wat
+++ b/tests/disas/winch/aarch64/i32_clz/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       clz     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     w0, w16
 ;;       rbit    w16, w0
 ;;       clz     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -25,7 +25,7 @@
 ;;       stur    w0, [x28, #4]
 ;;       rbit    w16, w0
 ;;       clz     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/params.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       rbit    w16, w0
 ;;       clz     w0, w16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_divs/const.wat
+++ b/tests/disas/winch/aarch64/i32_divs/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
@@ -30,8 +30,8 @@
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -30,8 +30,8 @@
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_divs/overflow.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -30,8 +30,8 @@
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/params.wat
+++ b/tests/disas/winch/aarch64/i32_divs/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -30,8 +30,8 @@
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -30,8 +30,8 @@
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
@@ -25,8 +25,8 @@
 ;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -25,8 +25,8 @@
 ;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -25,8 +25,8 @@
 ;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -25,8 +25,8 @@
 ;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -25,8 +25,8 @@
 ;;       cbz     w0, #0x4c
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_eq/const.wat
+++ b/tests/disas/winch/aarch64/i32_eq/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i32_eq/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, eq
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/params.wat
+++ b/tests/disas/winch/aarch64/i32_eq/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, eq
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       sxth    w0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       sxth    w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       sxth    w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       sxtb    w0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       sxtb    w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       sxtb    w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -23,7 +23,7 @@
 ;;       orr     x16, xzr, #0xfffffffe
 ;;       cmp     w0, w16, uxtx
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ge
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ge
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #2
 ;;       cset    x0, hs
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, hs
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, hs
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -23,7 +23,7 @@
 ;;       orr     x16, xzr, #0xfffffffe
 ;;       cmp     w0, w16, uxtx
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, gt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, gt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #2
 ;;       cset    x0, hi
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, hi
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, hi
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -23,7 +23,7 @@
 ;;       orr     x16, xzr, #0xfffffffe
 ;;       cmp     w0, w16, uxtx
 ;;       cset    x0, le
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, le
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, le
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #2
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ls
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ls
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -23,7 +23,7 @@
 ;;       orr     x16, xzr, #0xfffffffe
 ;;       cmp     w0, w16, uxtx
 ;;       cset    x0, lt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, lt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, lt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #2
 ;;       cset    x0, lo
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, lo
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, lo
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/const.wat
+++ b/tests/disas/winch/aarch64/i32_mul/const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i32_mul/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       mul     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7fffffff
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max_one.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x80000000
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/mixed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/params.wat
+++ b/tests/disas/winch/aarch64/i32_mul/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       mul     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mul     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/const.wat
+++ b/tests/disas/winch/aarch64/i32_ne/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       cmp     w0, #2
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ne/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ne
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/params.wat
+++ b/tests/disas/winch/aarch64/i32_ne/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       cmp     w1, w0, uxtx
 ;;       cset    x1, ne
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/const.wat
+++ b/tests/disas/winch/aarch64/i32_or/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       orr     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/locals.wat
+++ b/tests/disas/winch/aarch64/i32_or/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       orr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/params.wat
+++ b/tests/disas/winch/aarch64/i32_or/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       orr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #3
@@ -22,7 +22,7 @@
 ;;       cnt     v31.8b, v31.8b
 ;;       addv    b31, v31.8b
 ;;       umov    w0, v31.b[0]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/reg.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -22,7 +22,7 @@
 ;;       cnt     v31.8b, v31.8b
 ;;       addv    b31, v31.8b
 ;;       umov    w0, v31.b[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       mov     w0, v0.s[0]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       mov     w0, v0.s[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       mov     w0, v0.s[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -23,7 +23,7 @@
 ;;       mov     w0, v0.s[0]
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rems/const.wat
+++ b/tests/disas/winch/aarch64/i32_rems/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #5
@@ -28,8 +28,8 @@
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -28,8 +28,8 @@
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_rems/overflow.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -28,8 +28,8 @@
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/params.wat
+++ b/tests/disas/winch/aarch64/i32_rems/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -28,8 +28,8 @@
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -28,8 +28,8 @@
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #5
@@ -26,8 +26,8 @@
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -26,8 +26,8 @@
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
@@ -26,8 +26,8 @@
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -22,7 +22,7 @@
 ;;       sub     w0, w0, wzr
 ;;       mov     x16, #0x200
 ;;       ror     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/8_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       sub     w0, w0, wzr
 ;;       ror     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       sub     w0, w0, wzr
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -24,7 +24,7 @@
 ;;       sub     w0, w0, wzr
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     x16, #0x200
 ;;       ror     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       ror     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/16_const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     x16, #0x200
 ;;       lsl     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/8_const.wat
@@ -14,14 +14,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       lsl     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shl/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       lsl     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/params.wat
+++ b/tests/disas/winch/aarch64/i32_shl/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       lsl     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     x16, #0x200
 ;;       asr     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       asr     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       asr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       asr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     x16, #0x200
 ;;       lsr     w0, w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       lsr     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       lsr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       lsr     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/const.wat
+++ b/tests/disas/winch/aarch64/i32_sub/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     w0, w16
 ;;       sub     w0, w0, #0x14
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i32_sub/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7fffffff
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       sub     w0, w0, w16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max_one.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x80000000
 ;;       mov     w0, w16
 ;;       sub     w0, w0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/mixed.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       sub     w0, w0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/params.wat
+++ b/tests/disas/winch/aarch64/i32_sub/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, w0, uxtx
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       sub     w0, w0, w16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       sub     w0, w0, #0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -29,8 +29,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  w0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -32,8 +32,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x70
 ;;   54: fcvtzs  w0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -29,8 +29,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  w0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -28,8 +28,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  w0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -31,8 +31,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzu  w0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -28,8 +28,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  w0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -30,8 +30,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x70
 ;;   54: fcvtzs  w0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -33,8 +33,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x74
 ;;   58: fcvtzs  w0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
@@ -30,8 +30,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x70
 ;;   54: fcvtzs  w0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -28,8 +28,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  w0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -31,8 +31,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzu  w0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
@@ -28,8 +28,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  w0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/const.wat
+++ b/tests/disas/winch/aarch64/i32_xor/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       eor     w0, w0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i32_xor/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       eor     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/params.wat
+++ b/tests/disas/winch/aarch64/i32_xor/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
@@ -23,7 +23,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       eor     w1, w1, w0
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/const.wat
+++ b/tests/disas/winch/aarch64/i64_add/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     x0, x16
 ;;       add     x0, x0, #0x14
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/locals.wat
+++ b/tests/disas/winch/aarch64/i64_add/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       add     x1, x1, x0, uxtx
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max.wat
+++ b/tests/disas/winch/aarch64/i64_add/max.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0x7fffffffffffffff
 ;;       add     x0, x0, x16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_add/max_one.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       add     x0, x0, x16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_add/mixed.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       add     x0, x0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/params.wat
+++ b/tests/disas/winch/aarch64/i64_add/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       add     x1, x1, x0, uxtx
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/signed.wat
+++ b/tests/disas/winch/aarch64/i64_add/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       add     x0, x0, x16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       add     x0, x0, #0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/32_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #2
 ;;       mov     x0, x16
 ;;       and     x0, x0, #3
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/64_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7ffffffffffffffe
 ;;       mov     x0, x16
 ;;       and     x0, x0, #0x7fffffffffffffff
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/locals.wat
+++ b/tests/disas/winch/aarch64/i64_and/locals.wat
@@ -21,8 +21,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       and     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/params.wat
+++ b/tests/disas/winch/aarch64/i64_and/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       and     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/const.wat
+++ b/tests/disas/winch/aarch64/i64_clz/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     x0, x16
 ;;       clz     x0, x0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_clz/locals.wat
@@ -16,8 +16,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -26,7 +26,7 @@
 ;;       mov     x0, x16
 ;;       stur    x0, [x28]
 ;;       clz     x0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/params.wat
+++ b/tests/disas/winch/aarch64/i64_clz/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       clz     x0, x0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/const.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     x0, x16
 ;;       rbit    x16, x0
 ;;       clz     x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/locals.wat
@@ -16,8 +16,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -27,7 +27,7 @@
 ;;       stur    x0, [x28]
 ;;       rbit    x16, x0
 ;;       clz     x0, x16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/params.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       rbit    x16, x0
 ;;       clz     x0, x16
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_divs/const.wat
+++ b/tests/disas/winch/aarch64/i64_divs/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
@@ -28,8 +28,8 @@
 ;;       b.vs    #0x5c
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -28,8 +28,8 @@
 ;;       b.vs    #0x5c
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_divs/overflow.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -28,8 +28,8 @@
 ;;       b.vs    #0x5c
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/params.wat
+++ b/tests/disas/winch/aarch64/i64_divs/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -28,8 +28,8 @@
 ;;       b.vs    #0x5c
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -28,8 +28,8 @@
 ;;       b.vs    #0x5c
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/const.wat
+++ b/tests/disas/winch/aarch64/i64_divu/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
@@ -25,8 +25,8 @@
 ;;       cbz     x0, #0x4c
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -25,8 +25,8 @@
 ;;       cbz     x0, #0x4c
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/params.wat
+++ b/tests/disas/winch/aarch64/i64_divu/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -25,8 +25,8 @@
 ;;       cbz     x0, #0x4c
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_divu/signed.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -25,8 +25,8 @@
 ;;       cbz     x0, #0x4c
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -25,8 +25,8 @@
 ;;       cbz     x0, #0x4c
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_eq/const.wat
+++ b/tests/disas/winch/aarch64/i64_eq/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #1
 ;;       cset    x0, eq
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i64_eq/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, eq
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/params.wat
+++ b/tests/disas/winch/aarch64/i64_eq/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, eq
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       sxth    x0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxth    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxth    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       sxtb    x0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxtb    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
 ;;       ldur    x0, [x28]
 ;;       sxtb    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       sxtw    x0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       mov     w0, w0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -23,7 +23,7 @@
 ;;       mov     x16, #-2
 ;;       cmp     x0, x16, uxtx
 ;;       cset    x0, ge
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ge
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ge
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #2
 ;;       cset    x0, hs
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, hs
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, hs
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -23,7 +23,7 @@
 ;;       mov     x16, #-2
 ;;       cmp     x0, x16, uxtx
 ;;       cset    x0, gt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, gt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, gt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #2
 ;;       cset    x0, hi
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, hi
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, hi
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -23,7 +23,7 @@
 ;;       mov     x16, #-2
 ;;       cmp     x0, x16, uxtx
 ;;       cset    x0, le
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, le
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, le
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #2
 ;;       cset    x0, ls
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ls
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ls
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -23,7 +23,7 @@
 ;;       mov     x16, #-2
 ;;       cmp     x0, x16, uxtx
 ;;       cset    x0, lt
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, lt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, lt
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #2
 ;;       cset    x0, lo
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, lo
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, lo
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/const.wat
+++ b/tests/disas/winch/aarch64/i64_mul/const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     x0, x16
 ;;       mov     x16, #0x14
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i64_mul/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       mul     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x7fffffffffffffff
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max_one.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/mixed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/params.wat
+++ b/tests/disas/winch/aarch64/i64_mul/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       mul     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mul     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/const.wat
+++ b/tests/disas/winch/aarch64/i64_ne/const.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       cmp     x0, #2
 ;;       cset    x0, ne
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ne/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ne
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/params.wat
+++ b/tests/disas/winch/aarch64/i64_ne/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       cmp     x1, x0, uxtx
 ;;       cset    x1, ne
 ;;       mov     w0, w1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/32_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #2
 ;;       mov     x0, x16
 ;;       orr     x0, x0, #3
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/64_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7ffffffffffffffe
 ;;       mov     x0, x16
 ;;       orr     x0, x0, #0x7fffffffffffffff
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/locals.wat
+++ b/tests/disas/winch/aarch64/i64_or/locals.wat
@@ -21,8 +21,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       orr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/params.wat
+++ b/tests/disas/winch/aarch64/i64_or/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       orr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #3
@@ -22,7 +22,7 @@
 ;;       cnt     v31.8b, v31.8b
 ;;       addv    b31, v31.8b
 ;;       umov    w0, v31.b[0]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/reg.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
@@ -22,7 +22,7 @@
 ;;       cnt     v31.8b, v31.8b
 ;;       addv    b31, v31.8b
 ;;       umov    w0, v31.b[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       mov     x0, v0.d[0]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
@@ -14,15 +14,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       mov     x0, v0.d[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
@@ -12,14 +12,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       mov     x0, v0.d[0]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -23,7 +23,7 @@
 ;;       mov     x0, v0.d[0]
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rems/const.wat
+++ b/tests/disas/winch/aarch64/i64_rems/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #5
@@ -26,8 +26,8 @@
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_rems/overflow.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -26,8 +26,8 @@
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/params.wat
+++ b/tests/disas/winch/aarch64/i64_rems/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -26,8 +26,8 @@
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/const.wat
+++ b/tests/disas/winch/aarch64/i64_remu/const.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #5
@@ -26,8 +26,8 @@
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/one_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/params.wat
+++ b/tests/disas/winch/aarch64/i64_remu/params.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -26,8 +26,8 @@
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_remu/signed.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
@@ -26,8 +26,8 @@
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -26,8 +26,8 @@
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -22,7 +22,7 @@
 ;;       sub     x0, x0, xzr
 ;;       mov     x16, #0x200
 ;;       ror     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/8_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       sub     x0, x0, xzr
 ;;       ror     x0, x0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -40,7 +40,7 @@
 ;;       sub     x0, x0, xzr
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -24,7 +24,7 @@
 ;;       sub     x0, x0, xzr
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0x200
 ;;       ror     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       ror     x0, x0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0x200
 ;;       lsl     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       lsl     x0, x0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shl/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       lsl     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/params.wat
+++ b/tests/disas/winch/aarch64/i64_shl/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       lsl     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0x200
 ;;       asr     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       asr     x0, x0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       asr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       asr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       mov     x16, #0x200
 ;;       lsr     x0, x0, x16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       lsr     x0, x0, #2
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       lsr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       lsr     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/const.wat
+++ b/tests/disas/winch/aarch64/i64_sub/const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0xa
 ;;       mov     x0, x16
 ;;       sub     x0, x0, #0x14
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i64_sub/locals.wat
@@ -22,8 +22,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -39,7 +39,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       sub     x1, x1, x0, uxtx
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max.wat
@@ -12,15 +12,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x7fffffffffffffff
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       sub     x0, x0, x16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max_one.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x0, x16
 ;;       sub     x0, x0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/mixed.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       sub     x0, x0, #1
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/params.wat
+++ b/tests/disas/winch/aarch64/i64_sub/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       sub     x1, x1, x0, uxtx
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/signed.wat
@@ -13,15 +13,15 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #-1
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       sub     x0, x0, x16, uxtx
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
 ;;       sub     x0, x0, #0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -29,8 +29,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  x0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -32,8 +32,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x70
 ;;   54: fcvtzs  x0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -29,8 +29,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  x0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3f800000
@@ -28,8 +28,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  x0, s0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -31,8 +31,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzu  x0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    s0, [x28, #4]
@@ -28,8 +28,8 @@
 ;;       fcmp    s31, s0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  x0, s0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -29,8 +29,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  x0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -32,8 +32,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x70
 ;;   54: fcvtzs  x0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
@@ -29,8 +29,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzs  x0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x3ff0000000000000
@@ -28,8 +28,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  x0, d0
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       mov     x16, #0
@@ -31,8 +31,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x6c
 ;;   50: fcvtzu  x0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    d0, [x28]
@@ -28,8 +28,8 @@
 ;;       fcmp    d31, d0
 ;;       b.ge    #0x68
 ;;   4c: fcvtzu  x0, d0
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_xor/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/32_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #2
 ;;       mov     x0, x16
 ;;       eor     x0, x0, #3
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/64_const.wat
@@ -13,14 +13,14 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       orr     x16, xzr, #0x7ffffffffffffffe
 ;;       mov     x0, x16
 ;;       eor     x0, x0, #0x7fffffffffffffff
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i64_xor/locals.wat
@@ -21,8 +21,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       mov     x16, #0
@@ -38,7 +38,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       eor     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/params.wat
+++ b/tests/disas/winch/aarch64/i64_xor/params.wat
@@ -13,8 +13,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    x2, [x28, #8]
@@ -23,7 +23,7 @@
 ;;       ldur    x1, [x28, #8]
 ;;       eor     x1, x1, x0
 ;;       mov     x0, x1
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -24,8 +24,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x1
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x1, [x28, #0x18]
 ;;       stur    x2, [x28, #0x10]
 ;;       stur    w3, [x28, #0xc]
@@ -34,9 +34,9 @@
 ;;       ldur    x1, [x9, #0x58]
 ;;       mov     w2, w0
 ;;       add     x2, x2, #4
-;;       b.hs    #0x134
+;;       b.hs    #0x12c
 ;;   3c: cmp     x2, x1, uxtx
-;;       b.hi    #0x138
+;;       b.hi    #0x130
 ;;   44: ldur    x3, [x9, #0x50]
 ;;       add     x3, x3, x0, uxtx
 ;;       mov     x16, #0
@@ -48,9 +48,9 @@
 ;;       ldur    x2, [x9, #0x58]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.hs    #0x13c
+;;       b.hs    #0x134
 ;;   74: cmp     x3, x2, uxtx
-;;       b.hi    #0x140
+;;       b.hi    #0x138
 ;;   7c: ldur    x4, [x9, #0x50]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
@@ -65,9 +65,9 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x4, x4, x16, uxtx
-;;       b.hs    #0x144
+;;       b.hs    #0x13c
 ;;   b8: cmp     x4, x3, uxtx
-;;       b.hi    #0x148
+;;       b.hi    #0x140
 ;;   c0: ldur    x5, [x9, #0x50]
 ;;       add     x5, x5, x2, uxtx
 ;;       orr     x16, xzr, #0xfffff
@@ -77,29 +77,27 @@
 ;;       cmp     x4, x3, uxtx
 ;;       csel    x5, x6, x6, hi
 ;;       ldur    w2, [x5]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     w0, w2
 ;;       ldur    x1, [x28, #8]
 ;;       ldur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    w16, [x1]
 ;;       ldur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    w16, [x1, #4]
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
+;;  12c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  130: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  134: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  138: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  13c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  140: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  144: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  148: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/load/f32.wat
+++ b/tests/disas/winch/aarch64/load/f32.wat
@@ -11,8 +11,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -20,7 +20,7 @@
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
 ;;       ldur    s0, [x1]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/f64.wat
+++ b/tests/disas/winch/aarch64/load/f64.wat
@@ -10,8 +10,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -19,7 +19,7 @@
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
 ;;       ldur    d0, [x1]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i32.wat
+++ b/tests/disas/winch/aarch64/load/i32.wat
@@ -11,8 +11,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0
@@ -20,7 +20,7 @@
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
 ;;       ldur    w0, [x1]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i64.wat
+++ b/tests/disas/winch/aarch64/load/i64.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x18
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
 ;;       stur    x2, [x28]
@@ -22,13 +22,17 @@
 ;;       mov     w1, w16
 ;;       ldur    x2, [x9, #0x50]
 ;;       add     x2, x2, x1, uxtx
+;;       sub     sp, x28, #8
 ;;       sturb   w0, [x2]
+;;       mov     sp, x28
 ;;       mov     x16, #8
 ;;       mov     w0, w16
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
+;;       sub     sp, x28, #8
 ;;       ldursb  x0, [x1]
-;;       add     sp, sp, #0x18
-;;       mov     x28, sp
+;;       mov     sp, x28
+;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/nop/nop.wat
+++ b/tests/disas/winch/aarch64/nop/nop.wat
@@ -11,11 +11,11 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/400_params.wat
+++ b/tests/disas/winch/aarch64/params/400_params.wat
@@ -54,8 +54,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x28
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x20]
 ;;       stur    x1, [x28, #0x18]
 ;;       stur    w2, [x28, #0x14]
@@ -65,7 +65,7 @@
 ;;       stur    w6, [x28, #4]
 ;;       stur    w7, [x28]
 ;;       ldur    w0, [x28, #0x14]
-;;       add     sp, sp, #0x28
-;;       mov     x28, sp
+;;       add     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/multi_values.wat
+++ b/tests/disas/winch/aarch64/params/multi_values.wat
@@ -14,8 +14,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x1
-;;       sub     sp, sp, #0x28
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       stur    x1, [x28, #0x20]
 ;;       stur    x2, [x28, #0x18]
 ;;       stur    w3, [x28, #0x14]
@@ -25,31 +25,28 @@
 ;;       stur    x0, [x28]
 ;;       ldur    s0, [x28, #8]
 ;;       ldur    w16, [x28, #0x14]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
 ;;       ldur    w16, [x28, #0x14]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x28]
 ;;       ldur    s31, [x28, #0x14]
-;;       sub     sp, sp, #4
-;;       mov     x28, sp
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s31, [x28]
 ;;       ldur    x0, [x28, #0xc]
 ;;       ldur    s31, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    s31, [x0]
 ;;       ldur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    w16, [x0, #4]
 ;;       ldur    w16, [x28]
-;;       add     sp, sp, #4
-;;       mov     x28, sp
+;;       add     x28, x28, #4
 ;;       stur    w16, [x0, #8]
-;;       add     sp, sp, #0x28
-;;       mov     x28, sp
+;;       add     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -24,8 +24,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x20
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x18]
 ;;       stur    x1, [x28, #0x10]
 ;;       stur    w2, [x28, #0xc]
@@ -82,8 +82,8 @@
 ;;       cmp     x3, x2, uxtx
 ;;       csel    x4, x5, x5, hi
 ;;       stur    w0, [x4]
-;;       add     sp, sp, #0x20
-;;       mov     x28, sp
+;;       add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;  108: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/store/f32.wat
+++ b/tests/disas/winch/aarch64/store/f32.wat
@@ -10,8 +10,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x7fa00000
@@ -21,7 +21,7 @@
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
 ;;       stur    s0, [x1]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/f64.wat
+++ b/tests/disas/winch/aarch64/store/f64.wat
@@ -11,8 +11,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x7ff4000000000000
@@ -22,7 +22,7 @@
 ;;       ldur    x1, [x9, #0x50]
 ;;       add     x1, x1, x0, uxtx
 ;;       stur    d0, [x1]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i32.wat
+++ b/tests/disas/winch/aarch64/store/i32.wat
@@ -12,8 +12,8 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
@@ -23,7 +23,7 @@
 ;;       ldur    x2, [x9, #0x50]
 ;;       add     x2, x2, x1, uxtx
 ;;       stur    w0, [x2]
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i64.wat
+++ b/tests/disas/winch/aarch64/store/i64.wat
@@ -13,13 +13,13 @@
 ;;       mov     x29, sp
 ;;       mov     x28, sp
 ;;       mov     x9, x0
-;;       sub     sp, sp, #0x10
-;;       mov     x28, sp
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x16, #0x20
 ;;       mov     w0, w16
-;;       add     sp, sp, #0x10
-;;       mov     x28, sp
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -196,21 +196,27 @@ impl Assembler {
     }
 
     /// Load a signed register.
-    pub fn sload(&mut self, addr: Address, rd: WritableReg, size: OperandSize) {
-        self.ldr(addr, rd, size, true);
+    pub fn sload(&mut self, addr: Address, rd: WritableReg, size: OperandSize, flags: MemFlags) {
+        self.ldr(addr, rd, size, true, flags);
     }
 
     /// Load an unsigned register.
-    pub fn uload(&mut self, addr: Address, rd: WritableReg, size: OperandSize) {
-        self.ldr(addr, rd, size, false);
+    pub fn uload(&mut self, addr: Address, rd: WritableReg, size: OperandSize, flags: MemFlags) {
+        self.ldr(addr, rd, size, false, flags);
     }
 
     /// Load address into a register.
-    fn ldr(&mut self, addr: Address, rd: WritableReg, size: OperandSize, signed: bool) {
+    fn ldr(
+        &mut self,
+        addr: Address,
+        rd: WritableReg,
+        size: OperandSize,
+        signed: bool,
+        flags: MemFlags,
+    ) {
         use OperandSize::*;
         let writable_reg = rd.map(Into::into);
         let mem: AMode = addr.try_into().unwrap();
-        let flags = MemFlags::trusted();
 
         let inst = match (rd.to_reg().is_int(), signed, size) {
             (_, false, S8) => Inst::ULoad8 {

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -80,62 +80,62 @@ pub(crate) const fn sp() -> Reg {
 
 /// Shadow stack pointer register.
 ///
-/// The shadow stack pointer is used as the base for memory addressing
+/// The shadow stack pointer (SSP) is used as the base for memory addressing
 /// to workaround Aarch64's constraint on the stack pointer 16-byte
 /// alignment for memory addressing. This allows word-size loads and
-/// stores.  It's always assumed that the real stack pointer is
-/// 16-byte unaligned; the only exceptions to this assumption are the function
-/// prologue and epilogue in which we use the real stack pointer for
-/// addressing, assuming that the 16-byte alignment is respected.
+/// stores.  It's always assumed that the real stack pointer (SP) is
+/// 16-byte unaligned; the only exceptions to this assumption are:
 ///
-/// The fact that the shadow stack pointer is used for memory
-/// addressing, doesn't change the meaning of the real stack pointer,
-/// which should always be used to allocate and deallocate stack
-/// space. The real stack pointer is always treated as "primary".
-/// Throughout the code generation any change to the stack pointer is
-/// reflected in the shadow stack pointer via the
-/// [MacroAssembler::move_sp_to_shadow_sp] function.
+/// * The function prologue and epilogue in which we use SP
+///   for addressing, assuming that the 16-byte alignment is respected.
+/// * Call sites, in which the code generation process explicitly ensures that
+///   the stack pointer is 16-byte aligned.
+/// * Code that could result in signal handling, like loads/stores.
 ///
-/// This approach, requires copying the real stack pointer value into
-/// x28 every time the real stack pointer moves, which involves
-/// emitting one more instruction. For example, this is generally how
-/// the real stack pointer and x28 will look like during a function:
+/// SSP is utilized for space allocation. After each allocation, its value is
+/// copied to SP, ensuring that SP accurately reflects the allocated space.
+/// Accessing memory below SP may lead to undefined behavior, as this memory can
+/// be overwritten by interrupts and signal handlers.
 ///
-/// +-----------+
-/// |           |      Save x28 (callee-saved)
-/// +-----------+----- SP at function entry (after epilogue, slots for FP and LR)
-/// |           |      Copy the value of SP to x28
+/// This approach requires copying the value of SSP into SP every time SSP
+/// changes, more explicitly, this happens at three main locations:
+///
+/// 1. After space is allocated, to respect the requirement of avoiding
+///    addressing space below SP.
+/// 2. At function epilogue.
+/// 3. After explicit SP is emitted (code that could result in signal handling).
+///
+/// +-----------+      Prologue:
+/// |           |      * Save SSP (callee-saved)
+/// +-----------+----- * SP at function entry (after prologue, slots for FP and LR)
+/// |           |      * Copy the value of SP to SSP
 /// |           |
-/// +-----------+----- SP after reserving stack space for locals and arguments
-/// |           |      Copy the value of SP to x28
+/// +-----------+----- SSP after reserving stack space for locals and arguments
+/// |           |      Copy the value of SSP to SP
 /// |           |
-/// +-----------+----- SP after a push
-/// |           |      Copy the value of SP to x28 (similar after a pop)
+/// +-----------+----- SSP after a push
+/// |           |      Copy the value of SSP to SP
 /// |           |      
 /// |           |       
 /// |           |
-/// |           |
-/// +-----------+----- At epilogue restore x28 (callee-saved)
-/// +-----------+
+/// |           |      Epilogue:
+/// |           |      * Copy SSP to SP
+/// +-----------+----- * Restore SSP (callee-saved)
+/// +-----------+      
 ///
 /// In summary, the following invariants must be respected:
 ///
-/// * The real stack pointer is always primary, and must be used to
-///   allocate and deallocate stack space(e.g. push, pop). This
-///   operation must always be followed by a copy of the real stack
-///   pointer to x28.
-/// * The real stack pointer must never be used to
-///   address memory except when we are certain that the required
-///   alignment is respected (e.g.  during the prologue and epilogue)
-/// * The value of the real stack pointer is copied to x28 when
-///   entering a function.
-/// * The value of x28 doesn't change between
+/// * SSP is considered primary, and must be used to allocate and deallocate
+///   stack space(e.g. push, pop). This operation must always be followed by
+///   a copy of SSP to SP.
+/// * SP must never be used to address memory except when we are certain that
+///   the required alignment is respected (e.g.  during the prologue and epilogue)
+/// * SP must be explicitly aligned when code could result in signal handling.
+/// * The value of SP is copied to SSP when entering a function.
+/// * The value of SSP doesn't change between
 ///   function calls (as it's callee saved), compliant with
 ///   Aarch64's ABI.
-/// * x28 is not available during register allocation.
-/// * Since the real stack pointer is always primary, there's no need
-///   to copy the shadow stack pointer into the real stack
-///   pointer. The copy is only done SP -> Shadow SP direction.
+/// * SSP is not available during register allocation.
 pub(crate) const fn shadow_sp() -> Reg {
     xreg(28)
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -290,6 +290,7 @@ impl ExtendKind {
 /// Kinds of vector extends in WebAssembly. Each MacroAssembler implementation
 /// is responsible for emitting the correct sequence of instructions when
 /// lowering to machine code.
+#[derive(Copy, Clone)]
 pub(crate) enum VectorExtendKind {
     /// Sign extends eight 8 bit integers to eight 16 bit lanes.
     V128Extend8x8S,
@@ -476,6 +477,7 @@ impl LoadKind {
 }
 
 /// Kinds of behavior supported by Wasm loads.
+#[derive(Copy, Clone)]
 pub enum StoreKind {
     /// Store the entire bytes of the operand size without any modifications.
     Operand(OperandSize),
@@ -491,6 +493,7 @@ impl StoreKind {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct LaneSelector {
     pub lane: u8,
     pub size: OperandSize,


### PR DESCRIPTION
This commit marks another step toward finalizing AArch64 support in
Winch.

While enabling spec tests, I experienced some unexpected failures
related to Wasm loads/stores and traps. The observed
symptoms are as follows:

* Under normal conditions, Wasm loads/stores work as expected.
* In out-of-bounds scenarios, loads/stores result in a segmentation
  fault, whereas the expected behavior is to trigger an out-of-bounds trap.
* When out-of-bounds access can be determined statically, the program
  still results in a segmentation fault instead of the anticipated
  out-of-bounds trap.

Debugging revealed the following issues:

* The stack pointer was not correctly aligned to 16 bytes when entering
  signal handlers, which caused the segmentation fault.
* Wasm loads and stores were not flagged as untrusted, leading to
  segmentation faults even when the stack pointer was properly aligned.

This commit fixes the previous issues by:

* Correctly flagging wasm loads and stores as untrusted.
* Reworking the shadow stack pointer approach such that it allows
  aligning the stack pointer at arbitrary points in the program,
  particularly where signal handling might be needed. This rework
  involves changing some principles introduced in
  https://github.com/bytecodealliance/wasmtime/pull/5652; namely:
  changing the primary stack pointer register to be the shadow stack
  pointer. See the updated comments in the code for more details.

Note that this change doesn't enable spectests. I'll follow-up with more work to do so. To try this change, run:

```sh
  cargo run -- wast -Ccompiler=winch tests/spec_testsuite/address.wast
```

--

The diff is large-ish due to all the changes in disassembly tests, however, all code changes can [be found in this commit](https://github.com/bytecodealliance/wasmtime/pull/10146/commits/25932107478202d69a4b5bd379d521ab2a17e9ec).


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
