### PR TITLE
Document `memory64` wasm proposal as having tier 1 support

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -38,6 +38,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`multi-memory`]                           |
 | WebAssembly Proposal | [`threads`]                                |
 | WebAssembly Proposal | [`tail-call`]                              |
+| WebAssembly Proposal | [`memory64`]                               |
 | WASI Proposal        | [`wasi-io`]                                |
 | WASI Proposal        | [`wasi-clocks`]                            |
 | WASI Proposal        | [`wasi-filesystem`]                        |
@@ -71,7 +72,6 @@ For explanations of what each tier means see below.
 | Target               | `s390x-unknown-linux-gnu`  | Continuous fuzzing          |
 | Target               | `x86_64-pc-windows-gnu`    | Clear owner of the target   |
 | Target               | Support for `#![no_std]`   | Support beyond CI checks    |
-| WebAssembly Proposal | [`memory64`]               | Unstable wasm proposal      |
 | WebAssembly Proposal | [`function-references`]    | Unstable wasm proposal      |
 | WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
 


### PR DESCRIPTION
* [x] [Continuous fuzzing][fuzz1], and tested [to get fuzzed][fuzz2]
  * [x] [Custom fuzz target][fuzz-target]
* [x] Implementation ready to have CVEs assigned if necessary.
* [x] Reasonable to expect most developers to assist in maintenance.
* [x] RFC required for future changes affecting APIs/implementation.
* [x] [Stage 4 WebAssembly proposal](https://github.com/WebAssembly/proposals)
* [x] No known bugs/open questions.
* [x] [Available in Wasmtime API][rust-api]
* [x] [Available in Wasmtime C API][c-api]

[fuzz1]: https://github.com/bytecodealliance/wasmtime/blob/e60b6e623bca1203cf4b9c844254c25ccebe9d6d/crates/fuzzing/src/generators/module.rs#L49
[fuzz2]: https://github.com/bytecodealliance/wasmtime/blob/e60b6e623bca1203cf4b9c844254c25ccebe9d6d/crates/fuzzing/src/oracles.rs#L1311
[fuzz-target]: https://github.com/bytecodealliance/wasmtime/blob/e60b6e623bca1203cf4b9c844254c25ccebe9d6d/crates/fuzzing/src/oracles/memory.rs#L20-L23
[rust-api]: https://docs.rs/wasmtime/latest/wasmtime/struct.MemoryTypeBuilder.html#method.memory64
[c-api]: https://docs.wasmtime.dev/c-api/memory_8h.html#a3db783fad4992c3f6985c92274b14ad7

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
