### PR TITLE
Winch: Fix i8x16.max_u to use unsigned instruction

### DIFF
--- a/tests/disas/winch/x64/i8x16/max/max_u.wat
+++ b/tests/disas/winch/x64/i8x16/max/max_u.wat
@@ -17,7 +17,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x52
+;;       ja      0x51
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -26,9 +26,9 @@
 ;;       movdqu  %xmm1, (%rsp)
 ;;       movdqu  (%rsp), %xmm0
 ;;       movdqu  0x10(%rsp), %xmm1
-;;       vpmaxsb %xmm1, %xmm0, %xmm1
+;;       vpmaxub %xmm1, %xmm0, %xmm1
 ;;       movdqa  %xmm1, %xmm0
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   52: ud2
+;;   51: ud2

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -4280,7 +4280,7 @@ where
     fn visit_i8x16_max_u(&mut self) -> Self::Output {
         self.context
             .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
                 Ok(TypedReg::v128(dst))
             })
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fix implementation of `i8x16.max_u` in Winch to use unsigned machine instruction.