### PR TITLE
Always allow dead_code/unused_import warnings in `wasmtime`

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -281,12 +281,6 @@
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-// NB: this list is currently being burned down to remove all features listed
-// here to get warnings in all configurations of Wasmtime.
-#![cfg_attr(
-    any(not(feature = "runtime"), not(feature = "std")),
-    allow(dead_code, unused_imports)
-)]
 // Allow broken links when the default features is disabled because most of our
 // documentation is written for the "one build" of the `main` branch which has
 // most features enabled. This will present warnings in stripped-down doc builds

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -5,12 +5,11 @@ use crate::runtime::vm::send_sync_ptr::SendSyncPtr;
 use crate::runtime::vm::{mmap::UnalignedLength, Mmap};
 #[cfg(not(has_virtual_memory))]
 use alloc::alloc::Layout;
-use alloc::sync::Arc;
 use core::ops::{Deref, Range};
 #[cfg(not(has_virtual_memory))]
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
-use std::fs::File;
+use std::{fs::File, sync::Arc};
 
 /// A type which prefers to store backing memory in an OS-backed memory mapping
 /// but can fall back to the regular memory allocator as well.


### PR DESCRIPTION
Finishes the work started in #10131 and this means that the crate is no longer special and has the same default settings of all other crates in all situations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
