### PR TITLE
Standardize the arg order of commutative instructions in pursuit of a higher GVN hit ratio.

### DIFF
--- a/cranelift/codegen/src/ir/condcodes.rs
+++ b/cranelift/codegen/src/ir/condcodes.rs
@@ -32,7 +32,7 @@ pub trait CondCode: Copy {
 /// This condition code is used by the `icmp` instruction to compare integer values. There are
 /// separate codes for comparing the integers as signed or unsigned numbers where it makes a
 /// difference.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum IntCC {
     /// `==`.
@@ -194,7 +194,7 @@ impl FromStr for IntCC {
 /// The condition codes described here are used to produce a single boolean value from the
 /// comparison. The 14 condition codes here cover every possible combination of the relation above
 /// except the impossible `!UN & !EQ & !LT & !GT` and the always true `UN | EQ | LT | GT`.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum FloatCC {
     /// EQ | LT | GT

--- a/cranelift/codegen/src/ir/layout.rs
+++ b/cranelift/codegen/src/ir/layout.rs
@@ -25,12 +25,12 @@ use core::cmp;
 ///
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub struct Layout {
-    /// Linked list nodes for the layout order of blocks Forms a doubly linked list, terminated in
+    /// Linked list nodes for the layout order of blocks. Forms a doubly linked list, terminated at
     /// both ends by `None`.
     blocks: SecondaryMap<Block, BlockNode>,
 
-    /// Linked list nodes for the layout order of instructions. Forms a double linked list per block,
-    /// terminated in both ends by `None`.
+    /// Linked list nodes for the layout order of instructions. Forms a doubly linked list per block,
+    /// terminated at both ends by `None`.
     insts: SecondaryMap<Inst, InstNode>,
 
     /// First block in the layout order, or `None` when no blocks have been laid out.

--- a/cranelift/filetests/filetests/egraph/commutative-gvn.clif
+++ b/cranelift/filetests/filetests/egraph/commutative-gvn.clif
@@ -1,0 +1,23 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %f(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    brif v2, block1(v0), block1(v1)
+
+block1(v3: i32):
+    v4 = iadd v1, v0
+    v5 = iadd v4, v3
+    return v5
+}
+
+;; Check that `v4` is subsumed by `v2`, even if `iadd v0, v1` has different operand order than
+;; `iadd v1, v0`:
+
+; check:  block0(v0: i32, v1: i32):
+; nextln:     v2 = iadd v0, v1
+; check:  block1(v3: i32):
+; nextln:     v5 = iadd.i32 v2, v3
+; nextln:     return v5


### PR DESCRIPTION
This stands on the shoulders of #6135 but reorders only while computing GVN map lookup keys. It doesn't affect the codegenned instructions themselves, which will hopefully dodge the performance regression that led to that PR's reversion.