### PR TITLE
Winch: Refactor masm signatures to take kinds

### DIFF
--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -13,12 +13,13 @@ use crate::{
         CallingConvention,
     },
     masm::{
-        CalleeKind, DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, HandleOverflowKind,
-        Imm as I, IntCmpKind, LoadKind, MacroAssembler as Masm, MaxKind, MinKind, MulWideKind,
-        OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
-        SplatKind, StackSlot, StoreKind, TrapCode, TruncKind, V128AbsKind, V128ConvertKind,
-        V128ExtendKind, V128NarrowKind, V128TruncSatKind, VectorCompareKind, VectorEqualityKind,
-        Zero, TRUSTED_FLAGS, UNTRUSTED_FLAGS,
+        CalleeKind, DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I,
+        IntCmpKind, LoadKind, MacroAssembler as Masm, MulWideKind, OperandSize, RegImm, RemKind,
+        ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind, SplatKind, StackSlot, StoreKind,
+        TrapCode, TruncKind, V128AbsKind, V128AddKind, V128ConvertKind, V128ExtAddKind,
+        V128ExtMulKind, V128ExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind,
+        V128NegKind, V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero,
+        TRUSTED_FLAGS, UNTRUSTED_FLAGS,
     },
     stack::TypedReg,
 };
