### PR TITLE
asm: switch to using workspace clippy settings

### DIFF
--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -18,13 +18,8 @@ capstone = { workspace = true }
 [build-dependencies]
 cranelift-assembler-x64-meta = { path = "meta", version = "0.118.0" }
 
-[lints.clippy]
-all = "deny"
-pedantic = "warn"
-module_name_repetitions = { level = "allow", priority = 1 }
-similar_names = { level = "allow", priority = 1 }
-wildcard_imports = { level = "allow", priority = 1 }
-too_many_lines = { level = "allow", priority = 1 }
+[lints]
+workspace = true
 
 [features]
 fuzz = ['dep:arbitrary', 'dep:capstone']

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -8,9 +8,5 @@ rust-version.workspace = true
 
 [dependencies]
 
-[lints.clippy]
-all = "deny"
-pedantic = "warn"
-enum_glob_use = { level = "allow", priority = 1 }
-just_underscores_and_digits = { level = "allow", priority = 1 }
-wildcard_imports = { level = "allow", priority = 1 }
+[lints]
+workspace = true

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -280,7 +280,7 @@ impl LegacyPrefix {
 }
 
 #[derive(Debug, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Imm {
     None,
     ib,

--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Features {
 /// - __64-bit mode__: uses the full 64-bit address space
 /// - __compatibility mode__: allows use of legacy 32-bit code
 #[derive(Clone, Copy, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Feature {
     _64b,
     compat,

--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -194,7 +194,7 @@ impl From<Location> for Operand {
 
 /// An operand location, as expressed in Intel's _Instruction Set Reference_.
 #[derive(Clone, Copy, Debug)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Location {
     al,
     ax,

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -36,7 +36,6 @@ impl dsl::Format {
     }
 
     /// `buf.put1(...);`
-    #[allow(clippy::unused_self)]
     fn generate_legacy_prefix(&self, f: &mut Formatter, rex: &dsl::Rex) {
         use dsl::LegacyPrefix::*;
         if rex.prefix != NoPrefix {
@@ -60,7 +59,7 @@ impl dsl::Format {
         }
     }
 
-    #[allow(clippy::unused_self)]
+    // `buf.put1(...);`
     fn generate_opcode(&self, f: &mut Formatter, rex: &dsl::Rex) {
         f.empty_line();
         f.comment("Emit opcode.");

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -74,7 +74,7 @@ fn pretty_print_hexadecimal(hex: &[u8]) -> String {
 /// See `replace_signed_immediates`.
 macro_rules! hex_print_signed_imm {
     ($hex:expr, $from:ty => $to:ty) => {{
-        #[allow(clippy::cast_possible_wrap)]
+        #[allow(clippy::cast_possible_wrap, reason = "bit conversion is intended here")]
         let imm = <$from>::from_str_radix($hex, 16).unwrap() as $to;
         let mut simm = String::new();
         if imm < 0 {

--- a/cranelift/assembler-x64/src/imm.rs
+++ b/cranelift/assembler-x64/src/imm.rs
@@ -1,6 +1,6 @@
 //! Immediate operands to instructions.
 
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, reason = "'imm::Imm*' is fine")]
 
 use crate::api::CodeSink;
 use std::fmt;
@@ -17,9 +17,9 @@ macro_rules! hexify {
 /// Like `hexify!`, but this performs a sign extension.
 macro_rules! hexify_sign_extend {
     ($n:expr, $from:ty => $to:ty) => {{
-        #[allow(clippy::cast_possible_wrap)]
-        let n = <$to>::from($n as $from);
-        format!("$0x{:x}", n)
+        let from: $from = $n; // Assert the type we expect.
+        let to = <$to>::from(from);
+        format!("$0x{:x}", to)
     }};
 }
 
@@ -67,7 +67,7 @@ impl Simm8 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss)]
+        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put1(self.0 as u8);
     }
 
@@ -127,7 +127,7 @@ impl Simm16 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss)]
+        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put2(self.0 as u16);
     }
 
@@ -195,7 +195,7 @@ impl Simm32 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss)]
+        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put4(self.0 as u32);
     }
 

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -36,8 +36,10 @@
 //! With an [`Inst`], we can encode the instruction into a code buffer; see the
 //! [example](Inst).
 
-// All of the generated struct names use snake case.
-#![allow(non_camel_case_types)]
+#![allow(
+    non_camel_case_types,
+    reason = "all of the generated struct names use snake case"
+)]
 
 mod api;
 mod imm;

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -242,7 +242,10 @@ impl Scale {
 /// A general-purpose register or memory operand.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
-#[allow(clippy::module_name_repetitions)]
+#[allow(
+    clippy::module_name_repetitions,
+    reason = "'GprMem' indicates this has GPR and memory variants"
+)]
 pub enum GprMem<R: AsReg, M: AsReg> {
     Gpr(R),
     Mem(Amode<M>),
@@ -358,7 +361,7 @@ pub fn emit_modrm_sib_disp<R: AsReg>(
             // to the end of the u32 field. So, to compensate for
             // this, we emit a negative extra offset in the u32 field
             // initially, and the relocation will add to it.
-            #[allow(clippy::cast_sign_loss)]
+            #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
             sink.put4(-(i32::from(bytes_at_end)) as u32);
         }
     }

--- a/cranelift/assembler-x64/src/rex.rs
+++ b/cranelift/assembler-x64/src/rex.rs
@@ -1,12 +1,10 @@
 //! Encoding logic for REX instructions.
 
-#![allow(clippy::bool_to_int_with_if)]
+// #![allow(clippy::bool_to_int_with_if)]
 
 use crate::api::CodeSink;
 
-pub(crate) fn low8_will_sign_extend_to_32(x: u32) -> bool {
-    #[allow(clippy::cast_possible_wrap)]
-    let xs = x as i32;
+pub(crate) fn low8_will_sign_extend_to_32(xs: i32) -> bool {
     xs == ((xs << 24) >> 24)
 }
 
@@ -123,7 +121,7 @@ impl RexFlags {
 }
 
 #[derive(Copy, Clone)]
-#[allow(missing_docs)]
+#[allow(missing_docs, reason = "variants are self-explanatory")]
 pub enum Imm {
     None,
     Imm8(i8),
@@ -152,9 +150,8 @@ impl Imm {
             Some(scaling) => {
                 if val % i32::from(scaling) == 0 {
                     let scaled = val / i32::from(scaling);
-                    #[allow(clippy::cast_sign_loss)]
-                    if low8_will_sign_extend_to_32(scaled as u32) {
-                        #[allow(clippy::cast_possible_truncation)]
+                    if low8_will_sign_extend_to_32(scaled) {
+                        #[allow(clippy::cast_possible_truncation, reason = "pre-existing code")]
                         return Imm::Imm8(scaled as i8);
                     }
                 }
@@ -186,7 +183,7 @@ impl Imm {
     }
 
     /// Emit the truncated immediate into the code sink.
-    #[allow(clippy::cast_sign_loss)]
+    #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
     pub fn emit(self, sink: &mut impl CodeSink) {
         match self {
             Imm::None => {}


### PR DESCRIPTION
This removes all the custom clippy allowances and just adopts the project's Clippy settings. This was suggested over in [#10216].

[#10216]: https://github.com/bytecodealliance/wasmtime/pull/10216#discussion_r1951135923

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
