### PR TITLE
Exception and control tags

### DIFF
--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -23,7 +23,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
         Extern::SharedMemory(_) => panic!(
             "Shared Memory no implemented for wasm_* types. Please use wasmtime_* types instead"
         ),
-        Extern::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
+        Extern::Tag(_) => todo!(), // FIXME: #10252 C embedder API for exceptions and control tags.
     }
 }
 
@@ -144,7 +144,7 @@ impl From<Extern> for wasmtime_extern_t {
                     sharedmemory: ManuallyDrop::new(Box::new(sharedmemory)),
                 },
             },
-            Extern::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
+            Extern::Tag(_) => todo!(), // FIXME: #10252 C embedder API for exceptions and control tags.
         }
     }
 }

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -23,6 +23,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
         Extern::SharedMemory(_) => panic!(
             "Shared Memory no implemented for wasm_* types. Please use wasmtime_* types instead"
         ),
+        Extern::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
     }
 }
 
@@ -143,6 +144,7 @@ impl From<Extern> for wasmtime_extern_t {
                     sharedmemory: ManuallyDrop::new(Box::new(sharedmemory)),
                 },
             },
+            Extern::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
         }
     }
 }

--- a/crates/c-api/src/types/extern.rs
+++ b/crates/c-api/src/types/extern.rs
@@ -25,6 +25,7 @@ impl CExternType {
             ExternType::Global(f) => CExternType::Global(CGlobalType::new(f)),
             ExternType::Memory(f) => CExternType::Memory(CMemoryType::new(f)),
             ExternType::Table(f) => CExternType::Table(CTableType::new(f)),
+            ExternType::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
         }
     }
 }

