### PR TITLE
x64: Add support for the `shld` instruction

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -195,7 +195,10 @@ impl Rex {
 
         if self.opcodes.prefix.contains_66() {
             assert!(
-                operands.iter().all(|&op| op.location.bits() == 16),
+                operands
+                    .iter()
+                    .all(|&op| matches!(op.location.kind(), OperandKind::Imm(_) | OperandKind::FixedReg(_))
+                        || op.location.bits() == 16),
                 "when we encode the 66 prefix, we expect all operands to be 16-bit wide"
             );
         }
@@ -332,7 +335,7 @@ impl From<[u8; 3]> for Opcodes {
     fn from(bytes: [u8; 3]) -> Opcodes {
         let [a, b, c] = bytes;
         match (LegacyPrefix::try_from(a), b, c) {
-            (Ok(prefix), 0x0f, primary) => Opcodes { prefix, escape: false, primary, secondary: None },
+            (Ok(prefix), 0x0f, primary) => Opcodes { prefix, escape: true, primary, secondary: None },
             (Err(0x0f), primary, secondary) => Opcodes {
                 prefix: LegacyPrefix::NoPrefix,
                 escape: true,

--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -201,6 +201,8 @@ pub enum Location {
     eax,
     rax,
 
+    cl,
+
     imm8,
     imm16,
     imm32,
@@ -222,7 +224,7 @@ impl Location {
     pub fn bits(&self) -> u8 {
         use Location::*;
         match self {
-            al | imm8 | r8 | rm8 => 8,
+            al | cl | imm8 | r8 | rm8 => 8,
             ax | imm16 | r16 | rm16 => 16,
             eax | imm32 | r32 | rm32 => 32,
             rax | r64 | rm64 => 64,
@@ -240,7 +242,7 @@ impl Location {
     pub fn uses_memory(&self) -> bool {
         use Location::*;
         match self {
-            al | ax | eax | rax | imm8 | imm16 | imm32 | r8 | r16 | r32 | r64 => false,
+            al | cl | ax | eax | rax | imm8 | imm16 | imm32 | r8 | r16 | r32 | r64 => false,
             rm8 | rm16 | rm32 | rm64 => true,
         }
     }
@@ -251,7 +253,7 @@ impl Location {
     pub fn uses_variable_register(&self) -> bool {
         use Location::*;
         match self {
-            al | ax | eax | rax | imm8 | imm16 | imm32 => false,
+            al | ax | eax | rax | cl | imm8 | imm16 | imm32 => false,
             r8 | r16 | r32 | r64 | rm8 | rm16 | rm32 | rm64 => true,
         }
     }
@@ -261,7 +263,7 @@ impl Location {
     pub fn kind(&self) -> OperandKind {
         use Location::*;
         match self {
-            al | ax | eax | rax => OperandKind::FixedReg(*self),
+            al | ax | eax | rax | cl => OperandKind::FixedReg(*self),
             imm8 | imm16 | imm32 => OperandKind::Imm(*self),
             r8 | r16 | r32 | r64 => OperandKind::Reg(*self),
             rm8 | rm16 | rm32 | rm64 => OperandKind::RegMem(*self),
@@ -277,6 +279,8 @@ impl core::fmt::Display for Location {
             ax => write!(f, "ax"),
             eax => write!(f, "eax"),
             rax => write!(f, "rax"),
+
+            cl => write!(f, "cl"),
 
             imm8 => write!(f, "imm8"),
             imm16 => write!(f, "imm16"),

--- a/cranelift/assembler-x64/meta/src/generate/operand.rs
+++ b/cranelift/assembler-x64/meta/src/generate/operand.rs
@@ -53,7 +53,7 @@ impl dsl::Location {
             None => String::new(),
         };
         match self {
-            al | ax | eax | rax => None,
+            al | ax | eax | rax | cl => None,
             imm8 => Some("Imm8".into()),
             imm16 => Some("Imm16".into()),
             imm32 => Some("Imm32".into()),
@@ -71,6 +71,7 @@ impl dsl::Location {
             ax => "\"%ax\"".into(),
             eax => "\"%eax\"".into(),
             rax => "\"%rax\"".into(),
+            cl => "\"%cl\"".into(),
             imm8 | imm16 | imm32 => {
                 if extension.is_sign_extended() {
                     let variant = extension.generate_variant();
@@ -91,7 +92,7 @@ impl dsl::Location {
     pub fn generate_size(&self) -> Option<&str> {
         use dsl::Location::*;
         match self {
-            al | ax | eax | rax | imm8 | imm16 | imm32 => None,
+            al | ax | eax | rax | cl | imm8 | imm16 | imm32 => None,
             r8 | rm8 => Some("Size::Byte"),
             r16 | rm16 => Some("Size::Word"),
             r32 | rm32 => Some("Size::Doubleword"),
@@ -105,6 +106,7 @@ impl dsl::Location {
         use dsl::Location::*;
         match self {
             al | ax | eax | rax => Some("reg::enc::RAX"),
+            cl => Some("reg::enc::RCX"),
             imm8 | imm16 | imm32 | r8 | r16 | r32 | r64 | rm8 | rm16 | rm32 | rm64 => None,
         }
     }

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -1,10 +1,14 @@
 //! Defines x64 instructions using the DSL.
 
 mod and;
+mod shld;
 
 use crate::dsl::Inst;
 
 #[must_use]
 pub fn list() -> Vec<Inst> {
-    and::list()
+    let mut ret = Vec::new();
+    ret.extend(and::list());
+    ret.extend(shld::list());
+    ret
 }

--- a/cranelift/assembler-x64/meta/src/instructions/shld.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/shld.rs
@@ -1,0 +1,13 @@
+use crate::dsl::{fmt, inst, r, rex, rw};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("shldw", fmt("MRI", [rw(rm16), r(r16), r(imm8)]), rex([0x66, 0x0F, 0xA4]).ib(), _64b | compat),
+        inst("shldw", fmt("MRC", [rw(rm16), r(r16), r(cl)]), rex([0x66, 0x0F, 0xA5]).ib(), _64b | compat),
+        inst("shldl", fmt("MRI", [rw(rm32), r(r32), r(imm8)]), rex([0x0F, 0xA4]).ib(), _64b | compat),
+        inst("shldq", fmt("MRI", [rw(rm64), r(r64), r(imm8)]), rex([0x0F, 0xA4]).ib().w(), _64b),
+        inst("shldl", fmt("MRC", [rw(rm32), r(r32), r(cl)]), rex([0x0F, 0xA5]).ib(), _64b | compat),
+        inst("shldq", fmt("MRC", [rw(rm64), r(r64), r(cl)]), rex([0x0F, 0xA5]).ib().w(), _64b),
+    ]
+}

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -29,6 +29,8 @@ pub fn roundtrip(inst: &Inst<FuzzRegs>) {
         println!("> {inst}");
         println!("  debug: {inst:x?}");
         println!("  assembled: {}", pretty_print_hexadecimal(&assembled));
+        println!("  expected (capstone): {expected}");
+        println!("  actual (to_string):  {actual}");
         assert_eq!(expected, &actual);
     }
 }
@@ -56,9 +58,17 @@ fn disassemble(assembled: &[u8]) -> String {
     let insns = cs
         .disasm_all(assembled, 0x0)
         .expect("failed to disassemble");
-    assert_eq!(insns.len(), 1, "not a single instruction: {assembled:x?}");
+    assert_eq!(insns.len(), 1, "not a single instruction: {assembled:02x?}");
     let insn = insns.first().expect("at least one instruction");
-    assert_eq!(assembled.len(), insn.len());
+    assert_eq!(
+        assembled.len(),
+        insn.len(),
+        "\ncranelift generated {} bytes: {assembled:02x?}\n\
+         capstone  generated {} bytes: {:02x?}",
+        assembled.len(),
+        insn.len(),
+        insn.bytes(),
+    );
     insn.to_string()
 }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2932,21 +2932,72 @@
 (extern extractor is_gpr_mem is_gpr_mem)
 
 ;; Helpers to auto-convert to and from assembler types.
-(decl pure convert_gpr_to_assembler_read_write_gpr (Gpr) AssemblerReadWriteGpr)
+
+;; Gpr => AssemblerReadGpr
+(decl pure convert_gpr_to_assembler_read_gpr (Gpr) AssemblerReadGpr)
+(extern constructor convert_gpr_to_assembler_read_gpr convert_gpr_to_assembler_read_gpr)
+(convert Gpr AssemblerReadGpr convert_gpr_to_assembler_read_gpr)
+
+;; Gpr => AssemblerReadGprMem
+(decl pure convert_gpr_to_assembler_read_gpr_mem (Gpr) AssemblerReadGprMem)
+(extern constructor convert_gpr_to_assembler_read_gpr_mem convert_gpr_to_assembler_read_gpr_mem)
+(convert Gpr AssemblerReadGprMem convert_gpr_to_assembler_read_gpr_mem)
+
+;; Gpr => AssemblerReadWriteGpr
+(decl convert_gpr_to_assembler_read_write_gpr (Gpr) AssemblerReadWriteGpr)
 (extern constructor convert_gpr_to_assembler_read_write_gpr convert_gpr_to_assembler_read_write_gpr)
 (convert Gpr AssemblerReadWriteGpr convert_gpr_to_assembler_read_write_gpr)
 
-(decl pure convert_assembler_read_write_gpr_to_gpr (AssemblerReadWriteGpr) Gpr)
-(extern constructor convert_assembler_read_write_gpr_to_gpr convert_assembler_read_write_gpr_to_gpr)
-(convert AssemblerReadWriteGpr Gpr convert_assembler_read_write_gpr_to_gpr)
-
+;; Gpr => AssemblerReadWriteGprMem
 (decl pure convert_gpr_to_assembler_read_write_gpr_mem (Gpr) AssemblerReadWriteGprMem)
 (extern constructor convert_gpr_to_assembler_read_write_gpr_mem convert_gpr_to_assembler_read_write_gpr_mem)
 (convert Gpr AssemblerReadWriteGprMem convert_gpr_to_assembler_read_write_gpr_mem)
 
+;; GprMem => AssemblerReadGprMem
+(decl pure convert_gpr_mem_to_assembler_read_gpr_mem (GprMem) AssemblerReadGprMem)
+(extern constructor convert_gpr_mem_to_assembler_read_gpr_mem convert_gpr_mem_to_assembler_read_gpr_mem)
+(convert GprMem AssemblerReadGprMem convert_gpr_to_assembler_read_gpr_mem)
+
+;; GprMem => AssemblerReadWriteGprMem
+(decl pure convert_gpr_mem_to_assembler_read_write_gpr_mem (GprMem) AssemblerReadWriteGprMem)
+(extern constructor convert_gpr_mem_to_assembler_read_write_gpr_mem convert_gpr_mem_to_assembler_read_write_gpr_mem)
+(convert GprMem AssemblerReadWriteGprMem convert_gpr_mem_to_assembler_read_write_gpr_mem)
+
+;; Value => AssemblerReadGpr
+(decl convert_value_to_assembler_read_gpr (Value) AssemblerReadGpr)
+(rule (convert_value_to_assembler_read_gpr val) (put_in_gpr val))
+(convert Value AssemblerReadGpr convert_value_to_assembler_read_gpr)
+
+;; Value => AssemblerReadGprMem
+(decl convert_value_to_assembler_read_gpr_mem (Value) AssemblerReadGprMem)
+(rule (convert_value_to_assembler_read_gpr_mem val)
+  (convert_gpr_mem_to_assembler_read_gpr_mem (put_in_gpr_mem val)))
+(convert Value AssemblerReadGprMem convert_value_to_assembler_read_gpr_mem)
+
+;; Value => AssemblerReadWriteGprMem
+(decl convert_value_to_assembler_read_write_gpr_mem (Value) AssemblerReadWriteGprMem)
+(rule (convert_value_to_assembler_read_write_gpr_mem val) (put_in_gpr_mem val))
+(convert Value AssemblerReadWriteGprMem convert_value_to_assembler_read_write_gpr_mem)
+
+;; AssemblerReadWriteGpr => Gpr
+(decl pure convert_assembler_read_write_gpr_to_gpr (AssemblerReadWriteGpr) Gpr)
+(extern constructor convert_assembler_read_write_gpr_to_gpr convert_assembler_read_write_gpr_to_gpr)
+(convert AssemblerReadWriteGpr Gpr convert_assembler_read_write_gpr_to_gpr)
+
+;; AssemblerReadWriteGprMem => Gpr
 (decl pure convert_assembler_read_write_gpr_mem_to_gpr (AssemblerReadWriteGprMem) Gpr)
 (extern constructor convert_assembler_read_write_gpr_mem_to_gpr convert_assembler_read_write_gpr_mem_to_gpr)
 (convert AssemblerReadWriteGprMem Gpr convert_assembler_read_write_gpr_mem_to_gpr)
+
+;; AssemblerReadWriteGprMem => InstOutput
+(decl convert_assembler_read_write_gpr_mem_to_inst_output (AssemblerReadWriteGprMem) InstOutput)
+(rule (convert_assembler_read_write_gpr_mem_to_inst_output val)
+  (let ((ret Gpr val)) ret))
+(convert AssemblerReadWriteGprMem InstOutput convert_assembler_read_write_gpr_mem_to_inst_output)
+
+(decl u8_to_assembler_imm8 (u8) AssemblerImm8)
+(extern constructor u8_to_assembler_imm8 u8_to_assembler_imm8)
+(convert u8 AssemblerImm8 u8_to_assembler_imm8)
 
 ;; Helper for emitting `and` instructions. The high-priority rules all make use
 ;; of the new assembler lowerings, but we retain the original cranelift-codegen
@@ -3129,6 +3180,13 @@
 (rule 1 (x64_sar (ty_32_or_64 ty) src1 (gpr_from_imm8_gpr src2))
         (if-let true (use_bmi2))
         (x64_sarx ty src1 src2))
+
+;; Helper for creating `shld` instructions.
+(decl x64_shld (Type Gpr Gpr u8) Gpr)
+;; NB: i8 is intentionally missing here as x64 doesn't have such an instruction
+(rule (x64_shld $I16 src1 src2 amt) (x64_shldw_mri src1 src2 amt))
+(rule (x64_shld $I32 src1 src2 amt) (x64_shldl_mri src1 src2 amt))
+(rule (x64_shld $I64 src1 src2 amt) (x64_shldq_mri src1 src2 amt))
 
 ;; Helper for creating zeroing-of-high-bits instructions bzhi
 ;;

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -472,6 +472,21 @@
 (rule 7 (lower (has_type $I128 (bor x y)))
       (or_i128 x y))
 
+;; Specialized lowerings to generate the `shld` instruction.
+;;
+;; The `shld` instruction will shift a value left and shift-in bits from a
+;; different register. Pattern-match doing this with bit-ops and shifts to
+;; generate a `shld` instruction.
+(rule 8 (lower (has_type (ty_int_ref_16_to_64 ty)
+  (bor (ishl x (u8_from_iconst xs)) (ushr y (u8_from_iconst ys)))))
+  (if-let true (u64_eq (ty_bits ty) (u64_add xs ys)))
+  (x64_shld ty x y xs))
+(rule 8 (lower (has_type (ty_int_ref_16_to_64 ty)
+  (bor (ushr y (u8_from_iconst ys)) (ishl x (u8_from_iconst xs)))))
+  (if-let true (u64_eq (ty_bits ty) (u64_add xs ys)))
+  (x64_shld ty x y xs))
+
+
 ;;;; Rules for `bxor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `{i,b}64` and smaller.

--- a/cranelift/filetests/filetests/isa/x64/shld.clif
+++ b/cranelift/filetests/filetests/isa/x64/shld.clif
@@ -1,0 +1,239 @@
+test compile precise-output
+target x86_64
+
+function %x64_shld_i32_20(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 20
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   shldl $0x14, %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   shldl $0x14, %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i32_20_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 20
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   shldl $0x14, %esi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   shldl $0x14, %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i32_28(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ushr_imm v0, 4
+    v3 = ishl_imm v1, 28
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   shldl $0x1c, %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   shldl $0x1c, %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i32_28_swap(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ishl_imm v0, 28
+    v3 = ushr_imm v1, 4
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   shldl $0x1c, %esi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   shldl $0x1c, %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i64_52(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ushr_imm v0, 12
+    v3 = ishl_imm v1, 52
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   shldq $0x34, %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   shldq $0x34, %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i64_52_swap(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = ishl_imm v0, 52
+    v3 = ushr_imm v1, 12
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   shldq $0x34, %rsi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   shldq $0x34, %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i16_3(i16, i16) -> i16 {
+block0(v0: i16, v1: i16):
+    v2 = ushr_imm v0, 3
+    v3 = ishl_imm v1, 13
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rax
+;   shldw $0xd, %di, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rsi, %rax
+;   shldw $0xd, %di, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %x64_shld_i8_3(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = ushr_imm v0, 3
+    v3 = ishl_imm v1, 5
+    v4 = bor v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   shrb    $3, %dil, %dil
+;   shlb    $5, %sil, %sil
+;   movq    %rdi, %rax
+;   orl     %eax, %esi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   shrb $3, %dil
+;   shlb $5, %sil
+;   movq %rdi, %rax
+;   orl %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/tests/disas/x64-shld.wat
+++ b/tests/disas/x64-shld.wat
@@ -1,0 +1,107 @@
+;;! target = "x86_64"
+;;! test = "compile"
+
+(module
+  (func $i32_21 (param i32 i32) (result i32)
+    local.get 0
+    i32.const 11
+    i32.shl
+    local.get 1
+    i32.const 21
+    i32.shr_u
+    i32.or)
+  (func $i32_21_swapped (param i32 i32) (result i32)
+    local.get 1
+    i32.const 21
+    i32.shr_u
+    local.get 0
+    i32.const 11
+    i32.shl
+    i32.or)
+  (func $i32_11 (param i32 i32) (result i32)
+    local.get 0
+    i32.const 21
+    i32.shl
+    local.get 1
+    i32.const 11
+    i32.shr_u
+    i32.or)
+
+  (func $i64_21 (param i64 i64) (result i64)
+    local.get 0
+    i64.const 43
+    i64.shl
+    local.get 1
+    i64.const 21
+    i64.shr_u
+    i64.or)
+  (func $i64_21_swapped (param i64 i64) (result i64)
+    local.get 1
+    i64.const 21
+    i64.shr_u
+    local.get 0
+    i64.const 43
+    i64.shl
+    i64.or)
+  (func $i64_11 (param i64 i64) (result i64)
+    local.get 0
+    i64.const 53
+    i64.shl
+    local.get 1
+    i64.const 11
+    i64.shr_u
+    i64.or)
+)
+;; wasm[0]::function[0]::i32_21:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldl   $0xb, %ecx, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[1]::i32_21_swapped:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldl   $0xb, %ecx, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[2]::i32_11:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldl   $0x15, %ecx, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[3]::i64_21:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldq   $0x2b, %rcx, %rax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[4]::i64_21_swapped:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldq   $0x2b, %rcx, %rax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[5]::i64_11:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    %rdx, %rax
+;;       shldq   $0x35, %rcx, %rax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq


### PR DESCRIPTION
This commit is similar to #10229 except that it uses the x64 `shld` instruction. This instruction was not previously supported by Cranelift so I opted to add support via the new `cranelift-assembler-x64` crate instead of trying to fit it into the existing `emit.rs`/`MInst` infrastructure. This was a good learning experience for myself and was also fun to do!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
