### PR TITLE
winch: Sync fuel when emitting fuel checks

### DIFF
--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -259,6 +259,31 @@ fn get_fuel_clamps_at_zero(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
+#[wasmtime_test]
+#[cfg_attr(miri, ignore)]
+fn immediate_trap_with_fuel1(config: &mut Config) -> Result<()> {
+    config.consume_fuel(true);
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (func (export "main"))
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let main = instance.get_typed_func::<(), ()>(&mut store, "main")?;
+    store.set_fuel(1)?;
+
+    assert!(main.call(&mut store, ()).is_err());
+
+    Ok(())
+}
+
 #[wasmtime_test(strategies(only(Winch)))]
 #[cfg_attr(miri, ignore)]
 fn ensure_stack_alignment(config: &mut Config) -> Result<()> {

--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -14,21 +14,25 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x91
+;;       ja      0x9f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
+;;       movq    8(%r14), %rax
+;;       movq    (%rax), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rax)
 ;;       movq    8(%r14), %rcx
 ;;       movq    (%rcx), %rcx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   3d: movq    %r14, %rdi
-;;       callq   0x1f1
+;;       jl      0x58
+;;   4b: movq    %r14, %rdi
+;;       callq   0x201
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
-;;       addq    $2, %r11
+;;       addq    $1, %r11
 ;;       movq    %r11, (%rax)
 ;;       movq    0x58(%r14), %rcx
 ;;       movq    0x48(%r14), %rax
@@ -42,12 +46,12 @@
 ;;       movq    %r11, (%rax)
 ;;       movq    %r14, %rdi
 ;;       movq    %r14, %rsi
-;;       callq   0xa0
+;;       callq   0xb0
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   91: ud2
+;;   9f: ud2
 ;;
 ;; wasm[0]::function[2]::other:
 ;;       pushq   %rbp
@@ -56,23 +60,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xfe
-;;   bc: movq    %rdi, %r14
+;;       ja      0x10e
+;;   cc: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    8(%r14), %rcx
-;;       movq    (%rcx), %rcx
-;;       cmpq    $0, %rcx
-;;       jl      0xea
-;;   dd: movq    %r14, %rdi
-;;       callq   0x1f1
-;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
 ;;       addq    $1, %r11
 ;;       movq    %r11, (%rax)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x108
+;;   fb: movq    %r14, %rdi
+;;       callq   0x201
+;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   fe: ud2
+;;  10e: ud2

--- a/tests/disas/winch/x64/fuel/func.wat
+++ b/tests/disas/winch/x64/fuel/func.wat
@@ -15,17 +15,17 @@
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    8(%r14), %rcx
-;;       movq    (%rcx), %rcx
-;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   3d: movq    %r14, %rdi
-;;       callq   0x151
-;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
 ;;       addq    $1, %r11
 ;;       movq    %r11, (%rax)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x58
+;;   4b: movq    %r14, %rdi
+;;       callq   0x151
+;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/winch/x64/fuel/loop.wat
+++ b/tests/disas/winch/x64/fuel/loop.wat
@@ -17,17 +17,17 @@
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movq    8(%r14), %rcx
-;;       movq    (%rcx), %rcx
-;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   3d: movq    %r14, %rdi
-;;       callq   0x182
-;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
 ;;       addq    $1, %r11
 ;;       movq    %r11, (%rax)
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %rcx
+;;       cmpq    $0, %rcx
+;;       jl      0x58
+;;   4b: movq    %r14, %rdi
+;;       callq   0x182
+;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rcx
 ;;       movq    (%rcx), %rcx
 ;;       cmpq    $0, %rcx

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1099,6 +1099,7 @@ where
             return Ok(());
         }
 
+        self.emit_fuel_increment()?;
         let out_of_fuel = self.env.builtins.out_of_gas::<M::ABI, M::Ptr>()?;
         let fuel_reg = self.context.without::<Result<Reg>, M, _>(
             &out_of_fuel.sig().regs,


### PR DESCRIPTION
Prior to this commit, fuel consumed was not correctly updated when performing out-of-fuel checks. This is only relevant/noticeable when performing fuel checks on funciton entry, more concretely, when the store contains 1 fuel unit. Any program should immediately trap when the store contains 1 fuel unit, given that all programs should consume at least some fuel, even if empty.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
