### PR TITLE
winch(aarch64): Sync SP with SSP when claiming stack

### DIFF
--- a/tests/disas/winch/aarch64/br/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_br_if_cond.wat
@@ -16,5 +16,6 @@
 ;;       stur    x1, [x28]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br/as_br_value.wat
@@ -18,5 +18,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_if_cond.wat
@@ -23,5 +23,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_else.wat
+++ b/tests/disas/winch/aarch64/br/as_if_else.wat
@@ -31,5 +31,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_then.wat
+++ b/tests/disas/winch/aarch64/br/as_if_then.wat
@@ -31,5 +31,6 @@
 ;;   44: ldur    w0, [x28]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_loop_first.wat
+++ b/tests/disas/winch/aarch64/br/as_loop_first.wat
@@ -19,5 +19,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/br_jump.wat
+++ b/tests/disas/winch/aarch64/br/br_jump.wat
@@ -33,8 +33,10 @@
 ;;       mov     sp, x28
 ;;       stur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       b       #0x38
-;;   50: add     x28, x28, #0x18
+;;   54: add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
@@ -26,5 +26,6 @@
 ;;       b       #0x48
 ;;   48: add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_value.wat
@@ -23,5 +23,6 @@
 ;;       b       #0x3c
 ;;   3c: add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_if_cond.wat
@@ -37,5 +37,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
@@ -33,5 +33,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/large.wat
+++ b/tests/disas/winch/aarch64/br_table/large.wat
@@ -25380,5 +25380,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
+++ b/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
@@ -58,5 +58,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/multi.wat
+++ b/tests/disas/winch/aarch64/call/multi.wat
@@ -29,8 +29,10 @@
 ;;       ldur    x1, [x28, #4]
 ;;       ldur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x1]
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
@@ -52,10 +54,13 @@
 ;;       mov     x2, x9
 ;;       ldur    x0, [x28, #0xc]
 ;;       bl      #0
-;;   a0: add     x28, x28, #0xc
+;;   c0: add     x28, x28, #0xc
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0xc]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/params.wat
+++ b/tests/disas/winch/aarch64/call/params.wat
@@ -78,9 +78,11 @@
 ;;       mov     x16, #8
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
-;;       bl      #0x160
+;;       bl      #0x180
 ;;   a4: add     x28, x28, #0x24
