### PR TITLE
Bump MSRV to 1.83.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2025-01-09" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2025-02-20" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ edition = "2021"
 #
 # NB: once this is 1.84+ delete `pulley/build.rs` and the similar code in
 # `crate/wasmtime/build.rs`
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -27,41 +27,28 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     wasi::fd_close(fd).expect("closing a file");
     wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
-    // Yes, renaming a dir to an empty dir is a property guaranteed by rename(2)
-    // and its fairly important that it is atomic.
-    // But, we haven't found a way to emulate it on windows. So, sometimes this
-    // behavior is just hosed. Sorry.
-    if config().support_rename_dir_to_empty_dir() {
-        // Now, try renaming renaming a dir to existing empty dir
-        wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
-        wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
-        wasi::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
+    // Now, try renaming renaming a dir to existing empty dir
+    wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
+    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasi::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
 
-        // Check that source directory doesn't exist anymore
-        assert_errno!(
-            wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                .expect_err("opening a nonexistent path as a directory"),
-            wasi::ERRNO_NOENT
-        );
+    // Check that source directory doesn't exist anymore
+    assert_errno!(
+        wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+            .expect_err("opening a nonexistent path as a directory"),
+        wasi::ERRNO_NOENT
+    );
 
-        // Check that target directory exists
-        fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-            .expect("opening renamed path as a directory");
-        assert!(
-            fd > libc::STDERR_FILENO as wasi::Fd,
-            "file descriptor range check",
-        );
+    // Check that target directory exists
+    fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        .expect("opening renamed path as a directory");
+    assert!(
+        fd > libc::STDERR_FILENO as wasi::Fd,
+        "file descriptor range check",
+    );
 
-        wasi::fd_close(fd).expect("closing a file");
-        wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
-    } else {
-        wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
-        wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
-        wasi::path_rename(dir_fd, "source", dir_fd, "target")
-            .expect_err("windows does not support renaming a directory to an empty directory");
-        wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
-        wasi::path_remove_directory(dir_fd, "source").expect("removing a directory");
-    }
+    wasi::fd_close(fd).expect("closing a file");
+    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Now, try renaming a dir to existing non-empty dir
     wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
@@ -75,25 +62,14 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
         unix => wasi::ERRNO_NOTEMPTY
     );
 
-    // This is technically a different property, but the root of these divergent behaviors is in
-    // the semantics that windows gives us around renaming directories. So, it lives under the same
-    // flag.
-    if config().support_rename_dir_to_empty_dir() {
-        // Try renaming dir to a file
-        assert_errno!(
-            wasi::path_rename(dir_fd, "source", dir_fd, "target/file")
-                .expect_err("renaming a directory to a file"),
-            wasi::ERRNO_NOTDIR
-        );
-        wasi::path_unlink_file(dir_fd, "target/file").expect("removing a file");
-        wasi::path_remove_directory(dir_fd, "source").expect("removing a directory");
-    } else {
-        // Windows will let you erase a file by renaming a directory to it.
-        // WASI users can't depend on this error getting caught to prevent data loss.
+    // Try renaming dir to a file
+    assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target/file")
-            .expect("windows happens to support renaming a directory to a file");
-        wasi::path_remove_directory(dir_fd, "target/file").expect("removing a file");
-    }
+            .expect_err("renaming a directory to a file"),
+        wasi::ERRNO_NOTDIR
+    );
+    wasi::path_unlink_file(dir_fd, "target/file").expect("removing a file");
+    wasi::path_remove_directory(dir_fd, "source").expect("removing a directory");
     wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Now, try renaming a file to a nonexistent path

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -58,8 +58,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target")
             .expect_err("renaming directory to a nonempty directory"),
-        windows => wasi::ERRNO_ACCES,
-        unix => wasi::ERRNO_NOTEMPTY
+        wasi::ERRNO_NOTEMPTY
     );
 
     // Try renaming dir to a file
@@ -123,8 +122,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target")
             .expect_err("renaming a file to existing directory should fail"),
-        windows => wasi::ERRNO_ACCES,
-        unix => wasi::ERRNO_ISDIR
+        wasi::ERRNO_ISDIR
     );
 
     wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use test_programs::preview1::{assert_errno, config, create_file, open_scratch_directory};
+use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
 unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     // First, try renaming a dir to nonexistent path

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -122,7 +122,8 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target")
             .expect_err("renaming a file to existing directory should fail"),
-        wasi::ERRNO_ISDIR
+        windows => wasi::ERRNO_ACCES,
+        unix => wasi::ERRNO_ISDIR
     );
 
     wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");


### PR DESCRIPTION
This commit updates the minimum supported Rust version for Wasmtime and Cranelift to 1.83.0. This is coupled with Rust's release today of 1.85.0. Additionally the nightly version used in testing was updated to today's nightly too.



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
