### PR TITLE
Slightly simplify logic in `ref.test` translation

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -964,17 +964,11 @@ pub fn translate_ref_test(
 
     // Current block: check if the reference is null and branch appropriately.
     let is_null = func_env.translate_ref_is_null(builder.cursor(), val)?;
-    let is_null_result = if ref_ty.nullable {
-        is_null
-    } else {
-        let zero = builder.ins().iconst(ir::types::I32, 0);
-        let one = builder.ins().iconst(ir::types::I32, 1);
-        builder.ins().select(is_null, zero, one)
-    };
+    let result_when_is_null = builder.ins().iconst(ir::types::I32, ref_ty.nullable as i64);
     builder.ins().brif(
         is_null,
         continue_block,
-        &[is_null_result],
+        &[result_when_is_null],
         non_null_block,
         &[],
     );
@@ -990,17 +984,17 @@ pub fn translate_ref_test(
         let is_i31 = builder.ins().band(val, i31_mask);
         // If it is an `i31`, then create the result value based on whether we
         // want `i31`s to pass the test or not.
-        let is_i31_result = if ref_ty.heap_type == WasmHeapType::Eq {
-            is_i31
-        } else {
-            let zero = builder.ins().iconst(ir::types::I32, 0);
-            let one = builder.ins().iconst(ir::types::I32, 1);
-            builder.ins().select(is_i31, zero, one)
-        };
+        let result_when_is_i31 = builder.ins().iconst(
+            ir::types::I32,
+            matches!(
+                ref_ty.heap_type,
+                WasmHeapType::Any | WasmHeapType::Eq | WasmHeapType::I31
+            ) as i64,
+        );
         builder.ins().brif(
             is_i31,
             continue_block,
-            &[is_i31_result],
+            &[result_when_is_i31],
             non_null_non_i31_block,
             &[],
         );

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -31,60 +31,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v2, v45
-;;                                     v47 = iconst.i32 0
-;; @002e                               v4 = icmp eq v2, v47  ; v47 = 0
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v2, v41
+;;                                     v43 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v43  ; v43 = 0
 ;; @002e                               v5 = uextend.i32 v4
-;; @002e                               v7 = iconst.i32 1
-;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
-;; @002e                               brif v5, block5(v55), block3
+;; @002e                               brif v5, block5(v43), block3  ; v43 = 0
 ;;
 ;;                                 block3:
-;;                                     v62 = iconst.i32 1
-;;                                     v63 = band.i32 v2, v62  ; v62 = 1
-;;                                     v64 = iconst.i32 0
-;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
-;; @002e                               brif v63, block5(v65), block4
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v47 = iconst.i32 0
+;; @002e                               brif v8, block5(v47), block4  ; v47 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v21 = uextend.i64 v2
-;; @002e                               v22 = iconst.i64 4
-;; @002e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @002e                               v24 = iconst.i64 8
-;; @002e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @002e                               v20 = load.i64 notrap aligned readonly v0+48
-;; @002e                               v26 = icmp ule v25, v20
-;; @002e                               trapz v26, user1
-;; @002e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002e                               v27 = iadd v18, v23
-;; @002e                               v28 = load.i32 notrap aligned readonly v27
-;; @002e                               v15 = load.i64 notrap aligned readonly v0+64
-;; @002e                               v16 = load.i32 notrap aligned readonly v15
-;; @002e                               v29 = icmp eq v28, v16
-;; @002e                               v30 = uextend.i32 v29
-;; @002e                               brif v30, block7(v30), block6
+;; @002e                               v17 = uextend.i64 v2
+;; @002e                               v18 = iconst.i64 4
+;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @002e                               v20 = iconst.i64 8
+;; @002e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @002e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002e                               v22 = icmp ule v21, v16
+;; @002e                               trapz v22, user1
+;; @002e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002e                               v23 = iadd v14, v19
+;; @002e                               v24 = load.i32 notrap aligned readonly v23
+;; @002e                               v11 = load.i64 notrap aligned readonly v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly v11
+;; @002e                               v25 = icmp eq v24, v12
+;; @002e                               v26 = uextend.i32 v25
+;; @002e                               brif v26, block7(v26), block6
 ;;
 ;;                                 block6:
-;; @002e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v32)
+;; @002e                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @002e                               jump block7(v28)
 ;;
-;;                                 block7(v33: i32):
-;; @002e                               jump block5(v33)
+;;                                 block7(v29: i32):
+;; @002e                               jump block5(v29)
 ;;
-;;                                 block5(v34: i32):
-;;                                     v41 = load.i32 notrap v45
-;; @002e                               brif v34, block8, block2
+;;                                 block5(v30: i32):
+;;                                     v37 = load.i32 notrap v41
+;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v36 = load.i64 notrap aligned readonly v0+72
-;; @0034                               v37 = load.i64 notrap aligned readonly v0+88
-;; @0034                               call_indirect sig1, v36(v37, v0)
+;; @0034                               v32 = load.i64 notrap aligned readonly v0+72
+;; @0034                               v33 = load.i64 notrap aligned readonly v0+88
+;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v39 = load.i64 notrap aligned readonly v0+96
-;; @0038                               v40 = load.i64 notrap aligned readonly v0+112
-;; @0038                               call_indirect sig2, v39(v40, v0)
+;; @0038                               v35 = load.i64 notrap aligned readonly v0+96
+;; @0038                               v36 = load.i64 notrap aligned readonly v0+112
+;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -31,60 +31,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v2, v45
-;;                                     v47 = iconst.i32 0
-;; @002f                               v4 = icmp eq v2, v47  ; v47 = 0
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v2, v41
+;;                                     v43 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v43  ; v43 = 0
 ;; @002f                               v5 = uextend.i32 v4
-;; @002f                               v7 = iconst.i32 1
-;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
-;; @002f                               brif v5, block5(v55), block3
+;; @002f                               brif v5, block5(v43), block3  ; v43 = 0
 ;;
 ;;                                 block3:
-;;                                     v62 = iconst.i32 1
-;;                                     v63 = band.i32 v2, v62  ; v62 = 1
-;;                                     v64 = iconst.i32 0
-;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
-;; @002f                               brif v63, block5(v65), block4
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v47 = iconst.i32 0
+;; @002f                               brif v8, block5(v47), block4  ; v47 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v21 = uextend.i64 v2
-;; @002f                               v22 = iconst.i64 4
-;; @002f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @002f                               v24 = iconst.i64 8
-;; @002f                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @002f                               v20 = load.i64 notrap aligned readonly v0+48
-;; @002f                               v26 = icmp ule v25, v20
-;; @002f                               trapz v26, user1
-;; @002f                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002f                               v27 = iadd v18, v23
-;; @002f                               v28 = load.i32 notrap aligned readonly v27
-;; @002f                               v15 = load.i64 notrap aligned readonly v0+64
-;; @002f                               v16 = load.i32 notrap aligned readonly v15
-;; @002f                               v29 = icmp eq v28, v16
-;; @002f                               v30 = uextend.i32 v29
-;; @002f                               brif v30, block7(v30), block6
+;; @002f                               v17 = uextend.i64 v2
+;; @002f                               v18 = iconst.i64 4
+;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @002f                               v20 = iconst.i64 8
+;; @002f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @002f                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002f                               v22 = icmp ule v21, v16
+;; @002f                               trapz v22, user1
+;; @002f                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002f                               v23 = iadd v14, v19
+;; @002f                               v24 = load.i32 notrap aligned readonly v23
+;; @002f                               v11 = load.i64 notrap aligned readonly v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly v11
+;; @002f                               v25 = icmp eq v24, v12
+;; @002f                               v26 = uextend.i32 v25
+;; @002f                               brif v26, block7(v26), block6
 ;;
 ;;                                 block6:
-;; @002f                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v32)
+;; @002f                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @002f                               jump block7(v28)
 ;;