+;;       mov     sp, x28
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       ldur    w2, [x28]
@@ -114,11 +116,14 @@
 ;;       mov     x16, #8
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
-;;       bl      #0x160
-;;  134: add     x28, x28, #0x20
+;;       bl      #0x180
+;;  13c: add     x28, x28, #0x20
+;;       mov     sp, x28
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
@@ -157,6 +162,7 @@
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/recursive.wat
+++ b/tests/disas/winch/aarch64/call/recursive.wat
@@ -41,7 +41,7 @@
 ;;       b.eq    #0x44
 ;;       b       #0x3c
 ;;   3c: ldur    w0, [x28, #4]
-;;       b       #0xc4
+;;       b       #0xd4
 ;;   44: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #1
 ;;       sub     x28, x28, #4
@@ -54,7 +54,9 @@
 ;;       ldur    w2, [x28, #4]
 ;;       bl      #0
 ;;   70: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, #2
@@ -68,13 +70,16 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       bl      #0
-;;   ac: add     x28, x28, #4
+;;   b4: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/reg_on_stack.wat
+++ b/tests/disas/winch/aarch64/call/reg_on_stack.wat
@@ -35,6 +35,7 @@
 ;;       mov     w2, w16
 ;;       bl      #0
 ;;   50: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
@@ -44,21 +45,25 @@
 ;;       mov     x16, #1
 ;;       mov     w2, w16
 ;;       bl      #0
-;;   78: ldur    x9, [x28, #0x18]
+;;   7c: ldur    x9, [x28, #0x18]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    w0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       tst     w1, w1
-;;       b.eq    #0xac
-;;       b       #0xa4
-;;   a4: add     x28, x28, #4
+;;       b.eq    #0xbc
 ;;       b       #0xb0
-;;   ac: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   b0: add     x28, x28, #4
+;;       mov     sp, x28
+;;       b       #0xc0
+;;   bc: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -36,6 +36,7 @@
 ;;       mov     w3, w16
 ;;       bl      #0x80
 ;;   4c: add     x28, x28, #8
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       mov     x16, #2
 ;;       mov     w1, w16
@@ -43,6 +44,7 @@
 ;;       ldur    w1, [x28, #4]
 ;;       add     w0, w0, w1, uxtx
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
@@ -63,6 +65,7 @@
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -47,7 +47,7 @@
 ;;       b       #0x3c
 ;;   3c: mov     x16, #1
 ;;       mov     w0, w16
-;;       b       #0x244
+;;       b       #0x268
 ;;   48: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #2
 ;;       sub     x28, x28, #4
@@ -59,7 +59,7 @@
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
 ;;       sub     sp, x28, #4
-;;       b.hs    #0x254
+;;       b.hs    #0x27c
 ;;   78: mov     sp, x28
 ;;       mov     x16, x1
 ;;       mov     x16, #8
@@ -71,7 +71,7 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xd8
+;;       b.ne    #0xdc
 ;;       b       #0xac
 ;;   ac: sub     x28, x28, #4
 ;;       mov     sp, x28
@@ -80,26 +80,28 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x38c
+;;       bl      #0x3b4
 ;;   cc: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xdc
-;;   d8: and     x0, x0, #0xfffffffffffffffe
+;;       b       #0xe0
+;;   dc: and     x0, x0, #0xfffffffffffffffe
 ;;       sub     sp, x28, #4
-;;       cbz     x0, #0x258
-;;   e4: mov     sp, x28
+;;       cbz     x0, #0x280
+;;   e8: mov     sp, x28
 ;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
 ;;       sub     sp, x28, #4
-;;       b.ne    #0x25c
-;;  100: mov     sp, x28
+;;       b.ne    #0x284
+;;  104: mov     sp, x28
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
 ;;       sub     x28, x28, #4
@@ -108,8 +110,10 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  138: add     x28, x28, #4
+;;  140: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       ldur    w1, [x28, #4]
 ;;       sub     w1, w1, #1
@@ -124,8 +128,8 @@
 ;;       mov     x2, x9
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
-;;       b.hs    #0x260
-;;  17c: mov     x16, x1
+;;       b.hs    #0x288
+;;  18c: mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
 ;;       ldur    x2, [x2, #0x50]
@@ -135,9 +139,9 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0x1e4
-;;       b       #0x1ac
-;;  1ac: sub     x28, x28, #4
+;;       b.ne    #0x1fc
+;;       b       #0x1bc
+;;  1bc: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       sub     x28, x28, #0xc
@@ -146,42 +150,48 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28, #0xc]
-;;       bl      #0x38c
-;;  1d4: add     x28, x28, #0xc
+;;       bl      #0x3b4
+;;  1e4: add     x28, x28, #0xc
+;;       mov     sp, x28
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x18]
-;;       b       #0x1e8
-;;  1e4: and     x0, x0, #0xfffffffffffffffe
-;;       cbz     x0, #0x264
-;;  1ec: ldur    x16, [x9, #0x40]
+;;       b       #0x200
+;;  1fc: and     x0, x0, #0xfffffffffffffffe
+;;       cbz     x0, #0x28c
+;;  204: ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
-;;       b.ne    #0x268
-;;  200: sub     x28, x28, #8
+;;       b.ne    #0x290
+;;  218: sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
 ;;       mov     x0, x5
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       blr     x4
-;;  22c: add     x28, x28, #4
+;;  248: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     w1, w1, w0, uxtx
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  254: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  258: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  25c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  260: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  264: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  268: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  27c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  280: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  284: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  288: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  28c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  290: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -29,6 +29,7 @@
 ;;       stur    w2, [x28, #4]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -53,7 +54,7 @@
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
 ;;       sub     sp, x28, #4
-;;       b.hs    #0x170
+;;       b.hs    #0x184
 ;;   94: mov     sp, x28
 ;;       mov     x16, x1
 ;;       mov     x16, #8
@@ -65,7 +66,7 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xf4
+;;       b.ne    #0xf8
 ;;       b       #0xc8
 ;;   c8: sub     x28, x28, #4
 ;;       mov     sp, x28
@@ -74,26 +75,28 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x380
+;;       bl      #0x394
 ;;   e8: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xf8
-;;   f4: and     x0, x0, #0xfffffffffffffffe
+;;       b       #0xfc
+;;   f8: and     x0, x0, #0xfffffffffffffffe
 ;;       sub     sp, x28, #4
-;;       cbz     x0, #0x174
-;;  100: mov     sp, x28
+;;       cbz     x0, #0x188
+;;  104: mov     sp, x28
 ;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
 ;;       sub     sp, x28, #4
-;;       b.ne    #0x178
-;;  11c: mov     sp, x28
+;;       b.ne    #0x18c
+;;  120: mov     sp, x28
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       ldur    x5, [x3, #0x18]
 ;;       ldur    x4, [x3, #8]
 ;;       sub     x28, x28, #4
@@ -102,13 +105,16 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  154: add     x28, x28, #4
+;;  15c: add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  170: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  174: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  178: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  184: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  188: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  18c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
@@ -22,5 +22,6 @@
 ;;       fabs    s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
@@ -21,5 +21,6 @@
 ;;       fabs    s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/const.wat
+++ b/tests/disas/winch/aarch64/f32_add/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/locals.wat
+++ b/tests/disas/winch/aarch64/f32_add/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/params.wat
+++ b/tests/disas/winch/aarch64/f32_add/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
@@ -22,5 +22,6 @@
 ;;       frintp  s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
@@ -21,5 +21,6 @@
 ;;       frintp  s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   s0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       scvtf   s0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   s0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   s0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
@@ -24,5 +24,6 @@
 ;;       ucvtf   s0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   s0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   s0, x0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       scvtf   s0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   s0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   s0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
@@ -24,5 +24,6 @@
 ;;       ucvtf   s0, x1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   s0, x1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/const.wat
@@ -28,5 +28,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/locals.wat
@@ -43,5 +43,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/params.wat
@@ -26,5 +26,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/const.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/const.wat
@@ -21,5 +21,6 @@
 ;;       fcvt    s0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
@@ -24,5 +24,6 @@
 ;;       fcvt    s0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/params.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/params.wat
@@ -21,5 +21,6 @@
 ;;       fcvt    s0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/const.wat
+++ b/tests/disas/winch/aarch64/f32_div/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/locals.wat
+++ b/tests/disas/winch/aarch64/f32_div/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/params.wat
+++ b/tests/disas/winch/aarch64/f32_div/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/const.wat
+++ b/tests/disas/winch/aarch64/f32_eq/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
@@ -22,5 +22,6 @@
 ;;       frintm  s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
@@ -21,5 +21,6 @@
 ;;       frintm  s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/const.wat
+++ b/tests/disas/winch/aarch64/f32_ge/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/const.wat
+++ b/tests/disas/winch/aarch64/f32_gt/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/const.wat
+++ b/tests/disas/winch/aarch64/f32_le/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/const.wat
+++ b/tests/disas/winch/aarch64/f32_lt/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/const.wat
+++ b/tests/disas/winch/aarch64/f32_max/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/locals.wat
+++ b/tests/disas/winch/aarch64/f32_max/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/params.wat
+++ b/tests/disas/winch/aarch64/f32_max/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/const.wat
+++ b/tests/disas/winch/aarch64/f32_min/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/locals.wat
+++ b/tests/disas/winch/aarch64/f32_min/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/params.wat
+++ b/tests/disas/winch/aarch64/f32_min/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/const.wat
+++ b/tests/disas/winch/aarch64/f32_mul/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f32_mul/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/params.wat
+++ b/tests/disas/winch/aarch64/f32_mul/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/const.wat
+++ b/tests/disas/winch/aarch64/f32_ne/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -40,5 +40,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
@@ -22,5 +22,6 @@
 ;;       frintn  s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
@@ -21,5 +21,6 @@
 ;;       frintn  s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
@@ -22,5 +22,6 @@
 ;;       fneg    s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
@@ -21,5 +21,6 @@
 ;;       fneg    s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
@@ -21,5 +21,6 @@
 ;;       fmov    s0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
@@ -24,5 +24,6 @@
 ;;       fmov    s0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
@@ -21,5 +21,6 @@
 ;;       fmov    s0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
@@ -22,5 +22,6 @@
 ;;       fsqrt   s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
@@ -21,5 +21,6 @@
 ;;       fsqrt   s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/const.wat
+++ b/tests/disas/winch/aarch64/f32_sub/const.wat
@@ -27,5 +27,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f32_sub/locals.wat
@@ -42,5 +42,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/params.wat
+++ b/tests/disas/winch/aarch64/f32_sub/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, s1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
@@ -22,5 +22,6 @@
 ;;       frintz  s0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
@@ -21,5 +21,6 @@
 ;;       frintz  s0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
@@ -24,5 +24,6 @@
 ;;       fabs    d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
@@ -21,5 +21,6 @@
 ;;       fabs    d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/const.wat
+++ b/tests/disas/winch/aarch64/f64_add/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/locals.wat
+++ b/tests/disas/winch/aarch64/f64_add/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/params.wat
+++ b/tests/disas/winch/aarch64/f64_add/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
@@ -24,5 +24,6 @@
 ;;       frintp  d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
@@ -21,5 +21,6 @@
 ;;       frintp  d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   d0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       scvtf   d0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   d0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   d0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
@@ -24,5 +24,6 @@
 ;;       ucvtf   d0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   d0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   d0, x0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       scvtf   d0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
@@ -21,5 +21,6 @@
 ;;       scvtf   d0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   d0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
@@ -24,5 +24,6 @@
 ;;       ucvtf   d0, x1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
@@ -21,5 +21,6 @@
 ;;       ucvtf   d0, x1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/const.wat
@@ -32,5 +32,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/locals.wat
@@ -48,5 +48,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/params.wat
@@ -26,5 +26,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/const.wat
+++ b/tests/disas/winch/aarch64/f64_div/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/locals.wat
+++ b/tests/disas/winch/aarch64/f64_div/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/params.wat
+++ b/tests/disas/winch/aarch64/f64_div/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/const.wat
+++ b/tests/disas/winch/aarch64/f64_eq/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
@@ -24,5 +24,6 @@
 ;;       frintm  d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
@@ -21,5 +21,6 @@
 ;;       frintm  d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/const.wat
+++ b/tests/disas/winch/aarch64/f64_ge/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/const.wat
+++ b/tests/disas/winch/aarch64/f64_gt/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/const.wat
+++ b/tests/disas/winch/aarch64/f64_le/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/const.wat
+++ b/tests/disas/winch/aarch64/f64_lt/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/const.wat
+++ b/tests/disas/winch/aarch64/f64_max/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/locals.wat
+++ b/tests/disas/winch/aarch64/f64_max/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/params.wat
+++ b/tests/disas/winch/aarch64/f64_max/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/const.wat
+++ b/tests/disas/winch/aarch64/f64_min/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/locals.wat
+++ b/tests/disas/winch/aarch64/f64_min/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/params.wat
+++ b/tests/disas/winch/aarch64/f64_min/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/const.wat
+++ b/tests/disas/winch/aarch64/f64_mul/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f64_mul/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/params.wat
+++ b/tests/disas/winch/aarch64/f64_mul/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/const.wat
+++ b/tests/disas/winch/aarch64/f64_ne/const.wat
@@ -26,5 +26,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -41,5 +41,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
@@ -24,5 +24,6 @@
 ;;       frintn  d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
@@ -21,5 +21,6 @@
 ;;       frintn  d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
@@ -24,5 +24,6 @@
 ;;       fneg    d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
@@ -21,5 +21,6 @@
 ;;       fneg    d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/const.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/const.wat
@@ -21,5 +21,6 @@
 ;;       fcvt    d0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
@@ -24,5 +24,6 @@
 ;;       fcvt    d0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/params.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/params.wat
@@ -21,5 +21,6 @@
 ;;       fcvt    d0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
@@ -21,5 +21,6 @@
 ;;       fmov    d0, x0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
@@ -24,5 +24,6 @@
 ;;       fmov    d0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
@@ -21,5 +21,6 @@
 ;;       fmov    d0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
@@ -26,7 +26,9 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       add     x28, x28, #8
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x10
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
@@ -24,5 +24,6 @@
 ;;       fsqrt   d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
@@ -21,5 +21,6 @@
 ;;       fsqrt   d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/const.wat
+++ b/tests/disas/winch/aarch64/f64_sub/const.wat
@@ -31,5 +31,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f64_sub/locals.wat
@@ -47,5 +47,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/params.wat
+++ b/tests/disas/winch/aarch64/f64_sub/params.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, d1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
@@ -24,5 +24,6 @@
 ;;       frintz  d0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
@@ -21,5 +21,6 @@
 ;;       frintz  d0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/const.wat
+++ b/tests/disas/winch/aarch64/i32_add/const.wat
@@ -22,5 +22,6 @@
 ;;       add     w0, w0, #0x14
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/locals.wat
+++ b/tests/disas/winch/aarch64/i32_add/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max.wat
+++ b/tests/disas/winch/aarch64/i32_add/max.wat
@@ -21,5 +21,6 @@
 ;;       add     w0, w0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_add/max_one.wat
@@ -23,5 +23,6 @@
 ;;       add     w0, w0, w16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_add/mixed.wat
@@ -22,5 +22,6 @@
 ;;       add     w0, w0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/params.wat
+++ b/tests/disas/winch/aarch64/i32_add/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/signed.wat
+++ b/tests/disas/winch/aarch64/i32_add/signed.wat
@@ -23,5 +23,6 @@
 ;;       add     w0, w0, w16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
@@ -22,5 +22,6 @@
 ;;       add     w0, w0, #0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/const.wat
+++ b/tests/disas/winch/aarch64/i32_and/const.wat
@@ -22,5 +22,6 @@
 ;;       and     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/locals.wat
+++ b/tests/disas/winch/aarch64/i32_and/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/params.wat
+++ b/tests/disas/winch/aarch64/i32_and/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/const.wat
+++ b/tests/disas/winch/aarch64/i32_clz/const.wat
@@ -21,5 +21,6 @@
 ;;       clz     w0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_clz/locals.wat
@@ -28,5 +28,6 @@
 ;;       clz     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/params.wat
+++ b/tests/disas/winch/aarch64/i32_clz/params.wat
@@ -21,5 +21,6 @@
 ;;       clz     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/const.wat
@@ -22,5 +22,6 @@
 ;;       clz     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/locals.wat
@@ -27,5 +27,6 @@
 ;;       clz     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/params.wat
@@ -22,5 +22,6 @@
 ;;       clz     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_divs/const.wat
+++ b/tests/disas/winch/aarch64/i32_divs/const.wat
@@ -22,17 +22,18 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     w0, #0x60
+;;       cbz     w0, #0x64
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   40: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/one_zero.wat
@@ -22,17 +22,18 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x60
+;;       cbz     w0, #0x64
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   40: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_divs/overflow.wat
@@ -22,17 +22,18 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     w0, #0x60
+;;       cbz     w0, #0x64
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   40: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/params.wat
+++ b/tests/disas/winch/aarch64/i32_divs/params.wat
@@ -22,17 +22,18 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x60
+;;       cbz     w0, #0x64
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   40: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
@@ -22,17 +22,18 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x60
+;;       cbz     w0, #0x64
 ;;   34: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   40: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -22,11 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     w0, #0x4c
+;;       cbz     w0, #0x50
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -22,11 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x4c
+;;       cbz     w0, #0x50
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -22,11 +22,12 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x4c
+;;       cbz     w0, #0x50
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -22,11 +22,12 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     w0, #0x4c
+;;       cbz     w0, #0x50
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -22,11 +22,12 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x4c
+;;       cbz     w0, #0x50
 ;;   34: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_eq/const.wat
+++ b/tests/disas/winch/aarch64/i32_eq/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i32_eq/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/params.wat
+++ b/tests/disas/winch/aarch64/i32_eq/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxth    w0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxth    w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxth    w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxtb    w0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxtb    w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxtb    w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, hs
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, hi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, le
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, lt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, lo
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/const.wat
+++ b/tests/disas/winch/aarch64/i32_mul/const.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i32_mul/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max_one.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/mixed.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/params.wat
+++ b/tests/disas/winch/aarch64/i32_mul/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/signed.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
@@ -23,5 +23,6 @@
 ;;       mul     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/const.wat
+++ b/tests/disas/winch/aarch64/i32_ne/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ne/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/params.wat
+++ b/tests/disas/winch/aarch64/i32_ne/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/const.wat
+++ b/tests/disas/winch/aarch64/i32_or/const.wat
@@ -22,5 +22,6 @@
 ;;       orr     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/locals.wat
+++ b/tests/disas/winch/aarch64/i32_or/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/params.wat
+++ b/tests/disas/winch/aarch64/i32_or/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/const.wat
@@ -24,5 +24,6 @@
 ;;       umov    w0, v31.b[0]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/reg.wat
@@ -24,5 +24,6 @@
 ;;       umov    w0, v31.b[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, v0.s[0]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
@@ -24,5 +24,6 @@
 ;;       mov     w0, v0.s[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, v0.s[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
@@ -25,5 +25,6 @@
 ;;       fmov    s0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rems/const.wat
+++ b/tests/disas/winch/aarch64/i32_rems/const.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     w0, #0x58
+;;       cbz     w0, #0x5c
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
@@ -30,6 +30,7 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/one_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x58
+;;       cbz     w0, #0x5c
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
@@ -30,6 +30,7 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_rems/overflow.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     w0, #0x58
+;;       cbz     w0, #0x5c
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
@@ -30,6 +30,7 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/params.wat
+++ b/tests/disas/winch/aarch64/i32_rems/params.wat
@@ -22,7 +22,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x58
+;;       cbz     w0, #0x5c
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
@@ -30,6 +30,7 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
@@ -22,7 +22,7 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x58
+;;       cbz     w0, #0x5c
 ;;   34: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
@@ -30,6 +30,7 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -22,12 +22,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
+;;       cbz     w0, #0x54
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
+;;       cbz     w0, #0x54
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -22,12 +22,13 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x50
+;;       cbz     w0, #0x54
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -22,12 +22,13 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
+;;       cbz     w0, #0x54
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
+;;       cbz     w0, #0x54
 ;;   34: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -24,5 +24,6 @@
 ;;       ror     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/8_const.wat
@@ -23,5 +23,6 @@
 ;;       ror     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/16_const.wat
@@ -23,5 +23,6 @@
 ;;       ror     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/8_const.wat
@@ -22,5 +22,6 @@
 ;;       ror     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/16_const.wat
@@ -24,5 +24,6 @@
 ;;       lsl     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/8_const.wat
@@ -23,5 +23,6 @@
 ;;       lsl     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shl/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/params.wat
+++ b/tests/disas/winch/aarch64/i32_shl/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
@@ -23,5 +23,6 @@
 ;;       asr     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
@@ -22,5 +22,6 @@
 ;;       asr     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
@@ -23,5 +23,6 @@
 ;;       lsr     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
@@ -22,5 +22,6 @@
 ;;       lsr     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/const.wat
+++ b/tests/disas/winch/aarch64/i32_sub/const.wat
@@ -22,5 +22,6 @@
 ;;       sub     w0, w0, #0x14
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i32_sub/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max.wat
@@ -22,5 +22,6 @@
 ;;       sub     w0, w0, w16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max_one.wat
@@ -22,5 +22,6 @@
 ;;       sub     w0, w0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/mixed.wat
@@ -22,5 +22,6 @@
 ;;       sub     w0, w0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/params.wat
+++ b/tests/disas/winch/aarch64/i32_sub/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/signed.wat
@@ -23,5 +23,6 @@
 ;;       sub     w0, w0, w16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
@@ -22,5 +22,6 @@
 ;;       sub     w0, w0, #0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
@@ -19,20 +19,21 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
@@ -22,20 +22,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
+;;       b.vs    #0x6c
 ;;   34: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
+;;       b.le    #0x70
 ;;   44: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
+;;       b.ge    #0x74
 ;;   54: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
@@ -19,20 +19,21 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
@@ -19,19 +19,20 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
@@ -22,19 +22,20 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
@@ -19,19 +19,20 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
@@ -19,21 +19,22 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
+;;       b.vs    #0x6c
 ;;   30: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
+;;       b.le    #0x70
 ;;   44: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
+;;       b.ge    #0x74
 ;;   54: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
@@ -22,21 +22,22 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x6c
+;;       b.vs    #0x70
 ;;   34: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x70
+;;       b.le    #0x74
 ;;   48: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x74
+;;       b.ge    #0x78
 ;;   58: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
@@ -19,21 +19,22 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
+;;       b.vs    #0x6c
 ;;   30: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
+;;       b.le    #0x70
 ;;   44: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
+;;       b.ge    #0x74
 ;;   54: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
@@ -19,19 +19,20 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
@@ -22,19 +22,20 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
@@ -19,19 +19,20 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
@@ -24,5 +24,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/const.wat
+++ b/tests/disas/winch/aarch64/i32_xor/const.wat
@@ -22,5 +22,6 @@
 ;;       eor     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i32_xor/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/params.wat
+++ b/tests/disas/winch/aarch64/i32_xor/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/const.wat
+++ b/tests/disas/winch/aarch64/i64_add/const.wat
@@ -22,5 +22,6 @@
 ;;       add     x0, x0, #0x14
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/locals.wat
+++ b/tests/disas/winch/aarch64/i64_add/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max.wat
+++ b/tests/disas/winch/aarch64/i64_add/max.wat
@@ -22,5 +22,6 @@
 ;;       add     x0, x0, x16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_add/max_one.wat
@@ -23,5 +23,6 @@
 ;;       add     x0, x0, x16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_add/mixed.wat
@@ -22,5 +22,6 @@
 ;;       add     x0, x0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/params.wat
+++ b/tests/disas/winch/aarch64/i64_add/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/signed.wat
+++ b/tests/disas/winch/aarch64/i64_add/signed.wat
@@ -23,5 +23,6 @@
 ;;       add     x0, x0, x16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
@@ -22,5 +22,6 @@
 ;;       add     x0, x0, #0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/32_const.wat
@@ -22,5 +22,6 @@
 ;;       and     x0, x0, #3
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/64_const.wat
@@ -22,5 +22,6 @@
 ;;       and     x0, x0, #0x7fffffffffffffff
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/locals.wat
+++ b/tests/disas/winch/aarch64/i64_and/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/params.wat
+++ b/tests/disas/winch/aarch64/i64_and/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/const.wat
+++ b/tests/disas/winch/aarch64/i64_clz/const.wat
@@ -21,5 +21,6 @@
 ;;       clz     x0, x0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_clz/locals.wat
@@ -28,5 +28,6 @@
 ;;       clz     x0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/params.wat
+++ b/tests/disas/winch/aarch64/i64_clz/params.wat
@@ -21,5 +21,6 @@
 ;;       clz     x0, x0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/const.wat
@@ -22,5 +22,6 @@
 ;;       clz     x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/locals.wat
@@ -29,5 +29,6 @@
 ;;       clz     x0, x16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/params.wat
@@ -22,5 +22,6 @@
 ;;       clz     x0, x16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_divs/const.wat
+++ b/tests/disas/winch/aarch64/i64_divs/const.wat
@@ -22,15 +22,16 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0x14
 ;;       mov     x1, x16
-;;       cbz     x0, #0x58
+;;       cbz     x0, #0x5c
 ;;   34: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x5c
+;;       b.vs    #0x60
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/one_zero.wat
@@ -22,15 +22,16 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x58
+;;       cbz     x0, #0x5c
 ;;   34: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x5c
+;;       b.vs    #0x60
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_divs/overflow.wat
@@ -22,15 +22,16 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x1, x16
-;;       cbz     x0, #0x58
+;;       cbz     x0, #0x5c
 ;;   34: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x5c
+;;       b.vs    #0x60
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/params.wat
+++ b/tests/disas/winch/aarch64/i64_divs/params.wat
@@ -22,15 +22,16 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x58
+;;       cbz     x0, #0x5c
 ;;   34: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x5c
+;;       b.vs    #0x60
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
@@ -22,15 +22,16 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x58
+;;       cbz     x0, #0x5c
 ;;   34: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x5c
+;;       b.vs    #0x60
 ;;   40: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   58: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   60: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/const.wat
+++ b/tests/disas/winch/aarch64/i64_divu/const.wat
@@ -22,11 +22,12 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0x14
 ;;       mov     x1, x16
-;;       cbz     x0, #0x4c
+;;       cbz     x0, #0x50
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/one_zero.wat
@@ -22,11 +22,12 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x4c
+;;       cbz     x0, #0x50
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/params.wat
+++ b/tests/disas/winch/aarch64/i64_divu/params.wat
@@ -22,11 +22,12 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x4c
+;;       cbz     x0, #0x50
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_divu/signed.wat
@@ -22,11 +22,12 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x4c
+;;       cbz     x0, #0x50
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
@@ -22,11 +22,12 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x4c
+;;       cbz     x0, #0x50
 ;;   34: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   4c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   50: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_eq/const.wat
+++ b/tests/disas/winch/aarch64/i64_eq/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i64_eq/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/params.wat
+++ b/tests/disas/winch/aarch64/i64_eq/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxth    x0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxth    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxth    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxtb    x0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxtb    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxtb    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
@@ -21,5 +21,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
@@ -24,5 +24,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
@@ -21,5 +21,6 @@
 ;;       sxtw    x0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
@@ -24,5 +24,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, w0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, hs
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, hi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, le
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/const.wat
@@ -25,5 +25,6 @@
 ;;       cset    x0, lt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, lo
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/const.wat
+++ b/tests/disas/winch/aarch64/i64_mul/const.wat
@@ -23,5 +23,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i64_mul/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max.wat
@@ -22,5 +22,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max_one.wat
@@ -23,5 +23,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/mixed.wat
@@ -23,5 +23,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/params.wat
+++ b/tests/disas/winch/aarch64/i64_mul/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/signed.wat
@@ -23,5 +23,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
@@ -23,5 +23,6 @@
 ;;       mul     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/const.wat
+++ b/tests/disas/winch/aarch64/i64_ne/const.wat
@@ -24,5 +24,6 @@
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ne/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/params.wat
+++ b/tests/disas/winch/aarch64/i64_ne/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/32_const.wat
@@ -22,5 +22,6 @@
 ;;       orr     x0, x0, #3
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/64_const.wat
@@ -22,5 +22,6 @@
 ;;       orr     x0, x0, #0x7fffffffffffffff
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/locals.wat
+++ b/tests/disas/winch/aarch64/i64_or/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/params.wat
+++ b/tests/disas/winch/aarch64/i64_or/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/const.wat
@@ -24,5 +24,6 @@
 ;;       umov    w0, v31.b[0]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/reg.wat
@@ -24,5 +24,6 @@
 ;;       umov    w0, v31.b[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
@@ -21,5 +21,6 @@
 ;;       mov     x0, v0.d[0]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
@@ -24,5 +24,6 @@
 ;;       mov     x0, v0.d[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
@@ -21,5 +21,6 @@
 ;;       mov     x0, v0.d[0]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
@@ -25,5 +25,6 @@
 ;;       fmov    d0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rems/const.wat
+++ b/tests/disas/winch/aarch64/i64_rems/const.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #7
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/one_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_rems/overflow.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/params.wat
+++ b/tests/disas/winch/aarch64/i64_rems/params.wat
@@ -22,12 +22,13 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/const.wat
+++ b/tests/disas/winch/aarch64/i64_remu/const.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #7
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/one_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/params.wat
+++ b/tests/disas/winch/aarch64/i64_remu/params.wat
@@ -22,12 +22,13 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_remu/signed.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
@@ -22,12 +22,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
+;;       cbz     x0, #0x54
 ;;   34: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   54: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -24,5 +24,6 @@
 ;;       ror     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/8_const.wat
@@ -23,5 +23,6 @@
 ;;       ror     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/locals.wat
@@ -42,5 +42,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/params.wat
@@ -26,5 +26,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/16_const.wat
@@ -23,5 +23,6 @@
 ;;       ror     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/8_const.wat
@@ -22,5 +22,6 @@
 ;;       ror     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/16_const.wat
@@ -23,5 +23,6 @@
 ;;       lsl     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/8_const.wat
@@ -22,5 +22,6 @@
 ;;       lsl     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shl/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/params.wat
+++ b/tests/disas/winch/aarch64/i64_shl/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
@@ -23,5 +23,6 @@
 ;;       asr     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
@@ -22,5 +22,6 @@
 ;;       asr     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
@@ -23,5 +23,6 @@
 ;;       lsr     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
@@ -22,5 +22,6 @@
 ;;       lsr     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/const.wat
+++ b/tests/disas/winch/aarch64/i64_sub/const.wat
@@ -22,5 +22,6 @@
 ;;       sub     x0, x0, #0x14
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i64_sub/locals.wat
@@ -41,5 +41,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max.wat
@@ -22,5 +22,6 @@
 ;;       sub     x0, x0, x16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max_one.wat
@@ -22,5 +22,6 @@
 ;;       sub     x0, x0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/mixed.wat
@@ -22,5 +22,6 @@
 ;;       sub     x0, x0, #1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/params.wat
+++ b/tests/disas/winch/aarch64/i64_sub/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/signed.wat
@@ -23,5 +23,6 @@
 ;;       sub     x0, x0, x16, uxtx
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
@@ -22,5 +22,6 @@
 ;;       sub     x0, x0, #0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
@@ -19,20 +19,21 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
@@ -22,20 +22,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
+;;       b.vs    #0x6c
 ;;   34: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
+;;       b.le    #0x70
 ;;   44: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
+;;       b.ge    #0x74
 ;;   54: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
@@ -19,20 +19,21 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
@@ -19,19 +19,20 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
@@ -22,19 +22,20 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
@@ -19,19 +19,20 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
@@ -19,20 +19,21 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
@@ -22,20 +22,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
+;;       b.vs    #0x6c
 ;;   34: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
+;;       b.le    #0x70
 ;;   44: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
+;;       b.ge    #0x74
 ;;   54: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
@@ -19,20 +19,21 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   30: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
@@ -19,19 +19,20 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
@@ -22,19 +22,20 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
+;;       b.vs    #0x68
 ;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
+;;       b.le    #0x6c
 ;;   40: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
+;;       b.ge    #0x70
 ;;   50: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
@@ -19,19 +19,20 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x60
+;;       b.vs    #0x64
 ;;   30: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x64
+;;       b.le    #0x68
 ;;   3c: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x68
+;;       b.ge    #0x6c
 ;;   4c: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_xor/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/32_const.wat
@@ -22,5 +22,6 @@
 ;;       eor     x0, x0, #3
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/64_const.wat
@@ -22,5 +22,6 @@
 ;;       eor     x0, x0, #0x7fffffffffffffff
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i64_xor/locals.wat
@@ -40,5 +40,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/params.wat
+++ b/tests/disas/winch/aarch64/i64_xor/params.wat
@@ -25,5 +25,6 @@
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -34,9 +34,9 @@
 ;;       ldur    x1, [x9, #0x60]
 ;;       mov     w2, w0
 ;;       add     x2, x2, #4
-;;       b.hs    #0x12c
+;;       b.hs    #0x138
 ;;   3c: cmp     x2, x1, uxtx
-;;       b.hi    #0x130
+;;       b.hi    #0x13c
 ;;   44: ldur    x3, [x9, #0x58]
 ;;       add     x3, x3, x0, uxtx
 ;;       mov     x16, #0
@@ -48,9 +48,9 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.hs    #0x134
+;;       b.hs    #0x140
 ;;   74: cmp     x3, x2, uxtx
-;;       b.hi    #0x138
+;;       b.hi    #0x144
 ;;   7c: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
@@ -65,9 +65,9 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x4, x4, x16, uxtx
-;;       b.hs    #0x13c
+;;       b.hs    #0x148
 ;;   b8: cmp     x4, x3, uxtx
-;;       b.hi    #0x140
+;;       b.hi    #0x14c
 ;;   c0: ldur    x5, [x9, #0x58]
 ;;       add     x5, x5, x2, uxtx
 ;;       orr     x16, xzr, #0xfffff
@@ -87,17 +87,20 @@
 ;;       ldur    x1, [x28, #8]
 ;;       ldur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x1]
 ;;       ldur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x1, #4]
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  12c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  130: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  134: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  138: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  13c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  140: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  144: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  148: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  14c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/load/f32.wat
+++ b/tests/disas/winch/aarch64/load/f32.wat
@@ -22,5 +22,6 @@
 ;;       ldur    s0, [x1]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/f64.wat
+++ b/tests/disas/winch/aarch64/load/f64.wat
@@ -21,5 +21,6 @@
 ;;       ldur    d0, [x1]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i32.wat
+++ b/tests/disas/winch/aarch64/load/i32.wat
@@ -22,5 +22,6 @@
 ;;       ldur    w0, [x1]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i64.wat
+++ b/tests/disas/winch/aarch64/load/i64.wat
@@ -34,5 +34,6 @@
 ;;       mov     sp, x28
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/nop/nop.wat
+++ b/tests/disas/winch/aarch64/nop/nop.wat
@@ -17,5 +17,6 @@
 ;;       stur    x1, [x28]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/400_params.wat
+++ b/tests/disas/winch/aarch64/params/400_params.wat
@@ -67,5 +67,6 @@
 ;;       ldur    w0, [x28, #0x14]
 ;;       add     x28, x28, #0x28
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/multi_values.wat
+++ b/tests/disas/winch/aarch64/params/multi_values.wat
@@ -39,14 +39,18 @@
 ;;       ldur    x0, [x28, #0xc]
 ;;       ldur    s31, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    s31, [x0]
 ;;       ldur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x0, #4]
 ;;       ldur    w16, [x28]
 ;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x0, #8]
 ;;       add     x28, x28, #0x28
+;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -37,9 +37,9 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #4
-;;       b.hs    #0x108
+;;       b.hs    #0x10c
 ;;   48: cmp     x3, x2, uxtx
-;;       b.hi    #0x10c
+;;       b.hi    #0x110
 ;;   50: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       mov     x16, #0
@@ -52,9 +52,9 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.hs    #0x110
+;;       b.hs    #0x114
 ;;   84: cmp     x3, x2, uxtx
-;;       b.hi    #0x114
+;;       b.hi    #0x118
 ;;   8c: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
@@ -70,9 +70,9 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x3, x3, x16, uxtx
-;;       b.hs    #0x118
+;;       b.hs    #0x11c
 ;;   cc: cmp     x3, x2, uxtx
-;;       b.hi    #0x11c
+;;       b.hi    #0x120
 ;;   d4: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       orr     x16, xzr, #0xfffff
@@ -84,11 +84,12 @@
 ;;       stur    w0, [x4]
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  108: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  10c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  110: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  114: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  118: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  11c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  120: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/store/f32.wat
+++ b/tests/disas/winch/aarch64/store/f32.wat
@@ -23,5 +23,6 @@
 ;;       stur    s0, [x1]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/f64.wat
+++ b/tests/disas/winch/aarch64/store/f64.wat
@@ -24,5 +24,6 @@
 ;;       stur    d0, [x1]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i32.wat
+++ b/tests/disas/winch/aarch64/store/i32.wat
@@ -25,5 +25,6 @@
 ;;       stur    w0, [x2]
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i64.wat
+++ b/tests/disas/winch/aarch64/store/i64.wat
@@ -21,5 +21,6 @@
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
+;;       mov     sp, x28
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -163,6 +163,17 @@ impl Masm for MacroAssembler {
         self.asm
             .add_ir(bytes as u64, ssp, writable!(ssp), OperandSize::S64);
 
+        // We must ensure that the real stack pointer reflects the the offset
+        // tracked by `self.sp_offset`, we use such value to calculate
+        // alignment, which is crucial for calls.
+        //
+        // As an optimization: this synchronization doesn't need to happen all
+        // the time, in theory we could ensure to sync the shadow stack pointer
+        // with the stack pointer when alignment is required, like at callsites.
+        // This is the simplest approach at the time of writing, which
+        // integrates well with the rest of the aarch64 infrastructure.
+        self.move_shadow_sp_to_sp();
+
         self.decrement_sp(bytes);
         Ok(())
     }


### PR DESCRIPTION
This commit is a follow-up to
https://github.com/bytecodealliance/wasmtime/pull/10146  and represents another step toward fixing the remaining issues discovered through spec tests in the same vein as https://github.com/bytecodealliance/wasmtime/pull/10201

Specifically, this commit ensures that the stack pointer is always in sync with the shadow stack pointer. The previous approach was lossy because it only performed the sync when reserving stack space. While this approach worked in some cases, it failed to account for situations where the shadow stack pointer might be adjusted and aligned for calls. As a result, the stack pointer could become unaligned when claiming stack space, leading to issues at call sites.

It is possible to avoid the unconditional move and perform it only when alignment is needed, i.e., at call sites and when the real stack pointer is unaligned. However, as of now, the simplest solution is to always perform the sync, which integrates best with the current infrastructure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
