### PR TITLE
Add artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ examples/.cache
 cranelift/isle/veri/veri_engine/test_output
 crates/explorer/node_modules
 tests/all/pulley_provenance_test.cwasm
+artifacts


### PR DESCRIPTION
I think this is useful since the README.md in the c-api crate instructs people to run some commands building said c-api into a folder called artifacts. It is explicitly said to run the commands in the root of the wasmtime directory, and if this is not in the .gitignore file, it will be very annoying for people since git always shows changes.