### PR TITLE
Add vets for recently introduced crates

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -24,6 +24,22 @@ start = "2021-10-29"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.cranelift-assembler-x64]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-assembler-x64-meta]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.cranelift-bforest]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -555,6 +571,14 @@ criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-05-22"
 end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-io]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-keyvalue]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,8 +25,14 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.cranelift]
 audit-as-crates-io = true
 
+[policy.cranelift-assembler-x64]
+audit-as-crates-io = true
+
 [policy.cranelift-assembler-x64-fuzz]
 criteria = []
+
+[policy.cranelift-assembler-x64-meta]
+audit-as-crates-io = true
 
 [policy.cranelift-bforest]
 audit-as-crates-io = true
@@ -161,6 +167,9 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-http]
+audit-as-crates-io = true
+
+[policy.wasmtime-wasi-io]
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-keyvalue]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,14 @@ audited_as = "0.115.0"
 version = "0.118.0"
 audited_as = "0.116.1"
 
+[[unpublished.cranelift-assembler-x64]]
+version = "0.118.0"
+audited_as = "0.117.0"
+
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.118.0"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -585,6 +593,10 @@ audited_as = "28.0.0"
 version = "31.0.0"
 audited_as = "29.0.1"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "31.0.0"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -971,6 +983,18 @@ user-name = "Jeff Muizelaar"
 [[publisher.cranelift]]
 version = "0.116.1"
 when = "2025-01-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-assembler-x64]]
+version = "0.117.0"
+when = "2025-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-assembler-x64-meta]]
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1724,6 +1748,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "29.0.1"
 when = "2025-01-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-io]]
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
I believe this is similar to https://github.com/bytecodealliance/wasmtime/pull/10059

CI is currently failing due to missing audits for the following Bytecode Alliance authored crates:

* `wasmtime-wasi-io`
* `cranelift-assembler-x64`
* `cranelift-assembler-meta`


I decided to fold the audits into a single PR, but if preferred (or if there's a one-commit-per-audit sort of policy) I'm happy to open separate PRs for each.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
