### PR TITLE
Winch: v128 `min`, `max`, `extmul` and `extadd`

### DIFF
--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -432,13 +432,14 @@ impl WastTest {
                 "spec_testsuite/simd_i16x8_arith2.wast",
                 "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
                 "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
+                "spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
                 "spec_testsuite/simd_i32x4_arith2.wast",
                 "spec_testsuite/simd_i32x4_dot_i16x8.wast",
                 "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
-                "spec_testsuite/simd_i32x4_extmul_i16x8.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
                 "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
+                "spec_testsuite/simd_i64x2_arith2.wast",
                 "spec_testsuite/simd_i8x16_arith2.wast",
                 "spec_testsuite/simd_load.wast",
                 "spec_testsuite/simd_load_zero.wast",
@@ -499,6 +500,9 @@ impl WastTest {
                     "spec_testsuite/simd_i8x16_arith.wast",
                     "spec_testsuite/simd_bit_shift.wast",
                     "spec_testsuite/simd_lane.wast",
+                    "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
+                    "spec_testsuite/simd_i32x4_extmul_i16x8.wast",
+                    "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
                 ];
 
                 if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -430,16 +430,9 @@ impl WastTest {
                 "spec_testsuite/simd_f64x2_pmin_pmax.wast",
                 "spec_testsuite/simd_f64x2_rounding.wast",
                 "spec_testsuite/simd_i16x8_arith2.wast",
-                "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
-                "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
-                "spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
-                "spec_testsuite/simd_i32x4_arith2.wast",
                 "spec_testsuite/simd_i32x4_dot_i16x8.wast",
-                "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
                 "spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
-                "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
-                "spec_testsuite/simd_i64x2_arith2.wast",
                 "spec_testsuite/simd_i8x16_arith2.wast",
                 "spec_testsuite/simd_load.wast",
                 "spec_testsuite/simd_load_zero.wast",
@@ -503,6 +496,8 @@ impl WastTest {
                     "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
                     "spec_testsuite/simd_i32x4_extmul_i16x8.wast",
                     "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
+                    "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
+                    "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
                 ];
 
                 if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/tests/disas/winch/x64/i16x8/extadd/extadd_s.wat
+++ b/tests/disas/winch/x64/i16x8/extadd/extadd_s.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128) (result v128)
+        (local.get 0)
+        (i16x8.extadd_pairwise_i8x16_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x51
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movdqu  %xmm0, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       vpmovsxbw %xmm0, %xmm15
+;;       vpalignr $8, %xmm0, %xmm0, %xmm0
+;;       vpmovsxbw %xmm0, %xmm0
+;;       vpaddw  %xmm0, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   51: ud2

--- a/tests/disas/winch/x64/i16x8/extadd/extadd_u.wat
+++ b/tests/disas/winch/x64/i16x8/extadd/extadd_u.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128) (result v128)
+        (local.get 0)
+        (i16x8.extadd_pairwise_i8x16_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x50
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movdqu  %xmm0, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       vpmovzxbw %xmm0, %xmm15
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhbw %xmm15, %xmm0, %xmm0
+;;       vpaddw  %xmm0, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   50: ud2

--- a/tests/disas/winch/x64/i16x8/extmul/high_s.wat
+++ b/tests/disas/winch/x64/i16x8/extmul/high_s.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i16x8.extmul_high_i8x16_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x67
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpalignr $8, %xmm0, %xmm0, %xmm0
+;;       vpmovsxbw %xmm0, %xmm0
+;;       vpalignr $8, %xmm1, %xmm1, %xmm1
+;;       vpmovsxbw %xmm1, %xmm1
+;;       vpmullw %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   67: ud2

--- a/tests/disas/winch/x64/i16x8/extmul/high_u.wat
+++ b/tests/disas/winch/x64/i16x8/extmul/high_u.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i16x8.extmul_high_i8x16_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x65
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhbw %xmm15, %xmm0, %xmm0
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhbw %xmm15, %xmm1, %xmm1
+;;       vpmullw %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   65: ud2

--- a/tests/disas/winch/x64/i16x8/extmul/low_s.wat
+++ b/tests/disas/winch/x64/i16x8/extmul/low_s.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i16x8.extmul_low_i8x16_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovsxbw %xmm0, %xmm0
+;;       vpmovsxbw %xmm1, %xmm1
+;;       vpmullw %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5b: ud2

--- a/tests/disas/winch/x64/i16x8/extmul/low_u.wat
+++ b/tests/disas/winch/x64/i16x8/extmul/low_u.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i16x8.extmul_low_i8x16_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovzxbw %xmm0, %xmm0
+;;       vpmovzxbw %xmm1, %xmm1
+;;       vpmullw %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5b: ud2

--- a/tests/disas/winch/x64/i16x8/max/max_s.wat
+++ b/tests/disas/winch/x64/i16x8/max/max_s.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i16x8.max_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x51
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxsw %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   51: ud2

--- a/tests/disas/winch/x64/i16x8/max/max_u.wat
+++ b/tests/disas/winch/x64/i16x8/max/max_u.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i16x8.max_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxuw %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i16x8/min/min_s.wat
+++ b/tests/disas/winch/x64/i16x8/min/min_s.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i16x8.min_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x51
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminsw %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   51: ud2

--- a/tests/disas/winch/x64/i16x8/min/min_u.wat
+++ b/tests/disas/winch/x64/i16x8/min/min_u.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i16x8.min_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminuw %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i32x4/extadd/extadd_s.wat
+++ b/tests/disas/winch/x64/i32x4/extadd/extadd_s.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128) (result v128)
+        (local.get 0)
+        (i32x4.extadd_pairwise_i16x8_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x51
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movdqu  %xmm0, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       vpmovsxwd %xmm0, %xmm15
+;;       vpalignr $8, %xmm0, %xmm0, %xmm0
+;;       vpmovsxwd %xmm0, %xmm0
+;;       vpaddd  %xmm0, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   51: ud2

--- a/tests/disas/winch/x64/i32x4/extadd/extadd_u.wat
+++ b/tests/disas/winch/x64/i32x4/extadd/extadd_u.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128) (result v128)
+        (local.get 0)
+        (i32x4.extadd_pairwise_i16x8_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x50
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movdqu  %xmm0, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       vpmovzxwd %xmm0, %xmm15
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhwd %xmm15, %xmm0, %xmm0
+;;       vpaddd  %xmm0, %xmm0, %xmm0
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   50: ud2

--- a/tests/disas/winch/x64/i32x4/extmul/high_s.wat
+++ b/tests/disas/winch/x64/i32x4/extmul/high_s.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+    (local.get 0)
+    (local.get 1)
+    (i32x4.extmul_high_i16x8_s)
+    ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x68
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpalignr $8, %xmm0, %xmm0, %xmm0
+;;       vpmovsxwd %xmm0, %xmm0
+;;       vpalignr $8, %xmm1, %xmm1, %xmm1
+;;       vpmovsxwd %xmm1, %xmm1
+;;       vpmulld %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   68: ud2

--- a/tests/disas/winch/x64/i32x4/extmul/high_u.wat
+++ b/tests/disas/winch/x64/i32x4/extmul/high_u.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+    (local.get 0)
+    (local.get 1)
+    (i32x4.extmul_high_i16x8_u)
+    ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x66
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhwd %xmm15, %xmm0, %xmm0
+;;       vpxor   %xmm15, %xmm15, %xmm15
+;;       vpunpckhwd %xmm15, %xmm1, %xmm1
+;;       vpmulld %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   66: ud2

--- a/tests/disas/winch/x64/i32x4/extmul/low_s.wat
+++ b/tests/disas/winch/x64/i32x4/extmul/low_s.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+    (local.get 0)
+    (local.get 1)
+    (i32x4.extmul_low_i16x8_s)
+    ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovsxwd %xmm0, %xmm0
+;;       vpmovsxwd %xmm1, %xmm1
+;;       vpmulld %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5c: ud2

--- a/tests/disas/winch/x64/i32x4/extmul/low_u.wat
+++ b/tests/disas/winch/x64/i32x4/extmul/low_u.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+    (local.get 0)
+    (local.get 1)
+    (i32x4.extmul_low_i16x8_u)
+    ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovzxwd %xmm0, %xmm0
+;;       vpmovzxwd %xmm1, %xmm1
+;;       vpmulld %xmm0, %xmm1, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5c: ud2

--- a/tests/disas/winch/x64/i32x4/max/max_s.wat
+++ b/tests/disas/winch/x64/i32x4/max/max_s.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i32x4.max_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxsd %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i32x4/max/max_u.wat
+++ b/tests/disas/winch/x64/i32x4/max/max_u.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i32x4.max_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxud %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i32x4/min/min_s.wat
+++ b/tests/disas/winch/x64/i32x4/min/min_s.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i32x4.min_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminsd %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i32x4/min/min_u.wat
+++ b/tests/disas/winch/x64/i32x4/min/min_u.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func  (param v128 v128) (result v128)
+        (i32x4.min_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminud %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i64x2/extmul/high_s.wat
+++ b/tests/disas/winch/x64/i64x2/extmul/high_s.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i64x2.extmul_high_i32x4_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x86
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpshufd $0xee, %xmm0, %xmm0
+;;       vpmovsxdq %xmm0, %xmm0
+;;       vpshufd $0xee, %xmm1, %xmm1
+;;       vpmovsxdq %xmm1, %xmm1
+;;       vpsrlq  $0x20, %xmm1, %xmm15
+;;       vpmuldq %xmm0, %xmm15, %xmm2
+;;       vpsrlq  $0x20, %xmm0, %xmm15
+;;       vpmuludq %xmm1, %xmm15, %xmm15
+;;       vpaddq  %xmm2, %xmm15, %xmm15
+;;       vpsllq  $0x20, %xmm15, %xmm15
+;;       vpmuludq %xmm0, %xmm1, %xmm2
+;;       vpaddq  %xmm2, %xmm15, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   86: ud2

--- a/tests/disas/winch/x64/i64x2/extmul/high_u.wat
+++ b/tests/disas/winch/x64/i64x2/extmul/high_u.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i64x2.extmul_high_i32x4_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x86
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vxorps  %xmm15, %xmm15, %xmm15
+;;       vunpckhps %xmm15, %xmm0, %xmm0
+;;       vxorps  %xmm15, %xmm15, %xmm15
+;;       vunpckhps %xmm15, %xmm1, %xmm1
+;;       vpsrlq  $0x20, %xmm1, %xmm15
+;;       vpmuldq %xmm0, %xmm15, %xmm2
+;;       vpsrlq  $0x20, %xmm0, %xmm15
+;;       vpmuludq %xmm1, %xmm15, %xmm15
+;;       vpaddq  %xmm2, %xmm15, %xmm15
+;;       vpsllq  $0x20, %xmm15, %xmm15
+;;       vpmuludq %xmm0, %xmm1, %xmm2
+;;       vpaddq  %xmm2, %xmm15, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   86: ud2

--- a/tests/disas/winch/x64/i64x2/extmul/low_s.wat
+++ b/tests/disas/winch/x64/i64x2/extmul/low_s.wat
@@ -1,0 +1,41 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i64x2.extmul_low_i32x4_s)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x7c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovsxdq %xmm0, %xmm0
+;;       vpmovsxdq %xmm1, %xmm1
+;;       vpsrlq  $0x20, %xmm1, %xmm15
+;;       vpmuldq %xmm0, %xmm15, %xmm2
+;;       vpsrlq  $0x20, %xmm0, %xmm15
+;;       vpmuludq %xmm1, %xmm15, %xmm15
+;;       vpaddq  %xmm2, %xmm15, %xmm15
+;;       vpsllq  $0x20, %xmm15, %xmm15
+;;       vpmuludq %xmm0, %xmm1, %xmm2
+;;       vpaddq  %xmm2, %xmm15, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   7c: ud2

--- a/tests/disas/winch/x64/i64x2/extmul/low_u.wat
+++ b/tests/disas/winch/x64/i64x2/extmul/low_u.wat
@@ -1,0 +1,41 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param v128 v128) (result v128)
+        (local.get 0)
+        (local.get 1)
+        (i64x2.extmul_low_i32x4_u)
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x7c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmovzxdq %xmm0, %xmm0
+;;       vpmovzxdq %xmm1, %xmm1
+;;       vpsrlq  $0x20, %xmm1, %xmm15
+;;       vpmuldq %xmm0, %xmm15, %xmm2
+;;       vpsrlq  $0x20, %xmm0, %xmm15
+;;       vpmuludq %xmm1, %xmm15, %xmm15
+;;       vpaddq  %xmm2, %xmm15, %xmm15
+;;       vpsllq  $0x20, %xmm15, %xmm15
+;;       vpmuludq %xmm0, %xmm1, %xmm2
+;;       vpaddq  %xmm2, %xmm15, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   7c: ud2

--- a/tests/disas/winch/x64/i8x16/max/max_s.wat
+++ b/tests/disas/winch/x64/i8x16/max/max_s.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (memory 1 1)
+  (func  (param v128 v128) (result v128)
+        (i8x16.max_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxsb %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i8x16/max/max_u.wat
+++ b/tests/disas/winch/x64/i8x16/max/max_u.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (memory 1 1)
+  (func  (param v128 v128) (result v128)
+        (i8x16.max_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpmaxsb %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i8x16/min/min_s.wat
+++ b/tests/disas/winch/x64/i8x16/min/min_s.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (memory 1 1)
+  (func  (param v128 v128) (result v128)
+        (i8x16.min_s
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x52
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminsb %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   52: ud2

--- a/tests/disas/winch/x64/i8x16/min/min_u.wat
+++ b/tests/disas/winch/x64/i8x16/min/min_u.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (memory 1 1)
+  (func  (param v128 v128) (result v128)
+        (i8x16.min_u
+          (local.get 0)
+          (local.get 1)
+          )
+        ))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x51
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movdqu  %xmm0, 0x10(%rsp)
+;;       movdqu  %xmm1, (%rsp)
+;;       movdqu  (%rsp), %xmm0
+;;       movdqu  0x10(%rsp), %xmm1
+;;       vpminub %xmm1, %xmm0, %xmm1
+;;       movdqa  %xmm1, %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   51: ud2

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -14,10 +14,10 @@ use crate::{
     },
     masm::{
         CalleeKind, DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, HandleOverflowKind,
-        Imm as I, IntCmpKind, LoadKind, MacroAssembler as Masm, MulWideKind, OperandSize, RegImm,
-        RemKind, ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot,
-        StoreKind, TrapCode, TruncKind, V128AbsKind, V128ConvertKind, V128ExtendKind,
-        V128NarrowKind, VectorCompareKind, VectorEqualityKind, Zero, TRUSTED_FLAGS,
+        Imm as I, IntCmpKind, LoadKind, MacroAssembler as Masm, MaxKind, MinKind, MulWideKind,
+        OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
+        SplatKind, StackSlot, StoreKind, TrapCode, TruncKind, V128AbsKind, V128ConvertKind,
+        V128ExtendKind, V128NarrowKind, VectorCompareKind, VectorEqualityKind, Zero, TRUSTED_FLAGS,
         UNTRUSTED_FLAGS,
     },
     stack::TypedReg,
@@ -1192,6 +1192,28 @@ impl Masm for MacroAssembler {
 
     fn v128_bitmask(&mut self, _src: Reg, _dst: WritableReg, _size: OperandSize) -> Result<()> {
         bail!(CodeGenError::unimplemented_masm_instruction())
+    }
+
+    fn v128_min(
+        &mut self,
+        _src1: Reg,
+        _src2: Reg,
+        _dst: WritableReg,
+        _lane_width: OperandSize,
+        _kind: MinKind,
+    ) -> Result<()> {
+        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+    }
+
+    fn v128_max(
+        &mut self,
+        _src1: Reg,
+        _src2: Reg,
+        _dst: WritableReg,
+        _lane_width: OperandSize,
+        _kind: MaxKind,
+    ) -> Result<()> {
+        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
 }
 

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1224,6 +1224,16 @@ impl Masm for MacroAssembler {
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
+
+    fn v128_extadd_pairwise(
+        &mut self,
+        _src: Reg,
+        _dst: WritableReg,
+        _lane_width: OperandSize,
+        _kind: crate::masm::ExtAddKind,
+    ) -> Result<()> {
+        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1215,6 +1215,15 @@ impl Masm for MacroAssembler {
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
+
+    fn v128_extmul(
+        &mut self,
+        _context: &mut CodeGenContext<Emission>,
+        _lane_width: OperandSize,
+        _kind: crate::masm::ExtMulKind,
+    ) -> Result<()> {
+        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -38,6 +38,22 @@ impl RemKind {
     }
 }
 
+/// Min operation kind.
+pub(crate) enum MinKind {
+    /// Signed min.
+    Signed,
+    /// Unsigned min.
+    Unsigned,
+}
+
+/// Max operation kind.
+pub(crate) enum MaxKind {
+    /// Signed max.
+    Signed,
+    /// Unsigned max.
+    Unsigned,
+}
+
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,
@@ -1881,4 +1897,29 @@ pub(crate) trait MacroAssembler {
     /// Extracts the high bit of each lane in `src` and produces a scalar mask
     /// with all bits concatenated in `dst`.
     fn v128_bitmask(&mut self, src: Reg, dst: WritableReg, size: OperandSize) -> Result<()>;
+    /// Perform a lane-wise `min` operation between `src1` and `src2`, interpreted as packed
+    /// integers of size `lane_width`.
+    ///
+    /// `kind` specifies whether the operand are interpreted as signed or unsigned integers.
+    fn v128_min(
+        &mut self,
+        src1: Reg,
+        src2: Reg,
+        dst: WritableReg,
+        lane_width: OperandSize,
+        kind: MinKind,
+    ) -> Result<()>;
+
+    /// Perform a lane-wise `max` operation between `src1` and `src2`, interpreted as packed
+    /// integers of size `lane_width`.
+    ///
+    /// `kind` specifies whether the operand are interpreted as signed or unsigned integers.
+    fn v128_max(
+        &mut self,
+        src1: Reg,
+        src2: Reg,
+        dst: WritableReg,
+        lane_width: OperandSize,
+        kind: MaxKind,
+    ) -> Result<()>;
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -54,6 +54,18 @@ pub(crate) enum MaxKind {
     Unsigned,
 }
 
+/// Kind of extend-multiply
+pub(crate) enum ExtMulKind {
+    // Sign-extend higher-half of each lane.
+    HighSigned,
+    // Sign-extend lower-half of each lane.
+    LowSigned,
+    // Extend higher-half of each lane.
+    HighUnsigned,
+    // Extend lower-half of each lane.
+    LowUnsigned,
+}
+
 #[derive(Eq, PartialEq)]
 pub(crate) enum MulWideKind {
     Signed,
@@ -584,6 +596,7 @@ impl V128NarrowKind {
 }
 
 /// Kinds of vector extending operations supported by WebAssembly.
+#[derive(Debug, Copy, Clone)]
 pub(crate) enum V128ExtendKind {
     /// Low half of i8x16 sign extended.
     LowI8x16S,
@@ -1921,5 +1934,18 @@ pub(crate) trait MacroAssembler {
         dst: WritableReg,
         lane_width: OperandSize,
         kind: MaxKind,
+    ) -> Result<()>;
+
+    /// Perform lane-wise integer extended multiplication producing twice wider result than the inputs.
+    /// This is equivalent to a an extend followed by a multiply.
+    ///
+    /// The extention to be performed is infered from the `lane_width` and the `kind` of extmul,
+    /// e.g, if `lane_width` is `S16`, and `kind` is `LowSigned`, then we sign-extend the lower
+    /// 8bits of the 16bits lanes.
+    fn v128_extmul(
+        &mut self,
+        context: &mut CodeGenContext<Emission>,
+        lane_width: OperandSize,
+        kind: ExtMulKind,
     ) -> Result<()>;
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -54,7 +54,7 @@ pub(crate) enum MaxKind {
     Unsigned,
 }
 
-/// Kind of extend-multiply
+/// Kind of extend-multiply.
 pub(crate) enum ExtMulKind {
     // Sign-extend higher-half of each lane.
     HighSigned,
@@ -64,6 +64,14 @@ pub(crate) enum ExtMulKind {
     HighUnsigned,
     // Extend lower-half of each lane.
     LowUnsigned,
+}
+
+/// Kind of pairwise extend-add.
+pub(crate) enum ExtAddKind {
+    /// Signed pairwise extend add.
+    Signed,
+    /// Unsigned pairwise extend add.
+    Unsigned,
 }
 
 #[derive(Eq, PartialEq)]
@@ -1936,10 +1944,10 @@ pub(crate) trait MacroAssembler {
         kind: MaxKind,
     ) -> Result<()>;
 
-    /// Perform lane-wise integer extended multiplication producing twice wider result than the inputs.
-    /// This is equivalent to a an extend followed by a multiply.
+    /// Perform the lane-wise integer extended multiplication producing twice wider result than the
+    /// inputs. This is equivalent to an extend followed by a multiply.
     ///
-    /// The extention to be performed is infered from the `lane_width` and the `kind` of extmul,
+    /// The extension to be performed is inferred from the `lane_width` and the `kind` of extmul,
     /// e.g, if `lane_width` is `S16`, and `kind` is `LowSigned`, then we sign-extend the lower
     /// 8bits of the 16bits lanes.
     fn v128_extmul(
@@ -1947,5 +1955,15 @@ pub(crate) trait MacroAssembler {
         context: &mut CodeGenContext<Emission>,
         lane_width: OperandSize,
         kind: ExtMulKind,
+    ) -> Result<()>;
+
+    /// Perform the lane-wise integer extended pairwise addition producing extended results (twice
+    /// wider results than the inputs).
+    fn v128_extadd_pairwise(
+        &mut self,
+        src: Reg,
+        dst: WritableReg,
+        lane_width: OperandSize,
+        kind: ExtAddKind,
     ) -> Result<()>;
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -503,6 +503,18 @@ macro_rules! def_unsupported {
     (emit I8x16MaxS $($rest:tt)*) => {};
     (emit I16x8MaxS $($rest:tt)*) => {};
     (emit I32x4MaxS $($rest:tt)*) => {};
+    (emit I16x8ExtMulLowI8x16S $($rest:tt)*) => {};
+    (emit I32x4ExtMulLowI16x8S $($rest:tt)*) => {};
+    (emit I64x2ExtMulLowI32x4S $($rest:tt)*) => {};
+    (emit I16x8ExtMulHighI8x16S $($rest:tt)*) => {};
+    (emit I32x4ExtMulHighI16x8S $($rest:tt)*) => {};
+    (emit I64x2ExtMulHighI32x4S $($rest:tt)*) => {};
+    (emit I16x8ExtMulLowI8x16U $($rest:tt)*) => {};
+    (emit I32x4ExtMulLowI16x8U $($rest:tt)*) => {};
+    (emit I64x2ExtMulLowI32x4U $($rest:tt)*) => {};
+    (emit I16x8ExtMulHighI8x16U $($rest:tt)*) => {};
+    (emit I32x4ExtMulHighI16x8U $($rest:tt)*) => {};
+    (emit I64x2ExtMulHighI32x4U $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -4230,6 +4242,75 @@ where
                 masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
                 Ok(TypedReg::v128(dst))
             })
+    }
+
+    fn visit_i16x8_extmul_low_i8x16_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::LowSigned)
+    }
+
+    fn visit_i32x4_extmul_low_i16x8_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::LowSigned)
+    }
+
+    fn visit_i64x2_extmul_low_i32x4_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::LowSigned)
+    }
+
+    fn visit_i16x8_extmul_low_i8x16_u(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::LowUnsigned)
+    }
+
+    fn visit_i32x4_extmul_low_i16x8_u(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::LowUnsigned)
+    }
+
+    fn visit_i64x2_extmul_low_i32x4_u(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::LowUnsigned)
+    }
+
+    fn visit_i16x8_extmul_high_i8x16_u(&mut self) -> Self::Output {
+        self.masm.v128_extmul(
+            &mut self.context,
+            OperandSize::S16,
+            ExtMulKind::HighUnsigned,
+        )
+    }
+
+    fn visit_i32x4_extmul_high_i16x8_u(&mut self) -> Self::Output {
+        self.masm.v128_extmul(
+            &mut self.context,
+            OperandSize::S32,
+            ExtMulKind::HighUnsigned,
+        )
+    }
+
+    fn visit_i64x2_extmul_high_i32x4_u(&mut self) -> Self::Output {
+        self.masm.v128_extmul(
+            &mut self.context,
+            OperandSize::S64,
+            ExtMulKind::HighUnsigned,
+        )
+    }
+
+    fn visit_i16x8_extmul_high_i8x16_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::HighSigned)
+    }
+
+    fn visit_i32x4_extmul_high_i16x8_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::HighSigned)
+    }
+
+    fn visit_i64x2_extmul_high_i32x4_s(&mut self) -> Self::Output {
+        self.masm
+            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::HighSigned)
     }
 
     wasmparser::for_each_visit_simd_operator!(def_unsupported);

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -11,10 +11,10 @@ use crate::codegen::{
 };
 use crate::masm::{
     DivKind, Extend, ExtractLaneKind, FloatCmpKind, HandleOverflowKind, IntCmpKind, LoadKind,
-    MacroAssembler, MemMoveDirection, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind,
-    RmwOp, RoundingMode, SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind, StoreKind,
-    TruncKind, V128AbsKind, V128ConvertKind, V128ExtendKind, V128LoadExtendKind, V128NarrowKind,
-    VectorCompareKind, VectorEqualityKind, Zero,
+    MacroAssembler, MaxKind, MemMoveDirection, MinKind, MulWideKind, OperandSize, RegImm, RemKind,
+    ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind,
+    StoreKind, TruncKind, V128AbsKind, V128ConvertKind, V128ExtendKind, V128LoadExtendKind,
+    V128NarrowKind, VectorCompareKind, VectorEqualityKind, Zero,
 };
 
 use crate::reg::{writable, Reg};
