### PR TITLE
ci: generate a list of generated files

### DIFF
--- a/cranelift/assembler-x64/build.rs
+++ b/cranelift/assembler-x64/build.rs
@@ -1,5 +1,7 @@
 use cranelift_assembler_x64_meta as meta;
 use std::env;
+use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 
 fn main() {
@@ -13,12 +15,12 @@ fn main() {
         meta::generate_isle_definitions(out_dir.join("assembler-definitions.isle")),
     ];
 
-    println!(
-        "cargo:rustc-env=ASSEMBLER_BUILT_FILES={}",
-        built_files
-            .iter()
-            .map(|p| p.to_string_lossy().to_string())
-            .collect::<Vec<_>>()
-            .join(":")
-    );
+    // Generating this additional bit of Rust is necessary for listing the
+    // generated files.
+    let mut vec_of_built_files = File::create(out_dir.join("generated-files.rs")).unwrap();
+    writeln!(vec_of_built_files, "vec![").unwrap();
+    for file in &built_files {
+        writeln!(vec_of_built_files, "  \"{}\".into(),", file.display()).unwrap();
+    }
+    writeln!(vec_of_built_files, "]").unwrap();
 }

--- a/cranelift/assembler-x64/build.rs
+++ b/cranelift/assembler-x64/build.rs
@@ -20,7 +20,7 @@ fn main() {
     let mut vec_of_built_files = File::create(out_dir.join("generated-files.rs")).unwrap();
     writeln!(vec_of_built_files, "vec![").unwrap();
     for file in &built_files {
-        writeln!(vec_of_built_files, "  \"{}\".into(),", file.display()).unwrap();
+        writeln!(vec_of_built_files, "  {:?}.into(),", file.display()).unwrap();
     }
     writeln!(vec_of_built_files, "]").unwrap();
 }

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -81,8 +81,5 @@ pub use rex::RexFlags;
 
 /// List the files generated to create this assembler.
 pub fn generated_files() -> Vec<std::path::PathBuf> {
-    env!("ASSEMBLER_BUILT_FILES")
-        .split(':')
-        .map(std::path::PathBuf::from)
-        .collect()
+    include!(concat!(env!("OUT_DIR"), "/generated-files.rs"))
 }


### PR DESCRIPTION
This fix is necessary for Windows users who may be using absolute-path target directories: the previous solution, separating the paths by `:`, runs into issues with Windows absolute paths (e.g., `C:\...`). This change is similar to #10266 but should avoid any further OS compatibility issues during a hypothetical cross-compilation.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