@@ -1134,8 +1135,7 @@ impl Masm for MacroAssembler {
         _lhs: Reg,
         _rhs: Reg,
         _dst: WritableReg,
-        _size: OperandSize,
-        _handle_overflow: HandleOverflowKind,
+        _kind: V128AddKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1145,8 +1145,7 @@ impl Masm for MacroAssembler {
         _lhs: Reg,
         _rhs: Reg,
         _dst: WritableReg,
-        _size: OperandSize,
-        _handle_overflow: HandleOverflowKind,
+        _kind: V128SubKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1154,7 +1153,7 @@ impl Masm for MacroAssembler {
     fn v128_mul(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _lane_width: OperandSize,
+        _kind: V128MulKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1163,7 +1162,7 @@ impl Masm for MacroAssembler {
         bail!(CodeGenError::unimplemented_masm_instruction())
     }
 
-    fn v128_neg(&mut self, _op: WritableReg, _size: OperandSize) -> Result<()> {
+    fn v128_neg(&mut self, _op: WritableReg, _kind: V128NegKind) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
 
@@ -1197,7 +1196,7 @@ impl Masm for MacroAssembler {
     fn v128_trunc_sat(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _kind: V128TruncSatKind,
+        _kind: V128TruncKind,
     ) -> Result<()> {
         bail!(CodeGenError::unimplemented_masm_instruction())
     }
@@ -1207,8 +1206,7 @@ impl Masm for MacroAssembler {
         _src1: Reg,
         _src2: Reg,
         _dst: WritableReg,
-        _lane_width: OperandSize,
-        _kind: MinKind,
+        _kind: V128MinKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1218,8 +1216,7 @@ impl Masm for MacroAssembler {
         _src1: Reg,
         _src2: Reg,
         _dst: WritableReg,
-        _lane_width: OperandSize,
-        _kind: MaxKind,
+        _kind: V128MaxKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1227,8 +1224,7 @@ impl Masm for MacroAssembler {
     fn v128_extmul(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _lane_width: OperandSize,
-        _kind: crate::masm::ExtMulKind,
+        _kind: V128ExtMulKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }
@@ -1237,8 +1233,7 @@ impl Masm for MacroAssembler {
         &mut self,
         _src: Reg,
         _dst: WritableReg,
-        _lane_width: OperandSize,
-        _kind: crate::masm::ExtAddKind,
+        _kind: V128ExtAddKind,
     ) -> Result<()> {
         Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -38,40 +38,36 @@ impl RemKind {
     }
 }
 
-/// Min operation kind.
-pub(crate) enum MinKind {
-    /// Signed min.
-    Signed,
-    /// Unsigned min.
-    Unsigned,
+/// Kinds of vector min operation supported by WebAssembly.
+pub(crate) enum V128MinKind {
+    /// 16 lanes of signed 8-bit integers.
+    I8x16S,
+    /// 16 lanes of unsigned 8-bit integers.
+    I8x16U,
+    /// 8 lanes of signed 16-bit integers.
+    I16x8S,
+    /// 8 lanes of unsigned 16-bit integers.
+    I16x8U,
+    /// 4 lanes of signed 32-bit integers.
+    I32x4S,
+    /// 4 lanes of unsigned 32-bit integers.
+    I32x4U,
 }
 
-/// Max operation kind.
-pub(crate) enum MaxKind {
-    /// Signed max.
-    Signed,
-    /// Unsigned max.
-    Unsigned,
-}
-
-/// Kind of extend-multiply.
-pub(crate) enum ExtMulKind {
-    // Sign-extend higher-half of each lane.
-    HighSigned,
-    // Sign-extend lower-half of each lane.
-    LowSigned,
-    // Extend higher-half of each lane.
-    HighUnsigned,
-    // Extend lower-half of each lane.
-    LowUnsigned,
-}
-
-/// Kind of pairwise extend-add.
-pub(crate) enum ExtAddKind {
-    /// Signed pairwise extend add.
-    Signed,
-    /// Unsigned pairwise extend add.
-    Unsigned,
+/// Kinds of vector max operation supported by WebAssembly.
+pub(crate) enum V128MaxKind {
+    /// 16 lanes of signed 8-bit integers.
+    I8x16S,
+    /// 16 lanes of unsigned 8-bit integers.
+    I8x16U,
+    /// 8 lanes of signed 16-bit integers.
+    I16x8S,
+    /// 8 lanes of unsigned 16-bit integers.
+    I16x8U,
+    /// 4 lanes of signed 32-bit integers.
+    I32x4S,
+    /// 4 lanes of unsigned 32-bit integers.
+    I32x4U,
 }
 
 #[derive(Eq, PartialEq)]
@@ -259,16 +255,6 @@ pub(crate) enum Extend<T: ExtendType> {
     /// This is `Signed` or `Zero`, that are empty enums, which means that this variant cannot be
     /// constructed.
     __Kind(T),
-}
-
-/// How to handle overflow.
-pub enum HandleOverflowKind {
-    /// Do nothing.
-    None,
-    /// Perform signed saturation.
-    SignedSaturating,
-    /// Perform unsigned saturation.
-    UnsignedSaturating,
 }
 
 impl From<Extend<Zero>> for ExtendKind {
@@ -740,30 +726,181 @@ impl V128AbsKind {
     }
 }
 
-/// Kinds of saturating truncation for vectors supported by WebAssembly.
-pub(crate) enum V128TruncSatKind {
-    /// Signed F32x4.
-    F32x4S,
-    /// Unsigned F32x4.
-    F32x4U,
-    /// Signed F64x2.
-    F64x2SZero,
-    /// Unsigned F64x2.
-    F64x2UZero,
+/// Kinds of truncation for vectors supported by WebAssembly.
+pub(crate) enum V128TruncKind {
+    /// Integers from signed F32x4.
+    I32x4FromF32x4S,
+    /// Integers from unsigned F32x4.
+    I32x4FromF32x4U,
+    /// Integers from signed F64x2.
+    I32x4FromF64x2SZero,
+    /// Integers from unsigned F64x2.
+    I32x4FromF64x2UZero,
 }
 
-impl V128TruncSatKind {
+impl V128TruncKind {
     /// The size of the source lanes.
     pub(crate) fn src_lane_size(&self) -> OperandSize {
         match self {
-            V128TruncSatKind::F32x4S | V128TruncSatKind::F32x4U => OperandSize::S32,
-            V128TruncSatKind::F64x2SZero | V128TruncSatKind::F64x2UZero => OperandSize::S64,
+            V128TruncKind::I32x4FromF32x4S | V128TruncKind::I32x4FromF32x4U => OperandSize::S32,
+            V128TruncKind::I32x4FromF64x2SZero | V128TruncKind::I32x4FromF64x2UZero => {
+                OperandSize::S64
+            }
         }
     }
 
     /// The size of the destination lanes.
     pub(crate) fn dst_lane_size(&self) -> OperandSize {
         OperandSize::S32
+    }
+}
+
+/// Kinds of vector addition supported by WebAssembly.
+pub(crate) enum V128AddKind {
+    /// 16 lanes of 8-bit integers wrapping.
+    I8x16,
+    /// 16 lanes of 8-bit integers signed saturating.
+    I8x16SatS,
+    /// 16 lanes of 8-bit integers unsigned saturating.
+    I8x16SatU,
+    /// 8 lanes of 16-bit integers wrapping.
+    I16x8,
+    /// 8 lanes of 16-bit integers signed saturating.
+    I16x8SatS,
+    /// 8 lanes of 16-bit integers unsigned saturating.
+    I16x8SatU,
+    /// 4 lanes of 32-bit integers wrapping.
+    I32x4,
+    /// 2 lanes of 64-bit integers wrapping.
+    I64x2,
+}
+
+/// Kinds of vector subtraction supported by WebAssembly.
+pub(crate) enum V128SubKind {
+    /// 16 lanes of 8-bit integers wrapping.
+    I8x16,
+    /// 16 lanes of 8-bit integers signed saturating.
+    I8x16SatS,
+    /// 16 lanes of 8-bit integers unsigned saturating.
+    I8x16SatU,
+    /// 8 lanes of 16-bit integers wrapping.
+    I16x8,
+    /// 8 lanes of 16-bit integers signed saturating.
+    I16x8SatS,
+    /// 8 lanes of 16-bit integers unsigned saturating.
+    I16x8SatU,
+    /// 4 lanes of 32-bit integers wrapping.
+    I32x4,
+    /// 2 lanes of 64-bit integers wrapping.
+    I64x2,
+}
+
+impl From<V128NegKind> for V128SubKind {
+    fn from(value: V128NegKind) -> Self {
+        match value {
+            V128NegKind::I8x16 => Self::I8x16,
+            V128NegKind::I16x8 => Self::I16x8,
+            V128NegKind::I32x4 => Self::I32x4,
+            V128NegKind::I64x2 => Self::I64x2,
+        }
+    }
+}
+
+/// Kinds of vector multiplication supported by WebAssembly.
+pub(crate) enum V128MulKind {
+    /// 8 lanes of 16-bit integers.
+    I16x8,
+    /// 4 lanes of 32-bit integers.
+    I32x4,
+    /// 2 lanes of 64-bit integers.
+    I64x2,
+}
+
+/// Kinds of vector negation supported by WebAssembly.
+pub(crate) enum V128NegKind {
+    /// 16 lanes of 8-bit integers.
+    I8x16,
+    /// 8 lanes of 16-bit integers.
+    I16x8,
+    /// 4 lanes of 32-bit integers.
+    I32x4,
+    /// 2 lanes of 64-bit integers.
+    I64x2,
+}
+
+/// Kinds of extended pairwise addition supported by WebAssembly.
+pub(crate) enum V128ExtAddKind {
+    /// 16 lanes of signed 8-bit integers.
+    I8x16S,
+    /// 16 lanes of unsigned 8-bit integers.
+    I8x16U,
+    /// 8 lanes of signed 16-bit integers.
+    I16x8S,
+    /// 8 lanes of unsigned 16-bit integers.
+    I16x8U,
+}
+
+impl From<V128ExtAddKind> for V128AddKind {
+    fn from(value: V128ExtAddKind) -> Self {
+        match value {
+            V128ExtAddKind::I8x16S | V128ExtAddKind::I8x16U => Self::I16x8,
+            V128ExtAddKind::I16x8S | V128ExtAddKind::I16x8U => Self::I32x4,
+        }
+    }
+}
+
+/// Kinds of vector extended multiplication supported by WebAssembly.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum V128ExtMulKind {
+    LowI8x16S,
+    HighI8x16S,
+    LowI8x16U,
+    HighI8x16U,
+    LowI16x8S,
+    HighI16x8S,
+    LowI16x8U,
+    HighI16x8U,
+    LowI32x4S,
+    HighI32x4S,
+    LowI32x4U,
+    HighI32x4U,
+}
+
+impl From<V128ExtMulKind> for V128ExtendKind {
+    fn from(value: V128ExtMulKind) -> Self {
+        match value {
+            V128ExtMulKind::LowI8x16S => Self::LowI8x16S,
+            V128ExtMulKind::HighI8x16S => Self::HighI8x16S,
+            V128ExtMulKind::LowI8x16U => Self::LowI8x16U,
+            V128ExtMulKind::HighI8x16U => Self::HighI8x16U,
+            V128ExtMulKind::LowI16x8S => Self::LowI16x8S,
+            V128ExtMulKind::HighI16x8S => Self::HighI16x8S,
+            V128ExtMulKind::LowI16x8U => Self::LowI16x8U,
+            V128ExtMulKind::HighI16x8U => Self::HighI16x8U,
+            V128ExtMulKind::LowI32x4S => Self::LowI32x4S,
+            V128ExtMulKind::HighI32x4S => Self::HighI32x4S,
+            V128ExtMulKind::LowI32x4U => Self::LowI32x4U,
+            V128ExtMulKind::HighI32x4U => Self::HighI32x4U,
+        }
+    }
+}
+
+impl From<V128ExtMulKind> for V128MulKind {
+    fn from(value: V128ExtMulKind) -> Self {
+        match value {
+            V128ExtMulKind::LowI8x16S
+            | V128ExtMulKind::HighI8x16S
+            | V128ExtMulKind::LowI8x16U
+            | V128ExtMulKind::HighI8x16U => Self::I16x8,
+            V128ExtMulKind::LowI16x8S
+            | V128ExtMulKind::HighI16x8S
+            | V128ExtMulKind::LowI16x8U
+            | V128ExtMulKind::HighI16x8U => Self::I32x4,
+            V128ExtMulKind::LowI32x4S
+            | V128ExtMulKind::HighI32x4S
+            | V128ExtMulKind::LowI32x4U
+            | V128ExtMulKind::HighI32x4U => Self::I64x2,
+        }
     }
 }
 
@@ -1877,45 +2014,22 @@ pub(crate) trait MacroAssembler {
     /// vector.
     fn v128_extend(&mut self, src: Reg, dst: WritableReg, kind: V128ExtendKind) -> Result<()>;
 
-    /// Perform a vector add between `lsh` and `rhs`, placing the result in `dst`, where each lane
-    /// is interpreted to be `lane_width` long.
-    ///
-    /// `handle_overflow` determines how overflow should be handled.
-    fn v128_add(
-        &mut self,
-        lhs: Reg,
-        rhs: Reg,
-        dst: WritableReg,
-        lane_width: OperandSize,
-        handle_overflow: HandleOverflowKind,
-    ) -> Result<()>;
+    /// Perform a vector add between `lsh` and `rhs`, placing the result in
+    /// `dst`.
+    fn v128_add(&mut self, lhs: Reg, rhs: Reg, dst: WritableReg, kind: V128AddKind) -> Result<()>;
 
-    /// Perform a vector sub between `lhs` and `rhs`, placing the result in `dst`, where each lane
-    /// is interpreted to be `lane_width` long.
-    ///
-    /// `handle_overflow` determines how overflow should be handled.
-    fn v128_sub(
-        &mut self,
-        lhs: Reg,
-        rhs: Reg,
-        dst: WritableReg,
-        lane_width: OperandSize,
-        handle_overflow: HandleOverflowKind,
-    ) -> Result<()>;
+    /// Perform a vector sub between `lhs` and `rhs`, placing the result in `dst`.
+    fn v128_sub(&mut self, lhs: Reg, rhs: Reg, dst: WritableReg, kind: V128SubKind) -> Result<()>;
 
-    /// Perform a vector lane-wise mul between `lhs` and `rhs`, placing the result in `dst`, where each lane
-    /// is interpreted to be `size` long.
-    fn v128_mul(
-        &mut self,
-        context: &mut CodeGenContext<Emission>,
-        lane_width: OperandSize,
-    ) -> Result<()>;
+    /// Perform a vector lane-wise mul between `lhs` and `rhs`, placing the result in `dst`.
+    fn v128_mul(&mut self, context: &mut CodeGenContext<Emission>, kind: V128MulKind)
+        -> Result<()>;
 
     /// Perform an absolute operation on a vector.
     fn v128_abs(&mut self, src: Reg, dst: WritableReg, kind: V128AbsKind) -> Result<()>;
 
-    /// Vectorized negate of the content of `op`, with lanes of size `size`.
-    fn v128_neg(&mut self, op: WritableReg, size: OperandSize) -> Result<()>;
+    /// Vectorized negate of the content of `op`.
+    fn v128_neg(&mut self, op: WritableReg, kind: V128NegKind) -> Result<()>;
 
     /// Perform the shift operation specified by `kind`, by the shift amount specified by the 32-bit
     /// integer at the top the the stack, on the 128-bit vector specified by the second value
@@ -1954,34 +2068,16 @@ pub(crate) trait MacroAssembler {
     fn v128_trunc_sat(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        kind: V128TruncSatKind,
+        kind: V128TruncKind,
     ) -> Result<()>;
 
-    /// Perform a lane-wise `min` operation between `src1` and `src2`, interpreted as packed
-    /// integers of size `lane_width`.
-    ///
-    /// `kind` specifies whether the operand are interpreted as signed or unsigned integers.
-    fn v128_min(
-        &mut self,
-        src1: Reg,
-        src2: Reg,
-        dst: WritableReg,
-        lane_width: OperandSize,
-        kind: MinKind,
-    ) -> Result<()>;
+    /// Perform a lane-wise `min` operation between `src1` and `src2`.
+    fn v128_min(&mut self, src1: Reg, src2: Reg, dst: WritableReg, kind: V128MinKind)
+        -> Result<()>;
 
-    /// Perform a lane-wise `max` operation between `src1` and `src2`, interpreted as packed
-    /// integers of size `lane_width`.
-    ///
-    /// `kind` specifies whether the operand are interpreted as signed or unsigned integers.
-    fn v128_max(
-        &mut self,
-        src1: Reg,
-        src2: Reg,
-        dst: WritableReg,
-        lane_width: OperandSize,
-        kind: MaxKind,
-    ) -> Result<()>;
+    /// Perform a lane-wise `max` operation between `src1` and `src2`.
+    fn v128_max(&mut self, src1: Reg, src2: Reg, dst: WritableReg, kind: V128MaxKind)
+        -> Result<()>;
 
     /// Perform the lane-wise integer extended multiplication producing twice wider result than the
     /// inputs. This is equivalent to an extend followed by a multiply.
@@ -1992,8 +2088,7 @@ pub(crate) trait MacroAssembler {
     fn v128_extmul(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        lane_width: OperandSize,
-        kind: ExtMulKind,
+        kind: V128ExtMulKind,
     ) -> Result<()>;
 
     /// Perform the lane-wise integer extended pairwise addition producing extended results (twice
@@ -2002,8 +2097,7 @@ pub(crate) trait MacroAssembler {
         &mut self,
         src: Reg,
         dst: WritableReg,
-        lane_width: OperandSize,
-        kind: ExtAddKind,
+        kind: V128ExtAddKind,
     ) -> Result<()>;
 
     /// Lane-wise multiply signed 16-bit integers in `lhs` and `rhs` and add

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -10,12 +10,12 @@ use crate::codegen::{
     FnCall,
 };
 use crate::masm::{
-    DivKind, ExtAddKind, ExtMulKind, Extend, ExtractLaneKind, FloatCmpKind, HandleOverflowKind,
-    IntCmpKind, LoadKind, MacroAssembler, MaxKind, MemMoveDirection, MinKind, MulWideKind,
-    OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp, RoundingMode, SPOffset, ShiftKind,
-    Signed, SplatKind, SplatLoadKind, StoreKind, TruncKind, V128AbsKind, V128ConvertKind,
-    V128ExtendKind, V128LoadExtendKind, V128NarrowKind, V128TruncSatKind, VectorCompareKind,
-    VectorEqualityKind, Zero,
+    DivKind, Extend, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
+    MemMoveDirection, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp,
+    RoundingMode, SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind, StoreKind, TruncKind,
+    V128AbsKind, V128AddKind, V128ConvertKind, V128ExtAddKind, V128ExtMulKind, V128ExtendKind,
+    V128LoadExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind,
+    V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero,
 };
 
 use crate::reg::{writable, Reg};
@@ -3789,188 +3789,140 @@ where
 
     fn visit_i8x16_add(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_add(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I8x16)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_add(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_add(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I16x8)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i32x4_add(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_add(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I32x4)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i64x2_add(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S64, |masm, dst, src, size| {
-                masm.v128_add(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S64, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I64x2)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i8x16_sub(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_sub(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I8x16)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_sub(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_sub(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I16x8)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i32x4_sub(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_sub(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I32x4)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i64x2_sub(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S64, |masm, dst, src, size| {
-                masm.v128_sub(dst, src, writable!(dst), size, HandleOverflowKind::None)?;
+            .binop(self.masm, OperandSize::S64, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I64x2)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_mul(&mut self) -> Self::Output {
-        self.masm.v128_mul(&mut self.context, OperandSize::S16)
+        self.masm.v128_mul(&mut self.context, V128MulKind::I16x8)
     }
 
     fn visit_i32x4_mul(&mut self) -> Self::Output {
-        self.masm.v128_mul(&mut self.context, OperandSize::S32)
+        self.masm.v128_mul(&mut self.context, V128MulKind::I32x4)
     }
 
     fn visit_i64x2_mul(&mut self) -> Self::Output {
-        self.masm.v128_mul(&mut self.context, OperandSize::S64)
+        self.masm.v128_mul(&mut self.context, V128MulKind::I64x2)
     }
 
     fn visit_i8x16_add_sat_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_add(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::SignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I8x16SatS)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_add_sat_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_add(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::SignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I16x8SatS)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i8x16_add_sat_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_add(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::UnsignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I8x16SatU)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_add_sat_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_add(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::UnsignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_add(dst, src, writable!(dst), V128AddKind::I16x8SatU)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i8x16_sub_sat_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_sub(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::SignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I8x16SatS)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_sub_sat_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_sub(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::SignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I16x8SatS)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i8x16_sub_sat_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_sub(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::UnsignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I8x16SatU)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
 
     fn visit_i16x8_sub_sat_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_sub(
-                    dst,
-                    src,
-                    writable!(dst),
-                    size,
-                    HandleOverflowKind::UnsignedSaturating,
-                )?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_sub(dst, src, writable!(dst), V128SubKind::I16x8SatU)?;
                 Ok(TypedReg::new(WasmValType::V128, dst))
             })
     }
@@ -4019,28 +3971,28 @@ where
 
     fn visit_i8x16_neg(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_neg(writable!(op), OperandSize::S8)?;
+            masm.v128_neg(writable!(op), V128NegKind::I8x16)?;
             Ok(TypedReg::new(WasmValType::V128, op))
         })
     }
 
     fn visit_i16x8_neg(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_neg(writable!(op), OperandSize::S16)?;
+            masm.v128_neg(writable!(op), V128NegKind::I16x8)?;
             Ok(TypedReg::new(WasmValType::V128, op))
         })
     }
 
     fn visit_i32x4_neg(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_neg(writable!(op), OperandSize::S32)?;
+            masm.v128_neg(writable!(op), V128NegKind::I32x4)?;
             Ok(TypedReg::new(WasmValType::V128, op))
         })
     }
 
     fn visit_i64x2_neg(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_neg(writable!(op), OperandSize::S64)?;
+            masm.v128_neg(writable!(op), V128NegKind::I64x2)?;
             Ok(TypedReg::new(WasmValType::V128, op))
         })
     }
@@ -4115,8 +4067,8 @@ where
 
     fn visit_i8x16_min_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I8x16S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
@@ -4171,28 +4123,28 @@ where
 
     fn visit_i32x4_trunc_sat_f32x4_s(&mut self) -> Self::Output {
         self.masm
-            .v128_trunc_sat(&mut self.context, V128TruncSatKind::F32x4S)
+            .v128_trunc_sat(&mut self.context, V128TruncKind::I32x4FromF32x4S)
     }
 
     fn visit_i32x4_trunc_sat_f32x4_u(&mut self) -> Self::Output {
         self.masm
-            .v128_trunc_sat(&mut self.context, V128TruncSatKind::F32x4U)
+            .v128_trunc_sat(&mut self.context, V128TruncKind::I32x4FromF32x4U)
     }
 
     fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self) -> Self::Output {
         self.masm
-            .v128_trunc_sat(&mut self.context, V128TruncSatKind::F64x2SZero)
+            .v128_trunc_sat(&mut self.context, V128TruncKind::I32x4FromF64x2SZero)
     }
 
     fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self) -> Self::Output {
         self.masm
-            .v128_trunc_sat(&mut self.context, V128TruncSatKind::F64x2UZero)
+            .v128_trunc_sat(&mut self.context, V128TruncKind::I32x4FromF64x2UZero)
     }
 
     fn visit_i16x8_min_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I16x8S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
@@ -4215,16 +4167,16 @@ where
 
     fn visit_i32x4_min_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Signed)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I32x4S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i8x16_min_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I8x16U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
@@ -4239,161 +4191,152 @@ where
 
     fn visit_i16x8_min_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I16x8U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i32x4_min_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_min(src, dst, writable!(dst), size, MinKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_min(src, dst, writable!(dst), V128MinKind::I32x4U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i8x16_max_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I8x16S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i16x8_max_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I16x8S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i32x4_max_s(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Signed)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I32x4S)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i8x16_max_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S8, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S8, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I8x16U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i16x8_max_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S16, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S16, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I16x8U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i32x4_max_u(&mut self) -> Self::Output {
         self.context
-            .binop(self.masm, OperandSize::S32, |masm, dst, src, size| {
-                masm.v128_max(src, dst, writable!(dst), size, MaxKind::Unsigned)?;
+            .binop(self.masm, OperandSize::S32, |masm, dst, src, _size| {
+                masm.v128_max(src, dst, writable!(dst), V128MaxKind::I32x4U)?;
                 Ok(TypedReg::v128(dst))
             })
     }
 
     fn visit_i16x8_extmul_low_i8x16_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::LowSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI8x16S)
     }
 
     fn visit_i32x4_extmul_low_i16x8_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::LowSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI16x8S)
     }
 
     fn visit_i64x2_extmul_low_i32x4_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::LowSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI32x4S)
     }
 
     fn visit_i16x8_extmul_low_i8x16_u(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::LowUnsigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI8x16U)
     }
 
     fn visit_i32x4_extmul_low_i16x8_u(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::LowUnsigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI16x8U)
     }
 
     fn visit_i64x2_extmul_low_i32x4_u(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::LowUnsigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::LowI32x4U)
     }
 
     fn visit_i16x8_extmul_high_i8x16_u(&mut self) -> Self::Output {
-        self.masm.v128_extmul(
-            &mut self.context,
-            OperandSize::S16,
-            ExtMulKind::HighUnsigned,
-        )
+        self.masm
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI8x16U)
     }
 
     fn visit_i32x4_extmul_high_i16x8_u(&mut self) -> Self::Output {
-        self.masm.v128_extmul(
-            &mut self.context,
-            OperandSize::S32,
-            ExtMulKind::HighUnsigned,
-        )
+        self.masm
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI16x8U)
     }
 
     fn visit_i64x2_extmul_high_i32x4_u(&mut self) -> Self::Output {
-        self.masm.v128_extmul(
-            &mut self.context,
-            OperandSize::S64,
-            ExtMulKind::HighUnsigned,
-        )
+        self.masm
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI32x4U)
     }
 
     fn visit_i16x8_extmul_high_i8x16_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S16, ExtMulKind::HighSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI8x16S)
     }
 
     fn visit_i32x4_extmul_high_i16x8_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S32, ExtMulKind::HighSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI16x8S)
     }
 
     fn visit_i64x2_extmul_high_i32x4_s(&mut self) -> Self::Output {
         self.masm
-            .v128_extmul(&mut self.context, OperandSize::S64, ExtMulKind::HighSigned)
+            .v128_extmul(&mut self.context, V128ExtMulKind::HighI32x4S)
     }
 
     fn visit_i16x8_extadd_pairwise_i8x16_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_extadd_pairwise(op, writable!(op), OperandSize::S16, ExtAddKind::Signed)?;
