### PR TITLE
feat(wasmtime): add error hint for missing WASI imports

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -457,6 +457,18 @@ wasmtime_option_group! {
     }
 }
 
+impl WasiOptions {
+    /// Get the name of a relevant WASI option for a given import
+    pub fn option_for_import(import_name: &str) -> Option<&str> {
+        // TODO: do we have common import parsing machinery?
+        if import_name.contains("wasi:http") {
+            return Some("http");
+        }
+        // TODO: fill out
+        return None;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct WasiNnGraph {
     pub format: String,


### PR DESCRIPTION
This commit adds some code to print an error hint when a failed `wasmtime run` command could have been called with arguments (in particular `-S <capability>`) that would have enabled the command to succeed.

Output looks like this, when running a module that imports `wasi:http`:

```
warning: missing import [wasi:http/types@0.2.2] has a WASI import option [http]  that has not been enabled -- consider re-running with '-S http'.
Run `wasmtime -S help` for a full list of WASI import options.

Error: failed to run main module `http_hello_world.wasm`

Caused by:
    0: component imports instance `wasi:http/types@0.2.2`, but a matching implementation was not found in the linker
    1: instance export `fields` has the wrong type
```

There are a few bits left to figure out (ex. *seems* like wit-parser doesn't yet have any shared/reusable relatively simple function for parsing import names into constituent parts?), but wanted to put up a draft to get some feedback, and make sure this is even desirable for maintainers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
