### PR TITLE
asm: add implementations for more ALU operations

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -88,7 +88,8 @@ impl dsl::Format {
             [FixedReg(dst), Imm(_)] => {
                 // TODO: don't emit REX byte here.
                 fmtln!(f, "let {dst} = {};", dst.generate_fixed_reg().unwrap());
-                fmtln!(f, "let digit = 0;"); // No digit for this pattern.
+                assert_eq!(rex.digit, None, "we expect no digit for operands: [FixedReg, Imm]");
+                fmtln!(f, "let digit = 0;");
                 fmtln!(f, "rex.emit_two_op(buf, digit, {dst}.enc());");
             }
             [RegMem(dst), Imm(_)] => {

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -88,21 +88,20 @@ impl dsl::Format {
             [FixedReg(dst), Imm(_)] => {
                 // TODO: don't emit REX byte here.
                 fmtln!(f, "let {dst} = {};", dst.generate_fixed_reg().unwrap());
-                fmtln!(f, "let digit = 0x{:x};", rex.digit);
+                fmtln!(f, "let digit = 0;"); // No digit for this pattern.
                 fmtln!(f, "rex.emit_two_op(buf, digit, {dst}.enc());");
             }
             [RegMem(dst), Imm(_)] => {
-                if rex.digit > 0 {
-                    fmtln!(f, "let digit = 0x{:x};", rex.digit);
-                    fmtln!(f, "match &self.{dst} {{");
-                    f.indent(|f| {
-                        fmtln!(f, "GprMem::Gpr({dst}) => rex.emit_two_op(buf, digit, {dst}.enc()),");
-                        fmtln!(f, "GprMem::Mem({dst}) => {dst}.emit_rex_prefix(rex, digit, buf),");
-                    });
-                    fmtln!(f, "}}");
-                } else {
-                    unimplemented!();
-                }
+                let digit = rex
+                    .digit
+                    .expect("REX digit must be set for operands: [RegMem, Imm]");
+                fmtln!(f, "let digit = 0x{digit:x};");
+                fmtln!(f, "match &self.{dst} {{");
+                f.indent(|f| {
+                    fmtln!(f, "GprMem::Gpr({dst}) => rex.emit_two_op(buf, digit, {dst}.enc()),");
+                    fmtln!(f, "GprMem::Mem({dst}) => {dst}.emit_rex_prefix(rex, digit, buf),");
+                });
+                fmtln!(f, "}}");
             }
             [Reg(dst), RegMem(src)] => {
                 fmtln!(f, "let {dst} = self.{dst}.enc();");
@@ -144,8 +143,10 @@ impl dsl::Format {
                 // No need to emit a ModRM byte: we know the register used.
             }
             [RegMem(dst), Imm(_)] => {
-                debug_assert!(rex.digit > 0);
-                fmtln!(f, "let digit = 0x{:x};", rex.digit);
+                let digit = rex
+                    .digit
+                    .expect("REX digit must be set for operands: [RegMem, Imm]");
+                fmtln!(f, "let digit = 0x{digit:x};");
                 fmtln!(f, "match &self.{dst} {{");
                 f.indent(|f| {
                     fmtln!(f, "GprMem::Gpr({dst}) => emit_modrm(buf, digit, {dst}.enc()),");

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -1,14 +1,22 @@
 //! Defines x64 instructions using the DSL.
 
+mod add;
 mod and;
+mod or;
 mod shld;
+mod sub;
+mod xor;
 
 use crate::dsl::Inst;
 
 #[must_use]
 pub fn list() -> Vec<Inst> {
-    let mut ret = Vec::new();
-    ret.extend(and::list());
-    ret.extend(shld::list());
-    ret
+    let mut all = vec![];
+    all.extend(add::list());
+    all.extend(and::list());
+    all.extend(or::list());
+    all.extend(shld::list());
+    all.extend(sub::list());
+    all.extend(xor::list());
+    all
 }

--- a/cranelift/assembler-x64/meta/src/instructions/add.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/add.rs
@@ -1,0 +1,44 @@
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("addb", fmt("I", [rw(al), r(imm8)]), rex(0x4).ib(), _64b | compat),
+        inst("addw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x5]).iw(), _64b | compat),
+        inst("addl", fmt("I", [rw(eax), r(imm32)]), rex(0x5).id(), _64b | compat),
+        inst("addq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x5).w().id(), _64b),
+        inst("addb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(0).ib(), _64b | compat),
+        inst("addw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(0).iw(), _64b | compat),
+        inst("addl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(0).id(), _64b | compat),
+        inst("addq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(0).id(), _64b),
+        inst("addl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(0).ib(), _64b | compat),
+        inst("addq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(0).ib(), _64b),
+        inst("addb", fmt("MR", [rw(rm8), r(r8)]), rex(0x0).r(), _64b | compat),
+        inst("addw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x1]).r(), _64b | compat),
+        inst("addl", fmt("MR", [rw(rm32), r(r32)]), rex(0x1).r(), _64b | compat),
+        inst("addq", fmt("MR", [rw(rm64), r(r64)]), rex(0x1).w().r(), _64b),
+        inst("addb", fmt("RM", [rw(r8), r(rm8)]), rex(0x2).r(), _64b | compat),
+        inst("addw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x3]).r(), _64b | compat),
+        inst("addl", fmt("RM", [rw(r32), r(rm32)]), rex(0x3).r(), _64b | compat),
+        inst("addq", fmt("RM", [rw(r64), r(rm64)]), rex(0x3).w().r(), _64b),
+        // Add with carry.
+        inst("adcb", fmt("I", [rw(al), r(imm8)]), rex(0x14).ib(), _64b | compat),
+        inst("adcw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x15]).iw(), _64b | compat),
+        inst("adcl", fmt("I", [rw(eax), r(imm32)]), rex(0x15).id(), _64b | compat),
+        inst("adcq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x15).w().id(), _64b),
+        inst("adcb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(2).ib(), _64b | compat),
+        inst("adcw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(2).iw(), _64b | compat),
+        inst("adcl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(2).id(), _64b | compat),
+        inst("adcq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(2).id(), _64b),
+        inst("adcl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(2).ib(), _64b | compat),
+        inst("adcq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(2).ib(), _64b),
+        inst("adcb", fmt("MR", [rw(rm8), r(r8)]), rex(0x10).r(), _64b | compat),
+        inst("adcw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x11]).r(), _64b | compat),
+        inst("adcl", fmt("MR", [rw(rm32), r(r32)]), rex(0x11).r(), _64b | compat),
+        inst("adcq", fmt("MR", [rw(rm64), r(r64)]), rex(0x11).w().r(), _64b),
+        inst("adcb", fmt("RM", [rw(r8), r(rm8)]), rex(0x12).r(), _64b | compat),
+        inst("adcw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x13]).r(), _64b | compat),
+        inst("adcl", fmt("RM", [rw(r32), r(rm32)]), rex(0x13).r(), _64b | compat),
+        inst("adcq", fmt("RM", [rw(r64), r(rm64)]), rex(0x13).w().r(), _64b),
+    ]
+}

--- a/cranelift/assembler-x64/meta/src/instructions/or.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/or.rs
@@ -1,0 +1,25 @@
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("orb", fmt("I", [rw(al), r(imm8)]), rex(0x0C).ib(), _64b | compat),
+        inst("orw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x0D]).iw(), _64b | compat),
+        inst("orl", fmt("I", [rw(eax), r(imm32)]), rex(0x0D).id(), _64b | compat),
+        inst("orq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x0D).w().id(), _64b),
+        inst("orb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(1).ib(), _64b | compat),
+        inst("orw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(1).iw(), _64b | compat),
+        inst("orl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(1).id(), _64b | compat),
+        inst("orq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(1).id(), _64b),
+        inst("orl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(1).ib(), _64b | compat),
+        inst("orq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(1).ib(), _64b),
+        inst("orb", fmt("MR", [rw(rm8), r(r8)]), rex(0x08).r(), _64b | compat),
+        inst("orw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x09]).r(), _64b | compat),
+        inst("orl", fmt("MR", [rw(rm32), r(r32)]), rex(0x09).r(), _64b | compat),
+        inst("orq", fmt("MR", [rw(rm64), r(r64)]), rex(0x09).w().r(), _64b),
+        inst("orb", fmt("RM", [rw(r8), r(rm8)]), rex(0x0A).r(), _64b | compat),
+        inst("orw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x0B]).r(), _64b | compat),
+        inst("orl", fmt("RM", [rw(r32), r(rm32)]), rex(0x0B).r(), _64b | compat),
+        inst("orq", fmt("RM", [rw(r64), r(rm64)]), rex(0x0B).w().r(), _64b),
+    ]
+}

--- a/cranelift/assembler-x64/meta/src/instructions/sub.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/sub.rs
@@ -1,0 +1,44 @@
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("subb", fmt("I", [rw(al), r(imm8)]), rex(0x2C).ib(), _64b | compat),
+        inst("subw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x2D]).iw(), _64b | compat),
+        inst("subl", fmt("I", [rw(eax), r(imm32)]), rex(0x2D).id(), _64b | compat),
+        inst("subq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x2D).w().id(), _64b),
+        inst("subb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(5).ib(), _64b | compat),
+        inst("subw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(5).iw(), _64b | compat),
+        inst("subl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(5).id(), _64b | compat),
+        inst("subq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(5).id(), _64b),
+        inst("subl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(5).ib(), _64b | compat),
+        inst("subq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(5).ib(), _64b),
+        inst("subb", fmt("MR", [rw(rm8), r(r8)]), rex(0x28).r(), _64b | compat),
+        inst("subw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x29]).r(), _64b | compat),
+        inst("subl", fmt("MR", [rw(rm32), r(r32)]), rex(0x29).r(), _64b | compat),
+        inst("subq", fmt("MR", [rw(rm64), r(r64)]), rex(0x29).w().r(), _64b),
+        inst("subb", fmt("RM", [rw(r8), r(rm8)]), rex(0x2A).r(), _64b | compat),
+        inst("subw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x2B]).r(), _64b | compat),
+        inst("subl", fmt("RM", [rw(r32), r(rm32)]), rex(0x2B).r(), _64b | compat),
+        inst("subq", fmt("RM", [rw(r64), r(rm64)]), rex(0x2B).w().r(), _64b),
+        // Subtract with borrow.
+        inst("sbbb", fmt("I", [rw(al), r(imm8)]), rex(0x1C).ib(), _64b | compat),
+        inst("sbbw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x1D]).iw(), _64b | compat),
+        inst("sbbl", fmt("I", [rw(eax), r(imm32)]), rex(0x1D).id(), _64b | compat),
+        inst("sbbq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x1D).w().id(), _64b),
+        inst("sbbb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(3).ib(), _64b | compat),
+        inst("sbbw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(3).iw(), _64b | compat),
+        inst("sbbl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(3).id(), _64b | compat),
+        inst("sbbq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(3).id(), _64b),
+        inst("sbbl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(3).ib(), _64b | compat),
+        inst("sbbq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(3).ib(), _64b),
+        inst("sbbb", fmt("MR", [rw(rm8), r(r8)]), rex(0x18).r(), _64b | compat),
+        inst("sbbw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x19]).r(), _64b | compat),
+        inst("sbbl", fmt("MR", [rw(rm32), r(r32)]), rex(0x19).r(), _64b | compat),
+        inst("sbbq", fmt("MR", [rw(rm64), r(r64)]), rex(0x19).w().r(), _64b),
+        inst("sbbb", fmt("RM", [rw(r8), r(rm8)]), rex(0x1A).r(), _64b | compat),
+        inst("sbbw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x1B]).r(), _64b | compat),
+        inst("sbbl", fmt("RM", [rw(r32), r(rm32)]), rex(0x1B).r(), _64b | compat),
+        inst("sbbq", fmt("RM", [rw(r64), r(rm64)]), rex(0x1B).w().r(), _64b),
+    ]
+}

--- a/cranelift/assembler-x64/meta/src/instructions/xor.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/xor.rs
@@ -1,0 +1,25 @@
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("xorb", fmt("I", [rw(al), r(imm8)]), rex(0x34).ib(), _64b | compat),
+        inst("xorw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x35]).iw(), _64b | compat),
+        inst("xorl", fmt("I", [rw(eax), r(imm32)]), rex(0x35).id(), _64b | compat),
+        inst("xorq", fmt("I_SXL", [rw(rax), sxq(imm32)]), rex(0x35).w().id(), _64b),
+        inst("xorb", fmt("MI", [rw(rm8), r(imm8)]), rex(0x80).digit(6).ib(), _64b | compat),
+        inst("xorw", fmt("MI", [rw(rm16), r(imm16)]), rex([0x66, 0x81]).digit(6).iw(), _64b | compat),
+        inst("xorl", fmt("MI", [rw(rm32), r(imm32)]), rex(0x81).digit(6).id(), _64b | compat),
+        inst("xorq", fmt("MI_SXL", [rw(rm64), sxq(imm32)]), rex(0x81).w().digit(6).id(), _64b),
+        inst("xorl", fmt("MI_SXB", [rw(rm32), sxl(imm8)]), rex(0x83).digit(6).ib(), _64b | compat),
+        inst("xorq", fmt("MI_SXB", [rw(rm64), sxq(imm8)]), rex(0x83).w().digit(6).ib(), _64b),
+        inst("xorb", fmt("MR", [rw(rm8), r(r8)]), rex(0x30).r(), _64b | compat),
+        inst("xorw", fmt("MR", [rw(rm16), r(r16)]), rex([0x66, 0x31]).r(), _64b | compat),
+        inst("xorl", fmt("MR", [rw(rm32), r(r32)]), rex(0x31).r(), _64b | compat),
+        inst("xorq", fmt("MR", [rw(rm64), r(r64)]), rex(0x31).w().r(), _64b),
+        inst("xorb", fmt("RM", [rw(r8), r(rm8)]), rex(0x32).r(), _64b | compat),
+        inst("xorw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x33]).r(), _64b | compat),
+        inst("xorl", fmt("RM", [rw(r32), r(rm32)]), rex(0x33).r(), _64b | compat),
+        inst("xorq", fmt("RM", [rw(r64), r(rm64)]), rex(0x33).w().r(), _64b),
+    ]
+}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2747,9 +2747,11 @@
 
 ;; Helper for emitting `add` instructions.
 (decl x64_add (Type Gpr GprMemImm) Gpr)
-(rule 10 (x64_add $I8  src1 (is_imm8 src2))   (x64_addb_mi src1 src2))
-(rule 9 (x64_add $I16 src1 (is_imm16 src2))   (x64_addw_mi src1 src2))
-(rule 8 (x64_add $I32 src1 (is_imm32 src2))   (x64_addl_mi src1 src2))
+(rule 12 (x64_add $I8  src1 (is_imm8 src2))   (x64_addb_mi src1 src2))
+(rule 11 (x64_add $I16 src1 (is_imm16 src2))  (x64_addw_mi src1 src2))
+(rule 10 (x64_add $I32 src1 (is_simm8 src2))  (x64_addl_mi_sxb src1 src2))
+(rule 9 (x64_add $I32 src1 (is_imm32 src2))   (x64_addl_mi src1 src2))
+(rule 8 (x64_add $I64 src1 (is_simm8 src2))   (x64_addq_mi_sxb src1 src2))
 (rule 7 (x64_add $I64 src1 (is_simm32 src2))  (x64_addq_mi_sxl src1 src2))
 (rule 6 (x64_add $I8  src1 (is_gpr src2))     (x64_addl_rm src1 src2))
 (rule 5 (x64_add $I8  src1 (is_mem src2))     (x64_addb_rm src1 src2))
@@ -2821,9 +2823,11 @@
 
 ;; Helper for emitting `sub` instructions.
 (decl x64_sub (Type Gpr GprMemImm) Gpr)
-(rule 10 (x64_sub $I8  src1 (is_imm8 src2))   (x64_subb_mi src1 src2))
-(rule 9 (x64_sub $I16 src1 (is_imm16 src2))   (x64_subw_mi src1 src2))
-(rule 8 (x64_sub $I32 src1 (is_imm32 src2))   (x64_subl_mi src1 src2))
+(rule 12 (x64_sub $I8  src1 (is_imm8 src2))   (x64_subb_mi src1 src2))
+(rule 11 (x64_sub $I16 src1 (is_imm16 src2))  (x64_subw_mi src1 src2))
+(rule 10 (x64_sub $I32 src1 (is_simm8 src2))  (x64_subl_mi_sxb src1 src2))
+(rule 9 (x64_sub $I32 src1 (is_imm32 src2))   (x64_subl_mi src1 src2))
+(rule 8 (x64_sub $I64 src1 (is_simm8 src2))   (x64_subq_mi_sxb src1 src2))
 (rule 7 (x64_sub $I64 src1 (is_simm32 src2))  (x64_subq_mi_sxl src1 src2))
 (rule 6 (x64_sub $I8  src1 (is_gpr src2))     (x64_subl_rm src1 src2))
 (rule 5 (x64_sub $I8  src1 (is_mem src2))     (x64_subb_rm src1 src2))
@@ -3025,9 +3029,11 @@
 ;; Note that, to avoid potential partial-register stalls, we use the 32-bit-wide
 ;; instruction when we know the 8-bit or 16-bit values are both in registers.
 (decl x64_and (Type Gpr GprMemImm) Gpr)
-(rule 10 (x64_and $I8  src1 (is_imm8 src2))   (x64_andb_mi src1 src2))
-(rule 9 (x64_and $I16 src1 (is_imm16 src2))   (x64_andw_mi src1 src2))
-(rule 8 (x64_and $I32 src1 (is_imm32 src2))   (x64_andl_mi src1 src2))
+(rule 12 (x64_and $I8  src1 (is_imm8 src2))   (x64_andb_mi src1 src2))
+(rule 11 (x64_and $I16 src1 (is_imm16 src2))  (x64_andw_mi src1 src2))
+(rule 10 (x64_and $I32 src1 (is_simm8 src2))  (x64_andl_mi_sxb src1 src2))
+(rule 9 (x64_and $I32 src1 (is_imm32 src2))   (x64_andl_mi src1 src2))
+(rule 8 (x64_and $I64 src1 (is_simm8 src2))   (x64_andq_mi_sxb src1 src2))
 (rule 7 (x64_and $I64 src1 (is_simm32 src2))  (x64_andq_mi_sxl src1 src2))
 (rule 6 (x64_and $I8  src1 (is_gpr src2))     (x64_andl_rm src1 src2))
 (rule 5 (x64_and $I8  src1 (is_mem src2))     (x64_andb_rm src1 src2))
@@ -3053,9 +3059,11 @@
 
 ;; Helper for emitting `or` instructions.
 (decl x64_or (Type Gpr GprMemImm) Gpr)
-(rule 10 (x64_or $I8  src1 (is_imm8 src2))   (x64_orb_mi src1 src2))
-(rule 9 (x64_or $I16 src1 (is_imm16 src2))   (x64_orw_mi src1 src2))
-(rule 8 (x64_or $I32 src1 (is_imm32 src2))   (x64_orl_mi src1 src2))
+(rule 12 (x64_or $I8  src1 (is_imm8 src2))   (x64_orb_mi src1 src2))
+(rule 11 (x64_or $I16 src1 (is_imm16 src2))  (x64_orw_mi src1 src2))
+(rule 10 (x64_or $I32 src1 (is_simm8 src2))  (x64_orl_mi_sxb src1 src2))
+(rule 9 (x64_or $I32 src1 (is_imm32 src2))   (x64_orl_mi src1 src2))
+(rule 8 (x64_or $I64 src1 (is_simm8 src2))   (x64_orq_mi_sxb src1 src2))
 (rule 7 (x64_or $I64 src1 (is_simm32 src2))  (x64_orq_mi_sxl src1 src2))
 (rule 6 (x64_or $I8  src1 (is_gpr src2))     (x64_orl_rm src1 src2))
 (rule 5 (x64_or $I8  src1 (is_mem src2))     (x64_orb_rm src1 src2))
@@ -3071,9 +3079,11 @@
 
 ;; Helper for emitting `xor` instructions.
 (decl x64_xor (Type Gpr GprMemImm) Gpr)
-(rule 10 (x64_xor $I8  src1 (is_imm8 src2))   (x64_xorb_mi src1 src2))
-(rule 9 (x64_xor $I16 src1 (is_imm16 src2))   (x64_xorw_mi src1 src2))
-(rule 8 (x64_xor $I32 src1 (is_imm32 src2))   (x64_xorl_mi src1 src2))
+(rule 12 (x64_xor $I8  src1 (is_imm8 src2))   (x64_xorb_mi src1 src2))
+(rule 11 (x64_xor $I16 src1 (is_imm16 src2))  (x64_xorw_mi src1 src2))
+(rule 10 (x64_xor $I32 src1 (is_simm8 src2))  (x64_xorl_mi_sxb src1 src2))
+(rule 9 (x64_xor $I32 src1 (is_imm32 src2))   (x64_xorl_mi src1 src2))
+(rule 8 (x64_xor $I64 src1 (is_simm8 src2))   (x64_xorq_mi_sxb src1 src2))
 (rule 7 (x64_xor $I64 src1 (is_simm32 src2))  (x64_xorq_mi_sxl src1 src2))
 (rule 6 (x64_xor $I8  src1 (is_gpr src2))     (x64_xorl_rm src1 src2))
 (rule 5 (x64_xor $I8  src1 (is_mem src2))     (x64_xorb_rm src1 src2))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2747,7 +2747,17 @@
 
 ;; Helper for emitting `add` instructions.
 (decl x64_add (Type Gpr GprMemImm) Gpr)
-(rule (x64_add ty src1 src2)
+(rule 10 (x64_add $I8  src1 (is_imm8 src2))   (x64_addb_mi src1 src2))
+(rule 9 (x64_add $I16 src1 (is_imm16 src2))   (x64_addw_mi src1 src2))
+(rule 8 (x64_add $I32 src1 (is_imm32 src2))   (x64_addl_mi src1 src2))
+(rule 7 (x64_add $I64 src1 (is_simm32 src2))  (x64_addq_mi_sxl src1 src2))
+(rule 6 (x64_add $I8  src1 (is_gpr src2))     (x64_addl_rm src1 src2))
+(rule 5 (x64_add $I8  src1 (is_mem src2))     (x64_addb_rm src1 src2))
+(rule 4 (x64_add $I16 src1 (is_gpr src2))     (x64_addl_rm src1 src2))
+(rule 3 (x64_add $I16 src1 (is_mem src2))     (x64_addw_rm src1 src2))
+(rule 2 (x64_add $I32 src1 (is_gpr_mem src2)) (x64_addl_rm src1 src2))
+(rule 1 (x64_add $I64 src1 (is_gpr_mem src2)) (x64_addq_rm src1 src2))
+(rule 0 (x64_add ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Add)
                  src1
@@ -2811,7 +2821,17 @@
 
 ;; Helper for emitting `sub` instructions.
 (decl x64_sub (Type Gpr GprMemImm) Gpr)
-(rule (x64_sub ty src1 src2)
+(rule 10 (x64_sub $I8  src1 (is_imm8 src2))   (x64_subb_mi src1 src2))
+(rule 9 (x64_sub $I16 src1 (is_imm16 src2))   (x64_subw_mi src1 src2))
+(rule 8 (x64_sub $I32 src1 (is_imm32 src2))   (x64_subl_mi src1 src2))
+(rule 7 (x64_sub $I64 src1 (is_simm32 src2))  (x64_subq_mi_sxl src1 src2))
+(rule 6 (x64_sub $I8  src1 (is_gpr src2))     (x64_subl_rm src1 src2))
+(rule 5 (x64_sub $I8  src1 (is_mem src2))     (x64_subb_rm src1 src2))
+(rule 4 (x64_sub $I16 src1 (is_gpr src2))     (x64_subl_rm src1 src2))
+(rule 3 (x64_sub $I16 src1 (is_mem src2))     (x64_subw_rm src1 src2))
+(rule 2 (x64_sub $I32 src1 (is_gpr_mem src2)) (x64_subl_rm src1 src2))
+(rule 1 (x64_sub $I64 src1 (is_gpr_mem src2)) (x64_subq_rm src1 src2))
+(rule 0 (x64_sub ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Sub)
                  src1
@@ -3033,7 +3053,17 @@
 
 ;; Helper for emitting `or` instructions.
 (decl x64_or (Type Gpr GprMemImm) Gpr)
-(rule (x64_or ty src1 src2)
+(rule 10 (x64_or $I8  src1 (is_imm8 src2))   (x64_orb_mi src1 src2))
+(rule 9 (x64_or $I16 src1 (is_imm16 src2))   (x64_orw_mi src1 src2))
+(rule 8 (x64_or $I32 src1 (is_imm32 src2))   (x64_orl_mi src1 src2))
+(rule 7 (x64_or $I64 src1 (is_simm32 src2))  (x64_orq_mi_sxl src1 src2))
+(rule 6 (x64_or $I8  src1 (is_gpr src2))     (x64_orl_rm src1 src2))
+(rule 5 (x64_or $I8  src1 (is_mem src2))     (x64_orb_rm src1 src2))
+(rule 4 (x64_or $I16 src1 (is_gpr src2))     (x64_orl_rm src1 src2))
+(rule 3 (x64_or $I16 src1 (is_mem src2))     (x64_orw_rm src1 src2))
+(rule 2 (x64_or $I32 src1 (is_gpr_mem src2)) (x64_orl_rm src1 src2))
+(rule 1 (x64_or $I64 src1 (is_gpr_mem src2)) (x64_orq_rm src1 src2))
+(rule 0 (x64_or ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Or)
                  src1
@@ -3041,7 +3071,17 @@
 
 ;; Helper for emitting `xor` instructions.
 (decl x64_xor (Type Gpr GprMemImm) Gpr)
-(rule (x64_xor ty src1 src2)
+(rule 10 (x64_xor $I8  src1 (is_imm8 src2))   (x64_xorb_mi src1 src2))
+(rule 9 (x64_xor $I16 src1 (is_imm16 src2))   (x64_xorw_mi src1 src2))
+(rule 8 (x64_xor $I32 src1 (is_imm32 src2))   (x64_xorl_mi src1 src2))
+(rule 7 (x64_xor $I64 src1 (is_simm32 src2))  (x64_xorq_mi_sxl src1 src2))
+(rule 6 (x64_xor $I8  src1 (is_gpr src2))     (x64_xorl_rm src1 src2))
+(rule 5 (x64_xor $I8  src1 (is_mem src2))     (x64_xorb_rm src1 src2))
+(rule 4 (x64_xor $I16 src1 (is_gpr src2))     (x64_xorl_rm src1 src2))
+(rule 3 (x64_xor $I16 src1 (is_mem src2))     (x64_xorw_rm src1 src2))
+(rule 2 (x64_xor $I32 src1 (is_gpr_mem src2)) (x64_xorl_rm src1 src2))
+(rule 1 (x64_xor $I64 src1 (is_gpr_mem src2)) (x64_xorq_rm src1 src2))
+(rule 0 (x64_xor ty src1 src2)
       (alu_rmi_r ty
                  (AluRmiROpcode.Xor)
                  src1

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -509,7 +509,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rdx
@@ -544,7 +544,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
@@ -577,7 +577,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
@@ -610,7 +610,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
@@ -643,7 +643,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -15,7 +15,7 @@ block0(v0: i128):
 ; block0:
 ;   lzcntq  %rsi, %rcx
 ;   lzcntq  %rdi, %rax
-;   addq    %rax, $64, %rax
+;   addq $0x40, %rax
 ;   cmpq    $64, %rcx
 ;   cmovnzq %rcx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -100,7 +100,7 @@ block0(v0: i16):
 ; block0:
 ;   movzwq  %di, %rax
 ;   lzcntq  %rax, %rax
-;   subq    %rax, $48, %rax
+;   subq $0x30, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -129,7 +129,7 @@ block0(v0: i8):
 ; block0:
 ;   movzbq  %dil, %rax
 ;   lzcntq  %rax, %rax
-;   subq    %rax, $56, %rax
+;   subq $0x38, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -18,13 +18,13 @@ block0(v0: i128):
 ;   bsrq    %rsi, %r9
 ;   cmovzq  %rcx, %r9, %r9
 ;   movl    $63, %edi
-;   subq    %rdi, %r9, %rdi
+;   subq %r9, %rdi
 ;   movabsq $-1, %rdx
 ;   bsrq    %r8, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
-;   subq    %rax, %r10, %rax
-;   addq    %rax, $64, %rax
+;   subq %r10, %rax
+;   addq $0x40, %rax
 ;   cmpq    $64, %rdi
 ;   cmovnzq %rdi, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -70,7 +70,7 @@ block0(v0: i64):
 ;   bsrq    %rdi, %r8
 ;   cmovzq  %rax, %r8, %r8
 ;   movl    $63, %eax
-;   subq    %rax, %r8, %rax
+;   subq %r8, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -103,7 +103,7 @@ block0(v0: i32):
 ;   bsrl    %edi, %r8d
 ;   cmovzl  %eax, %r8d, %r8d
 ;   movl    $31, %eax
-;   subl    %eax, %r8d, %eax
+;   subl %r8d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -137,8 +137,8 @@ block0(v0: i16):
 ;   bsrq    %rax, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
-;   subq    %rax, %r10, %rax
-;   subq    %rax, $48, %rax
+;   subq %r10, %rax
+;   subq $0x30, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -174,8 +174,8 @@ block0(v0: i8):
 ;   bsrq    %rax, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
-;   subq    %rax, %r10, %rax
-;   subq    %rax, $56, %rax
+;   subq %r10, %rax
+;   subq $0x38, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -15,7 +15,7 @@ block0(v0: i128):
 ; block0:
 ;   tzcntq  %rdi, %rax
 ;   tzcntq  %rsi, %r9
-;   addq    %r9, $64, %r9
+;   addq $0x40, %r9
 ;   cmpq    $64, %rax
 ;   cmovzq  %r9, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -99,7 +99,7 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzwl  %di, %ecx
-;   orl     %ecx, $65536, %ecx
+;   orl $0x10000, %ecx
 ;   tzcntl  %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -128,7 +128,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbl  %dil, %ecx
-;   orl     %ecx, $256, %ecx
+;   orl $0x100, %ecx
 ;   tzcntl  %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -19,7 +19,7 @@ block0(v0: i128):
 ;   movl    $64, %edi
 ;   bsfq    %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
-;   addq    %rdx, $64, %rdx
+;   addq $0x40, %rdx
 ;   cmpq    $64, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -115,7 +115,7 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzwl  %di, %ecx
-;   orl     %ecx, $65536, %ecx
+;   orl $0x10000, %ecx
 ;   movl    $16, %r9d
 ;   bsfl    %ecx, %eax
 ;   cmovzl  %r9d, %eax, %eax
@@ -148,7 +148,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbl  %dil, %ecx
-;   orl     %ecx, $256, %ecx
+;   orl $0x100, %ecx
 ;   movl    $8, %r9d
 ;   bsfl    %ecx, %eax
 ;   cmovzl  %r9d, %eax, %eax

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -107,9 +107,9 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   orq     %rax, %rdx, %rax
+;   orq %rdx, %rax
 ;   movq    %rsi, %rdx
-;   orq     %rdx, %rcx, %rdx
+;   orq %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -138,9 +138,9 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   xorq    %rax, %rdx, %rax
+;   xorq %rdx, %rax
 ;   movq    %rsi, %rdx
-;   xorq    %rdx, %rcx, %rdx
+;   xorq %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -204,13 +204,13 @@ block0(v0: i128, v1: i128):
 ;   imulq   %rdx, %rcx, %rdx
 ;   movq    %rax, %rcx
 ;   imulq   %rsi, %rcx, %rsi
-;   addq    %rdx, %rsi, %rdx
+;   addq %rsi, %rdx
 ;   movq    %rdi, %rax
 ;   movq    %rdx, %r8
 ;   mulq    %rax, %rcx, %rax, %rdx
 ;   movq    %rdx, %rcx
 ;   movq    %r8, %rdx
-;   addq    %rdx, %rcx, %rdx
+;   addq %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -325,15 +325,15 @@ block0(v0: i128, v1: i128):
 ;   movq    %r15, 32(%rsp)
 ; block0:
 ;   movq    %rdi, %rax
-;   xorq    %rax, %rdx, %rax
+;   xorq %rdx, %rax
 ;   movq    %rsi, %r8
-;   xorq    %r8, %rcx, %r8
+;   xorq %rcx, %r8
 ;   orq     %rax, %r8, %rax
 ;   setz    %al
 ;   movq    %rdi, %r8
-;   xorq    %r8, %rdx, %r8
+;   xorq %rdx, %r8
 ;   movq    %rsi, %r9
-;   xorq    %r9, %rcx, %r9
+;   xorq %rcx, %r9
 ;   orq     %r8, %r9, %r8
 ;   setnz   %r9b
 ;   cmpq    %rdx, %rdi
@@ -758,16 +758,16 @@ block0(v0: i128):
 ;   shrq    $1, %rax, %rax
 ;   movabsq $8608480567731124087, %r8
 ;   andq %r8, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq %r8, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq %r8, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   movq    %rdi, %rax
 ;   shrq    $4, %rax, %rax
-;   addq    %rax, %rdi, %rax
+;   addq %rdi, %rax
 ;   movabsq $1085102592571150095, %rdi
 ;   andq %rdi, %rax
 ;   movabsq $72340172838076673, %rdx
@@ -777,22 +777,22 @@ block0(v0: i128):
 ;   shrq    $1, %rdi, %rdi
 ;   movabsq $8608480567731124087, %rcx
 ;   andq %rcx, %rdi
-;   subq    %rsi, %rdi, %rsi
+;   subq %rdi, %rsi
 ;   shrq    $1, %rdi, %rdi
 ;   andq %rcx, %rdi
-;   subq    %rsi, %rdi, %rsi
+;   subq %rdi, %rsi
 ;   shrq    $1, %rdi, %rdi
 ;   andq %rcx, %rdi
-;   subq    %rsi, %rdi, %rsi
+;   subq %rdi, %rsi
 ;   movq    %rsi, %rdi
 ;   shrq    $4, %rdi, %rdi
-;   addq    %rdi, %rsi, %rdi
+;   addq %rsi, %rdi
 ;   movabsq $1085102592571150095, %r10
 ;   andq %r10, %rdi
 ;   movabsq $72340172838076673, %rcx
 ;   imulq   %rdi, %rcx, %rdi
 ;   shrq    $56, %rdi, %rdi
-;   addq    %rax, %rdi, %rax
+;   addq %rdi, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -863,82 +863,82 @@ block0(v0: i128):
 ;   shrq    $1, %rsi, %rsi
 ;   andq %rcx, %rsi
 ;   shlq    $1, %rdx, %rdx
-;   orq     %rdx, %rsi, %rdx
+;   orq %rsi, %rdx
 ;   movabsq $3689348814741910323, %r9
 ;   movq    %rdx, %r10
 ;   andq %r9, %r10
 ;   shrq    $2, %rdx, %rdx
 ;   andq %r9, %rdx
 ;   shlq    $2, %r10, %r10
-;   orq     %r10, %rdx, %r10
+;   orq %rdx, %r10
 ;   movabsq $1085102592571150095, %rsi
 ;   movq    %r10, %rax
 ;   andq %rsi, %rax
 ;   shrq    $4, %r10, %r10
 ;   andq %rsi, %r10
 ;   shlq    $4, %rax, %rax
-;   orq     %rax, %r10, %rax
+;   orq %r10, %rax
 ;   movabsq $71777214294589695, %rcx
 ;   movq    %rax, %rdx
 ;   andq %rcx, %rdx
 ;   shrq    $8, %rax, %rax
 ;   andq %rcx, %rax
 ;   shlq    $8, %rdx, %rdx
-;   orq     %rdx, %rax, %rdx
+;   orq %rax, %rdx
 ;   movabsq $281470681808895, %r10
 ;   movq    %rdx, %r9
 ;   andq %r10, %r9
 ;   shrq    $16, %rdx, %rdx
 ;   andq %r10, %rdx
 ;   shlq    $16, %r9, %r9
-;   orq     %r9, %rdx, %r9
+;   orq %rdx, %r9
 ;   movabsq $4294967295, %rsi
 ;   movq    %r9, %rax
 ;   andq %rsi, %rax
 ;   shrq    $32, %r9, %r9
 ;   shlq    $32, %rax, %rax
-;   orq     %rax, %r9, %rax
+;   orq %r9, %rax
 ;   movabsq $6148914691236517205, %rdx
 ;   movq    %rdi, %rcx
 ;   andq %rdx, %rcx
 ;   shrq    $1, %rdi, %rdi
 ;   andq %rdx, %rdi
 ;   shlq    $1, %rcx, %rcx
-;   orq     %rcx, %rdi, %rcx
+;   orq %rdi, %rcx
 ;   movabsq $3689348814741910323, %rdx
 ;   movq    %rcx, %r8
 ;   andq %rdx, %r8
 ;   shrq    $2, %rcx, %rcx
 ;   andq %rdx, %rcx
 ;   shlq    $2, %r8, %r8
-;   orq     %r8, %rcx, %r8
+;   orq %rcx, %r8
 ;   movabsq $1085102592571150095, %r10
 ;   movq    %r8, %r11
 ;   andq %r10, %r11
 ;   shrq    $4, %r8, %r8
 ;   andq %r10, %r8
 ;   shlq    $4, %r11, %r11
-;   orq     %r11, %r8, %r11
+;   orq %r8, %r11
 ;   movabsq $71777214294589695, %rdi
 ;   movq    %r11, %rcx
 ;   andq %rdi, %rcx
 ;   shrq    $8, %r11, %r11
 ;   andq %rdi, %r11
 ;   shlq    $8, %rcx, %rcx
-;   orq     %rcx, %r11, %rcx
+;   orq %r11, %rcx
 ;   movabsq $281470681808895, %rdx
 ;   movq    %rcx, %r8
 ;   andq %rdx, %r8
 ;   shrq    $16, %rcx, %rcx
 ;   andq %rdx, %rcx
 ;   shlq    $16, %r8, %r8
-;   orq     %r8, %rcx, %r8
+;   orq %rcx, %r8
 ;   movabsq $4294967295, %r10
 ;   movq    %r8, %rdx
 ;   andq %r10, %rdx
 ;   shrq    $32, %r8, %r8
 ;   shlq    $32, %rdx, %rdx
-;   orq     %rdx, %r8, %rdx
+;   orq %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1339,13 +1339,13 @@ block0(v0: i128):
 ;   bsrq    %rsi, %r9
 ;   cmovzq  %rcx, %r9, %r9
 ;   movl    $63, %edi
-;   subq    %rdi, %r9, %rdi
+;   subq %r9, %rdi
 ;   movabsq $-1, %rdx
 ;   bsrq    %r8, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
-;   subq    %rax, %r10, %rax
-;   addq    %rax, $64, %rax
+;   subq %r10, %rax
+;   addq $0x40, %rax
 ;   cmpq    $64, %rdi
 ;   cmovnzq %rdi, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -1393,7 +1393,7 @@ block0(v0: i128):
 ;   movl    $64, %edi
 ;   bsfq    %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
-;   addq    %rdx, $64, %rdx
+;   addq $0x40, %rdx
 ;   cmpq    $64, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -1469,12 +1469,12 @@ block0(v0: i128, v1: i128):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
@@ -1526,12 +1526,12 @@ block0(v0: i128, v1: i128):
 ;   movq    %rcx, %r11
 ;   movl    $64, %ecx
 ;   movq    %r11, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
 ;   cmovzq  %rsi, %rax, %rax
@@ -1585,13 +1585,13 @@ block0(v0: i128, v1: i128):
 ;   movq    %rcx, %r11
 ;   movl    $64, %ecx
 ;   movq    %r11, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r9
 ;   shlq    %cl, %r9, %r9
 ;   xorq    %r11, %r11, %r11
 ;   testq   $127, %rax
 ;   cmovzq  %r11, %r9, %r9
-;   orq     %rdi, %r9, %rdi
+;   orq %r9, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
@@ -1651,38 +1651,38 @@ block0(v0: i128, v1: i128):
 ;   shlq    %cl, %r11, %r11
 ;   movl    $64, %ecx
 ;   movq    %r8, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rdi, %r10
 ;   shrq    %cl, %r10, %r10
 ;   xorq    %rax, %rax, %rax
 ;   movq    %r8, %rcx
 ;   testq   $127, %rcx
 ;   cmovzq  %rax, %r10, %r10
-;   orq     %r10, %r11, %r10
+;   orq %r11, %r10
 ;   testq   $64, %rcx
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movl    $128, %ecx
 ;   movq    %r8, %r10
-;   subq    %rcx, %r10, %rcx
+;   subq %r10, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
 ;   movq    %rcx, %r8
 ;   movl    $64, %ecx
 ;   movq    %r8, %r10
-;   subq    %rcx, %r10, %rcx
+;   subq %r10, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %r8, %r8, %r8
 ;   testq   $127, %r10
 ;   cmovzq  %r8, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %r10
 ;   movq    %r9, %r10
 ;   cmovzq  %rsi, %r10, %r10
 ;   cmovzq  %r9, %r8, %r8
-;   orq     %rax, %r10, %rax
-;   orq     %rdx, %r8, %rdx
+;   orq %r10, %rax
+;   orq %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1756,37 +1756,37 @@ block0(v0: i128, v1: i128):
 ;   shrq    %cl, %r10, %r10
 ;   movl    $64, %ecx
 ;   movq    %r9, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r11
 ;   shlq    %cl, %r11, %r11
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %r9, %rcx
 ;   testq   $127, %rcx
 ;   cmovzq  %rdx, %r11, %r11
-;   orq     %r11, %r8, %r11
+;   orq %r8, %r11
 ;   testq   $64, %rcx
 ;   movq    %r10, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movl    $128, %ecx
 ;   movq    %r9, %r10
-;   subq    %rcx, %r10, %rcx
+;   subq %r10, %rcx
 ;   movq    %rdi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   subq    %rcx, %r9, %rcx
+;   subq %r9, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %r11, %r11, %r11
 ;   testq   $127, %r9
 ;   cmovzq  %r11, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r9
 ;   cmovzq  %r8, %r11, %r11
 ;   cmovzq  %rdi, %r8, %r8
-;   orq     %rax, %r11, %rax
-;   orq     %rdx, %r8, %rdx
+;   orq %r11, %rax
+;   orq %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -23,12 +23,12 @@ block0(v0: i64, v1: i64):
 ;   lea     0(%rdi,%r10,1), %r10
 ;   movq    %r10, 0(%rsi)
 ;   movq    %rdi, %r11
-;   subq    %r11, const(0), %r11
+;   subq (%rip), %r11
 ;   movq    %r11, 0(%rsi)
 ;   movq    %rdi, %rax
 ;   andq (%rip), %rax
 ;   movq    %rax, 0(%rsi)
-;   orq     %rdi, const(0), %rdi
+;   orq (%rip), %rdi
 ;   movq    %rdi, 0(%rsi)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -25,12 +25,12 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
@@ -81,12 +81,12 @@ block0(v0: i128, v1: i64):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
@@ -138,12 +138,12 @@ block0(v0: i128, v1: i32):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
@@ -195,12 +195,12 @@ block0(v0: i128, v1: i16):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
@@ -252,12 +252,12 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
-;   subq    %rcx, %r8, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -13,7 +13,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
-;   addl    %eax, 0(%rdi), %eax
+;   addl (%rdi), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -41,7 +41,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
-;   addl    %eax, 0(%rdi), %eax
+;   addl (%rdi), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -69,7 +69,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
-;   addq    %rax, 0(%rdi), %rax
+;   addq (%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -97,7 +97,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
-;   addq    %rax, 0(%rdi), %rax
+;   addq (%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  0(%rdi), %rax
-;   addl    %eax, %esi, %eax
+;   addl %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -15,16 +15,16 @@ block0(v0: i64):
 ;   shrq    $1, %rax, %rax
 ;   movabsq $8608480567731124087, %rdx
 ;   andq %rdx, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq %rdx, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq %rdx, %rax
-;   subq    %rdi, %rax, %rdi
+;   subq %rax, %rdi
 ;   movq    %rdi, %rax
 ;   shrq    $4, %rax, %rax
-;   addq    %rax, %rdi, %rax
+;   addq %rdi, %rax
 ;   movabsq $1085102592571150095, %r11
 ;   andq %r11, %rax
 ;   movabsq $72340172838076673, %rcx
@@ -78,16 +78,16 @@ block0(v0: i64):
 ;   shrq    $1, %rcx, %rcx
 ;   movabsq $8608480567731124087, %r8
 ;   andq %r8, %rcx
-;   subq    %rdx, %rcx, %rdx
+;   subq %rcx, %rdx
 ;   shrq    $1, %rcx, %rcx
 ;   andq %r8, %rcx
-;   subq    %rdx, %rcx, %rdx
+;   subq %rcx, %rdx
 ;   shrq    $1, %rcx, %rcx
 ;   andq %r8, %rcx
-;   subq    %rdx, %rcx, %rdx
+;   subq %rcx, %rdx
 ;   movq    %rdx, %rax
 ;   shrq    $4, %rax, %rax
-;   addq    %rax, %rdx, %rax
+;   addq %rdx, %rax
 ;   movabsq $1085102592571150095, %rsi
 ;   andq %rsi, %rax
 ;   movabsq $72340172838076673, %rdx
@@ -140,16 +140,16 @@ block0(v0: i32):
 ;   shrl    $1, %eax, %eax
 ;   movl    $2004318071, %edx
 ;   andl %edx, %eax
-;   subl    %edi, %eax, %edi
+;   subl %eax, %edi
 ;   shrl    $1, %eax, %eax
 ;   andl %edx, %eax
-;   subl    %edi, %eax, %edi
+;   subl %eax, %edi
 ;   shrl    $1, %eax, %eax
 ;   andl %edx, %eax
-;   subl    %edi, %eax, %edi
+;   subl %eax, %edi
 ;   movq    %rdi, %r9
 ;   shrl    $4, %r9d, %r9d
-;   addl    %r9d, %edi, %r9d
+;   addl %edi, %r9d
 ;   andl $0xf0f0f0f, %r9d
 ;   imull   %r9d, 0x1010101, %eax
 ;   shrl    $24, %eax, %eax
@@ -199,16 +199,16 @@ block0(v0: i64):
 ;   shrl    $1, %ecx, %ecx
 ;   movl    $2004318071, %r8d
 ;   andl %r8d, %ecx
-;   subl    %eax, %ecx, %eax
+;   subl %ecx, %eax
 ;   shrl    $1, %ecx, %ecx
 ;   andl %r8d, %ecx
-;   subl    %eax, %ecx, %eax
+;   subl %ecx, %eax
 ;   shrl    $1, %ecx, %ecx
 ;   andl %r8d, %ecx
-;   subl    %eax, %ecx, %eax
+;   subl %ecx, %eax
 ;   movq    %rax, %r10
 ;   shrl    $4, %r10d, %r10d
-;   addl    %r10d, %eax, %r10d
+;   addl %eax, %r10d
 ;   andl $0xf0f0f0f, %r10d
 ;   imull   %r10d, 0x1010101, %eax
 ;   shrl    $24, %eax, %eax

--- a/cranelift/filetests/filetests/isa/x64/shld.clif
+++ b/cranelift/filetests/filetests/isa/x64/shld.clif
@@ -219,7 +219,7 @@ block0(v0: i8, v1: i8):
 ;   shrb    $3, %dil, %dil
 ;   shlb    $5, %sil, %sil
 ;   movq    %rdi, %rax
-;   orl     %eax, %esi, %eax
+;   orl %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -917,7 +917,7 @@ block0(v0: i8x16, v1: i32):
 ;   andq $0x7, %rdi
 ;   vpunpcklbw %xmm0, %xmm0, %xmm5
 ;   vpunpckhbw %xmm0, %xmm0, %xmm7
-;   addl    %edi, $8, %edi
+;   addl $0x8, %edi
 ;   vmovd   %edi, %xmm3
 ;   vpsraw  %xmm5, %xmm3, %xmm5
 ;   vpsraw  %xmm7, %xmm3, %xmm7

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -1400,7 +1400,7 @@ block0(v0: i8x16, v1: i32):
 ;   andq $7, %rdi
 ;   vmovd %edi, %xmm5
 ;   vpsllw %xmm5, %xmm0, %xmm7
-;   leaq 0x16(%rip), %rsi
+;   leaq 0x19(%rip), %rsi
 ;   shlq $4, %rdi
 ;   vmovdqu (%rsi, %rdi), %xmm5
 ;   vpand %xmm5, %xmm7, %xmm0
@@ -1409,6 +1409,8 @@ block0(v0: i8x16, v1: i32):
 ;   retq
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %i8x16_shl_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):
@@ -1636,7 +1638,7 @@ block0(v0: i8x16, v1: i32):
 ;   andq $7, %rdi
 ;   vmovd %edi, %xmm5
 ;   vpsrlw %xmm5, %xmm0, %xmm7
-;   leaq 0x16(%rip), %rsi
+;   leaq 0x19(%rip), %rsi
 ;   shlq $4, %rdi
 ;   vpand (%rsi, %rdi), %xmm7, %xmm0
 ;   movq %rbp, %rsp
@@ -1646,6 +1648,8 @@ block0(v0: i8x16, v1: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %i8x16_ushr_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -345,7 +345,7 @@ block0(v0: i32):
 ;   andq $7, %rdi
 ;   movd %edi, %xmm5
 ;   psllw %xmm5, %xmm0
-;   leaq 0x2e(%rip), %rsi
+;   leaq 0x31(%rip), %rsi
 ;   shlq $4, %rdi
 ;   movdqu (%rsi, %rdi), %xmm5
 ;   pand %xmm5, %xmm0
@@ -358,9 +358,12 @@ block0(v0: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb %al, (%rcx)
-;   addb (%rbx), %al
-;   addb $5, %al
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rdx)
+;   addl 0x9080706(, %rax), %eax
+;   orb (%rbx), %cl
+;   orb $0xd, %al
 
 function %ishl_i8x16_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):
@@ -632,6 +635,9 @@ block0(v0: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 ;   addb %al, (%rcx)
 ;   addb (%rbx), %al
 ;   addb $5, %al
@@ -899,7 +905,7 @@ block0(v0: i64x2, v1: i32):
 ; block1: ; offset 0x4
 ;   andq $0x3f, %rdi
 ;   movq %rdi, %xmm5
-;   movdqu 0x28(%rip), %xmm1
+;   movdqu 0x2b(%rip), %xmm1
 ;   psrlq %xmm5, %xmm1
 ;   psrlq %xmm5, %xmm0
 ;   movdqa %xmm0, %xmm7
@@ -918,7 +924,7 @@ block0(v0: i64x2, v1: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb $0, (%rax)
+;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -602,7 +602,7 @@ block0(v0: i32):
 ;   movdqa  %xmm1, %xmm0
 ;   punpcklbw %xmm0, %xmm1, %xmm0
 ;   punpckhbw %xmm1, %xmm1, %xmm1
-;   addl    %edi, $8, %edi
+;   addl $0x8, %edi
 ;   movd    %edi, %xmm3
 ;   psraw   %xmm0, %xmm3, %xmm0
 ;   psraw   %xmm1, %xmm3, %xmm1
@@ -632,12 +632,9 @@ block0(v0: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb %al, (%rax)
-;   addb %al, (%rax)
-;   addl %eax, (%rdx)
-;   addl 0x9080706(, %rax), %eax
-;   orb (%rbx), %cl
-;   orb $0xd, %al
+;   addb %al, (%rcx)
+;   addb (%rbx), %al
+;   addb $5, %al
 
 function %sshr_i8x16_imm(i8x16, i32) -> i8x16 {
 block0(v0: i8x16, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -24,13 +24,13 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r11
 ;   movl    $64, %ecx
 ;   movq    %r11, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r9
 ;   shlq    %cl, %r9, %r9
 ;   xorq    %r11, %r11, %r11
 ;   testq   $127, %rax
 ;   cmovzq  %r11, %r9, %r9
-;   orq     %rdi, %r9, %rdi
+;   orq %r9, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
@@ -88,13 +88,13 @@ block0(v0: i128, v1: i64):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
 ;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %rdi, %r8, %rdi
+;   orq %r8, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -153,13 +153,13 @@ block0(v0: i128, v1: i32):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
 ;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %rdi, %r8, %rdi
+;   orq %r8, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -218,13 +218,13 @@ block0(v0: i128, v1: i16):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
 ;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %rdi, %r8, %rdi
+;   orq %r8, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -283,13 +283,13 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
 ;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %rdi, %r8, %rdi
+;   orq %r8, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -229,7 +229,7 @@ block0(v0: i64, v1: i64):
 ;   lea     0(%r9,%rdx,1), %rdx
 ;   lea     0(%r8,%rdx,1), %rdx
 ;   movq    rsp(24 + virtual offset), %r8
-;   addq    %r11, 0(%r8), %r11
+;   addq (%r8), %r11
 ;   movq    rsp(0 + virtual offset), %rdi
 ;   lea     0(%r11,%rdi,1), %r8
 ;   lea     0(%rdx,%r8,1), %rax

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -43,7 +43,7 @@ block0(v0: i64, v1: i64):
 ;   lea     rbp(stack args max - 64), %rcx
 ;   movzbq  0(%rdi), %rax
 ;   movzbq  0(%rcx), %r9
-;   addl    %eax, %r9d, %eax
+;   addl %r9d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -165,7 +165,7 @@ block0(v0: i64, v1: i64):
 ;   lea     rbp(stack args max - 64), %rcx
 ;   movzbq  0(%rsi), %rax
 ;   movzbq  0(%rcx), %r9
-;   addl    %eax, %r9d, %eax
+;   addl %r9d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -86,7 +86,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   %rsi, %rsi
 ;   jz #trap=user1
 ;   movq    %rbp, %rsp
@@ -144,7 +144,7 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   %rsi, %rsi
 ;   jnz #trap=user1
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -23,12 +23,12 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
 ;   cmovzq  %rsi, %rax, %rax
@@ -81,12 +81,12 @@ block0(v0: i128, v1: i64):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
@@ -140,12 +140,12 @@ block0(v0: i128, v1: i32):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
@@ -199,12 +199,12 @@ block0(v0: i128, v1: i16):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
@@ -258,12 +258,12 @@ block0(v0: i128, v1: i8):
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %rax
-;   subq    %rcx, %rax, %rcx
+;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
-;   orq     %rsi, %rdi, %rsi
+;   orq %rdi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -25,13 +25,13 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x28
-;;   1b: movq    0x50(%rdi), %rsi
+;;       ja      0x25
+;;   18: movq    0x50(%rdi), %rsi
 ;;       movl    %ecx, (%rsi, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   28: ud2
+;;   25: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
@@ -40,10 +40,10 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x68
-;;   5b: movq    0x50(%rdi), %rsi
+;;       ja      0x65
+;;   58: movq    0x50(%rdi), %rsi
 ;;       movl    (%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -25,13 +25,13 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x25
-;;   18: movq    0x50(%rdi), %rsi
+;;       ja      0x28
+;;   1b: movq    0x50(%rdi), %rsi
 ;;       movl    %ecx, (%rsi, %r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
+;;   28: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
@@ -40,10 +40,10 @@
 ;;       movl    %edx, %r10d
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %r10
-;;       ja      0x65
-;;   58: movq    0x50(%rdi), %rsi
+;;       ja      0x68
+;;   5b: movq    0x50(%rdi), %rsi
 ;;       movl    (%rsi, %r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   68: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;       movq    0x58(%rdi), %r8
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x22
-;;   15: movq    0x50(%rdi), %r11
+;;       ja      0x25
+;;   18: movq    0x50(%rdi), %r11
 ;;       movl    %ecx, (%r11, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   22: ud2
+;;   25: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
@@ -38,10 +38,10 @@
 ;;       movq    0x58(%rdi), %r8
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x62
-;;   55: movq    0x50(%rdi), %r11
+;;       ja      0x65
+;;   58: movq    0x50(%rdi), %r11
 ;;       movl    (%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   62: ud2
+;;   65: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;       movq    0x58(%rdi), %r8
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x25
-;;   18: movq    0x50(%rdi), %r11
+;;       ja      0x22
+;;   15: movq    0x50(%rdi), %r11
 ;;       movl    %ecx, (%r11, %rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   25: ud2
+;;   22: ud2
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
@@ -38,10 +38,10 @@
 ;;       movq    0x58(%rdi), %r8
 ;;       subq    $4, %r8
 ;;       cmpq    %r8, %rdx
-;;       ja      0x65
-;;   58: movq    0x50(%rdi), %r11
+;;       ja      0x62
+;;   55: movq    0x50(%rdi), %r11
 ;;       movl    (%r11, %rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   62: ud2


### PR DESCRIPTION
This adds DSL definitions in the assembler _and_ uses the new instructions for ISLE lowering for the following instructions:
- `add`
- `adc`
- `or`
- `sub`
- `sbb`
- `xor`

The original `AluRmiROpcode` variants are not yet gone; perhaps in a future pass.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
