### PR TITLE
Add a bunch of trace logging for CLIF and Wasm-to-CLIF translation

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -1178,12 +1178,17 @@ fn gen_inst_builder(inst: &Instruction, format: &InstructionFormat, fmt: &mut Fo
         // Call to the format constructor,
         let fcall = format!("self.{}({})", format.name, args.join(", "));
 
+        fmtln!(fmt, "let (inst, dfg) = {};", fcall);
+        fmtln!(
+            fmt,
+            "crate::trace!(\"inserted {inst:?}: {}\", dfg.display_inst(inst));"
+        );
+
         if inst.value_results.is_empty() {
-            fmtln!(fmt, "{}.0", fcall);
+            fmtln!(fmt, "inst");
             return;
         }
 
-        fmtln!(fmt, "let (inst, dfg) = {};", fcall);
         if inst.value_results.len() == 1 {
             fmt.line("dfg.first_result(inst)");
         } else {

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -357,6 +357,8 @@ impl<'a> FunctionBuilder<'a> {
     /// successor), the block will be declared filled and it will not be possible to append
     /// instructions to it.
     pub fn switch_to_block(&mut self, block: Block) {
+        log::trace!("switch to {block:?}");
+
         // First we check that the previous block has been filled.
         debug_assert!(
             self.position.is_none()

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -28,6 +28,12 @@ use wasmtime_environ::{
 };
 use wasmtime_environ::{FUNCREF_INIT_BIT, FUNCREF_MASK};
 
+#[derive(Debug)]
+pub(crate) enum Extension {
+    Sign,
+    Zero,
+}
+
 /// A struct with an `Option<ir::FuncRef>` member for every builtin
 /// function, to de-duplicate constructing/getting its function.
 pub(crate) struct BuiltinFunctions {
@@ -1955,28 +1961,16 @@ impl FuncEnvironment<'_> {
         struct_type_index: TypeIndex,
         field_index: u32,
         struct_ref: ir::Value,
+        extension: Option<Extension>,
     ) -> WasmResult<ir::Value> {
-        gc::translate_struct_get(self, builder, struct_type_index, field_index, struct_ref)
-    }
-
-    pub fn translate_struct_get_s(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        struct_type_index: TypeIndex,
-        field_index: u32,
-        struct_ref: ir::Value,
-    ) -> WasmResult<ir::Value> {
-        gc::translate_struct_get_s(self, builder, struct_type_index, field_index, struct_ref)
-    }
-
-    pub fn translate_struct_get_u(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        struct_type_index: TypeIndex,
-        field_index: u32,
-        struct_ref: ir::Value,
-    ) -> WasmResult<ir::Value> {
-        gc::translate_struct_get_u(self, builder, struct_type_index, field_index, struct_ref)
+        gc::translate_struct_get(
+            self,
+            builder,
+            struct_type_index,
+            field_index,
+            struct_ref,
+            extension,
+        )
     }
 
     pub fn translate_struct_set(
@@ -2181,28 +2175,9 @@ impl FuncEnvironment<'_> {
         array_type_index: TypeIndex,
         array: ir::Value,
         index: ir::Value,
+        extension: Option<Extension>,
     ) -> WasmResult<ir::Value> {
-        gc::translate_array_get(self, builder, array_type_index, array, index)
-    }
-
-    pub fn translate_array_get_s(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        array_type_index: TypeIndex,
-        array: ir::Value,
-        index: ir::Value,
-    ) -> WasmResult<ir::Value> {
-        gc::translate_array_get_s(self, builder, array_type_index, array, index)
-    }
-
-    pub fn translate_array_get_u(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        array_type_index: TypeIndex,
-        array: ir::Value,
-        index: ir::Value,
-    ) -> WasmResult<ir::Value> {
-        gc::translate_array_get_u(self, builder, array_type_index, array, index)
+        gc::translate_array_get(self, builder, array_type_index, array, index, extension)
     }
 
     pub fn translate_array_set(

--- a/crates/cranelift/src/gc/disabled.rs
+++ b/crates/cranelift/src/gc/disabled.rs
@@ -1,7 +1,7 @@
 //! `GcCompiler` implementation when GC support is disabled.
 
 use super::GcCompiler;
-use crate::func_environ::FuncEnvironment;
+use crate::func_environ::{Extension, FuncEnvironment};
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use wasmtime_environ::{wasm_unsupported, TypeIndex, WasmRefType, WasmResult};
@@ -41,26 +41,7 @@ pub fn translate_struct_get(
     _struct_type_index: TypeIndex,
     _field_index: u32,
     _struct_ref: ir::Value,
-) -> WasmResult<ir::Value> {
-    disabled()
-}
-
-pub fn translate_struct_get_s(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder<'_>,
-    _struct_type_index: TypeIndex,
-    _field_index: u32,
-    _struct_ref: ir::Value,
-) -> WasmResult<ir::Value> {
-    disabled()
-}
-
-pub fn translate_struct_get_u(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder<'_>,
-    _struct_type_index: TypeIndex,
-    _field_index: u32,
-    _struct_ref: ir::Value,
+    _extension: Option<Extension>,
 ) -> WasmResult<ir::Value> {
     disabled()
 }
@@ -130,26 +111,7 @@ pub fn translate_array_get(
     _array_type_index: TypeIndex,
     _array: ir::Value,
     _index: ir::Value,
-) -> WasmResult<ir::Value> {
-    disabled()
-}
-
-pub fn translate_array_get_s(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder,
-    _array_type_index: TypeIndex,
-    _array: ir::Value,
-    _index: ir::Value,
-) -> WasmResult<ir::Value> {
-    disabled()
-}
-
-pub fn translate_array_get_u(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder,
-    _array_type_index: TypeIndex,
-    _array: ir::Value,
-    _index: ir::Value,
+    _extension: Option<Extension>,
 ) -> WasmResult<ir::Value> {
     disabled()
 }


### PR DESCRIPTION
This is some general trace logging to help with debugging issues like https://github.com/bytecodealliance/wasmtime/issues/10171.

This adds trace logging for:

* `InstructionBuilder` methods
* Switching `FunctionBuilder`s between blocks
* A ton of GC-related Wasm-to-CLIF translation bits

The result is that it is wayyyyyyyy easier to tell what CLIF is generated for what purpose when staring at trace logs, particularly for Wasm GC things where a single Wasm instruction might become many blocks of CLIF.

At the same time, this consolidates some `translate_{array,struct}_get{,_s,_u}` helpers so that there is less code duplication (purely mechanical; should not change any actual translations or instructions we emit) just so that there were fewer places to add trace logs to.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
