### PR TITLE
Winch: Rename v128 extend kind enum

### DIFF
--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -4,7 +4,7 @@ use crate::{
     isa::{reg::Reg, CallingConvention},
     masm::{
         DivKind, Extend, ExtendKind, ExtendType, IntCmpKind, MulWideKind, OperandSize, RemKind,
-        RoundingMode, ShiftKind, Signed, VectorExtendKind, Zero,
+        RoundingMode, ShiftKind, Signed, V128LoadExtendKind, Zero,
     },
     reg::writable,
     x64::regs::scratch,
@@ -497,18 +497,18 @@ impl Assembler {
         &mut self,
         src: &Address,
         dst: WritableReg,
-        ext: VectorExtendKind,
+        ext: V128LoadExtendKind,
         flags: MemFlags,
     ) {
         assert!(dst.to_reg().is_float());
 
         let op = match ext {
-            VectorExtendKind::V128Extend8x8S => AvxOpcode::Vpmovsxbw,
-            VectorExtendKind::V128Extend8x8U => AvxOpcode::Vpmovzxbw,
-            VectorExtendKind::V128Extend16x4S => AvxOpcode::Vpmovsxwd,
-            VectorExtendKind::V128Extend16x4U => AvxOpcode::Vpmovzxwd,
-            VectorExtendKind::V128Extend32x2S => AvxOpcode::Vpmovsxdq,
-            VectorExtendKind::V128Extend32x2U => AvxOpcode::Vpmovzxdq,
+            V128LoadExtendKind::E8x8S => AvxOpcode::Vpmovsxbw,
+            V128LoadExtendKind::E8x8U => AvxOpcode::Vpmovzxbw,
+            V128LoadExtendKind::E16x4S => AvxOpcode::Vpmovsxwd,
+            V128LoadExtendKind::E16x4U => AvxOpcode::Vpmovzxwd,
+            V128LoadExtendKind::E32x2S => AvxOpcode::Vpmovsxdq,
+            V128LoadExtendKind::E32x2U => AvxOpcode::Vpmovzxdq,
         };
 
         let src = Self::to_synthetic_amode(

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -287,23 +287,23 @@ impl ExtendKind {
     }
 }
 
-/// Kinds of vector extends in WebAssembly. Each MacroAssembler implementation
-/// is responsible for emitting the correct sequence of instructions when
-/// lowering to machine code.
+/// Kinds of vector load and extends in WebAssembly. Each MacroAssembler
+/// implementation is responsible for emitting the correct sequence of
+/// instructions when lowering to machine code.
 #[derive(Copy, Clone)]
-pub(crate) enum VectorExtendKind {
+pub(crate) enum V128LoadExtendKind {
     /// Sign extends eight 8 bit integers to eight 16 bit lanes.
-    V128Extend8x8S,
+    E8x8S,
     /// Zero extends eight 8 bit integers to eight 16 bit lanes.
-    V128Extend8x8U,
+    E8x8U,
     /// Sign extends four 16 bit integers to four 32 bit lanes.
-    V128Extend16x4S,
+    E16x4S,
     /// Zero extends four 16 bit integers to four 32 bit lanes.
-    V128Extend16x4U,
+    E16x4U,
     /// Sign extends two 32 bit integers to two 64 bit lanes.
-    V128Extend32x2S,
+    E32x2S,
     /// Zero extends two 32 bit integers to two 64 bit lanes.
-    V128Extend32x2U,
+    E32x2U,
 }
 
 /// Kinds of splat loads supported by WebAssembly.
@@ -431,7 +431,7 @@ pub(crate) enum LoadKind {
     /// Scalar (non-vector) extend.
     ScalarExtend(ExtendKind),
     /// Vector extend.
-    VectorExtend(VectorExtendKind),
+    VectorExtend(V128LoadExtendKind),
     /// Load content into select lane.
     VectorLane(LaneSelector),
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -13,7 +13,7 @@ use crate::masm::{
     DivKind, Extend, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
     MemMoveDirection, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp,
     RoundingMode, SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind, StoreKind, TruncKind,
-    VectorCompareKind, VectorEqualityKind, VectorExtendKind, Zero,
+    V128LoadExtendKind, VectorCompareKind, VectorEqualityKind, Zero,
 };
 
 use crate::reg::{writable, Reg};
@@ -2790,7 +2790,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend8x8S),
+            LoadKind::VectorExtend(V128LoadExtendKind::E8x8S),
         )
     }
 
@@ -2798,7 +2798,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend8x8U),
+            LoadKind::VectorExtend(V128LoadExtendKind::E8x8U),
         )
     }
 
@@ -2806,7 +2806,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend16x4S),
+            LoadKind::VectorExtend(V128LoadExtendKind::E16x4S),
         )
     }
 
@@ -2814,7 +2814,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend16x4U),
+            LoadKind::VectorExtend(V128LoadExtendKind::E16x4U),
         )
     }
 
@@ -2822,7 +2822,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend32x2S),
+            LoadKind::VectorExtend(V128LoadExtendKind::E32x2S),
         )
     }
 
@@ -2830,7 +2830,7 @@ where
         self.emit_wasm_load(
             &memarg,
             WasmValType::V128,
-            LoadKind::VectorExtend(VectorExtendKind::V128Extend32x2U),
+            LoadKind::VectorExtend(V128LoadExtendKind::E32x2U),
         )
     }
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
A simple refactor to rename `VectorExtendKind` to `V128LoadExtendKind`. The reason why being that I need to introduce a _kind_ enum for the V128 extend instructions and `V128ExtendKind` seems like it would be a suitable name. The `VectorExtendKind` enum is only used by the SIMD _load and extend_ instructions so it seems appropriate to me to incorporate that it's specific to loads in the name.