### PR TITLE
Bump Wasmtime to 31.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "30.0.0"
+version = "31.0.0"
 
 [[package]]
 name = "byteorder"
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -738,18 +738,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.117.0"
+version = "0.118.0"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen-shared",
@@ -801,18 +801,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.117.0"
+version = "0.118.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.117.0"
+version = "0.118.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1235,7 +1235,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3830,7 +3830,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4213,14 +4213,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4236,14 +4236,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4398,11 +4398,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "30.0.0"
+version = "31.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "cc",
  "object",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4576,14 +4576,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "30.0.0"
+version = "31.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast-util"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "30.0.0"
+version = "31.0.0"
 
 [[package]]
 name = "wast"
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,7 +4940,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "30.0.0"
+version = "31.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "30.0.0"
+version = "31.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -221,62 +221,62 @@ allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=30.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "30.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=30.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=30.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=30.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=30.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=30.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=30.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=30.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=30.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=30.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=30.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "30.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "30.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "30.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "30.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "30.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "30.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "30.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=30.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=30.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=30.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=30.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=30.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=31.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "31.0.0", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=31.0.0" }
+wasmtime-cache = { path = "crates/cache", version = "=31.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=31.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=31.0.0" }
+wasmtime-winch = { path = "crates/winch", version = "=31.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=31.0.0" }
+wasmtime-explorer = { path = "crates/explorer", version = "=31.0.0" }
+wasmtime-fiber = { path = "crates/fiber", version = "=31.0.0" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=31.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=31.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "31.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "31.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "31.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "31.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "31.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "31.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "31.0.0" }
+wasmtime-component-util = { path = "crates/component-util", version = "=31.0.0" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=31.0.0" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=31.0.0" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=31.0.0" }
+wasmtime-slab = { path = "crates/slab", version = "=31.0.0" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=30.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=30.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=30.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=30.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=31.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=31.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=31.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=31.0.0", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=30.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=30.0.0" }
-wasmtime-math = { path = "crates/math", version = "=30.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=31.0.0" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=31.0.0" }
+wasmtime-math = { path = "crates/math", version = "=31.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=30.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=31.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.117.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.117.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.117.0" }
-cranelift-native = { path = "cranelift/native", version = "0.117.0" }
-cranelift-module = { path = "cranelift/module", version = "0.117.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.117.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.117.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.118.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.118.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.118.0" }
+cranelift-native = { path = "cranelift/native", version = "0.118.0" }
+cranelift-module = { path = "cranelift/module", version = "0.118.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.118.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.118.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.117.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.117.0" }
+cranelift-object = { path = "cranelift/object", version = "0.118.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.118.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.117.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.117.0" }
-cranelift-control = { path = "cranelift/control", version = "0.117.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.117.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.118.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.118.0" }
+cranelift-control = { path = "cranelift/control", version = "0.118.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.118.0" }
 
-winch-codegen = { path = "winch/codegen", version = "=30.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=31.0.0" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,27 +1,10 @@
-## 30.0.0
+## 31.0.0
 
 Unreleased.
 
 ### Added
 
-* New `wasmtime-wasi-io` crate provides a `#![no_std]` wasi:io implementation,
-  factored out of `wasmtime-wasi`. Users of `wasmtime-wasi` don't have to
-  depend on this new crate.
-  [#10036](https://github.com/bytecodealliance/wasmtime/pull/10036)
-
 ### Changed
-
-* `wasmtime-wasi` split the `WasiView` trait into `IoView` and `WasiView`, and
-  `wasmtime-wasi-http` re-uses `IoView` in `WasiHttpView`. Details on porting
-  for embedders in PR.
-  [#10016](https://github.com/bytecodealliance/wasmtime/pull/10016)
-
-* `wasmtime-wasi` renamed some exported types and traits. Embedders which use 
-  `Pollable`, `InputStream`, `OutputStream`, `Subscribe`, `HostInputStream`,
-  `HostOutputStream`, `PollableFuture`, or `ClosureFuture` from that crate
-  will need to rename those imports to their new names, describe in PR.
-  [#10036](https://github.com/bytecodealliance/wasmtime/pull/10036)
-
 
 --------------------------------------------------------------------------------
 
@@ -29,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [30.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-30.0.0/RELEASES.md)
 * [29.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-29.0.0/RELEASES.md)
 * [28.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-28.0.0/RELEASES.md)
 * [27.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-27.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.117.0"
+version = "0.118.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 arbtest = "0.3.1"
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.117.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.118.0" }
 
 [lints.clippy]
 all = "deny"

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.117.0"
+version = "0.118.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.117.0"
+version = "0.118.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.117.0"
+version = "0.118.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.117.0"
+version = "0.118.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,8 +25,8 @@ arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-assembler-x64 = { path = "../assembler-x64", version = "0.117.0" }
-cranelift-codegen-shared = { path = "./shared", version = "0.117.0" }
+cranelift-assembler-x64 = { path = "../assembler-x64", version = "0.118.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.118.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -55,8 +55,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.117.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.117.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.118.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.118.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.117.0"
+version = "0.118.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,8 +16,8 @@ workspace = true
 rustdoc-args = ["--document-private-items"]
 
 [dependencies]
-cranelift-assembler-x64 = { path = "../../assembler-x64", version = "0.117.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.117.0" }
+cranelift-assembler-x64 = { path = "../../assembler-x64", version = "0.118.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.118.0" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.117.0"
+version = "0.118.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.117.0"
+version = "0.118.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.117.0"
+version = "0.118.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.117.0"
+version = "0.118.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.117.0"
+version = "0.118.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.117.0"
+version = "0.118.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.117.0"
+version = "0.118.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.117.0"
+version = "0.118.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,11 +206,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "30.0.0"
+#define WASMTIME_VERSION "31.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 30
+#define WASMTIME_VERSION_MAJOR 31
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -24,6 +28,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-bforest]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.115.0"
@@ -37,6 +45,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -48,6 +60,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-codegen]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.115.0"
@@ -61,6 +77,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -72,6 +92,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-control]]
 version = "0.115.0"
@@ -85,6 +109,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-control]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -96,6 +124,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-entity]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.115.0"
@@ -109,6 +141,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -120,6 +156,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.115.0"
@@ -133,6 +173,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -144,6 +188,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-jit]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-module]]
 version = "0.115.0"