--- a/crates/c-api/src/types/extern.rs
+++ b/crates/c-api/src/types/extern.rs
@@ -25,7 +25,7 @@ impl CExternType {
             ExternType::Global(f) => CExternType::Global(CGlobalType::new(f)),
             ExternType::Memory(f) => CExternType::Memory(CMemoryType::new(f)),
             ExternType::Table(f) => CExternType::Table(CTableType::new(f)),
-            ExternType::Tag(_) => todo!(), // FIXME(dhil): C embedder API for exceptions and control tags.
+            ExternType::Tag(_) => todo!(), // FIXME: #10252 C embedder API for exceptions and control tags.
         }
     }
 }

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -1229,7 +1229,7 @@ impl<'a> Inliner<'a> {
                 EntityIndex::Table(i) => frame.tables[i].clone().into(),
                 EntityIndex::Global(i) => frame.globals[i].clone().into(),
                 EntityIndex::Memory(i) => frame.memories[i].clone().into(),
-                EntityIndex::Tag(_) => todo!(), // FIXME(dhil): Implement support for tags in the component model
+                EntityIndex::Tag(_) => todo!(), // FIXME: #10252 support for tags in the component model
             },
         }
     }

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -1229,6 +1229,7 @@ impl<'a> Inliner<'a> {
                 EntityIndex::Table(i) => frame.tables[i].clone().into(),
                 EntityIndex::Global(i) => frame.globals[i].clone().into(),
                 EntityIndex::Memory(i) => frame.memories[i].clone().into(),
+                EntityIndex::Tag(_) => todo!(), // FIXME(dhil): Implement support for tags in the component model
             },
         }
     }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -584,6 +584,12 @@ impl Module {
     pub fn num_defined_memories(&self) -> usize {
         self.memories.len() - self.num_imported_memories
     }
+
+    /// Returns the number of tags defined by this module itself: all tags
+    /// minus imported tags.
+    pub fn num_defined_tags(&self) -> usize {
+        self.tags.len() - self.num_imported_tags
+    }
 }
 
 impl TypeTrace for Module {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -333,6 +333,9 @@ pub struct Module {
     /// Number of imported or aliased globals in the module.
     pub num_imported_globals: usize,
 
+    /// Number of imported or aliased tags in the module.
+    pub num_imported_tags: usize,
+
     /// Number of functions that "escape" from this module may need to have a
     /// `VMFuncRef` constructed for them.
     ///
@@ -354,6 +357,9 @@ pub struct Module {
 
     /// WebAssembly global initializers for locally-defined globals.
     pub global_initializers: PrimaryMap<DefinedGlobalIndex, ConstExpr>,
+
+    /// WebAssembly exception and control tags.
+    pub tags: PrimaryMap<TagIndex, Tag>,
 }
 
 /// Initialization routines for creating an instance, encompassing imports,
@@ -500,6 +506,29 @@ impl Module {
         index.index() < self.num_imported_globals
     }
 
+    /// Test whether the given tag index is for an imported tag.
+    #[inline]
+    pub fn is_imported_tag(&self, index: TagIndex) -> bool {
+        index.index() < self.num_imported_tags
+    }
+
+    /// Convert a `DefinedTagIndex` into a `TagIndex`.
+    #[inline]
+    pub fn tag_index(&self, defined_tag: DefinedTagIndex) -> TagIndex {
+        TagIndex::new(self.num_imported_tags + defined_tag.index())
+    }
+
+    /// Convert a `TagIndex` into a `DefinedTagIndex`. Returns None if the
+    /// index is an imported tag.
+    #[inline]
+    pub fn defined_tag_index(&self, tag: TagIndex) -> Option<DefinedTagIndex> {
+        if tag.index() < self.num_imported_tags {
+            None
+        } else {
+            Some(DefinedTagIndex::new(tag.index() - self.num_imported_tags))
+        }
+    }
+
     /// Returns an iterator of all the imports in this module, along with their
     /// module name, field name, and type that's being imported.
     pub fn imports(&self) -> impl ExactSizeIterator<Item = (&str, &str, EntityType)> {
@@ -517,7 +546,14 @@ impl Module {
             EntityIndex::Table(i) => EntityType::Table(self.tables[i]),
             EntityIndex::Memory(i) => EntityType::Memory(self.memories[i]),
             EntityIndex::Function(i) => EntityType::Function(self.functions[i].signature),
+            EntityIndex::Tag(i) => EntityType::Tag(self.tags[i]),
         }
+    }
+
+    /// Appends a new tag to this module with the given type information.
+    pub fn push_tag(&mut self, signature: impl Into<EngineOrModuleTypeIndex>) -> TagIndex {
+        let signature = signature.into();
+        self.tags.push(Tag { signature })
     }
 
     /// Appends a new function to this module with the given type information,
@@ -572,12 +608,14 @@ impl TypeTrace for Module {
             num_imported_tables: _,
             num_imported_memories: _,
             num_imported_globals: _,
+            num_imported_tags: _,
             num_escaped_funcs: _,
             functions,
             tables,
             memories: _,
             globals,
             global_initializers: _,
+            tags,
         } = self;
 
         for t in types.values().copied() {
@@ -591,6 +629,9 @@ impl TypeTrace for Module {
         }
         for g in globals.values() {
             g.trace(func)?;
+        }
+        for t in tags.values() {
+            t.trace(func)?;
         }
         Ok(())
     }
@@ -616,12 +657,14 @@ impl TypeTrace for Module {
             num_imported_tables: _,
             num_imported_memories: _,
             num_imported_globals: _,
+            num_imported_tags: _,
             num_escaped_funcs: _,
             functions,
             tables,
             memories: _,
             globals,
             global_initializers: _,
+            tags,
         } = self;
 
         for t in types.values_mut() {
@@ -635,6 +678,9 @@ impl TypeTrace for Module {
         }
         for g in globals.values_mut() {
             g.trace_mut(func)?;
+        }
+        for t in tags.values_mut() {
+            t.trace_mut(func)?;
         }
         Ok(())
     }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -676,16 +676,10 @@ impl<P: PtrSize> VMOffsets<P> {
         0 * self.pointer_size()
     }
 
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmtag_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
     /// Return the size of `VMTagImport`.
     #[inline]
     pub fn size_of_vmtag_import(&self) -> u8 {
-        2 * self.pointer_size()
+        1 * self.pointer_size()
     }
 }
 

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -35,8 +35,8 @@
 // }
 
 use crate::{
-    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, FuncRefIndex,
-    GlobalIndex, MemoryIndex, Module, OwnedMemoryIndex, TableIndex,
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, FuncIndex,
+    FuncRefIndex, GlobalIndex, MemoryIndex, Module, OwnedMemoryIndex, TableIndex, TagIndex,
 };
 use cranelift_entity::packed_option::ReservedValue;
 
@@ -69,6 +69,8 @@ pub struct VMOffsets<P> {
     pub num_imported_memories: u32,
     /// The number of imported globals in the module.
     pub num_imported_globals: u32,
+    /// The number of imported tags in the module.
+    pub num_imported_tags: u32,
     /// The number of defined tables in the module.
     pub num_defined_tables: u32,
     /// The number of defined memories in the module.
@@ -77,6 +79,8 @@ pub struct VMOffsets<P> {
     pub num_owned_memories: u32,
     /// The number of defined globals in the module.
     pub num_defined_globals: u32,
+    /// The number of defined tags in the module.
+    pub num_defined_tags: u32,
     /// The number of escaped functions in the module, the size of the func_refs
     /// array.
     pub num_escaped_funcs: u32,
@@ -86,10 +90,12 @@ pub struct VMOffsets<P> {
     imported_tables: u32,
     imported_memories: u32,
     imported_globals: u32,
+    imported_tags: u32,
     defined_tables: u32,
     defined_memories: u32,
     owned_memories: u32,
     defined_globals: u32,
+    defined_tags: u32,
     defined_func_refs: u32,
     size: u32,
 }
@@ -148,6 +154,12 @@ pub trait PtrSize {
     #[inline]
     fn size_of_vmglobal_definition(&self) -> u8 {
         16
+    }
+
+    /// Return the size of `VMTagDefinition`.
+    #[inline]
+    fn size_of_vmtag_definition(&self) -> u8 {
+        4
     }
 
     // Offsets within `VMRuntimeLimits`
@@ -323,6 +335,8 @@ pub struct VMOffsetsFields<P> {
     pub num_imported_memories: u32,
     /// The number of imported globals in the module.
     pub num_imported_globals: u32,
+    /// The number of imported tags in the module.
+    pub num_imported_tags: u32,
     /// The number of defined tables in the module.
     pub num_defined_tables: u32,
     /// The number of defined memories in the module.
@@ -331,6 +345,8 @@ pub struct VMOffsetsFields<P> {
     pub num_owned_memories: u32,
     /// The number of defined globals in the module.
     pub num_defined_globals: u32,
+    /// The number of defined tags in the module.
+    pub num_defined_tags: u32,
     /// The number of escaped functions in the module, the size of the function
     /// references array.
     pub num_escaped_funcs: u32,
@@ -353,10 +369,12 @@ impl<P: PtrSize> VMOffsets<P> {
             num_imported_tables: cast_to_u32(module.num_imported_tables),
             num_imported_memories: cast_to_u32(module.num_imported_memories),
             num_imported_globals: cast_to_u32(module.num_imported_globals),
+            num_imported_tags: cast_to_u32(module.num_imported_tags),
             num_defined_tables: cast_to_u32(module.num_defined_tables()),
             num_defined_memories: cast_to_u32(module.num_defined_memories()),
             num_owned_memories,
             num_defined_globals: cast_to_u32(module.globals.len() - module.num_imported_globals),
+            num_defined_tags: cast_to_u32(module.tags.len() - module.num_imported_tags),
             num_escaped_funcs: cast_to_u32(module.num_escaped_funcs),
         })
     }
@@ -382,9 +400,11 @@ impl<P: PtrSize> VMOffsets<P> {
                     num_imported_tables: _,
                     num_imported_memories: _,
                     num_imported_globals: _,
+                    num_imported_tags: _,
                     num_defined_tables: _,
                     num_defined_globals: _,
                     num_defined_memories: _,
+                    num_defined_tags: _,
                     num_owned_memories: _,
                     num_escaped_funcs: _,
 
@@ -416,8 +436,10 @@ impl<P: PtrSize> VMOffsets<P> {
 
         calculate_sizes! {
             defined_func_refs: "module functions",
+            defined_tags: "defined tags",
             defined_globals: "defined globals",
             defined_tables: "defined tables",
+            imported_tags: "imported tags",
             imported_globals: "imported globals",
             imported_tables: "imported tables",
             imported_functions: "imported functions",
@@ -436,19 +458,23 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             num_imported_tables: fields.num_imported_tables,
             num_imported_memories: fields.num_imported_memories,
             num_imported_globals: fields.num_imported_globals,
+            num_imported_tags: fields.num_imported_tags,
             num_defined_tables: fields.num_defined_tables,
             num_defined_memories: fields.num_defined_memories,
             num_owned_memories: fields.num_owned_memories,
             num_defined_globals: fields.num_defined_globals,
+            num_defined_tags: fields.num_defined_tags,
             num_escaped_funcs: fields.num_escaped_funcs,
             imported_functions: 0,
             imported_tables: 0,
             imported_memories: 0,
             imported_globals: 0,
+            imported_tags: 0,
             defined_tables: 0,
             defined_memories: 0,
             owned_memories: 0,
             defined_globals: 0,
+            defined_tags: 0,
             defined_func_refs: 0,
             size: 0,
         };
@@ -495,11 +521,15 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
                 = cmul(ret.num_imported_tables, ret.size_of_vmtable_import()),
             size(imported_globals)
                 = cmul(ret.num_imported_globals, ret.size_of_vmglobal_import()),
+            size(imported_tags)
+                = cmul(ret.num_imported_tags, ret.size_of_vmtag_import()),
             size(defined_tables)
                 = cmul(ret.num_defined_tables, ret.size_of_vmtable_definition()),
             align(16),
             size(defined_globals)
                 = cmul(ret.num_defined_globals, ret.ptr.size_of_vmglobal_definition()),
+            size(defined_tags)
+                = cmul(ret.num_defined_tags, ret.ptr.size_of_vmtag_definition()),
             size(defined_func_refs) = cmul(
                 ret.num_escaped_funcs,
                 ret.ptr.size_of_vm_func_ref(),
@@ -638,6 +668,27 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 }
 
+/// Offsets for `VMTagImport`.
+impl<P: PtrSize> VMOffsets<P> {
+    /// The offset of the `from` field.
+    #[inline]
+    pub fn vmtag_import_from(&self) -> u8 {
+        0 * self.pointer_size()
+    }
+
+    /// The offset of the `vmctx` field.
+    #[inline]
+    pub fn vmtag_import_vmctx(&self) -> u8 {
+        1 * self.pointer_size()
+    }
+
+    /// Return the size of `VMTagImport`.
+    #[inline]
+    pub fn size_of_vmtag_import(&self) -> u8 {
+        2 * self.pointer_size()
+    }
+}
+
 /// Offsets for `VMContext`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `tables` array.
@@ -664,6 +715,12 @@ impl<P: PtrSize> VMOffsets<P> {
         self.imported_globals
     }
 
+    /// The offset of the `tags` array.
+    #[inline]
+    pub fn vmctx_imported_tags_begin(&self) -> u32 {
+        self.imported_tags
+    }
+
     /// The offset of the `tables` array.
     #[inline]
     pub fn vmctx_tables_begin(&self) -> u32 {
@@ -686,6 +743,12 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_globals_begin(&self) -> u32 {
         self.defined_globals
+    }
+
+    /// The offset of the `tags` array.
+    #[inline]
+    pub fn vmctx_tags_begin(&self) -> u32 {
+        self.defined_tags
     }
 
     /// The offset of the `func_refs` array.
@@ -732,6 +795,13 @@ impl<P: PtrSize> VMOffsets<P> {
             + index.as_u32() * u32::from(self.size_of_vmglobal_import())
     }
 
+    /// Return the offset to `VMTagImport` index `index`.
+    #[inline]
+    pub fn vmctx_vmtag_import(&self, index: TagIndex) -> u32 {
+        assert!(index.as_u32() < self.num_imported_tags);
+        self.vmctx_imported_tags_begin() + index.as_u32() * u32::from(self.size_of_vmtag_import())
+    }
+
     /// Return the offset to `VMTableDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmtable_definition(&self, index: DefinedTableIndex) -> u32 {
@@ -761,6 +831,13 @@ impl<P: PtrSize> VMOffsets<P> {
         assert!(index.as_u32() < self.num_defined_globals);
         self.vmctx_globals_begin()
             + index.as_u32() * u32::from(self.ptr.size_of_vmglobal_definition())
+    }
+
+    /// Return the offset to the `VMTagDefinition` index `index`.
+    #[inline]
+    pub fn vmctx_vmtag_definition(&self, index: DefinedTagIndex) -> u32 {
+        assert!(index.as_u32() < self.num_defined_tags);
+        self.vmctx_tags_begin() + index.as_u32() * u32::from(self.ptr.size_of_vmtag_definition())
     }
 
     /// Return the offset to the `VMFuncRef` for the given function
@@ -837,6 +914,12 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_vmglobal_import_from(&self, index: GlobalIndex) -> u32 {
         self.vmctx_vmglobal_import(index) + u32::from(self.vmglobal_import_from())
+    }
+
+    /// Return the offset to the `from` field in `VMTagImport` index `index`.
+    #[inline]
+    pub fn vmctx_vmtag_import_from(&self, index: TagIndex) -> u32 {
+        self.vmctx_vmtag_import(index) + u32::from(self.vmtag_import_from())
     }
 }
 

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -23,6 +23,7 @@ pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
         ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)?),
         ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
         ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
+        ExternType::Tag(_tag_ty) => todo!(), // FIXME: #10252
     })
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1068,6 +1068,30 @@ impl Config {
         self
     }
 
+    /// Configures whether the [WebAssembly stack switching
+    /// proposal][proposal] will be enabled for compilation.
+    ///
+    /// This feature gates the use of control tags.
+    ///
+    /// This feature depends on the `function_reference_types` and
+    /// `exceptions` features.
+    ///
+    /// This feature is `false` by default.
+    ///
+    /// # Errors
+    ///
+    /// [proposal]: https://github.com/webassembly/stack-switching
+    pub fn wasm_stack_switching(&mut self, enable: bool) -> &mut Self {
+        // FIXME(dhil): Once the config provides a handle
+        // for turning on/off exception handling proposal support,
+        // this ought to only enable stack switching.
+        self.wasm_feature(
+            WasmFeatures::EXCEPTIONS | WasmFeatures::STACK_SWITCHING,
+            enable,
+        );
+        self
+    }
+
     /// Configures whether the WebAssembly component-model [proposal] will
     /// be enabled for compilation.
     ///

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -203,6 +203,7 @@ struct WasmFeatures {
     component_model_async: bool,
     gc_types: bool,
     wide_arithmetic: bool,
+    stack_switching: bool,
 }
 
 impl Metadata<'_> {
@@ -249,7 +250,6 @@ impl Metadata<'_> {
         assert!(!component_model_nested_names);
         assert!(!shared_everything_threads);
         assert!(!legacy_exceptions);
-        assert!(!stack_switching);
 
         Metadata {
             target: engine.compiler().triple().to_string(),
@@ -275,6 +275,7 @@ impl Metadata<'_> {
                 component_model_async,
                 gc_types,
                 wide_arithmetic,
+                stack_switching,
             },
         }
     }
