### PR TITLE
[30.0.0] ci: generate a list of generated files

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,8 @@ Released 2025-02-21.
 [Zulip discussion]: https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Wasmtime.2030.20x64.20assembler.20build.20error.20on.20Windows
 [#10270]: https://github.com/bytecodealliance/wasmtime/pull/10270
 
+--------------------------------------------------------------------------------
+
 ## 30.0.0
 
 Released 2025-02-20.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,16 @@
+## 30.0.1
+
+Released 2025-02-21.
+
+### Fixed
+
+* Fixes an issue building the `cranelift-assembler-x64` crate on Windows
+  when the Rust toolchain is on a different drive than the project using
+  `wasmtime`. For more details, see the [Zulip discussion]. [#10270]
+
+[Zulip discussion]: https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Wasmtime.2030.20x64.20assembler.20build.20error.20on.20Windows
+[#10270]: https://github.com/bytecodealliance/wasmtime/pull/10270
+
 ## 30.0.0
 
 Released 2025-02-20.

--- a/cranelift/assembler-x64/build.rs
+++ b/cranelift/assembler-x64/build.rs
@@ -1,5 +1,7 @@
 use cranelift_assembler_x64_meta as meta;
 use std::env;
+use std::fs::File;
+use std::io::Write;
 use std::path::Path;
 
 fn main() {
@@ -13,12 +15,12 @@ fn main() {
         meta::generate_isle_definitions(out_dir.join("assembler-definitions.isle")),
     ];
 
-    println!(
-        "cargo:rustc-env=ASSEMBLER_BUILT_FILES={}",
-        built_files
-            .iter()
-            .map(|p| p.to_string_lossy().to_string())
-            .collect::<Vec<_>>()
-            .join(":")
-    );
+    // Generating this additional bit of Rust is necessary for listing the
+    // generated files.
+    let mut vec_of_built_files = File::create(out_dir.join("generated-files.rs")).unwrap();
+    writeln!(vec_of_built_files, "vec![").unwrap();
+    for file in &built_files {
+        writeln!(vec_of_built_files, "  {:?}.into(),", file.display()).unwrap();
+    }
+    writeln!(vec_of_built_files, "]").unwrap();
 }

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -79,8 +79,5 @@ pub use rex::RexFlags;
 
 /// List the files generated to create this assembler.
 pub fn generated_files() -> Vec<std::path::PathBuf> {
-    env!("ASSEMBLER_BUILT_FILES")
-        .split(':')
-        .map(std::path::PathBuf::from)
-        .collect()
+    include!(concat!(env!("OUT_DIR"), "/generated-files.rs"))
 }

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -78,6 +78,7 @@ pub use reg::{Gpr, NonRspGpr, Size};
 pub use rex::RexFlags;
 
 /// List the files generated to create this assembler.
+#[must_use]
 pub fn generated_files() -> Vec<std::path::PathBuf> {
     include!(concat!(env!("OUT_DIR"), "/generated-files.rs"))
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -24,6 +24,22 @@ start = "2021-10-29"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.cranelift-assembler-x64]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-assembler-x64-meta]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.cranelift-bforest]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -555,6 +571,14 @@ criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-05-22"
 end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-io]]
+who = "Saúl Cabrera <saulecabrera@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-02-20"
+end = "2026-02-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-keyvalue]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,8 +25,14 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.cranelift]
 audit-as-crates-io = true
 
+[policy.cranelift-assembler-x64]
+audit-as-crates-io = true
+
 [policy.cranelift-assembler-x64-fuzz]
 criteria = []
+
+[policy.cranelift-assembler-x64-meta]
+audit-as-crates-io = true
 
 [policy.cranelift-bforest]
 audit-as-crates-io = true
@@ -161,6 +167,9 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-http]
+audit-as-crates-io = true
+
+[policy.wasmtime-wasi-io]
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-keyvalue]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,18 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift]]
+version = "0.118.0"
+audited_as = "0.116.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.118.0"
+audited_as = "0.117.0"
+
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.118.0"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -437,6 +449,14 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "31.0.0"
+audited_as = "29.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "31.0.0"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -779,6 +799,18 @@ user-name = "Jeff Muizelaar"
 [[publisher.cranelift]]
 version = "0.115.0"
 when = "2024-12-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-assembler-x64]]
+version = "0.117.0"
+when = "2025-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-assembler-x64-meta]]
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1514,6 +1546,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "28.0.0"
 when = "2024-12-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-io]]
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is a backport of #10267: The fix is necessary for Windows users who may be using absolute-path target directories: the previous solution, separating the paths by `:`, runs into issues with Windows absolute paths (e.g., `C:\...`). This change is similar to #10266 but should avoid any further OS compatibility issues during a hypothetical cross-compilation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
