### PR TITLE
doc: fix typo in `VMComponentContext`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -145,7 +145,7 @@ unsafe impl VmSafe for VMLowering {}
 /// component instance in Wasmtime. While the static size of this type is 0 the
 /// actual runtime size is variable depending on the shape of the component that
 /// this corresponds to. This structure always trails a `ComponentInstance`
-/// allocation and the allocation/liftetime of this allocation is managed by
+/// allocation and the allocation/lifetime of this allocation is managed by
 /// `ComponentInstance`.
 #[repr(C)]
 // Set an appropriate alignment for this structure where the most-aligned value


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