@@ -484,6 +485,7 @@ impl Metadata<'_> {
             component_model_async,
             gc_types,
             wide_arithmetic,
+            stack_switching,
         } = self.features;
 
         use wasmparser::WasmFeatures as F;
@@ -575,7 +577,11 @@ impl Metadata<'_> {
             other.contains(F::WIDE_ARITHMETIC),
             "WebAssembly wide-arithmetic support",
         )?;
-
+        Self::check_bool(
+            stack_switching,
+            other.contains(F::STACK_SWITCHING),
+            "WebAssembly stack switching support",
+        )?;
         Ok(())
     }
 

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -44,7 +44,6 @@ impl Tag {
         let export = &store[self.0];
         crate::runtime::vm::VMTagImport {
             from: export.definition.into(),
-            vmctx: export.vmctx.into(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -58,13 +58,10 @@ impl Tag {
     /// # Panics
     ///
     /// Panics if either tag do not belong to the given `store`.
-    pub fn eq(&self, other: &Tag, store: impl AsContext) -> bool {
-        self._eq(other, store.as_context().0)
-    }
-
-    pub(crate) fn _eq(&self, other: &Tag, store: &StoreOpaque) -> bool {
-        let a = &store[self.0];
-        let b = &store[other.0];
+    pub fn eq(a: &Tag, b: &Tag, store: impl AsContext) -> bool {
+        let store = store.as_context().0;
+        let a = &store[a.0];
+        let b = &store[b.0];
         a.definition.eq(&b.definition)
     }
 }

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -1,0 +1,70 @@
+use crate::runtime::types::TagType;
+use crate::{
+    store::{StoreData, StoreOpaque, Stored},
+    AsContext,
+};
+
+/// A WebAssembly `tag`.
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)] // here for the C API
+pub struct Tag(pub(super) Stored<crate::runtime::vm::ExportTag>);
+
+impl Tag {
+    pub(crate) unsafe fn from_wasmtime_tag(
+        mut wasmtime_export: crate::runtime::vm::ExportTag,
+        store: &mut StoreOpaque,
+    ) -> Self {
+        use wasmtime_environ::TypeTrace;
+        wasmtime_export
+            .tag
+            .canonicalize_for_runtime_usage(&mut |module_index| {
+                crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
+                    instance.engine_type_index(module_index)
+                })
+            });
+
+        Tag(store.store_data_mut().insert(wasmtime_export))
+    }
+
+    /// Returns the underlying type of this `tag`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `store` does not own this tag.
+    pub fn ty(&self, store: impl AsContext) -> TagType {
+        self._ty(store.as_context().0)
+    }
+
+    pub(crate) fn _ty(&self, store: &StoreOpaque) -> TagType {
+        let ty = &store[self.0].tag;
+        TagType::from_wasmtime_tag(store.engine(), &ty)
+    }
+
+    pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Tag {
+        &data[self.0].tag
+    }
+
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTagImport {
+        let export = &store[self.0];
+        crate::runtime::vm::VMTagImport {
+            from: export.definition.into(),
+            vmctx: export.vmctx.into(),
+        }
+    }
+
+    /// Determines whether this tag is reference equal to the other
+    /// given tag in the given store.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either tag do not belong to the given `store`.
+    pub fn eq(&self, other: &Tag, store: impl AsContext) -> bool {
+        self._eq(other, store.as_context().0)
+    }
+
+    pub(crate) fn _eq(&self, other: &Tag, store: &StoreOpaque) -> bool {
+        let a = &store[self.0];
+        let b = &store[other.0];
+        a.definition.eq(&b.definition)
+    }
+}

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -754,7 +754,6 @@ impl OwnedImports {
             crate::runtime::vm::Export::Tag(t) => {
                 self.tags.push(VMTagImport {
                     from: t.definition.into(),
-                    vmctx: t.vmctx.into(),
                 });
             }
         }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -2,19 +2,20 @@ use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     Imports, InstanceAllocationRequest, ModuleRuntimeInfo, StorePtr, VMFuncRef, VMFunctionImport,
