### PR TITLE
Enable warnings if `gc` is disabled

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2729,6 +2729,7 @@ impl Default for Collector {
     }
 }
 
+#[cfg(feature = "gc")]
 impl Collector {
     fn not_auto(&self) -> Option<Collector> {
         match self {

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -285,9 +285,6 @@
 // here to get warnings in all configurations of Wasmtime.
 #![cfg_attr(
     any(
-        not(feature = "gc"),
-        not(feature = "gc-drc"),
-        not(feature = "gc-null"),
         not(feature = "cranelift"),
         not(feature = "runtime"),
         not(feature = "std"),

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -13,7 +13,6 @@ use crate::{
 use alloc::sync::Arc;
 use core::ffi::c_void;
 use core::mem::{self, MaybeUninit};
-use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 #[cfg(feature = "async")]
 use core::{future::Future, pin::Pin};
@@ -1211,7 +1210,7 @@ impl Func {
             // already. If it is at capacity (unlikely) then we need to do a GC
             // to free up space.
             let num_gc_refs = ty.as_wasm_func_type().non_i31_gc_ref_params_count();
-            if let Some(num_gc_refs) = NonZeroUsize::new(num_gc_refs) {
+            if let Some(num_gc_refs) = core::num::NonZeroUsize::new(num_gc_refs) {
                 return Ok(opaque
                     .gc_store()?
                     .gc_heap

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2443,6 +2443,7 @@ impl HostFunc {
     }
 
     /// Analog of [`Func::wrap_inner`]
+    #[cfg(feature = "async")]
     pub fn wrap_inner<F, T, Params, Results>(engine: &Engine, func: F) -> Self
     where
         F: Fn(Caller<'_, T>, Params) -> Results + Send + Sync + 'static,

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2443,7 +2443,7 @@ impl HostFunc {
     }
 
     /// Analog of [`Func::wrap_inner`]
-    #[cfg(feature = "async")]
+    #[cfg(any(feature = "component-model", feature = "async"))]
     pub fn wrap_inner<F, T, Params, Results>(engine: &Engine, func: F) -> Self
     where
         F: Fn(Caller<'_, T>, Params) -> Results + Send + Sync + 'static,

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -9,7 +9,6 @@ use crate::{
 use core::ffi::c_void;
 use core::marker;
 use core::mem::{self, MaybeUninit};
-use core::num::NonZeroUsize;
 use core::ptr::{self, NonNull};
 use wasmtime_environ::VMSharedTypeIndex;
 
@@ -155,7 +154,7 @@ where
         {
             // See the comment in `Func::call_impl_check_args`.
             let num_gc_refs = _params.vmgcref_pointing_to_object_count();
-            if let Some(num_gc_refs) = NonZeroUsize::new(num_gc_refs) {
+            if let Some(num_gc_refs) = core::num::NonZeroUsize::new(num_gc_refs) {
                 return _store
                     .unwrap_gc_store()
                     .gc_heap

--- a/crates/wasmtime/src/runtime/gc.rs
+++ b/crates/wasmtime/src/runtime/gc.rs
@@ -83,6 +83,7 @@ impl<T> fmt::Display for GcHeapOutOfMemory<T> {
 impl<T> core::error::Error for GcHeapOutOfMemory<T> {}
 
 impl<T> GcHeapOutOfMemory<T> {
+    #[cfg(feature = "gc")]
     pub(crate) fn new(inner: T) -> Self {
         Self { inner }
     }

--- a/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
@@ -1,7 +1,6 @@
-use crate::runtime::vm::VMGcRef;
 use crate::{
-    store::{AutoAssertNoGc, StoreContextMut, StoreOpaque},
-    ArrayType, AsContext, AsContextMut, GcRefImpl, Result, Rooted, Val, I31,
+    store::{StoreContextMut, StoreOpaque},
+    ArrayType, AsContext, AsContextMut, GcRefImpl, Result, Val,
 };
 
 /// Support for `ArrayRefPre` disabled at compile time because the `gc` cargo
@@ -15,13 +14,6 @@ pub enum ArrayRef {}
 impl GcRefImpl for ArrayRef {}
 
 impl ArrayRef {
-    pub(crate) fn from_cloned_gc_ref(
-        _store: &mut AutoAssertNoGc<'_>,
-        _gc_ref: VMGcRef,
-    ) -> Rooted<Self> {
-        unreachable!()
-    }
-
     pub fn ty(&self, _store: impl AsContext) -> Result<ArrayType> {
         match *self {}
     }

--- a/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
@@ -1,7 +1,5 @@
-use crate::runtime::vm::VMGcRef;
 use crate::{
-    store::{AutoAssertNoGc, StoreOpaque},
-    ArrayRef, AsContext, AsContextMut, GcRefImpl, HeapType, ManuallyRooted, Result, Rooted,
+    store::StoreOpaque, ArrayRef, AsContext, GcRefImpl, HeapType, ManuallyRooted, Result, Rooted,
     StructRef, I31,
 };
 
@@ -40,13 +38,6 @@ impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<EqRef> {
 impl GcRefImpl for EqRef {}
 
 impl EqRef {
-    pub(crate) fn from_cloned_gc_ref(
-        _store: &mut AutoAssertNoGc<'_>,
-        _gc_ref: VMGcRef,
-    ) -> Rooted<Self> {
-        unreachable!()
-    }
-
     pub fn ty(&self, _store: impl AsContext) -> Result<HeapType> {
         match *self {}
     }

--- a/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
@@ -1,12 +1,9 @@
-use crate::prelude::*;
 use crate::runtime::vm::{GcStore, VMGcRef};
 use crate::{
     runtime::Uninhabited,
     store::{AutoAssertNoGc, StoreOpaque},
     AsContext, AsContextMut, GcRef, Result, RootedGcRef,
 };
-use core::any::Any;
-use core::ffi::c_void;
 use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
 use core::marker;
@@ -46,13 +43,6 @@ impl RootSet {
     }
 
     pub(crate) fn exit_lifo_scope(&mut self, _gc_store: Option<&mut GcStore>, _scope: usize) {}
-
-    pub(crate) fn with_lifo_scope<T>(
-        store: &mut StoreOpaque,
-        f: impl FnOnce(&mut StoreOpaque) -> T,
-    ) -> T {
-        f(store)
-    }
 }
 
 /// This type is disabled because the `gc` cargo feature was not enabled at
@@ -124,10 +114,6 @@ impl<T: GcRef> Rooted<T> {
     ) -> Result<bool> {
         a.assert_unreachable()
     }
-
-    pub(crate) fn unchecked_cast<U: GcRef>(self) -> Rooted<U> {
-        match self.inner {}
-    }
 }
 
 /// This type has been disabled because the `gc` cargo feature was not enabled
@@ -197,10 +183,6 @@ impl<T> ManuallyRooted<T>
 where
     T: GcRef,
 {
-    pub(crate) fn comes_from_same_store(&self, _store: &StoreOpaque) -> bool {
-        match self.inner {}
-    }
-
     pub fn clone(&self, _store: impl AsContextMut) -> Self {
         match self.inner {}
     }
@@ -214,10 +196,6 @@ where
     }
 
     pub fn into_rooted(self, _context: impl AsContextMut) -> Rooted<T> {
-        match self.inner {}
-    }
-
-    pub(crate) fn unchecked_cast<U: GcRef>(self) -> ManuallyRooted<U> {
         match self.inner {}
     }
 }

--- a/crates/wasmtime/src/runtime/gc/disabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/structref.rs
@@ -1,7 +1,6 @@
-use crate::runtime::vm::VMGcRef;
 use crate::{
-    store::{AutoAssertNoGc, StoreContextMut, StoreOpaque},
-    AsContext, AsContextMut, GcRefImpl, Result, Rooted, StructType, Val, I31,
+    store::{StoreContextMut, StoreOpaque},
+    AsContext, AsContextMut, GcRefImpl, Result, StructType, Val,
 };
 
 /// Support for `StructRefPre` disabled at compile time because the `gc` cargo
@@ -15,13 +14,6 @@ pub enum StructRef {}
 impl GcRefImpl for StructRef {}
 
 impl StructRef {
-    pub(crate) fn from_cloned_gc_ref(
-        _store: &mut AutoAssertNoGc<'_>,
-        _gc_ref: VMGcRef,
-    ) -> Rooted<Self> {
-        unreachable!()
-    }
-
     pub fn ty(&self, _store: impl AsContext) -> Result<StructType> {
         match *self {}
     }

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1095,6 +1095,7 @@ impl Module {
     }
 
     /// Lookup the stack map at a program counter value.
+    #[cfg(feature = "gc")]
     pub(crate) fn lookup_stack_map(&self, pc: usize) -> Option<&wasmtime_environ::StackMap> {
         let text_offset = pc - self.inner.module.text().as_ptr() as usize;
         let (index, func_offset) = self.inner.module.func_by_text_offset(text_offset)?;

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -66,6 +66,7 @@ impl ModuleRegistry {
     }
 
     /// Fetches a registered module given a program counter value.
+    #[cfg(feature = "gc")]
     pub fn lookup_module_by_pc(&self, pc: usize) -> Option<&Module> {
         let (module, _) = self.module_and_offset(pc)?;
         Some(module)

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use crate::runtime::vm::mpk::{self, ProtectionMask};
-use crate::runtime::vm::GcRootsList;
 use crate::store::{ResourceLimiterInner, StoreInner, StoreOpaque};
 #[cfg(feature = "call-hook")]
 use crate::CallHook;
@@ -251,7 +250,7 @@ impl StoreOpaque {
     }
 
     #[cfg(feature = "gc")]
-    async fn trace_roots_async(&mut self, gc_roots_list: &mut GcRootsList) {
+    async fn trace_roots_async(&mut self, gc_roots_list: &mut crate::runtime::vm::GcRootsList) {
         use crate::runtime::vm::Yield;
 
         log::trace!("Begin trace GC roots");

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -2,10 +2,9 @@ use crate::memory::{LinearMemory, MemoryCreator};
 use crate::prelude::*;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::{
-    CompiledModuleId, GcHeapAllocationIndex, Imports, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, Memory, MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo,
-    OnDemandInstanceAllocator, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr,
-    Table, TableAllocationIndex,
+    CompiledModuleId, Imports, InstanceAllocationRequest, InstanceAllocator, InstanceAllocatorImpl,
+    Memory, MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo, OnDemandInstanceAllocator,
+    RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr, Table, TableAllocationIndex,
 };
 use crate::store::{InstanceId, StoreOpaque};
 use crate::MemoryType;
@@ -246,14 +245,17 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
     fn allocate_gc_heap(
         &self,
         _gc_runtime: &dyn crate::runtime::vm::GcRuntime,
-    ) -> Result<(GcHeapAllocationIndex, Box<dyn crate::runtime::vm::GcHeap>)> {
+    ) -> Result<(
+        crate::runtime::vm::GcHeapAllocationIndex,
+        Box<dyn crate::runtime::vm::GcHeap>,
+    )> {
         unreachable!()
     }
 
     #[cfg(feature = "gc")]
     fn deallocate_gc_heap(
         &self,
-        _allocation_index: GcHeapAllocationIndex,
+        _allocation_index: crate::runtime::vm::GcHeapAllocationIndex,
         _gc_heap: Box<dyn crate::runtime::vm::GcHeap>,
     ) {
         unreachable!()

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -392,6 +392,7 @@ impl RegisteredType {
     ///
     /// Only struct and array types have GC layouts; function types do not have
     /// layouts.
+    #[cfg(feature = "gc")]
     pub fn layout(&self) -> Option<&GcLayout> {
         self.layout.as_ref()
     }

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1401,6 +1401,7 @@ impl StorageType {
     /// https://webassembly.github.io/gc/core/syntax/types.html#bitwidth-fieldtype
     /// and
     /// https://webassembly.github.io/gc/core/syntax/types.html#bitwidth-valtype
+    #[cfg(feature = "gc")]
     pub(crate) fn data_byte_size(&self) -> Option<u32> {
         match self {
             StorageType::I8 => Some(1),
@@ -1979,6 +1980,7 @@ impl ArrayType {
         Engine::same(self.registered_type.engine(), engine)
     }
 
+    #[cfg(feature = "gc")]
     pub(crate) fn registered_type(&self) -> &RegisteredType {
         &self.registered_type
     }
@@ -2342,6 +2344,7 @@ impl FuncType {
         self.registered_type.index()
     }
 
+    #[cfg(feature = "gc")]
     pub(crate) fn as_wasm_func_type(&self) -> &WasmFuncType {
         self.registered_type.unwrap_func()
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -31,7 +31,6 @@ mod memory;
 mod mmap_vec;
 mod provenance;
 mod send_sync_ptr;
-mod send_sync_unsafe_cell;
 mod store_box;
 mod sys;
 mod table;
@@ -95,7 +94,6 @@ pub use crate::runtime::vm::vmcontext::{
     VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
-pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
 mod module_id;
 pub use module_id::CompiledModuleId;
@@ -113,6 +111,11 @@ mod mmap;
 mod async_yield;
 #[cfg(feature = "async")]
 pub use crate::runtime::vm::async_yield::*;
+
+#[cfg(feature = "gc-null")]
+mod send_sync_unsafe_cell;
+#[cfg(feature = "gc-null")]
+pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
 cfg_if::cfg_if! {
     if #[cfg(has_virtual_memory)] {

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -1,14 +1,15 @@
 //! Evaluating const expressions.
 
+use crate::prelude::*;
 use crate::runtime::vm::{Instance, VMGcRef, ValRaw, I31};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
-use crate::{
-    prelude::*, ArrayRef, ArrayRefPre, ArrayType, StructRef, StructRefPre, StructType, Val,
-};
+#[cfg(feature = "gc")]
+use crate::{ArrayRef, ArrayRefPre, ArrayType, StructRef, StructRefPre, StructType, Val};
 use smallvec::SmallVec;
+use wasmtime_environ::{ConstExpr, ConstOp, FuncIndex, GlobalIndex};
+#[cfg(feature = "gc")]
 use wasmtime_environ::{
-    ConstExpr, ConstOp, FuncIndex, GlobalIndex, ModuleInternedTypeIndex, WasmCompositeInnerType,
-    WasmCompositeType, WasmSubType,
+    ModuleInternedTypeIndex, WasmCompositeInnerType, WasmCompositeType, WasmSubType,
 };
 
 /// An interpreter for const expressions.

--- a/crates/wasmtime/src/runtime/vm/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/disabled.rs
@@ -5,22 +5,14 @@
 
 #![allow(missing_docs)]
 
-use crate::prelude::*;
-use crate::runtime::vm::{GcHeap, GcRuntime};
-use wasmtime_environ::{
-    GcArrayLayout, GcStructLayout, GcTypeLayouts, WasmArrayType, WasmStructType,
-};
-
 pub enum VMExternRef {}
-
-pub enum VMEqRef {}
 
 pub enum VMStructRef {}
 
 pub enum VMArrayRef {}
 
 pub struct VMGcObjectDataMut<'a> {
-    inner: VMStructRef,
+    _inner: VMStructRef,
     _phantom: core::marker::PhantomData<&'a mut ()>,
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled.rs
@@ -3,6 +3,7 @@
 mod arrayref;
 mod data;
 mod externref;
+#[cfg(feature = "gc-drc")]
 mod free_list;
 mod structref;
 
@@ -21,15 +22,11 @@ mod null;
 #[cfg(feature = "gc-null")]
 pub use null::*;
 
-use crate::runtime::vm::GcRuntime;
-
-/// The default GC heap capacity: 512KiB.
-#[cfg(not(miri))]
-const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 19;
-
-/// The default GC heap capacity for miri: 64KiB.
-#[cfg(miri)]
-const DEFAULT_GC_HEAP_CAPACITY: usize = 1 << 16;
+/// The default GC heap capacity.
+//
+// Note that this is a bit smaller for miri to avoid overheads.
+#[cfg(any(feature = "gc-drc", feature = "gc-null"))]
+const DEFAULT_GC_HEAP_CAPACITY: usize = if cfg!(miri) { 1 << 16 } else { 1 << 19 };
 
 // Explicit methods with `#[allow]` to clearly indicate that truncation is
 // desired when used.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -9,8 +9,8 @@ use crate::{
     prelude::*,
     vm::{
         mmap::AlignedLength, ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection,
-        GcHeap, GcHeapObject, GcProgress, GcRootsIter, Mmap, SendSyncUnsafeCell, TypedGcRef,
-        VMGcHeader, VMGcRef,
+        GcHeap, GcHeapObject, GcProgress, GcRootsIter, GcRuntime, Mmap, SendSyncUnsafeCell,
+        TypedGcRef, VMGcHeader, VMGcRef,
     },
     GcHeapOutOfMemory,
 };

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -37,6 +37,7 @@ pub unsafe trait GcRuntime: 'static + Send + Sync {
     fn layouts(&self) -> &dyn GcTypeLayouts;
 
     /// Construct a new GC heap.
+    #[cfg(feature = "gc")]
     fn new_gc_heap(&self) -> Result<Box<dyn GcHeap>>;
 }
 
@@ -524,11 +525,19 @@ pub struct GcRootsList(Vec<RawGcRoot>);
 //    contents of the roots list (when it is non-empty, during GCs) borrow from
 //    the store, which creates self-references.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(
+    not(feature = "gc"),
+    expect(
+        dead_code,
+        reason = "not worth it at this time to #[cfg] away these variants",
+    )
+)]
 enum RawGcRoot {
     Stack(SendSyncPtr<u32>),
     NonStack(SendSyncPtr<VMGcRef>),
 }
 
+#[cfg(feature = "gc")]
 impl GcRootsList {
     /// Add a GC root that is inside a Wasm stack frame to this list.
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -400,6 +400,7 @@ impl Instance {
         self.runtime_info.env_module()
     }
 
+    #[cfg(feature = "gc")]
     pub(crate) fn runtime_module(&self) -> Option<&crate::Module> {
         match &self.runtime_info {
             ModuleRuntimeInfo::Module(m) => Some(m),

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -57,7 +57,9 @@
 use crate::prelude::*;
 use crate::runtime::vm::table::{Table, TableElementType};
 use crate::runtime::vm::vmcontext::VMFuncRef;
-use crate::runtime::vm::{HostResultHasUnwindSentinel, Instance, TrapReason, VMGcRef, VMStore};
+#[cfg(feature = "gc")]
+use crate::runtime::vm::VMGcRef;
+use crate::runtime::vm::{HostResultHasUnwindSentinel, Instance, TrapReason, VMStore};
 use core::convert::Infallible;
 use core::ptr::NonNull;
 #[cfg(feature = "threads")]

--- a/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
@@ -16,6 +16,7 @@ pub fn keys(_: usize) -> &'static [ProtectionKey] {
     &[]
 }
 
+#[cfg(any(feature = "async", feature = "pooling-allocator"))]
 pub fn allow(_: ProtectionMask) {}
 
 #[cfg(feature = "async")]
@@ -25,6 +26,7 @@ pub fn current_mask() -> ProtectionMask {
 
 #[derive(Clone, Copy, Debug)]
 pub enum ProtectionKey {}
+
 impl ProtectionKey {
     #[cfg(feature = "pooling-allocator")]
     pub fn protect(&self, _: &mut [u8]) -> Result<()> {
@@ -37,8 +39,12 @@ impl ProtectionKey {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[cfg(any(feature = "async", feature = "pooling-allocator"))]
 pub struct ProtectionMask;
+
+#[cfg(any(feature = "async", feature = "pooling-allocator"))]
 impl ProtectionMask {
+    #[cfg(any(feature = "async", feature = "pooling-allocator"))]
     pub fn all() -> Self {
         Self
     }

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -37,6 +37,10 @@ pub struct Backtrace(Vec<Frame>);
 #[derive(Debug)]
 pub struct Frame {
     pc: usize,
+    #[cfg_attr(
+        not(feature = "gc"),
+        expect(dead_code, reason = "not worth #[cfg] annotations to remove")
+    )]
     fp: usize,
 }
 
@@ -47,6 +51,7 @@ impl Frame {
     }
 
     /// Get this frame's frame pointer.
+    #[cfg(feature = "gc")]
     pub fn fp(&self) -> usize {
         self.fp
     }
@@ -88,6 +93,7 @@ impl Backtrace {
     }
 
     /// Walk the current Wasm stack, calling `f` for each frame we walk.
+    #[cfg(feature = "gc")]
     pub fn trace(store: &StoreOpaque, f: impl FnMut(Frame) -> ControlFlow<()>) {
         let limits = store.runtime_limits();
         let unwind = store.unwinder();


### PR DESCRIPTION
Continuation of work in #10131. This additionally handles turning off `gc-null` and `gc-drc` and the various combinations within.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
