### PR TITLE
Continuation types

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1458,6 +1458,8 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                 return CheckIndirectCallTypeSignature::StaticTrap;
             }
 
+            WasmHeapType::Cont | WasmHeapType::ConcreteCont(_) | WasmHeapType::NoCont => todo!(), // FIXME: #10248 stack switching support.
+
             // Engine-indexed types don't show up until runtime and it's a Wasm
             // validation error to perform a call through a non-function table,
             // so these cases are dynamically not reachable.
@@ -1701,6 +1703,7 @@ impl<'module_environment> TargetEnvironment for FuncEnvironment<'module_environm
         let needs_stack_map = match wasm_ty.top() {
             WasmHeapTopType::Extern | WasmHeapTopType::Any => true,
             WasmHeapTopType::Func => false,
+            WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
         };
         (ty, needs_stack_map)
     }
@@ -1816,6 +1819,9 @@ impl FuncEnvironment<'_> {
             WasmHeapTopType::Func => {
                 Ok(self.get_or_init_func_ref_table_elem(builder, table_index, index, false))
             }
+
+            // Continuation types.
+            WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
         }
     }
 
@@ -1862,6 +1868,9 @@ impl FuncEnvironment<'_> {
                     .store(flags, value_with_init_bit, elem_addr, 0);
                 Ok(())
             }
+
+            // Continuation types.
+            WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
         }
     }
 
@@ -2213,6 +2222,7 @@ impl FuncEnvironment<'_> {
             WasmHeapTopType::Func => pos.ins().iconst(self.pointer_type(), 0),
             // NB: null GC references don't need to be in stack maps.
             WasmHeapTopType::Any | WasmHeapTopType::Extern => pos.ins().iconst(types::I32, 0),
+            WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
         })
     }
 

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -148,6 +148,7 @@ fn read_field_at_addr(
                         .call(get_interned_func_ref, &[vmctx, func_ref_id, expected_ty]);
                     builder.func.dfg.first_result(call_inst)
                 }
+                WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
             },
         },
     };
@@ -1059,6 +1060,8 @@ pub fn translate_ref_test(
 
             func_env.is_subtype(builder, actual_shared_ty, expected_shared_ty)
         }
+
+        WasmHeapType::Cont | WasmHeapType::ConcreteCont(_) | WasmHeapType::NoCont => todo!(), // FIXME: #10248 stack switching support.
     };
     builder.ins().jump(continue_block, &[result]);
 
@@ -1391,6 +1394,8 @@ impl FuncEnvironment<'_> {
             WasmHeapType::Func | WasmHeapType::ConcreteFunc(_) | WasmHeapType::NoFunc => {
                 unreachable!()
             }
+
+            WasmHeapType::Cont | WasmHeapType::ConcreteCont(_) | WasmHeapType::NoCont => todo!(), // FIXME: #10248 stack switching support.
         };
 
         match (ty.nullable, might_be_i31) {

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -202,6 +202,7 @@ fn reference_type(wasm_ht: WasmHeapType, pointer_type: ir::Type) -> ir::Type {
     match wasm_ht.top() {
         WasmHeapTopType::Func => pointer_type,
         WasmHeapTopType::Any | WasmHeapTopType::Extern => ir::types::I32,
+        WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
     }
 }
 

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -1220,7 +1220,7 @@ impl ModuleTranslation<'_> {
                 // initializer won't trap so we could continue processing
                 // segments, but that's left as a future optimization if
                 // necessary.
-                WasmHeapTopType::Any | WasmHeapTopType::Extern => break,
+                WasmHeapTopType::Any | WasmHeapTopType::Extern | WasmHeapTopType::Cont => break,
             }
 
             // Function indices can be optimized here, but fully general

--- a/crates/environ/src/compile/module_types.rs
+++ b/crates/environ/src/compile/module_types.rs
@@ -438,6 +438,7 @@ where
                         WasmCompositeInnerType::Array(_) => WasmHeapType::ConcreteArray(index),
                         WasmCompositeInnerType::Func(_) => WasmHeapType::ConcreteFunc(index),
                         WasmCompositeInnerType::Struct(_) => WasmHeapType::ConcreteStruct(index),