-    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport,
+    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport, VMTagImport,
 };
 use crate::store::{InstanceId, StoreOpaque, Stored};
 use crate::types::matching;
 use crate::{
     AsContextMut, Engine, Export, Extern, Func, Global, Memory, Module, ModuleExport, SharedMemory,
-    StoreContext, StoreContextMut, Table, TypedFunc,
+    StoreContext, StoreContextMut, Table, Tag, TypedFunc,
 };
 use alloc::sync::Arc;
 use core::ptr::NonNull;
 use wasmparser::WasmFeatures;
 use wasmtime_environ::{
-    EntityIndex, EntityType, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap, TableIndex, TypeTrace,
+    EntityIndex, EntityType, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap, TableIndex, TagIndex,
+    TypeTrace,
 };
 
 /// An instantiated WebAssembly module.
@@ -593,6 +594,18 @@ impl Instance {
         self.get_export(store, name)?.into_global()
     }
 
+    /// Looks up a tag [`Tag`] by name.
+    ///
+    /// Returns `None` if there was no export named `name`, or if there was but
+    /// it wasn't a tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `store` does not own this instance.
+    pub fn get_tag(&self, store: impl AsContextMut, name: &str) -> Option<Tag> {
+        self.get_export(store, name)?.into_tag()
+    }
+
     #[cfg(feature = "component-model")]
     pub(crate) fn id(&self, store: &StoreOpaque) -> InstanceId {
         store[self.0].id
@@ -646,6 +659,7 @@ pub(crate) struct OwnedImports {
     tables: PrimaryMap<TableIndex, VMTableImport>,
     memories: PrimaryMap<MemoryIndex, VMMemoryImport>,
     globals: PrimaryMap<GlobalIndex, VMGlobalImport>,
+    tags: PrimaryMap<TagIndex, VMTagImport>,
 }
 
 impl OwnedImports {
@@ -661,6 +675,7 @@ impl OwnedImports {
             tables: PrimaryMap::new(),
             memories: PrimaryMap::new(),
             globals: PrimaryMap::new(),
+            tags: PrimaryMap::new(),
         }
     }
 
@@ -670,6 +685,7 @@ impl OwnedImports {
         self.tables.reserve(raw.num_imported_tables);
         self.memories.reserve(raw.num_imported_memories);
         self.globals.reserve(raw.num_imported_globals);
+        self.tags.reserve(raw.num_imported_tags);
     }
 
     #[cfg(feature = "component-model")]
@@ -678,6 +694,7 @@ impl OwnedImports {
         self.tables.clear();
         self.memories.clear();
         self.globals.clear();
+        self.tags.clear();
     }
 
     fn push(&mut self, item: &Extern, store: &mut StoreOpaque, module: &Module) {
@@ -696,6 +713,9 @@ impl OwnedImports {
             }
             Extern::SharedMemory(i) => {
                 self.memories.push(i.vmimport(store));
+            }
+            Extern::Tag(i) => {
+                self.tags.push(i.vmimport(store));
             }
         }
     }
