### PR TITLE
ci: use semicolons for path separation on Windows

### DIFF
--- a/cranelift/assembler-x64/build.rs
+++ b/cranelift/assembler-x64/build.rs
@@ -13,12 +13,16 @@ fn main() {
         meta::generate_isle_definitions(out_dir.join("assembler-definitions.isle")),
     ];
 
+    #[cfg(not(target_os = "windows"))]
+    const SEPARATOR: &str = ":";
+    #[cfg(target_os = "windows")]
+    const SEPARATOR: &str = ";";
     println!(
         "cargo:rustc-env=ASSEMBLER_BUILT_FILES={}",
         built_files
             .iter()
             .map(|p| p.to_string_lossy().to_string())
             .collect::<Vec<_>>()
-            .join(":")
+            .join(SEPARATOR)
     );
 }

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -81,8 +81,12 @@ pub use rex::RexFlags;
 
 /// List the files generated to create this assembler.
 pub fn generated_files() -> Vec<std::path::PathBuf> {
+    #[cfg(not(target_os = "windows"))]
+    const SEPARATOR: char = ':';
+    #[cfg(target_os = "windows")]
+    const SEPARATOR: char = ';';
     env!("ASSEMBLER_BUILT_FILES")
-        .split(':')
+        .split(SEPARATOR)
         .map(std::path::PathBuf::from)
         .collect()
 }


### PR DESCRIPTION
The new assembler uses `:` to separate a list of paths containing generated code. We received a report that on Windows this could lead to build issues; this change uses `;` for Windows instead.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
