### PR TITLE
asm: avoid propagating `arbitrary`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,6 @@ name = "cranelift-codegen"
 version = "0.118.0"
 dependencies = [
  "anyhow",
- "arbitrary",
  "bumpalo",
  "capstone",
  "cranelift-assembler-x64",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 features = ["all-arch"]
 
 [dependencies]
-arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -5,7 +5,6 @@ use super::{
     SyntheticAmode, VCodeConstant, WritableGpr,
 };
 use crate::ir::TrapCode;
-use arbitrary::Arbitrary;
 use cranelift_assembler_x64 as asm;
 
 /// Define the types of registers Cranelift will use.
@@ -42,12 +41,6 @@ impl asm::AsReg for PairedGpr {
     }
 }
 
-impl<'a> Arbitrary<'a> for PairedGpr {
-    fn arbitrary(_: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        unimplemented!("assembler fuzzing is not implemented at this level")
-    }
-}
-
 /// This bridges the gap between codegen and assembler register types.
 impl asm::AsReg for Gpr {
     fn enc(&self) -> u8 {
@@ -56,12 +49,6 @@ impl asm::AsReg for Gpr {
 
     fn new(_: u8) -> Self {
         panic!("disallow creation of new assembler registers")
-    }
-}
-
-impl<'a> Arbitrary<'a> for Gpr {
-    fn arbitrary(_: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        unimplemented!("assembler fuzzing is not implemented at this level")
     }
 }
 


### PR DESCRIPTION
This is something that @alexcrichton already fixed over in the assembler crate--no need to implement `Arbitrary` unnecessarily. It's unclear how this stayed in here in `cranelift-codegen` but this change removes it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
