### PR TITLE
Enable `parallel-compilation` CLI feature from `wasmtime-fuzzing`

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -50,6 +50,7 @@ features = [
   'pooling-allocator',
   'pulley',
   'threads',
+  'parallel-compilation',
 ]
 
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled


### PR DESCRIPTION
Turns out our request to disable parallel compilation was being ignored because we weren't enabling the right crate feature. Let's enable it so it doesn't get ignored while fuzzing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
