### PR TITLE
chore: Add issue triage process to contributing docs

### DIFF
--- a/docs/contributing-development-process.md
+++ b/docs/contributing-development-process.md
@@ -2,7 +2,8 @@
 
 We use [issues] for asking questions ([open one here][newissue]!) and tracking
 bugs and unimplemented features, and [pull requests] (PRs) for tracking and
-reviewing code submissions.
+reviewing code submissions. We triage new issues at each of our bi-weekly
+[Wasmtime meetings][meetings].
 
 ### Before submitting a PR
 
@@ -77,3 +78,4 @@ removing warnings, etc.
 [issue keywords]: https://help.github.com/articles/closing-issues-using-keywords/
 [Core Team]: https://github.com/orgs/bytecodealliance/people/
 [newissue]: https://github.com/bytecodealliance/wasmtime/issues/new
+[meetings]: https://github.com/bytecodealliance/meetings/tree/main/wasmtime


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
This adds an explanation of the triage process to the contributing docs for the core project proposal in https://github.com/bytecodealliance/governance/issues/114.