-;;                                 block7(v33: i32):
-;; @002f                               jump block5(v33)
+;;                                 block7(v29: i32):
+;; @002f                               jump block5(v29)
 ;;
-;;                                 block5(v34: i32):
-;;                                     v41 = load.i32 notrap v45
-;; @002f                               brif v34, block2, block8
+;;                                 block5(v30: i32):
+;;                                     v37 = load.i32 notrap v41
+;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v36 = load.i64 notrap aligned readonly v0+72
-;; @0035                               v37 = load.i64 notrap aligned readonly v0+88
-;; @0035                               call_indirect sig1, v36(v37, v0)
+;; @0035                               v32 = load.i64 notrap aligned readonly v0+72
+;; @0035                               v33 = load.i64 notrap aligned readonly v0+88
+;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v39 = load.i64 notrap aligned readonly v0+96
-;; @0039                               v40 = load.i64 notrap aligned readonly v0+112
-;; @0039                               call_indirect sig2, v39(v40, v0)
+;; @0039                               v35 = load.i64 notrap aligned readonly v0+96
+;; @0039                               v36 = load.i64 notrap aligned readonly v0+112
+;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -19,52 +19,49 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v39 = stack_addr.i64 ss0
-;;                                     store notrap v2, v39
-;;                                     v41 = iconst.i32 0
-;; @001e                               v4 = icmp eq v2, v41  ; v41 = 0
+;;                                     v35 = stack_addr.i64 ss0
+;;                                     store notrap v2, v35
+;;                                     v37 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v37  ; v37 = 0
 ;; @001e                               v5 = uextend.i32 v4
-;; @001e                               v7 = iconst.i32 1
-;;                                     v49 = select v2, v7, v41  ; v7 = 1, v41 = 0
-;; @001e                               brif v5, block4(v49), block2
+;; @001e                               brif v5, block4(v37), block2  ; v37 = 0
 ;;
 ;;                                 block2:
-;;                                     v56 = iconst.i32 1
-;;                                     v57 = band.i32 v2, v56  ; v56 = 1
-;;                                     v58 = iconst.i32 0
-;;                                     v59 = select v57, v58, v56  ; v58 = 0, v56 = 1
-;; @001e                               brif v57, block4(v59), block3
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v41 = iconst.i32 0
+;; @001e                               brif v8, block4(v41), block3  ; v41 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v21 = uextend.i64 v2
-;; @001e                               v22 = iconst.i64 4
-;; @001e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @001e                               v24 = iconst.i64 8
-;; @001e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @001e                               v20 = load.i64 notrap aligned readonly v0+48
-;; @001e                               v26 = icmp ule v25, v20
-;; @001e                               trapz v26, user1
-;; @001e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001e                               v27 = iadd v18, v23
-;; @001e                               v28 = load.i32 notrap aligned readonly v27
-;; @001e                               v15 = load.i64 notrap aligned readonly v0+64
-;; @001e                               v16 = load.i32 notrap aligned readonly v15
-;; @001e                               v29 = icmp eq v28, v16
-;; @001e                               v30 = uextend.i32 v29
-;; @001e                               brif v30, block6(v30), block5
+;; @001e                               v17 = uextend.i64 v2
+;; @001e                               v18 = iconst.i64 4
+;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @001e                               v20 = iconst.i64 8
+;; @001e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @001e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001e                               v22 = icmp ule v21, v16
+;; @001e                               trapz v22, user1
+;; @001e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001e                               v23 = iadd v14, v19
+;; @001e                               v24 = load.i32 notrap aligned readonly v23
+;; @001e                               v11 = load.i64 notrap aligned readonly v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly v11
+;; @001e                               v25 = icmp eq v24, v12
+;; @001e                               v26 = uextend.i32 v25
+;; @001e                               brif v26, block6(v26), block5
 ;;
 ;;                                 block5:
-;; @001e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v32)
+;; @001e                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @001e                               jump block6(v28)
 ;;
-;;                                 block6(v33: i32):
-;; @001e                               jump block4(v33)
+;;                                 block6(v29: i32):
+;; @001e                               jump block4(v29)
 ;;
-;;                                 block4(v34: i32):
-;; @001e                               trapz v34, user19
-;;                                     v35 = load.i32 notrap v39
+;;                                 block4(v30: i32):
+;; @001e                               trapz v30, user19
+;;                                     v31 = load.i32 notrap v35
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v35
+;; @0021                               return v31
 ;; }

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -15,40 +15,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v32 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
-;; @001b                               brif v5, block4(v37), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v45 = iconst.i32 1
-;;                                     v46 = band.i32 v2, v45  ; v45 = 1
-;;                                     v47 = iconst.i32 0
-;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
-;; @001b                               brif v46, block4(v48), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v30 = iconst.i32 0
+;; @001b                               brif v8, block4(v30), block3  ; v30 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v19 = uextend.i64 v2
-;; @001b                               v20 = iconst.i64 0
-;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
-;;                                     v44 = iconst.i64 8
-;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
-;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v24 = icmp ule v23, v18
-;; @001b                               trapz v24, user1
-;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v25 = iadd v16, v21
-;; @001b                               v26 = load.i32 notrap aligned readonly v25
-;; @001b                               v27 = iconst.i32 -1476395008
-;; @001b                               v28 = band v26, v27  ; v27 = -1476395008
-;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1476395008
-;; @001b                               v30 = uextend.i32 v29
-;; @001b                               jump block4(v30)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1476395008
+;; @001b                               v24 = band v22, v23  ; v23 = -1476395008
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1476395008
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v31: i32):
-;; @001e                               jump block1(v31)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -18,34 +18,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v19 = iconst.i64 0
-;; @0020                               v4 = icmp eq v2, v19  ; v19 = 0
+;;                                     v17 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v17  ; v17 = 0
 ;; @0020                               v5 = uextend.i32 v4
-;; @0020                               v7 = iconst.i32 1
 ;; @0020                               v6 = iconst.i32 0
-;;                                     v24 = select v2, v7, v6  ; v7 = 1, v6 = 0
-;; @0020                               brif v5, block4(v24), block2
+;; @0020                               brif v5, block4(v6), block2  ; v6 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v12 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v10 = load.i64 notrap aligned readonly v0+64
-;; @0020                               v11 = load.i32 notrap aligned readonly v10
-;; @0020                               v13 = icmp eq v12, v11
-;; @0020                               v14 = uextend.i32 v13
-;; @0020                               brif v14, block6(v14), block5
+;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               brif v12, block6(v12), block5
 ;;
 ;;                                 block5:
-;; @0020                               v16 = call fn0(v0, v12, v11)
-;; @0020                               jump block6(v16)
+;; @0020                               v14 = call fn0(v0, v10, v9)
+;; @0020                               jump block6(v14)
 ;;
-;;                                 block6(v17: i32):
-;; @0020                               jump block4(v17)
+;;                                 block6(v15: i32):
+;; @0020                               jump block4(v15)
 ;;
-;;                                 block4(v18: i32):
-;; @0023                               jump block1(v18)
+;;                                 block4(v16: i32):
+;; @0023                               jump block1(v16)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -18,47 +18,44 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = iconst.i32 0
-;; @001d                               v4 = icmp eq v2, v35  ; v35 = 0
+;;                                     v31 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v31  ; v31 = 0
 ;; @001d                               v5 = uextend.i32 v4
-;; @001d                               v7 = iconst.i32 1
-;;                                     v40 = select v2, v7, v35  ; v7 = 1, v35 = 0
-;; @001d                               brif v5, block4(v40), block2
+;; @001d                               brif v5, block4(v31), block2  ; v31 = 0
 ;;
 ;;                                 block2:
-;;                                     v47 = iconst.i32 1
-;;                                     v48 = band.i32 v2, v47  ; v47 = 1
-;;                                     v49 = iconst.i32 0
-;;                                     v50 = select v48, v49, v47  ; v49 = 0, v47 = 1
-;; @001d                               brif v48, block4(v50), block3
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v32 = iconst.i32 0
+;; @001d                               brif v8, block4(v32), block3  ; v32 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v21 = uextend.i64 v2
-;; @001d                               v22 = iconst.i64 4
-;; @001d                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @001d                               v24 = iconst.i64 8
-;; @001d                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @001d                               v20 = load.i64 notrap aligned readonly v0+48
-;; @001d                               v26 = icmp ule v25, v20
-;; @001d                               trapz v26, user1
-;; @001d                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001d                               v27 = iadd v18, v23
-;; @001d                               v28 = load.i32 notrap aligned readonly v27
-;; @001d                               v15 = load.i64 notrap aligned readonly v0+64
-;; @001d                               v16 = load.i32 notrap aligned readonly v15
-;; @001d                               v29 = icmp eq v28, v16
-;; @001d                               v30 = uextend.i32 v29
-;; @001d                               brif v30, block6(v30), block5
+;; @001d                               v17 = uextend.i64 v2
+;; @001d                               v18 = iconst.i64 4
+;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @001d                               v20 = iconst.i64 8
+;; @001d                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @001d                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001d                               v22 = icmp ule v21, v16
+;; @001d                               trapz v22, user1
+;; @001d                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001d                               v23 = iadd v14, v19
+;; @001d                               v24 = load.i32 notrap aligned readonly v23
+;; @001d                               v11 = load.i64 notrap aligned readonly v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly v11
+;; @001d                               v25 = icmp eq v24, v12
+;; @001d                               v26 = uextend.i32 v25
+;; @001d                               brif v26, block6(v26), block5
 ;;
 ;;                                 block5:
-;; @001d                               v32 = call fn0(v0, v28, v16)
-;; @001d                               jump block6(v32)
+;; @001d                               v28 = call fn0(v0, v24, v12)
+;; @001d                               jump block6(v28)
 ;;
-;;                                 block6(v33: i32):
-;; @001d                               jump block4(v33)
+;;                                 block6(v29: i32):
+;; @001d                               jump block4(v29)
 ;;
-;;                                 block4(v34: i32):
-;; @0020                               jump block1(v34)
+;;                                 block4(v30: i32):
+;; @0020                               jump block1(v30)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -15,38 +15,36 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v29 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v29  ; v29 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v34 = select v2, v7, v29  ; v7 = 1, v29 = 0
-;; @001b                               brif v5, block4(v34), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v42 = iconst.i32 1
-;;                                     v43 = band.i32 v2, v42  ; v42 = 1
-;; @001b                               brif v43, block4(v43), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v16 = uextend.i64 v2
-;; @001b                               v17 = iconst.i64 0
-;; @001b                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 0
-;;                                     v41 = iconst.i64 8
-;; @001b                               v20 = uadd_overflow_trap v16, v41, user1  ; v41 = 8
-;; @001b                               v15 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v21 = icmp ule v20, v15
-;; @001b                               trapz v21, user1
-;; @001b                               v13 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v22 = iadd v13, v18
-;; @001b                               v23 = load.i32 notrap aligned readonly v22
-;; @001b                               v24 = iconst.i32 -1610612736
-;; @001b                               v25 = band v23, v24  ; v24 = -1610612736
-;; @001b                               v26 = icmp eq v25, v24  ; v24 = -1610612736
-;; @001b                               v27 = uextend.i32 v26
-;; @001b                               jump block4(v27)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1610612736
+;; @001b                               v24 = band v22, v23  ; v23 = -1610612736
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1610612736
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v28: i32):
-;; @001e                               jump block1(v28)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -15,40 +15,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v32 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
-;; @001b                               brif v5, block4(v37), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v45 = iconst.i32 1
-;;                                     v46 = band.i32 v2, v45  ; v45 = 1
-;;                                     v47 = iconst.i32 0
-;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
-;; @001b                               brif v46, block4(v48), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v30 = iconst.i32 0
+;; @001b                               brif v8, block4(v30), block3  ; v30 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v19 = uextend.i64 v2
-;; @001b                               v20 = iconst.i64 0
-;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
-;;                                     v44 = iconst.i64 8
-;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
-;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v24 = icmp ule v23, v18
-;; @001b                               trapz v24, user1
-;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v25 = iadd v16, v21
-;; @001b                               v26 = load.i32 notrap aligned readonly v25
-;; @001b                               v27 = iconst.i32 -1342177280
-;; @001b                               v28 = band v26, v27  ; v27 = -1342177280
-;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1342177280
-;; @001b                               v30 = uextend.i32 v29
-;; @001b                               jump block4(v30)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1342177280
+;; @001b                               v24 = band v22, v23  ; v23 = -1342177280
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1342177280
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v31: i32):
-;; @001e                               jump block1(v31)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -31,60 +31,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v2, v45
-;;                                     v47 = iconst.i32 0
-;; @002e                               v4 = icmp eq v2, v47  ; v47 = 0
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v2, v41
+;;                                     v43 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v43  ; v43 = 0
 ;; @002e                               v5 = uextend.i32 v4
-;; @002e                               v7 = iconst.i32 1
-;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
-;; @002e                               brif v5, block5(v55), block3
+;; @002e                               brif v5, block5(v43), block3  ; v43 = 0
 ;;
 ;;                                 block3:
-;;                                     v62 = iconst.i32 1
-;;                                     v63 = band.i32 v2, v62  ; v62 = 1
-;;                                     v64 = iconst.i32 0
-;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
-;; @002e                               brif v63, block5(v65), block4
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v47 = iconst.i32 0
+;; @002e                               brif v8, block5(v47), block4  ; v47 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v21 = uextend.i64 v2
-;; @002e                               v22 = iconst.i64 4
-;; @002e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @002e                               v24 = iconst.i64 8
-;; @002e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @002e                               v20 = load.i64 notrap aligned readonly v0+48
-;; @002e                               v26 = icmp ule v25, v20
-;; @002e                               trapz v26, user1
-;; @002e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002e                               v27 = iadd v18, v23
-;; @002e                               v28 = load.i32 notrap aligned readonly v27
-;; @002e                               v15 = load.i64 notrap aligned readonly v0+64
-;; @002e                               v16 = load.i32 notrap aligned readonly v15
-;; @002e                               v29 = icmp eq v28, v16
-;; @002e                               v30 = uextend.i32 v29
-;; @002e                               brif v30, block7(v30), block6
+;; @002e                               v17 = uextend.i64 v2
+;; @002e                               v18 = iconst.i64 4
+;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @002e                               v20 = iconst.i64 8
+;; @002e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @002e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002e                               v22 = icmp ule v21, v16
+;; @002e                               trapz v22, user1
+;; @002e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002e                               v23 = iadd v14, v19
+;; @002e                               v24 = load.i32 notrap aligned readonly v23
+;; @002e                               v11 = load.i64 notrap aligned readonly v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly v11
+;; @002e                               v25 = icmp eq v24, v12
+;; @002e                               v26 = uextend.i32 v25
+;; @002e                               brif v26, block7(v26), block6
 ;;
 ;;                                 block6:
-;; @002e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @002e                               jump block7(v32)
+;; @002e                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @002e                               jump block7(v28)
 ;;
-;;                                 block7(v33: i32):
-;; @002e                               jump block5(v33)
+;;                                 block7(v29: i32):
+;; @002e                               jump block5(v29)
 ;;
-;;                                 block5(v34: i32):
-;;                                     v41 = load.i32 notrap v45
-;; @002e                               brif v34, block8, block2
+;;                                 block5(v30: i32):
+;;                                     v37 = load.i32 notrap v41
+;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v36 = load.i64 notrap aligned readonly v0+72
-;; @0034                               v37 = load.i64 notrap aligned readonly v0+88
-;; @0034                               call_indirect sig1, v36(v37, v0)
+;; @0034                               v32 = load.i64 notrap aligned readonly v0+72
+;; @0034                               v33 = load.i64 notrap aligned readonly v0+88
+;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v39 = load.i64 notrap aligned readonly v0+96
-;; @0038                               v40 = load.i64 notrap aligned readonly v0+112
-;; @0038                               call_indirect sig2, v39(v40, v0)
+;; @0038                               v35 = load.i64 notrap aligned readonly v0+96
+;; @0038                               v36 = load.i64 notrap aligned readonly v0+112
+;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -31,60 +31,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v45 = stack_addr.i64 ss0
-;;                                     store notrap v2, v45
-;;                                     v47 = iconst.i32 0
-;; @002f                               v4 = icmp eq v2, v47  ; v47 = 0
+;;                                     v41 = stack_addr.i64 ss0
+;;                                     store notrap v2, v41
+;;                                     v43 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v43  ; v43 = 0
 ;; @002f                               v5 = uextend.i32 v4
-;; @002f                               v7 = iconst.i32 1
-;;                                     v55 = select v2, v7, v47  ; v7 = 1, v47 = 0
-;; @002f                               brif v5, block5(v55), block3
+;; @002f                               brif v5, block5(v43), block3  ; v43 = 0
 ;;
 ;;                                 block3:
-;;                                     v62 = iconst.i32 1
-;;                                     v63 = band.i32 v2, v62  ; v62 = 1
-;;                                     v64 = iconst.i32 0
-;;                                     v65 = select v63, v64, v62  ; v64 = 0, v62 = 1
-;; @002f                               brif v63, block5(v65), block4
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v47 = iconst.i32 0
+;; @002f                               brif v8, block5(v47), block4  ; v47 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v21 = uextend.i64 v2
-;; @002f                               v22 = iconst.i64 4
-;; @002f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @002f                               v24 = iconst.i64 8
-;; @002f                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @002f                               v20 = load.i64 notrap aligned readonly v0+48
-;; @002f                               v26 = icmp ule v25, v20
-;; @002f                               trapz v26, user1
-;; @002f                               v18 = load.i64 notrap aligned readonly v0+40
-;; @002f                               v27 = iadd v18, v23
-;; @002f                               v28 = load.i32 notrap aligned readonly v27
-;; @002f                               v15 = load.i64 notrap aligned readonly v0+64
-;; @002f                               v16 = load.i32 notrap aligned readonly v15
-;; @002f                               v29 = icmp eq v28, v16
-;; @002f                               v30 = uextend.i32 v29
-;; @002f                               brif v30, block7(v30), block6
+;; @002f                               v17 = uextend.i64 v2
+;; @002f                               v18 = iconst.i64 4
+;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @002f                               v20 = iconst.i64 8
+;; @002f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @002f                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002f                               v22 = icmp ule v21, v16
+;; @002f                               trapz v22, user1
+;; @002f                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002f                               v23 = iadd v14, v19
+;; @002f                               v24 = load.i32 notrap aligned readonly v23
+;; @002f                               v11 = load.i64 notrap aligned readonly v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly v11
+;; @002f                               v25 = icmp eq v24, v12
+;; @002f                               v26 = uextend.i32 v25
+;; @002f                               brif v26, block7(v26), block6
 ;;
 ;;                                 block6:
