### PR TITLE
doc: avoid number of `FuncKind` variants

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -289,8 +289,7 @@ pub(crate) struct FuncData {
     ty: Option<Box<FuncType>>,
 }
 
-/// The three ways that a function can be created and referenced from within a
-/// store.
+/// The ways that a function can be created and referenced from within a store.
 enum FuncKind {
     /// A function already owned by the store via some other means. This is
     /// used, for example, when creating a `Func` from an instance's exported


### PR DESCRIPTION
Especially since there are actually four now, not three.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
