### PR TITLE
winch(aarch64): Correct treatment for stores and other trapping ops

### DIFF
--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -149,9 +149,8 @@ impl Assembler {
     }
 
     /// Store a register.
-    pub fn str(&mut self, reg: Reg, addr: Address, size: OperandSize) {
+    pub fn str(&mut self, reg: Reg, addr: Address, size: OperandSize, flags: MemFlags) {
         let mem: AMode = addr.try_into().unwrap();
-        let flags = MemFlags::trusted();
 
         use OperandSize::*;
         let inst = match (reg.is_int(), size) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -225,14 +225,14 @@ impl Masm for MacroAssembler {
             RegImm::Reg(reg) => reg,
         };
 
-        self.asm.str(src, dst, size);
+        self.asm.str(src, dst, size, TRUSTED_FLAGS);
         Ok(())
     }
 
     fn wasm_store(&mut self, src: Reg, dst: Self::Address, op_kind: StoreKind) -> Result<()> {
         self.with_aligned_sp(|masm| match op_kind {
             StoreKind::Operand(size) => {
-                masm.asm.str(src, dst, size);
+                masm.asm.str(src, dst, size, UNTRUSTED_FLAGS);
                 Ok(())
             }
             StoreKind::Atomic(_size) => {
@@ -385,9 +385,11 @@ impl Masm for MacroAssembler {
         size: OperandSize,
         trap: TrapCode,
     ) -> Result<()> {
-        self.add(dst, lhs, rhs, size)?;
-        self.asm.trapif(Cond::Hs, trap);
-        Ok(())
+        self.with_aligned_sp(|masm| {
+            masm.add(dst, lhs, rhs, size)?;
+            masm.asm.trapif(Cond::Hs, trap);
+            Ok(())
+        })
     }
 
     fn sub(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {
@@ -743,7 +745,7 @@ impl Masm for MacroAssembler {
     fn push(&mut self, reg: Reg, size: OperandSize) -> Result<StackSlot> {
         self.reserve_stack(size.bytes())?;
         let address = self.address_from_sp(SPOffset::from_u32(self.sp_offset))?;
-        self.asm.str(reg, address, size);
+        self.asm.str(reg, address, size, TRUSTED_FLAGS);
 
         Ok(StackSlot {
             offset: SPOffset::from_u32(self.sp_offset),

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -385,6 +385,9 @@ impl Masm for MacroAssembler {
         size: OperandSize,
         trap: TrapCode,
     ) -> Result<()> {
+        // Similar to all the other potentially-trapping operations, we need to
+        // ensure that the real SP is 16-byte aligned in case control flow is
+        // transferred to a signal handler.
         self.with_aligned_sp(|masm| {
             masm.add(dst, lhs, rhs, size)?;
             masm.asm.trapif(Cond::Hs, trap);


### PR DESCRIPTION
This commit is one more in the series of executing spec tests for aarch64.

It's mostly a small follow-up to https://github.com/bytecodealliance/wasmtime/pull/10146, in which I omitted contextualizing the memory flags for stores as well as ensuring that the SP is aligned when emitting other trapping instructions like `checked_uadd`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