-;; @002f                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @002f                               jump block7(v32)
+;; @002f                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @002f                               jump block7(v28)
 ;;
-;;                                 block7(v33: i32):
-;; @002f                               jump block5(v33)
+;;                                 block7(v29: i32):
+;; @002f                               jump block5(v29)
 ;;
-;;                                 block5(v34: i32):
-;;                                     v41 = load.i32 notrap v45
-;; @002f                               brif v34, block2, block8
+;;                                 block5(v30: i32):
+;;                                     v37 = load.i32 notrap v41
+;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v36 = load.i64 notrap aligned readonly v0+72
-;; @0035                               v37 = load.i64 notrap aligned readonly v0+88
-;; @0035                               call_indirect sig1, v36(v37, v0)
+;; @0035                               v32 = load.i64 notrap aligned readonly v0+72
+;; @0035                               v33 = load.i64 notrap aligned readonly v0+88
+;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v39 = load.i64 notrap aligned readonly v0+96
-;; @0039                               v40 = load.i64 notrap aligned readonly v0+112
-;; @0039                               call_indirect sig2, v39(v40, v0)
+;; @0039                               v35 = load.i64 notrap aligned readonly v0+96
+;; @0039                               v36 = load.i64 notrap aligned readonly v0+112
+;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -19,52 +19,49 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v39 = stack_addr.i64 ss0
-;;                                     store notrap v2, v39
-;;                                     v41 = iconst.i32 0
-;; @001e                               v4 = icmp eq v2, v41  ; v41 = 0
+;;                                     v35 = stack_addr.i64 ss0
+;;                                     store notrap v2, v35
+;;                                     v37 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v37  ; v37 = 0
 ;; @001e                               v5 = uextend.i32 v4
-;; @001e                               v7 = iconst.i32 1
-;;                                     v49 = select v2, v7, v41  ; v7 = 1, v41 = 0
-;; @001e                               brif v5, block4(v49), block2
+;; @001e                               brif v5, block4(v37), block2  ; v37 = 0
 ;;
 ;;                                 block2:
-;;                                     v56 = iconst.i32 1
-;;                                     v57 = band.i32 v2, v56  ; v56 = 1
-;;                                     v58 = iconst.i32 0
-;;                                     v59 = select v57, v58, v56  ; v58 = 0, v56 = 1
-;; @001e                               brif v57, block4(v59), block3
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v41 = iconst.i32 0
+;; @001e                               brif v8, block4(v41), block3  ; v41 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v21 = uextend.i64 v2
-;; @001e                               v22 = iconst.i64 4
-;; @001e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @001e                               v24 = iconst.i64 8
-;; @001e                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @001e                               v20 = load.i64 notrap aligned readonly v0+48
-;; @001e                               v26 = icmp ule v25, v20
-;; @001e                               trapz v26, user1
-;; @001e                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001e                               v27 = iadd v18, v23
-;; @001e                               v28 = load.i32 notrap aligned readonly v27
-;; @001e                               v15 = load.i64 notrap aligned readonly v0+64
-;; @001e                               v16 = load.i32 notrap aligned readonly v15
-;; @001e                               v29 = icmp eq v28, v16
-;; @001e                               v30 = uextend.i32 v29
-;; @001e                               brif v30, block6(v30), block5
+;; @001e                               v17 = uextend.i64 v2
+;; @001e                               v18 = iconst.i64 4
+;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @001e                               v20 = iconst.i64 8
+;; @001e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @001e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001e                               v22 = icmp ule v21, v16
+;; @001e                               trapz v22, user1
+;; @001e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001e                               v23 = iadd v14, v19
+;; @001e                               v24 = load.i32 notrap aligned readonly v23
+;; @001e                               v11 = load.i64 notrap aligned readonly v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly v11
+;; @001e                               v25 = icmp eq v24, v12
+;; @001e                               v26 = uextend.i32 v25
+;; @001e                               brif v26, block6(v26), block5
 ;;
 ;;                                 block5:
-;; @001e                               v32 = call fn0(v0, v28, v16), stack_map=[i32 @ ss0+0]
-;; @001e                               jump block6(v32)
+;; @001e                               v28 = call fn0(v0, v24, v12), stack_map=[i32 @ ss0+0]
+;; @001e                               jump block6(v28)
 ;;
-;;                                 block6(v33: i32):
-;; @001e                               jump block4(v33)
+;;                                 block6(v29: i32):
+;; @001e                               jump block4(v29)
 ;;
