### PR TITLE
Require lint reasons in `pulley-interpreter`

### DIFF
--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -715,11 +715,6 @@ for_each_extended_op!(define_extended_decoder);
 pub fn unwrap_uninhabited<T>(res: Result<T, Uninhabited>) -> T {
     match res {
         Ok(ok) => ok,
-
-        // Nightly rust warns that this pattern is unreachable, but stable rust
-        // doesn't.
-        #[allow(unreachable_patterns)]
-        Err(err) => match err {},
     }
 }
 
@@ -741,8 +736,8 @@ pub mod operands {
             )*
         ) => {
             $(
-                #[allow(unused_variables)]
-                #[allow(missing_docs)]
+                #[allow(unused_variables, reason = "macro-generated")]
+                #[allow(missing_docs, reason = "macro-generated")]
                 pub fn $snake_name<T: BytecodeStream>(pc: &mut T) -> Result<($($($field_ty,)*)?), T::Error> {
                     Ok((($($((<$field_ty>::decode(pc))?,)*)?)))
                 }
@@ -752,7 +747,8 @@ pub mod operands {
 
     for_each_op!(define_operands_decoder);
 
-    #[allow(missing_docs)]
+    /// Decode an extended opcode from `pc` to match the payload of the
+    /// "extended" opcode.
     pub fn extended<T: BytecodeStream>(pc: &mut T) -> Result<(ExtendedOpcode,), T::Error> {
         Ok((ExtendedOpcode::decode(pc)?,))
     }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -418,7 +418,7 @@ impl Default for XRegVal {
     }
 }
 
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "self-describing methods")]
 impl XRegVal {
     pub fn new_i32(x: i32) -> Self {
         let mut val = XRegVal::default();
@@ -537,7 +537,7 @@ impl Default for FRegVal {
     }
 }
 
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "self-describing methods")]
 impl FRegVal {
     pub fn new_f32(f: f32) -> Self {
         let mut val = Self::default();
@@ -620,7 +620,7 @@ impl Default for VRegVal {
     }
 }
 
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "self-describing methods")]
 impl VRegVal {
     pub fn new_u128(i: u128) -> Self {
         let mut val = Self::default();

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -9,6 +9,8 @@
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
+
+#[cfg(feature = "decode")]
 extern crate alloc;
 
 /// Calls the given macro with each opcode.
@@ -1405,6 +1407,7 @@ pub use op::*;
 pub mod opcode;
 pub use opcode::*;
 
+#[cfg(any(feature = "encode", feature = "decode"))]
 pub(crate) unsafe fn unreachable_unchecked<T>() -> T {
     #[cfg(debug_assertions)]
     unreachable!();

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -5,13 +5,10 @@
 #![cfg_attr(pulley_tail_calls, allow(incomplete_features, unstable_features))]
 #![deny(missing_docs)]
 #![no_std]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
-
-#[allow(unused_extern_crates)] // Some cfg's don't use this.
 extern crate alloc;
 
 /// Calls the given macro with each opcode.
@@ -1408,12 +1405,11 @@ pub use op::*;
 pub mod opcode;
 pub use opcode::*;
 
-#[allow(dead_code)] // Unused in some `cfg`s.
 pub(crate) unsafe fn unreachable_unchecked<T>() -> T {
     #[cfg(debug_assertions)]
     unreachable!();
 
-    #[cfg_attr(debug_assertions, allow(unreachable_code))]
+    #[cfg(not(debug_assertions))]
     unsafe {
         core::hint::unreachable_unchecked()
     }

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -36,7 +36,7 @@ macro_rules! define_op {
                 $(
                     // TODO: add doc comments to all fields and update all
                     // the macros to match them.
-                    #[allow(missing_docs)]
+                    #[allow(missing_docs, reason = "macro-generated code")]
                     pub $field : $field_ty,
                 )*
             )? }
@@ -86,7 +86,7 @@ macro_rules! define_extended_op {
                 $(
                     // TODO: add doc comments to all fields and update all
                     // the macros to match them.
-                    #[allow(missing_docs)]
+                    #[allow(missing_docs, reason = "macro-generated code")]
                     pub $field : $field_ty,
                 )*
             )? }

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -65,7 +65,8 @@ macro_rules! impl_reg {
 #[repr(u8)]
 #[derive(Debug,Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(non_camel_case_types, missing_docs)]
+#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum XReg {
     x0,  x1,  x2,  x3,  x4,  x5,  x6,  x7,  x8,  x9,
@@ -107,7 +108,8 @@ fn assert_special_start_is_right() {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(non_camel_case_types, missing_docs)]
+#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum FReg {
     f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,  f8,  f9,
@@ -120,7 +122,8 @@ pub enum FReg {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(non_camel_case_types, missing_docs)]
+#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum VReg {
     v0,  v1,  v2,  v3,  v4,  v5,  v6,  v7,  v8,  v9,
@@ -137,7 +140,7 @@ impl_reg!(VReg, V, 0..32);
 ///
 /// Never appears inside an instruction -- instructions always name a particular
 /// class of register -- but this is useful for testing and things like that.
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "self-describing variants")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AnyReg {


### PR DESCRIPTION
Continuing work originally started in #9696

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