+            masm.v128_extadd_pairwise(op, writable!(op), V128ExtAddKind::I8x16S)?;
             Ok(TypedReg::v128(op))
         })
     }
 
     fn visit_i16x8_extadd_pairwise_i8x16_u(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_extadd_pairwise(op, writable!(op), OperandSize::S16, ExtAddKind::Unsigned)?;
+            masm.v128_extadd_pairwise(op, writable!(op), V128ExtAddKind::I8x16U)?;
             Ok(TypedReg::v128(op))
         })
     }
 
     fn visit_i32x4_extadd_pairwise_i16x8_s(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_extadd_pairwise(op, writable!(op), OperandSize::S32, ExtAddKind::Signed)?;
+            masm.v128_extadd_pairwise(op, writable!(op), V128ExtAddKind::I16x8S)?;
             Ok(TypedReg::v128(op))
         })
     }
 
     fn visit_i32x4_extadd_pairwise_i16x8_u(&mut self) -> Self::Output {
         self.context.unop(self.masm, |masm, op| {
-            masm.v128_extadd_pairwise(op, writable!(op), OperandSize::S32, ExtAddKind::Unsigned)?;
+            masm.v128_extadd_pairwise(op, writable!(op), V128ExtAddKind::I16x8U)?;
             Ok(TypedReg::v128(op))
         })
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Refactors a number of SIMD methods in the macroassembler interface to take various kind enums. For most of these operations, I want to introduce support for floats and the existing interfaces don't make that very straightforward. I also updated `extadd` and `extmul` for the sake of consistency.

This change also allows potentially reusing some of the conversions between macroassembler kinds in a future AArch64 implementation.