@@ -731,6 +751,12 @@ impl OwnedImports {
                     index: m.index,
                 });
             }
+            crate::runtime::vm::Export::Tag(t) => {
+                self.tags.push(VMTagImport {
+                    from: t.definition.into(),
+                    vmctx: t.vmctx.into(),
+                });
+            }
         }
     }
 
@@ -740,6 +766,7 @@ impl OwnedImports {
             globals: self.globals.values().as_slice(),
             memories: self.memories.values().as_slice(),
             functions: self.functions.values().as_slice(),
+            tags: self.tags.values().as_slice(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -129,6 +129,7 @@ pub(crate) enum DefinitionType {
     // no longer be the current size of the table/memory.
     Table(wasmtime_environ::Table, u64),
     Memory(wasmtime_environ::Memory, u64),
+    Tag(wasmtime_environ::Tag),
 }
 
 impl<T> Linker<T> {
@@ -1388,6 +1389,7 @@ impl DefinitionType {
                 DefinitionType::Memory(*t.wasmtime_ty(data), t.internal_size(store))
             }
             Extern::SharedMemory(t) => DefinitionType::Memory(*t.ty().wasmtime_memory(), t.size()),
+            Extern::Tag(t) => DefinitionType::Tag(*t.wasmtime_ty(data)),
         }
     }
 
@@ -1397,6 +1399,7 @@ impl DefinitionType {
             DefinitionType::Table(..) => "table",
             DefinitionType::Memory(..) => "memory",
             DefinitionType::Global(_) => "global",
+            DefinitionType::Tag(_) => "tag",
         }
     }
 }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -26,6 +26,7 @@ pub struct StoreData {
     globals: Vec<crate::runtime::vm::ExportGlobal>,
     instances: Vec<crate::instance::InstanceData>,
     memories: Vec<crate::runtime::vm::ExportMemory>,
+    tags: Vec<crate::runtime::vm::ExportTag>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
 }
@@ -52,6 +53,7 @@ impl_store_data! {
     globals => crate::runtime::vm::ExportGlobal,
     instances => crate::instance::InstanceData,
     memories => crate::runtime::vm::ExportMemory,
+    tags => crate::runtime::vm::ExportTag,
 }
 
 impl StoreData {
@@ -63,6 +65,7 @@ impl StoreData {
             globals: Vec::new(),
             instances: Vec::new(),
             memories: Vec::new(),
+            tags: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),
         }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -93,7 +93,7 @@ pub use crate::runtime::vm::unwind::*;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -1,8 +1,9 @@
 use crate::runtime::vm::vmcontext::{
     VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
+    VMTagDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, Global, Memory, Table};
+use wasmtime_environ::{DefinedMemoryIndex, Global, Memory, Table, Tag};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -17,6 +18,9 @@ pub enum Export {
 
     /// A global export value.
     Global(ExportGlobal),
+
+    /// A tag export value.
+    Tag(ExportTag),
 }
 
 /// A function export value.
