### PR TITLE
Update cargo-nextest used on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1070,7 +1070,7 @@ jobs:
     name: Miri
     runs-on: ubuntu-latest
     env:
-      CARGO_NEXTEST_VERSION: 0.9.67
+      CARGO_NEXTEST_VERSION: 0.9.88
       MIRIFLAGS: -Zmiri-permissive-provenance
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This commit updates the version of `cargo nextest` used on CI from 0.9.67 to 0.9.88. It turns out that the nightly used in testing, `nightly-2025-01-09`, cannot actually compile 0.9.67 due to a bug in the `ahash` crate dependency. This never showed up prior on CI because we cache the build of `cargo nextest` so the update of rustc to a new nightly did not force a rebuild to happen. Now that the cache has been removed the error is now showing up, so this will hopefully unblock the queue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