+                        WasmCompositeInnerType::Cont(_) => WasmHeapType::ConcreteCont(index),
                     }
                 } else if let Some((wasmparser_types, _)) = self.rec_group_context.as_ref() {
                     let wasmparser_ty = &wasmparser_types[id].composite_type;
@@ -453,7 +454,7 @@ where
                             WasmHeapType::ConcreteStruct(index)
                         }
                         wasmparser::CompositeInnerType::Cont(_) => {
-                            panic!("unimplemented continuation types")
+                            WasmHeapType::ConcreteCont(index)
                         }
                     }
                 } else {
@@ -477,6 +478,7 @@ where
                         WasmCompositeInnerType::Array(_) => WasmHeapType::ConcreteArray(index),
                         WasmCompositeInnerType::Func(_) => WasmHeapType::ConcreteFunc(index),
                         WasmCompositeInnerType::Struct(_) => WasmHeapType::ConcreteStruct(index),
+                        WasmCompositeInnerType::Cont(_) => WasmHeapType::ConcreteCont(index),
                     }
                 } else if let Some((parser_types, rec_group)) = self.rec_group_context.as_ref() {
                     let rec_group_index = interned.index() - self.types.types.len_types();
@@ -497,7 +499,7 @@ where
                             WasmHeapType::ConcreteStruct(index)
                         }
                         wasmparser::CompositeInnerType::Cont(_) => {
-                            panic!("unimplemented continuation types")
+                            WasmHeapType::ConcreteCont(index)
                         }
                     }
                 } else {

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -162,6 +162,7 @@ pub trait GcTypeLayouts {
             WasmCompositeInnerType::Array(ty) => Some(self.array_layout(ty).into()),
             WasmCompositeInnerType::Struct(ty) => Some(self.struct_layout(ty).into()),
             WasmCompositeInnerType::Func(_) => None,
+            WasmCompositeInnerType::Cont(_) => None,
         }
     }
 

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -851,6 +851,7 @@ impl TypeRegistryInner {
                     .struct_layout(s)
                     .into(),
             ),
+            wasmtime_environ::WasmCompositeInnerType::Cont(_) => todo!(), // FIXME: #10248 stack switching support.
         };
 
         // Add the type to our slab.

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1096,6 +1096,8 @@ impl HeapType {
             | WasmHeapType::ConcreteStruct(EngineOrModuleTypeIndex::RecGroup(_)) => {
                 panic!("HeapType::from_wasm_type on non-canonicalized-for-runtime-usage heap type")
             }
+
+            WasmHeapType::Cont | WasmHeapType::ConcreteCont(_) | WasmHeapType::NoCont => todo!(), // FIXME: #10248 stack switching support.
         }
     }
 

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -187,6 +187,7 @@ fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Resul
         (H::ConcreteArray(actual), H::ConcreteArray(expected)) => actual == expected,
         (H::ConcreteFunc(actual), H::ConcreteFunc(expected)) => actual == expected,
         (H::ConcreteStruct(actual), H::ConcreteStruct(expected)) => actual == expected,
+        (H::ConcreteCont(actual), H::ConcreteCont(expected)) => actual == expected,
 
         (H::NoFunc, H::NoFunc) => true,
         (_, H::NoFunc) => false,
@@ -242,6 +243,15 @@ fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Resul
 
         (H::None, H::ConcreteStruct(_)) => true,
         (_, H::ConcreteStruct(_)) => false,
+
+        (H::NoCont | H::ConcreteCont(_) | H::Cont, H::Cont) => true,
+        (_, H::Cont) => false,
+
+        (H::NoCont, H::ConcreteCont(_)) => true,
+        (H::NoCont, H::NoCont) => true,
+
+        (_, H::NoCont) => false,
+        (_, H::ConcreteCont(_)) => false,
 
         (H::None, H::None) => true,
         (_, H::None) => false,

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1088,6 +1088,7 @@ impl Instance {
                             )
                         }),
                     )?,
+                    WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -606,6 +606,8 @@ fn initialize_tables(
                         let items = (0..table.size()).map(|_| funcref);
                         table.init_func(0, items)?;
                     }
+
+                    WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -263,6 +263,7 @@ fn wasm_to_table_type(ty: WasmRefType) -> TableElementType {
     match ty.heap_type.top() {
         WasmHeapTopType::Func => TableElementType::Func,
         WasmHeapTopType::Any | WasmHeapTopType::Extern => TableElementType::GcRef,
+        WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -500,6 +500,7 @@ impl VMGlobalDefinition {
                     global.init_gc_ref(store.gc_store_mut()?, r.as_ref())
                 }
                 WasmHeapTopType::Func => *global.as_func_ref_mut() = raw.get_funcref().cast(),
+                WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
             },
         }
         Ok(global)
@@ -533,6 +534,7 @@ impl VMGlobalDefinition {
                     }
                 }),
                 WasmHeapTopType::Func => ValRaw::funcref(self.as_func_ref().cast()),
+                WasmHeapTopType::Cont => todo!(), // FIXME: #10248 stack switching support.
             },
         })
     }


### PR DESCRIPTION
This patch is a subset of PR #10177. It adds continuation types to the `wasmtime-environ` crate. It does not add the runtime types.

CC @frank-emrich