@@ -104,5 +108,27 @@ unsafe impl Sync for ExportGlobal {}
 impl From<ExportGlobal> for Export {
     fn from(func: ExportGlobal) -> Export {
         Export::Global(func)
+    }
+}
+
+/// A tag export value.
+#[derive(Debug, Clone)]
+pub struct ExportTag {
+    /// The address of the global storage.
+    pub definition: NonNull<VMTagDefinition>,
+    /// Pointer to the containing `VMContext`. May be null for host-created
+    /// globals.
+    pub vmctx: NonNull<VMContext>,
+    /// The global declaration, used for compatibility checking.
+    pub tag: Tag,
+}
+
+// See docs on send/sync for `ExportFunction` above.
+unsafe impl Send for ExportTag {}
+unsafe impl Sync for ExportTag {}
+
+impl From<ExportTag> for Export {
+    fn from(func: ExportTag) -> Export {
+        Export::Tag(func)
     }
 }

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -116,9 +116,6 @@ impl From<ExportGlobal> for Export {
 pub struct ExportTag {
     /// The address of the global storage.
     pub definition: NonNull<VMTagDefinition>,
-    /// Pointer to the containing `VMContext`. May be null for host-created
-    /// globals.
-    pub vmctx: NonNull<VMContext>,
     /// The global declaration, used for compatibility checking.
     pub tag: Tag,
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -1025,10 +1025,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
 
@@ -1053,10 +1055,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
         assert_eq!(
@@ -1080,10 +1084,12 @@ mod tests {
             num_imported_tables: 0,
             num_imported_memories: 0,
             num_imported_globals: 0,
+            num_imported_tags: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             num_owned_memories: 0,
             num_defined_globals: 0,
+            num_defined_tags: 0,
             num_escaped_funcs: 0,
         });
         assert_eq!(

--- a/crates/wasmtime/src/runtime/vm/imports.rs
+++ b/crates/wasmtime/src/runtime/vm/imports.rs
@@ -1,5 +1,5 @@
 use crate::runtime::vm::vmcontext::{
-    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport,
+    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport, VMTagImport,
 };
 
 /// Resolved import pointers.
@@ -26,4 +26,7 @@ pub struct Imports<'a> {
 
     /// Resolved addresses for imported globals.
     pub globals: &'a [VMGlobalImport],
+
+    /// Resolved addresses for imported tags.
+    pub tags: &'a [VMTagImport],
 }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -9,11 +9,12 @@ use crate::runtime::vm::table::{Table, TableElement, TableElementType};
 use crate::runtime::vm::vmcontext::{
     VMBuiltinFunctionsArray, VMContext, VMFuncRef, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext, VMRuntimeLimits,
-    VMTableDefinition, VMTableImport,
+    VMTableDefinition, VMTableImport, VMTagDefinition, VMTagImport,
 };
 use crate::runtime::vm::{
-    ExportFunction, ExportGlobal, ExportMemory, ExportTable, GcStore, Imports, ModuleRuntimeInfo,
-    SendSyncPtr, VMFunctionBody, VMGcRef, VMStore, VMStoreRawPtr, VmPtr, VmSafe, WasmFault,
+    ExportFunction, ExportGlobal, ExportMemory, ExportTable, ExportTag, GcStore, Imports,
+    ModuleRuntimeInfo, SendSyncPtr, VMFunctionBody, VMGcRef, VMStore, VMStoreRawPtr, VmPtr, VmSafe,
+    WasmFault,
 };
 use crate::store::{StoreInner, StoreOpaque};
 use crate::{prelude::*, StoreContextMut};
@@ -30,9 +31,10 @@ use sptr::Strict;
 use wasmtime_environ::ModuleInternedTypeIndex;
 use wasmtime_environ::{
     packed_option::ReservedValue, DataIndex, DefinedGlobalIndex, DefinedMemoryIndex,
-    DefinedTableIndex, ElemIndex, EntityIndex, EntityRef, EntitySet, FuncIndex, GlobalIndex,
-    HostPtr, MemoryIndex, Module, PrimaryMap, PtrSize, TableIndex, TableInitialValue,
-    TableSegmentElements, Trap, VMOffsets, VMSharedTypeIndex, WasmHeapTopType, VMCONTEXT_MAGIC,
+    DefinedTableIndex, DefinedTagIndex, ElemIndex, EntityIndex, EntityRef, EntitySet, FuncIndex,
+    GlobalIndex, HostPtr, MemoryIndex, Module, PrimaryMap, PtrSize, TableIndex, TableInitialValue,
+    TableSegmentElements, TagIndex, Trap, VMOffsets, VMSharedTypeIndex, WasmHeapTopType,
+    VMCONTEXT_MAGIC,
 };
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::Wmemcheck;
@@ -441,6 +443,16 @@ impl Instance {
         unsafe { &*self.vmctx_plus_offset(self.offsets().vmctx_vmglobal_import(index)) }
     }
 
+    /// Return the indexed `VMTagImport`.
+    fn imported_tag(&self, index: TagIndex) -> &VMTagImport {
+        unsafe { &*self.vmctx_plus_offset(self.offsets().vmctx_vmtag_import(index)) }
+    }
+
+    /// Return the indexed `VMTagDefinition`.
+    fn tag_ptr(&mut self, index: DefinedTagIndex) -> NonNull<VMTagDefinition> {
+        unsafe { self.vmctx_plus_offset_mut(self.offsets().vmctx_vmtag_definition(index)) }
+    }
+
     /// Return the indexed `VMTableDefinition`.
     #[allow(dead_code)]
     fn table(&mut self, index: DefinedTableIndex) -> VMTableDefinition {
@@ -711,6 +723,18 @@ impl Instance {
             },
             vmctx: Some(self.vmctx()),
             global: self.env_module().globals[index],
+        }
+    }
+
+    fn get_exported_tag(&mut self, index: TagIndex) -> ExportTag {
+        ExportTag {
+            definition: if let Some(def_index) = self.env_module().defined_tag_index(index) {
+                self.tag_ptr(def_index)
+            } else {
+                self.imported_tag(index).from.as_non_null()
+            },
+            vmctx: self.vmctx(),
+            tag: self.env_module().tags[index],
         }
     }
 
@@ -1406,6 +1430,14 @@ impl Instance {
             imports.globals.len(),
         );
 
+        debug_assert_eq!(imports.tags.len(), module.num_imported_tags);
+        ptr::copy_nonoverlapping(
+            imports.tags.as_ptr(),
+            self.vmctx_plus_offset_mut(offsets.vmctx_imported_tags_begin())
+                .as_ptr(),
+            imports.tags.len(),
+        );
+
         // N.B.: there is no need to initialize the funcrefs array because we
         // eagerly construct each element in it whenever asked for a reference
         // to that element. In other words, there is no state needed to track
@@ -1449,6 +1481,21 @@ impl Instance {
         // allocated.
         for (index, _init) in module.global_initializers.iter() {
             self.global_ptr(index).write(VMGlobalDefinition::new());
+        }
+
+        // Initialize the defined tags
+        for i in 0..module.tags.len() - module.num_imported_tags {
+            let defined_index = DefinedTagIndex::new(i);
+            let tag_index = module.tag_index(defined_index);
+            let tag = module.tags[tag_index];
+            let ptr = self.tag_ptr(defined_index);
+            ptr.write(VMTagDefinition::new(match tag.signature {
+                wasmtime_environ::EngineOrModuleTypeIndex::Module(interned_index) => {
+                    self.engine_type_index(interned_index)
+                }
+                wasmtime_environ::EngineOrModuleTypeIndex::Engine(engine_index) => engine_index,
+                wasmtime_environ::EngineOrModuleTypeIndex::RecGroup(_) => unreachable!(),
+            }));
         }
     }
 
@@ -1504,6 +1551,11 @@ impl InstanceHandle {
         self.instance_mut().get_exported_global(export)
     }
 
+    /// Lookup a tag by index.
+    pub fn get_exported_tag(&mut self, export: TagIndex) -> ExportTag {
+        self.instance_mut().get_exported_tag(export)
+    }
+
     /// Lookup a memory by index.
     pub fn get_exported_memory(&mut self, export: MemoryIndex) -> ExportMemory {
         self.instance_mut().get_exported_memory(export)
@@ -1521,6 +1573,7 @@ impl InstanceHandle {
             EntityIndex::Global(i) => Export::Global(self.get_exported_global(i)),
             EntityIndex::Table(i) => Export::Table(self.get_exported_table(i)),
             EntityIndex::Memory(i) => Export::Memory(self.get_exported_memory(i)),
+            EntityIndex::Tag(i) => Export::Tag(self.get_exported_tag(i)),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1489,13 +1489,9 @@ impl Instance {
             let defined_index = DefinedTagIndex::new(i);
             let tag_index = module.tag_index(defined_index);
             let tag = module.tags[tag_index];
-            ptr.write(VMTagDefinition::new(match tag.signature {
-                wasmtime_environ::EngineOrModuleTypeIndex::Module(interned_index) => {
-                    self.engine_type_index(interned_index)
-                }
-                wasmtime_environ::EngineOrModuleTypeIndex::Engine(engine_index) => engine_index,
-                wasmtime_environ::EngineOrModuleTypeIndex::RecGroup(_) => unreachable!(),
-            }));
+            ptr.write(VMTagDefinition::new(
+                tag.signature.unwrap_engine_type_index(),
+            ));
             ptr = ptr.add(1);
         }
     }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1484,11 +1484,11 @@ impl Instance {
         }
 
         // Initialize the defined tags
-        for i in 0..module.tags.len() - module.num_imported_tags {
+        let mut ptr = self.vmctx_plus_offset_mut(offsets.vmctx_tags_begin());
+        for i in 0..module.num_defined_tags() {
             let defined_index = DefinedTagIndex::new(i);
             let tag_index = module.tag_index(defined_index);
             let tag = module.tags[tag_index];
-            let ptr = self.tag_ptr(defined_index);
             ptr.write(VMTagDefinition::new(match tag.signature {
                 wasmtime_environ::EngineOrModuleTypeIndex::Module(interned_index) => {
                     self.engine_type_index(interned_index)
@@ -1496,6 +1496,7 @@ impl Instance {
                 wasmtime_environ::EngineOrModuleTypeIndex::Engine(engine_index) => engine_index,
                 wasmtime_environ::EngineOrModuleTypeIndex::RecGroup(_) => unreachable!(),
             }));
+            ptr = ptr.add(1);
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -733,7 +733,6 @@ impl Instance {
             } else {
                 self.imported_tag(index).from.as_non_null()
             },
-            vmctx: self.vmctx(),
             tag: self.env_module().tags[index],
         }
     }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -270,8 +270,6 @@ mod test_vmglobal_import {
 pub struct VMTagImport {
     /// A pointer to the imported tag description.
     pub from: VmPtr<VMTagDefinition>,
-    /// A pointer to the owning instance.
-    pub vmctx: VmPtr<VMContext>,
 }
 
 // SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -263,6 +263,41 @@ mod test_vmglobal_import {
     }
 }
 
+/// The fields compiled code needs to access to utilize a WebAssembly
+/// tag imported from another instance.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+pub struct VMTagImport {
+    /// A pointer to the imported tag description.
+    pub from: VmPtr<VMTagDefinition>,
+    /// A pointer to the owning instance.
+    pub vmctx: VmPtr<VMContext>,
+}
+
+// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+unsafe impl VmSafe for VMTagImport {}
+
+#[cfg(test)]
+mod test_vmtag_import {
+    use super::VMTagImport;
+    use core::mem::{offset_of, size_of};
+    use wasmtime_environ::{Module, VMOffsets};
+
+    #[test]
+    fn check_vmtag_import_offsets() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(
+            size_of::<VMTagImport>(),
+            usize::from(offsets.size_of_vmtag_import())
+        );
+        assert_eq!(
+            offset_of!(VMTagImport, from),
+            usize::from(offsets.vmtag_import_from())
+        );
+    }
+}
+
 /// The fields compiled code needs to access to utilize a WebAssembly linear
 /// memory defined within the instance, namely the start address and the
 /// size in bytes.
@@ -666,6 +701,49 @@ mod test_vmshared_type_index {
             size_of::<VMSharedTypeIndex>(),
             usize::from(offsets.size_of_vmshared_type_index())
         );
+    }
+}
+
+/// A WebAssembly tag defined within the instance.
+///
+#[derive(Debug)]
+#[repr(C)]
+pub struct VMTagDefinition {
+    /// Function signature's type id.
+    pub type_index: VMSharedTypeIndex,
+}
+
+impl VMTagDefinition {
+    pub fn new(type_index: VMSharedTypeIndex) -> Self {
+        Self { type_index }
+    }
+}
+
+// SAFETY: the above structure is repr(C) and only contains VmSafe
+// fields.
+unsafe impl VmSafe for VMTagDefinition {}
+
+#[cfg(test)]
+mod test_vmtag_definition {
+    use super::VMTagDefinition;
+    use std::mem::size_of;
+    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+
+    #[test]
+    fn check_vmtag_definition_offsets() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(
+            size_of::<VMTagDefinition>(),
+            usize::from(offsets.ptr.size_of_vmtag_definition())
+        );
+    }
+
+    #[test]
+    fn check_vmtag_begins_aligned() {
+        let module = Module::new();
+        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        assert_eq!(offsets.vmctx_tags_begin() % 16, 0);
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -279,12 +279,12 @@ unsafe impl VmSafe for VMTagImport {}
 mod test_vmtag_import {
     use super::VMTagImport;
     use core::mem::{offset_of, size_of};
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
     fn check_vmtag_import_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMTagImport>(),
             usize::from(offsets.size_of_vmtag_import())
@@ -725,12 +725,12 @@ unsafe impl VmSafe for VMTagDefinition {}
 mod test_vmtag_definition {
     use super::VMTagDefinition;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, PtrSize, VMOffsets};
+    use wasmtime_environ::{HostPtr, Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vmtag_definition_offsets() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMTagDefinition>(),
             usize::from(offsets.ptr.size_of_vmtag_definition())
@@ -740,7 +740,7 @@ mod test_vmtag_definition {
     #[test]
     fn check_vmtag_begins_aligned() {
         let module = Module::new();
-        let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
+        let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(offsets.vmctx_tags_begin() % 16, 0);
     }
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -42,6 +42,7 @@ mod stack_overflow;
 mod store;
 mod structs;
 mod table;
+mod tags;
 mod threads;
 mod traps;
 mod types;

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -28,17 +28,17 @@ fn wasm_export_tags() -> Result<()> {
 
     let t1_ty = t1.ty(&store);
     let t2_ty = t2.ty(&store);
-    assert!(t1.eq(&t1, &store));
-    assert!(!t1.eq(&t2, &store));
+    assert!(Tag::eq(&t1, &t1, &store));
+    assert!(!Tag::eq(&t1, &t2, &store));
     assert!(FuncType::eq(t1_ty.ty(), t2_ty.ty()));
 
     let t3 = instance.get_tag(&mut store, "t3");
     assert!(t3.is_some());
     let t3 = t3.unwrap();
     let t3_ty = t3.ty(&store);
-    assert!(t3.eq(&t3, &store));
-    assert!(!t3.eq(&t1, &store));
-    assert!(!t3.eq(&t2, &store));
+    assert!(Tag::eq(&t3, &t3, &store));
+    assert!(!Tag::eq(&t3, &t1, &store));
+    assert!(!Tag::eq(&t3, &t2, &store));
     assert!(!FuncType::eq(t1_ty.ty(), t3_ty.ty()));
 
     return Ok(());
@@ -54,8 +54,9 @@ fn wasm_import_tags() -> Result<()> {
         "#;
     let m2_src = r#"
             (module
+                (tag (export "t1_2") (import "" "") (param i32) (result i32))
+                (tag (export "t1_22") (import "" "") (param i32) (result i32))
                 (tag (export "t2") (param i32) (result i32))
-                (tag (import "" "") (param i32) (result i32))
             )
         "#;
     let _ = env_logger::try_init();
@@ -68,7 +69,12 @@ fn wasm_import_tags() -> Result<()> {
 
     let m1_instance = Instance::new(&mut store, &m1, &[])?;
     let t1 = m1_instance.get_tag(&mut store, "t1").unwrap();
-    let _m2_instance = Instance::new(&mut store, &m2, &[t1.into()])?;
+    let m2_instance = Instance::new(&mut store, &m2, &[t1.into(), t1.into()])?;
+    let t1_2 = m2_instance.get_tag(&mut store, "t1_2").unwrap();
+    assert!(Tag::eq(&t1, &t1_2, &store));
+    let t1_22 = m2_instance.get_tag(&mut store, "t1_22").unwrap();
+    assert!(Tag::eq(&t1, &t1_22, &store));
+    assert!(Tag::eq(&t1_2, &t1_22, &store));
 
     return Ok(());
 }

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -1,0 +1,74 @@
+use wasmtime::*;
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn wasm_export_tags() -> Result<()> {
+    let source = r#"
+            (module
+                (tag (export "t1") (param i32) (result i32))
+                (tag (export "t2") (param i32) (result i32))
+                (tag (export "t3") (param i64) (result i32))
+            )
+        "#;
+    let _ = env_logger::try_init();
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let module = Module::new(&engine, source)?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let t1 = instance.get_tag(&mut store, "t1");
+    assert!(t1.is_some());
+    let t1 = t1.unwrap();
+
+    let t2 = instance.get_tag(&mut store, "t2");
+    assert!(t2.is_some());
+    let t2 = t2.unwrap();
+
+    let t1_ty = t1.ty(&store);
+    let t2_ty = t2.ty(&store);
+    assert!(t1.eq(&t1, &store));
+    assert!(!t1.eq(&t2, &store));
+    assert!(FuncType::eq(t1_ty.ty(), t2_ty.ty()));
+
+    let t3 = instance.get_tag(&mut store, "t3");
+    assert!(t3.is_some());
+    let t3 = t3.unwrap();
+    let t3_ty = t3.ty(&store);
+    assert!(t3.eq(&t3, &store));
+    assert!(!t3.eq(&t1, &store));
+    assert!(!t3.eq(&t2, &store));
+    assert!(!FuncType::eq(t1_ty.ty(), t3_ty.ty()));
+
+    return Ok(());
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn wasm_import_tags() -> Result<()> {
+    let m1_src = r#"
+            (module
+                (tag (export "t1") (param i32) (result i32))
+            )
+        "#;
+    let m2_src = r#"
+            (module
+                (tag (export "t2") (param i32) (result i32))
+                (tag (import "" "") (param i32) (result i32))
+            )
+        "#;
+    let _ = env_logger::try_init();
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let m1 = Module::new(&engine, m1_src)?;
+    let m2 = Module::new(&engine, m2_src)?;
+
+    let m1_instance = Instance::new(&mut store, &m1, &[])?;
+    let t1 = m1_instance.get_tag(&mut store, "t1").unwrap();
+    let _m2_instance = Instance::new(&mut store, &m2, &[t1.into()])?;
+
+    return Ok(());
+}


### PR DESCRIPTION
This patch is a subset of PR #10177. It adds support for tags in Wasmtime. Tags are used by the exception handling and stack switching proposals for typing and matching transfers of control.

This patch does not implement component model or C API support for tags. Issue #10252 tracks these two things.

CC @frank-emrich