@@ -157,6 +205,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-module]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-native]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -168,6 +220,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-native]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-native]]
+version = "0.118.0"
+audited_as = "0.116.1"
 
 [[unpublished.cranelift-object]]
 version = "0.115.0"
@@ -181,6 +237,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-object]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -193,6 +253,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -205,6 +269,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
 [[unpublished.pulley-interpreter]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -216,6 +284,10 @@ audited_as = "27.0.0"
 [[unpublished.pulley-interpreter]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasi-common]]
 version = "28.0.0"
@@ -229,6 +301,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasi-common]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -240,6 +316,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "28.0.0"
@@ -253,6 +333,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-cache]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -264,6 +348,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-cache]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-cache]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "28.0.0"
@@ -277,6 +365,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-cli]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -288,6 +380,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-cli-flags]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "28.0.0"
@@ -301,6 +397,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-component-macro]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-component-util]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -312,6 +412,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-component-util]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-component-util]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-cranelift]]
 version = "28.0.0"
@@ -325,6 +429,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-cranelift]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -336,6 +444,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-environ]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "28.0.0"
@@ -349,6 +461,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -360,6 +476,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-fiber]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "28.0.0"
@@ -373,6 +493,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -384,11 +508,19 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-math]]
 version = "30.0.0"
 audited_as = "29.0.0"
 
+[[unpublished.wasmtime-math]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -400,6 +532,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-slab]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-slab]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "28.0.0"
@@ -413,6 +549,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "28.0.0"
 audited_as = "27.0.0"
@@ -424,6 +564,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "28.0.0"
@@ -437,6 +581,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -448,6 +596,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "28.0.0"
@@ -461,6 +613,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -472,6 +628,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-threads]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "28.0.0"
@@ -485,6 +645,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -496,6 +660,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-winch]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "28.0.0"
@@ -509,6 +677,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -520,6 +692,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wmemcheck]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wiggle]]
 version = "28.0.0"
@@ -533,6 +709,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wiggle]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -545,6 +725,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -556,6 +740,10 @@ audited_as = "27.0.0"
 [[unpublished.wiggle-macro]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -572,6 +760,10 @@ audited_as = "27.0.0"
 [[unpublished.winch-codegen]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.winch-codegen]]
+version = "31.0.0"
+audited_as = "29.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -777,104 +969,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.116.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1089,8 +1281,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1297,8 +1489,8 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.unicode-width]]
-version = "0.1.12"
-when = "2024-04-26"
+version = "0.2.0"
+when = "2024-09-19"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
@@ -1339,8 +1531,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1410,152 +1602,152 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-math]]
-version = "29.0.0"
-when = "2025-01-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1579,20 +1771,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1611,8 +1803,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "29.0.1"
+when = "2025-01-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2099,7 +2291,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-05-15"
-end = "2024-05-03"
+end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -2108,7 +2300,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-12-05"
-end = "2024-05-03"
+end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -2117,7 +2309,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2024-05-03"
+end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-30.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 30.0.0 to 31.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 30.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-30.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-30.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-30.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