@@ -491,6 +491,18 @@ macro_rules! def_unsupported {
     (emit I16x8Bitmask $($rest:tt)*) => {};
     (emit I32x4Bitmask $($rest:tt)*) => {};
     (emit I64x2Bitmask $($rest:tt)*) => {};
+    (emit I8x16MinU $($rest:tt)*) => {};
+    (emit I16x8MinU $($rest:tt)*) => {};
+    (emit I32x4MinU $($rest:tt)*) => {};
+    (emit I8x16MinS $($rest:tt)*) => {};
+    (emit I16x8MinS $($rest:tt)*) => {};
+    (emit I32x4MinS $($rest:tt)*) => {};
+    (emit I8x16MaxU $($rest:tt)*) => {};
+    (emit I16x8MaxU $($rest:tt)*) => {};
+    (emit I32x4MaxU $($rest:tt)*) => {};
+    (emit I8x16MaxS $($rest:tt)*) => {};
+    (emit I16x8MaxS $($rest:tt)*) => {};
+    (emit I32x4MaxS $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -4073,6 +4085,13 @@ where
         self.context
             .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
                 masm.v128_q15mulr_sat_s(dst, src, writable!(dst), size)?;
+            })
+    }
+
+    fn visit_i8x16_min_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
                 Ok(TypedReg::v128(dst))
             })
     }
