### PR TITLE
Add a note that `no_std` builds panic on contention

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -144,7 +144,10 @@ that will require building from source.
 
 [^5]: Rust targets that are `#![no_std]` don't support the entire feature set of
 Wasmtime. For example the `threads` Cargo feature requires the standard library.
-For more information see the [`no_std` documentation][nostd].
+For more information see the [`no_std` documentation][nostd]. Additionally these
+targets are sound in the presence of multiple threads but will panic on
+contention of data structures. If you're doing multithreaded things in `no_std`
+please file an issue so we can help solve your use case.
 
 [nostd]: ./stability-platform-support.md
 


### PR DESCRIPTION
While it's predicted that `no_std` builds won't be using threading that's not necessarily a given. Add a note to the documentation to call out that `no_std` builds panic on contention with a request for filing an issue if that's not suitable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
