### PR TITLE
support pulley even if host triplet also works

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2124,6 +2124,11 @@ impl Config {
             return target_lexicon::Triple::pulley_host();
         }
 
+        #[cfg(feature = "pulley")]
+        if self.target == Some(target_lexicon::Triple::pulley_host()) {
+            return target_lexicon::Triple::pulley_host();
+        }
+
         // And at this point the target is for sure the host.
         target_lexicon::Triple::host()
     }


### PR DESCRIPTION
Previously executing pulley required winch or cranelift even if pulley would be available - because the host triplet was used unconditionally if possible.