@@ -4123,6 +4142,94 @@ where
         self.context.v128_bitmask_op(self.masm, |masm, src, dst| {
             masm.v128_bitmask(src, writable!(dst), OperandSize::S64)
         })
+    }
+
+    fn visit_i16x8_min_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i32x4_min_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i8x16_min_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i16x8_min_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i32x4_min_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
+                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i8x16_max_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i16x8_max_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i32x4_max_s(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i8x16_max_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i16x8_max_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
+                Ok(TypedReg::v128(dst))
+            })
+    }
+
+    fn visit_i32x4_max_u(&mut self) -> Self::Output {
+        self.context
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
+                Ok(TypedReg::v128(dst))
+            })
     }
 
     wasmparser::for_each_visit_simd_operator!(def_unsupported);


### PR DESCRIPTION
This PR implements another batch of SIMD instruction for winch x64 backend:

- `i8x16.max_u`
- `i16x8.max_u`
- `i32x4.max_u`
- `i8x16.max_s`
- `i16x8.max_s`
- `i32x4.max_s`
- `i8x16.min_u`
- `i16x8.min_u`
- `i32x4.min_u`
- `i8x16.min_s`
- `i16x8.min_s`
- `i32x4.min_s`
- `i16x8.extmul_low_i8x16_s`
- `i16x8.extmul_high_i8x16_s`
- `i16x8.extmul_low_i8x16_u`
- `i16x8.extmul_high_i8x16_u`
- `i32x4.extmul_low_i16x8_s`
- `i32x4.extmul_high_i16x8_s`
- `i32x4.extmul_low_i16x8_u`
- `i32x4.extmul_high_i16x8_u`
- `i64x2.extmul_low_i32x4_s`
- `i64x2.extmul_high_i32x4_s`
- `i64x2.extmul_low_i32x4_u`
- `i64x2.extmul_high_i32x4_u`
- `i16x8.extadd_pairwise_i8x16_s`
- `i16x8.extadd_pairwise_i8x16_u`
- `i32x4.extadd_pairwise_i16x8_s`
- `i32x4.extadd_pairwise_i16x8_u`


The add-extend and mul-extend operation are implemented in terms of already existing primitive. This is because almost every single one of those wasm instruction resulted in a special sequence of x64 instruction. While the current implemention emits far from optimal code, it has the advantage of being straighforward. We can always specialize the implementations later.

#8093