-;;                                 block4(v34: i32):
-;; @001e                               trapz v34, user19
-;;                                     v35 = load.i32 notrap v39
+;;                                 block4(v30: i32):
+;; @001e                               trapz v30, user19
+;;                                     v31 = load.i32 notrap v35
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:
-;; @0021                               return v35
+;; @0021                               return v31
 ;; }

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -15,40 +15,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v32 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
-;; @001b                               brif v5, block4(v37), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v45 = iconst.i32 1
-;;                                     v46 = band.i32 v2, v45  ; v45 = 1
-;;                                     v47 = iconst.i32 0
-;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
-;; @001b                               brif v46, block4(v48), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v30 = iconst.i32 0
+;; @001b                               brif v8, block4(v30), block3  ; v30 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v19 = uextend.i64 v2
-;; @001b                               v20 = iconst.i64 0
-;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
-;;                                     v44 = iconst.i64 8
-;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
-;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v24 = icmp ule v23, v18
-;; @001b                               trapz v24, user1
-;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v25 = iadd v16, v21
-;; @001b                               v26 = load.i32 notrap aligned readonly v25
-;; @001b                               v27 = iconst.i32 -1476395008
-;; @001b                               v28 = band v26, v27  ; v27 = -1476395008
-;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1476395008
-;; @001b                               v30 = uextend.i32 v29
-;; @001b                               jump block4(v30)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1476395008
+;; @001b                               v24 = band v22, v23  ; v23 = -1476395008
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1476395008
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v31: i32):
-;; @001e                               jump block1(v31)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -18,34 +18,32 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v19 = iconst.i64 0
-;; @0020                               v4 = icmp eq v2, v19  ; v19 = 0
+;;                                     v17 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v17  ; v17 = 0
 ;; @0020                               v5 = uextend.i32 v4
-;; @0020                               v7 = iconst.i32 1
 ;; @0020                               v6 = iconst.i32 0
-;;                                     v24 = select v2, v7, v6  ; v7 = 1, v6 = 0
-;; @0020                               brif v5, block4(v24), block2
+;; @0020                               brif v5, block4(v6), block2  ; v6 = 0
 ;;
 ;;                                 block2:
 ;; @0020                               jump block3
 ;;
 ;;                                 block3:
-;; @0020                               v12 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v10 = load.i64 notrap aligned readonly v0+64
-;; @0020                               v11 = load.i32 notrap aligned readonly v10
-;; @0020                               v13 = icmp eq v12, v11
-;; @0020                               v14 = uextend.i32 v13
-;; @0020                               brif v14, block6(v14), block5
+;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               brif v12, block6(v12), block5
 ;;
 ;;                                 block5:
-;; @0020                               v16 = call fn0(v0, v12, v11)
-;; @0020                               jump block6(v16)
+;; @0020                               v14 = call fn0(v0, v10, v9)
+;; @0020                               jump block6(v14)
 ;;
-;;                                 block6(v17: i32):
-;; @0020                               jump block4(v17)
+;;                                 block6(v15: i32):
+;; @0020                               jump block4(v15)
 ;;
-;;                                 block4(v18: i32):
-;; @0023                               jump block1(v18)
+;;                                 block4(v16: i32):
+;; @0023                               jump block1(v16)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0023                               return v3

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -18,47 +18,44 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = iconst.i32 0
-;; @001d                               v4 = icmp eq v2, v35  ; v35 = 0
+;;                                     v31 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v31  ; v31 = 0
 ;; @001d                               v5 = uextend.i32 v4
-;; @001d                               v7 = iconst.i32 1
-;;                                     v40 = select v2, v7, v35  ; v7 = 1, v35 = 0
-;; @001d                               brif v5, block4(v40), block2
+;; @001d                               brif v5, block4(v31), block2  ; v31 = 0
 ;;
 ;;                                 block2:
-;;                                     v47 = iconst.i32 1
-;;                                     v48 = band.i32 v2, v47  ; v47 = 1
-;;                                     v49 = iconst.i32 0
-;;                                     v50 = select v48, v49, v47  ; v49 = 0, v47 = 1
-;; @001d                               brif v48, block4(v50), block3
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v32 = iconst.i32 0
+;; @001d                               brif v8, block4(v32), block3  ; v32 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v21 = uextend.i64 v2
-;; @001d                               v22 = iconst.i64 4
-;; @001d                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 4
-;; @001d                               v24 = iconst.i64 8
-;; @001d                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @001d                               v20 = load.i64 notrap aligned readonly v0+48
-;; @001d                               v26 = icmp ule v25, v20
-;; @001d                               trapz v26, user1
-;; @001d                               v18 = load.i64 notrap aligned readonly v0+40
-;; @001d                               v27 = iadd v18, v23
-;; @001d                               v28 = load.i32 notrap aligned readonly v27
-;; @001d                               v15 = load.i64 notrap aligned readonly v0+64
-;; @001d                               v16 = load.i32 notrap aligned readonly v15
-;; @001d                               v29 = icmp eq v28, v16
-;; @001d                               v30 = uextend.i32 v29
-;; @001d                               brif v30, block6(v30), block5
+;; @001d                               v17 = uextend.i64 v2
+;; @001d                               v18 = iconst.i64 4
+;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
+;; @001d                               v20 = iconst.i64 8
+;; @001d                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @001d                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001d                               v22 = icmp ule v21, v16
+;; @001d                               trapz v22, user1
+;; @001d                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001d                               v23 = iadd v14, v19
+;; @001d                               v24 = load.i32 notrap aligned readonly v23
+;; @001d                               v11 = load.i64 notrap aligned readonly v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly v11
+;; @001d                               v25 = icmp eq v24, v12
+;; @001d                               v26 = uextend.i32 v25
+;; @001d                               brif v26, block6(v26), block5
 ;;
 ;;                                 block5:
