### PR TITLE
Tighten up assertions for basic-gvn test.

### DIFF
--- a/cranelift/filetests/filetests/egraph/basic-gvn.clif
+++ b/cranelift/filetests/filetests/egraph/basic-gvn.clif
@@ -19,9 +19,9 @@ block2(v6: i32):
 ;; Check that the `iadd` for `v4` is subsumed by `v2`:
 
 ; check: block0(v0: i32, v1: i32):
-; check:      v2 = iadd v0, v1
+; nextln:      v2 = iadd v0, v1
 ; check:  block1:
-; check:      v5 = iadd.i32 v2, v0
+; nextln:      v5 = iadd.i32 v2, v0
 ; nextln:     return v5
 ; check: block2:
 ; nextln:    return v1

--- a/cranelift/isle/isle/README.md
+++ b/cranelift/isle/isle/README.md
@@ -6,4 +6,4 @@ clif instructions to vcode's `MachInst`s in Cranelift.
 ISLE is a statically-typed term-rewriting language. You define rewriting rules
 that map input terms (clif instructions) into output terms (`MachInst`s). These
 rules get compiled down into Rust source test that uses a tree of `match`
-expressions that is as good or better than what you would have written by hand.
+expressions as good as or better than what you would have written by hand.


### PR DESCRIPTION
Assert that the v4 assignment is gone. If it isn't, GVN didn't manage to dedupe v2 and v4. Also assert that nothing appears before the v2 assignment, as that would be a new instruction worth hearing about.