### PR TITLE
wasi-nn: pull test artifacts from new location

### DIFF
--- a/crates/wasi-nn/tests/check/openvino.rs
+++ b/crates/wasi-nn/tests/check/openvino.rs
@@ -22,8 +22,7 @@ pub fn is_installed() -> Result<()> {
 /// download the artifacts if necessary.
 pub fn are_artifacts_available() -> Result<()> {
     let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap();
-    const BASE_URL: &str =
-        "https://github.com/intel/openvino-rs/raw/72d75601e9be394b3e8c7ff28313d66ef53ff358/crates/openvino/tests/fixtures/mobilenet";
+    const BASE_URL: &str = "https://download.01.org/openvinotoolkit/fixtures/mobilenet";
     let artifacts_dir = artifacts_dir();
     if !artifacts_dir.is_dir() {
         fs::create_dir(&artifacts_dir)?;


### PR DESCRIPTION
Over in the [openvino-rs] repository, we removed large test artifacts that required Git LFS and moved these artifacts to a new download site, [download.01.org]. This broke Wasmtime's CI and was fixed in #9380 by pinning to a commit version. This change adopts the [download.01.org] site in Wasmtime's CI to fully cut the dependency to GitHub's LFS bandwidth limits.

[openvino-rs]: https://github.com/intel/openvino-rs
[download.01.org]: https://download.01.org/openvinotoolkit/fixtures

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
