### PR TITLE
Document Pulley as having Tier 2 support

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -74,6 +74,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`memory64`]               | Unstable wasm proposal      |
 | WebAssembly Proposal | [`function-references`]    | Unstable wasm proposal      |
 | WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
+| Execution Backend    | Pulley                     | More time fuzzing/baking    |
 
 [`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
@@ -105,7 +106,6 @@ For explanations of what each tier means see below.
 | Target               | `x86_64-unknown-none` [^5]        | CI testing, full-time maintainer |
 | Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
-| Execution Backend    | Pulley                            | fuzzing                     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
 | WASI Proposal        | [`wasi-nn`]                       | More expansive CI testing   |
 | WASI Proposal        | [`wasi-threads`]                  | More CI, unstable proposal  |


### PR DESCRIPTION
* [x] Test are run in CI.
* [x] Complete implementation of all Tier 1 proposals. (except `threads`, intentionally)
* [x] Expected that all maintainers will have to handle minor changes affecting Pulley.
* [x] Future major changes requiring an RFC required to consider Pulley.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
