### PR TITLE
aarch64: Add support for the `extr` instruction

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3302,6 +3302,12 @@
 (decl a64_rotr_imm (Type Reg ImmShift) Reg)
 (rule (a64_rotr_imm ty x y) (alu_rr_imm_shift (ALUOp.RotR) ty x y))
 
+;; Helpers for generating `extr` instructions
+(decl a64_extr (Type Reg Reg ImmShift) Reg)
+(rule (a64_extr ty x y shift) (alu_rrr_shift (ALUOp.RotR) ty x y (a64_extr_imm ty shift)))
+(decl a64_extr_imm (Type ImmShift) ShiftOpAndAmt)
+(extern constructor a64_extr_imm a64_extr_imm)
+
 ;; Helpers for generating `rbit` instructions.
 (spec (rbit ty a)
   (provide

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1007,7 +1007,7 @@
       (SubS #x08)
       (SDiv #x09)
       (UDiv #x0a)
-      (RotR #x0b)
+      (Extr #x0b)
       (Lsr #x0c)
       (Asr #x0d)
       (Lsl #x0e)))
@@ -1037,7 +1037,7 @@
     (UMulH)
     (SDiv)
     (UDiv)
-    (RotR)
+    (Extr)
     (Lsr)
     (Asr)
     (Lsl)
@@ -3282,6 +3282,9 @@
 (rule (sshr_vec_imm x amt size) (vec_shift_imm (VecShiftImmOp.Sshr) amt x size))
 
 ;; Helpers for generating `rotr` instructions.
+;;
+;; Note that the `Extr` opcode is used here as `rotr` is an alias for that
+;; instruction where two operands are the same register.
 (spec (a64_rotr ty x y)
   (provide
     (= result
@@ -3290,7 +3293,7 @@
            (rotr x y))))
   (require (or (= ty 32) (= ty 64))))
 (decl a64_rotr (Type Reg Reg) Reg)
-(rule (a64_rotr ty x y) (alu_rrr (ALUOp.RotR) ty x y))
+(rule (a64_rotr ty x y) (alu_rrr (ALUOp.Extr) ty x y))
 
 (spec (a64_rotr_imm ty x y)
   (provide
@@ -3300,11 +3303,11 @@
            (rotr x (zero_ext 64 y)))))
   (require (or (= ty 32) (= ty 64))))
 (decl a64_rotr_imm (Type Reg ImmShift) Reg)
-(rule (a64_rotr_imm ty x y) (alu_rr_imm_shift (ALUOp.RotR) ty x y))
+(rule (a64_rotr_imm ty x y) (alu_rr_imm_shift (ALUOp.Extr) ty x y))
 
 ;; Helpers for generating `extr` instructions
 (decl a64_extr (Type Reg Reg ImmShift) Reg)
-(rule (a64_extr ty x y shift) (alu_rrr_shift (ALUOp.RotR) ty x y (a64_extr_imm ty shift)))
+(rule (a64_extr ty x y shift) (alu_rrr_shift (ALUOp.Extr) ty x y (a64_extr_imm ty shift)))
 (decl a64_extr_imm (Type ImmShift) ShiftOpAndAmt)
 (extern constructor a64_extr_imm a64_extr_imm)
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -759,7 +759,7 @@ impl MachInstEmit for Inst {
                     ALUOp::AddS => 0b00101011_000,
                     ALUOp::SubS => 0b01101011_000,
                     ALUOp::SDiv | ALUOp::UDiv => 0b00011010_110,
-                    ALUOp::RotR | ALUOp::Lsr | ALUOp::Asr | ALUOp::Lsl => 0b00011010_110,
+                    ALUOp::Extr | ALUOp::Lsr | ALUOp::Asr | ALUOp::Lsl => 0b00011010_110,
                     ALUOp::SMulH => 0b10011011_010,
                     ALUOp::UMulH => 0b10011011_110,
                 };
@@ -768,7 +768,7 @@ impl MachInstEmit for Inst {
                 let bit15_10 = match alu_op {
                     ALUOp::SDiv => 0b000011,
                     ALUOp::UDiv => 0b000010,
-                    ALUOp::RotR => 0b001011,
+                    ALUOp::Extr => 0b001011,
                     ALUOp::Lsr => 0b001001,
                     ALUOp::Asr => 0b001010,
                     ALUOp::Lsl => 0b001000,
@@ -859,7 +859,7 @@ impl MachInstEmit for Inst {
             } => {
                 let amt = immshift.value();
                 let (top10, immr, imms) = match alu_op {
-                    ALUOp::RotR => (0b0001001110, machreg_to_gpr(rn), u32::from(amt)),
+                    ALUOp::Extr => (0b0001001110, machreg_to_gpr(rn), u32::from(amt)),
                     ALUOp::Lsr => (0b0101001100, u32::from(amt), 0b011111),
                     ALUOp::Asr => (0b0001001100, u32::from(amt), 0b011111),
                     ALUOp::Lsl => {
@@ -906,7 +906,7 @@ impl MachInstEmit for Inst {
                     ALUOp::OrrNot => 0b001_01010001,
                     ALUOp::EorNot => 0b010_01010001,
                     ALUOp::AndNot => 0b000_01010001,
-                    ALUOp::RotR => 0b000_10011100,
+                    ALUOp::Extr => 0b000_10011100,
                     _ => unimplemented!("{:?}", alu_op),
                 };
                 let top11 = top11 | size.sf_bit() << 10;

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -906,6 +906,7 @@ impl MachInstEmit for Inst {
                     ALUOp::OrrNot => 0b001_01010001,
                     ALUOp::EorNot => 0b010_01010001,
                     ALUOp::AndNot => 0b000_01010001,
+                    ALUOp::RotR => 0b000_10011100,
                     _ => unimplemented!("{:?}", alu_op),
                 };
                 let top11 = top11 | size.sf_bit() << 10;

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -451,25 +451,25 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::AluRRR {
-            alu_op: ALUOp::RotR,
+            alu_op: ALUOp::Extr,
             size: OperandSize::Size32,
             rd: writable_xreg(4),
             rn: xreg(5),
             rm: xreg(6),
         },
         "A42CC61A",
-        "ror w4, w5, w6",
+        "extr w4, w5, w6",
     ));
     insns.push((
         Inst::AluRRR {
-            alu_op: ALUOp::RotR,
+            alu_op: ALUOp::Extr,
             size: OperandSize::Size64,
             rd: writable_xreg(4),
             rn: xreg(5),
             rm: xreg(6),
         },
         "A42CC69A",
-        "ror x4, x5, x6",
+        "extr x4, x5, x6",
     ));
     insns.push((
         Inst::AluRRR {
@@ -1130,25 +1130,25 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::AluRRImmShift {
-            alu_op: ALUOp::RotR,
+            alu_op: ALUOp::Extr,
             size: OperandSize::Size32,
             rd: writable_xreg(20),
             rn: xreg(21),
             immshift: ImmShift::maybe_from_u64(19).unwrap(),
         },
         "B44E9513",
-        "ror w20, w21, #19",
+        "extr w20, w21, #19",
     ));
     insns.push((
         Inst::AluRRImmShift {
-            alu_op: ALUOp::RotR,
+            alu_op: ALUOp::Extr,
             size: OperandSize::Size64,
             rd: writable_xreg(20),
             rn: xreg(21),
             immshift: ImmShift::maybe_from_u64(42).unwrap(),
         },
         "B4AAD593",
-        "ror x20, x21, #42",
+        "extr x20, x21, #42",
     ));
     insns.push((
         Inst::AluRRImmShift {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1213,7 +1213,7 @@ impl Inst {
                 ALUOp::AndNot => "bic",
                 ALUOp::OrrNot => "orn",
                 ALUOp::EorNot => "eon",
-                ALUOp::RotR => "ror",
+                ALUOp::Extr => "extr",
                 ALUOp::Lsr => "lsr",
                 ALUOp::Asr => "asr",
                 ALUOp::Lsl => "lsl",

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1435,19 +1435,16 @@
 ;; The immediate used for the `extr` instruction itself is the N for the
 ;; shift-right. Two patterns are used here to detect either ordering of the
 ;; `bor`.
-(rule 5 (lower (has_type ty (bor (ishl x (u8_from_iconst xs))
-                                 (ushr y (u8_from_iconst ys)))))
-  (if-let shift (a64_extr_shift ty xs ys))
-  (a64_extr ty x y shift))
-(rule 5 (lower (has_type ty (bor (ushr y (u8_from_iconst ys))
-                                 (ishl x (u8_from_iconst xs)))))
-  (if-let shift (a64_extr_shift ty xs ys))
-  (a64_extr ty x y shift))
-
-;; Helper in Rust to test whether the pair of shifts of `u8` add up to the type
-;; width specified. Optionally returns the second value as `ImmShift`.
-(decl pure partial a64_extr_shift (Type u8 u8) ImmShift)
-(extern constructor a64_extr_shift a64_extr_shift)
+;;
+;; (x << xs) | (y >> ys) if (xs + ys == widthof(ty)) => extr(x, y, ys)
+(rule 5 (lower (has_type (ty_32_or_64 ty)
+  (bor (ishl x (u8_from_iconst xs)) (ushr y (u8_from_iconst ys)))))
+  (if-let true (u64_eq (ty_bits ty) (u64_add xs ys)))
+  (a64_extr ty x y (imm_shift_from_u8 ys)))
+(rule 5 (lower (has_type (ty_32_or_64 ty)
+  (bor (ushr y (u8_from_iconst ys)) (ishl x (u8_from_iconst xs)))))
+  (if-let true (u64_eq (ty_bits ty) (u64_add xs ys)))
+  (a64_extr ty x y (imm_shift_from_u8 ys)))
 
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1426,6 +1426,29 @@
 (rule 3 (lower (has_type $I128 (bor x (bnot y)))) (i128_alu_bitop (ALUOp.OrrNot) $I64 x y))
 (rule 4 (lower (has_type $I128 (bor (bnot y) x))) (i128_alu_bitop (ALUOp.OrrNot) $I64 x y))
 
+;; Specialized lowerings to generate the `extr` instruction.
+;;
+;; The `extr` instruction creates `a:b` and then extracts either 32 or 64-bits
+;; starting from an immediate index. This is pattern-matched here as a `bor` of
+;; the high/low halves of two values shifted around.
+;;
+;; The immediate used for the `extr` instruction itself is the N for the
+;; shift-right. Two patterns are used here to detect either ordering of the
+;; `bor`.
+(rule 5 (lower (has_type ty (bor (ishl x (u8_from_iconst xs))
+                                 (ushr y (u8_from_iconst ys)))))
+  (if-let shift (a64_extr_shift ty xs ys))
+  (a64_extr ty x y shift))
+(rule 5 (lower (has_type ty (bor (ushr y (u8_from_iconst ys))
+                                 (ishl x (u8_from_iconst xs)))))
+  (if-let shift (a64_extr_shift ty xs ys))
+  (a64_extr ty x y shift))
+
+;; Helper in Rust to test whether the pair of shifts of `u8` add up to the type
+;; width specified. Optionally returns the second value as `ImmShift`.
+(decl pure partial a64_extr_shift (Type u8 u8) ImmShift)
+(extern constructor a64_extr_shift a64_extr_shift)
+
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule bxor_fits_in_64 -1 (lower (has_type (fits_in_64 ty) (bxor x y)))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -763,17 +763,6 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         Some(bit as u8)
     }
 
-    /// Used as a helper for generation of `extr` instructions.
-    ///
-    /// Tests that `xs + ys == ty.bits()` and then casts `ys` to the `ImmShift`
-    /// return value.
-    fn a64_extr_shift(&mut self, ty: Type, xs: u8, ys: u8) -> Option<ImmShift> {
-        if u32::from(xs.checked_add(ys)?) != ty.bits() {
-            return None;
-        }
-        ImmShift::maybe_from_u64(ys.into())
-    }
-
     /// Use as a helper when generating `AluRRRShift` for `extr` instructions.
     fn a64_extr_imm(&mut self, ty: Type, shift: ImmShift) -> ShiftOpAndAmt {
         // The `ShiftOpAndAmt` immediate is used with `AluRRRShift` shape which

--- a/cranelift/filetests/filetests/isa/aarch64/extr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/extr.clif
@@ -1,0 +1,111 @@
+test compile precise-output
+target aarch64
+
+function %a64_extr_i32_12(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 20
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror w0, w1, w0, LSL 12
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr w0, w1, w0, #0xc
+;   ret
+
+function %a64_extr_i32_12_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 20
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror w0, w0, w1, LSL 12
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr w0, w0, w1, #0xc
+;   ret
+
+function %a64_extr_i32_28(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 4
+    v3 = ishl_imm v1, 28
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror w0, w1, w0, LSL 4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr w0, w1, w0, #4
+;   ret
+
+function %a64_extr_i32_28_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 4
+    v3 = ushr_imm v1, 28
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror w0, w0, w1, LSL 28
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr w0, w0, w1, #0x1c
+;   ret
+
+function %a64_extr_i64_12(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 52
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror x0, x1, x0, LSR 12
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr x0, x1, x0, #0xc
+;   ret
+
+function %a64_extr_i64_12_swap(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ishl_imm v0, 52
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   ror x0, x0, x1, LSR 12
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   extr x0, x0, x1, #0xc
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/extr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/extr.clif
@@ -11,7 +11,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w1, w0, LSL 12
+;   extr w0, w1, w0, LSL 12
 ;   ret
 ;
 ; Disassembled:
@@ -29,7 +29,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w0, w1, LSL 12
+;   extr w0, w0, w1, LSL 12
 ;   ret
 ;
 ; Disassembled:
@@ -47,7 +47,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w1, w0, LSL 4
+;   extr w0, w1, w0, LSL 4
 ;   ret
 ;
 ; Disassembled:
@@ -65,7 +65,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w0, w1, LSL 28
+;   extr w0, w0, w1, LSL 28
 ;   ret
 ;
 ; Disassembled:
@@ -83,7 +83,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   ror x0, x1, x0, LSR 12
+;   extr x0, x1, x0, LSR 12
 ;   ret
 ;
 ; Disassembled:
@@ -101,7 +101,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   ror x0, x0, x1, LSR 12
+;   extr x0, x0, x1, LSR 12
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
@@ -72,7 +72,7 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   ror x0, x0, x1
+;   extr x0, x0, x1
 ;   ret
 ;
 ; Disassembled:
@@ -88,7 +88,7 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w0, w1
+;   extr w0, w0, w1
 ;   ret
 ;
 ; Disassembled:
@@ -219,7 +219,7 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ; block0:
 ;   sub x3, xzr, x1
-;   ror x0, x0, x3
+;   extr x0, x0, x3
 ;   ret
 ;
 ; Disassembled:
@@ -237,7 +237,7 @@ block0(v0: i32, v1: i32):
 ; VCode:
 ; block0:
 ;   sub w3, wzr, w1
-;   ror w0, w0, w3
+;   extr w0, w0, w3
 ;   ret
 ;
 ; Disassembled:
@@ -527,7 +527,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   ror x0, x0, #17
+;   extr x0, x0, #17
 ;   ret
 ;
 ; Disassembled:
@@ -544,7 +544,7 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   ror x0, x0, #47
+;   extr x0, x0, #47
 ;   ret
 ;
 ; Disassembled:
@@ -561,7 +561,7 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   ror w0, w0, #15
+;   extr w0, w0, #15
 ;   ret
 ;
 ; Disassembled:

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 set opt_level=none
 target aarch64
@@ -31,7 +32,7 @@ block0:
     v4 = band v3, v2
     return v4
 }
-; run
+; run: %bnot_band() == 1
 
 ;; We have a optimization rule in the midend that turns this into a bmask
 ;; It's easier to have a runtest to ensure that it is correct than to inspect the output.
@@ -52,3 +53,61 @@ block0(v0: i16):
 ; run: %bitops_bmask(1) == -1
 ; run: %bitops_bmask(0xFFFF) == -1
 ; run: %bitops_bmask(0x8000) == -1
+
+function %a64_extr_i32_12(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 20
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i32_12(0x1234_5678, 0x1234_5678) == 0x678_1234_5
+; run: %a64_extr_i32_12(0x1234_5678, 0x9abc_def0) == 0xef0_1234_5
+
+function %a64_extr_i32_12_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 20
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i32_12_swap(0x1234_5678, 0x1234_5678) == 0x678_1234_5
+; run: %a64_extr_i32_12_swap(0x1234_5678, 0x9abc_def0) == 0x678_9abc_d
+
+function %a64_extr_i32_28(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 4
+    v3 = ishl_imm v1, 28
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i32_28(0x1234_5678, 0x1234_5678) == 0x8_1234_567
+; run: %a64_extr_i32_28(0x1234_5678, 0x9abc_def0) == 0x0_1234_567
+
+function %a64_extr_i32_28_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 4
+    v3 = ushr_imm v1, 28
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i32_28_swap(0x1234_5678, 0x1234_5678) == 0x234_5678_1
+; run: %a64_extr_i32_28_swap(0x1234_5678, 0x9abc_def0) == 0x234_5678_9
+
+function %a64_extr_i64_12(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 52
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i64_12(0x0102_0304_0506_0708, 0x090a_0b0c_0d0e_0f00) == 0xf00_0102_0304_0506_0
+
+function %a64_extr_i64_12_swap(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ishl_imm v0, 52
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+; run: %a64_extr_i64_12_swap(0x0102_0304_0506_0708, 0x090a_0b0c_0d0e_0f00) == 0x708_090a_0b0c_0d0e_0

--- a/tests/disas/aarch64-extr.wat
+++ b/tests/disas/aarch64-extr.wat
@@ -1,0 +1,96 @@
+;;! target = "aarch64"
+;;! test = "compile"
+
+(module
+  (func $i32_21 (param i32 i32) (result i32)
+    local.get 0
+    i32.const 11
+    i32.shl
+    local.get 1
+    i32.const 21
+    i32.shr_u
+    i32.or)
+  (func $i32_21_swapped (param i32 i32) (result i32)
+    local.get 1
+    i32.const 21
+    i32.shr_u
+    local.get 0
+    i32.const 11
+    i32.shl
+    i32.or)
+  (func $i32_11 (param i32 i32) (result i32)
+    local.get 0
+    i32.const 21
+    i32.shl
+    local.get 1
+    i32.const 11
+    i32.shr_u
+    i32.or)
+
+  (func $i64_21 (param i64 i64) (result i64)
+    local.get 0
+    i64.const 43
+    i64.shl
+    local.get 1
+    i64.const 21
+    i64.shr_u
+    i64.or)
+  (func $i64_21_swapped (param i64 i64) (result i64)
+    local.get 1
+    i64.const 21
+    i64.shr_u
+    local.get 0
+    i64.const 43
+    i64.shl
+    i64.or)
+  (func $i64_11 (param i64 i64) (result i64)
+    local.get 0
+    i64.const 53
+    i64.shl
+    local.get 1
+    i64.const 11
+    i64.shr_u
+    i64.or)
+)
+
+;; wasm[0]::function[0]::i32_21:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    w2, w5, w4, #0x15
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[1]::i32_21_swapped:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    w2, w5, w4, #0x15
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[2]::i32_11:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    w2, w5, w4, #0xb
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[3]::i64_21:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    x2, x5, x4, #0x15
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[4]::i64_21_swapped:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    x2, x5, x4, #0x15
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;
+;; wasm[0]::function[5]::i64_11:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       extr    x2, x5, x4, #0xb
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret

--- a/tests/disas/aarch64-extr.wat
+++ b/tests/disas/aarch64-extr.wat
@@ -56,41 +56,41 @@
 ;; wasm[0]::function[0]::i32_21:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    w2, w5, w4, #0x15
+;;       extr    w2, w4, w5, #0x15
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]::i32_21_swapped:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    w2, w5, w4, #0x15
+;;       extr    w2, w4, w5, #0x15
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[2]::i32_11:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    w2, w5, w4, #0xb
+;;       extr    w2, w4, w5, #0xb
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[3]::i64_21:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    x2, x5, x4, #0x15
+;;       extr    x2, x4, x5, #0x15
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[4]::i64_21_swapped:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    x2, x5, x4, #0x15
+;;       extr    x2, x4, x5, #0x15
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[5]::i64_11:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       extr    x2, x5, x4, #0xb
+;;       extr    x2, x4, x5, #0xb
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -1040,17 +1040,18 @@ impl Assembler {
     }
 
     // Convert ShiftKind to ALUOp. If kind == Rotl, then emulate it by emitting
-    // the negation of the given reg r, and returns ALUOp::RotR.
+    // the negation of the given reg r, and returns ALUOp::Extr (an alias for
+    // `ror` the rotate-right instruction)
     fn shift_kind_to_alu_op(&mut self, kind: ShiftKind, r: Reg, size: OperandSize) -> ALUOp {
         match kind {
             ShiftKind::Shl => ALUOp::Lsl,
             ShiftKind::ShrS => ALUOp::Asr,
             ShiftKind::ShrU => ALUOp::Lsr,
-            ShiftKind::Rotr => ALUOp::RotR,
+            ShiftKind::Rotr => ALUOp::Extr,
             ShiftKind::Rotl => {
                 // neg(r) is sub(zero, r).
                 self.alu_rrr(ALUOp::Sub, regs::zero(), r, writable!(r), size);
-                ALUOp::RotR
+                ALUOp::Extr
             }
         }
     }


### PR DESCRIPTION
This is pattern-matched from `bor` patterns of a specific shape. I found this when doing some benchmarking of Wasmtime on aarch64 and I saw LLVM generating this pattern but Wasmtime didn't. I didn't perform any benchmarking between wasmtime/native though, so I'm just relying on this reducing the number of instructions to probably be a wee bit faster.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