-;; @001d                               v32 = call fn0(v0, v28, v16)
-;; @001d                               jump block6(v32)
+;; @001d                               v28 = call fn0(v0, v24, v12)
+;; @001d                               jump block6(v28)
 ;;
-;;                                 block6(v33: i32):
-;; @001d                               jump block4(v33)
+;;                                 block6(v29: i32):
+;; @001d                               jump block4(v29)
 ;;
-;;                                 block4(v34: i32):
-;; @0020                               jump block1(v34)
+;;                                 block4(v30: i32):
+;; @0020                               jump block1(v30)
 ;;
 ;;                                 block1(v3: i32):
 ;; @0020                               return v3

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -15,38 +15,36 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v29 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v29  ; v29 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v34 = select v2, v7, v29  ; v7 = 1, v29 = 0
-;; @001b                               brif v5, block4(v34), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v42 = iconst.i32 1
-;;                                     v43 = band.i32 v2, v42  ; v42 = 1
-;; @001b                               brif v43, block4(v43), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v16 = uextend.i64 v2
-;; @001b                               v17 = iconst.i64 0
-;; @001b                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 0
-;;                                     v41 = iconst.i64 8
-;; @001b                               v20 = uadd_overflow_trap v16, v41, user1  ; v41 = 8
-;; @001b                               v15 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v21 = icmp ule v20, v15
-;; @001b                               trapz v21, user1
-;; @001b                               v13 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v22 = iadd v13, v18
-;; @001b                               v23 = load.i32 notrap aligned readonly v22
-;; @001b                               v24 = iconst.i32 -1610612736
-;; @001b                               v25 = band v23, v24  ; v24 = -1610612736
-;; @001b                               v26 = icmp eq v25, v24  ; v24 = -1610612736
-;; @001b                               v27 = uextend.i32 v26
-;; @001b                               jump block4(v27)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1610612736
+;; @001b                               v24 = band v22, v23  ; v23 = -1610612736
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1610612736
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v28: i32):
-;; @001e                               jump block1(v28)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -15,40 +15,37 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v32 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v32  ; v32 = 0
+;;                                     v28 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v28  ; v28 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               v7 = iconst.i32 1
-;;                                     v37 = select v2, v7, v32  ; v7 = 1, v32 = 0
-;; @001b                               brif v5, block4(v37), block2
+;; @001b                               brif v5, block4(v28), block2  ; v28 = 0
 ;;
 ;;                                 block2:
-;;                                     v45 = iconst.i32 1
-;;                                     v46 = band.i32 v2, v45  ; v45 = 1
-;;                                     v47 = iconst.i32 0
-;;                                     v48 = select v46, v47, v45  ; v47 = 0, v45 = 1
-;; @001b                               brif v46, block4(v48), block3
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v30 = iconst.i32 0
+;; @001b                               brif v8, block4(v30), block3  ; v30 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v19 = uextend.i64 v2
-;; @001b                               v20 = iconst.i64 0
-;; @001b                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 0
-;;                                     v44 = iconst.i64 8
-;; @001b                               v23 = uadd_overflow_trap v19, v44, user1  ; v44 = 8
-;; @001b                               v18 = load.i64 notrap aligned readonly v0+48
-;; @001b                               v24 = icmp ule v23, v18
-;; @001b                               trapz v24, user1
-;; @001b                               v16 = load.i64 notrap aligned readonly v0+40
-;; @001b                               v25 = iadd v16, v21
-;; @001b                               v26 = load.i32 notrap aligned readonly v25
-;; @001b                               v27 = iconst.i32 -1342177280
-;; @001b                               v28 = band v26, v27  ; v27 = -1342177280
-;; @001b                               v29 = icmp eq v28, v27  ; v27 = -1342177280
-;; @001b                               v30 = uextend.i32 v29
-;; @001b                               jump block4(v30)
+;; @001b                               v15 = uextend.i64 v2
+;; @001b                               v16 = iconst.i64 0
+;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
+;;                                     v29 = iconst.i64 8
+;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
+;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v20 = icmp ule v19, v14
+;; @001b                               trapz v20, user1
+;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v21 = iadd v12, v17
+;; @001b                               v22 = load.i32 notrap aligned readonly v21
+;; @001b                               v23 = iconst.i32 -1342177280
+;; @001b                               v24 = band v22, v23  ; v23 = -1342177280
+;; @001b                               v25 = icmp eq v24, v23  ; v23 = -1342177280
+;; @001b                               v26 = uextend.i32 v25
+;; @001b                               jump block4(v26)
 ;;
-;;                                 block4(v31: i32):
-;; @001e                               jump block1(v31)
+;;                                 block4(v27: i32):
+;; @001e                               jump block1(v27)
 ;;
 ;;                                 block1(v3: i32):
 ;; @001e                               return v3


### PR DESCRIPTION
When the ref is null or i31, just use an `iconst` result value directly, rather than reusing the result of the check for null or i31. Reusing the result doesn't actually yield better code (equivalently good or worse depending on if null/i31 are allowed or not) and is somewhat subtle -- I have to stop and re-think through its correctness each time I see it again -- so this change should be a welcome improvement.

This does not change the logic of the emitted code, but does slightly change the emitted code itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
