### PR TITLE
Release Wasmtime 30.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "30.0.0"
+version = "30.0.1"
 
 [[package]]
 name = "byteorder"
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -738,18 +738,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.117.0"
+version = "0.117.1"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen-shared",
@@ -801,18 +801,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.117.0"
+version = "0.117.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.117.0"
+version = "0.117.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1235,7 +1235,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3830,7 +3830,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4213,14 +4213,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4236,14 +4236,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4398,11 +4398,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "30.0.0"
+version = "30.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "cc",
  "object",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4576,14 +4576,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "30.0.0"
+version = "30.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast-util"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "30.0.0"
+version = "30.0.1"
 
 [[package]]
 name = "wast"
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,7 +4940,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "30.0.0"
+version = "30.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "30.0.0"
+version = "30.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -221,62 +221,62 @@ allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=30.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "30.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=30.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=30.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=30.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=30.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=30.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=30.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=30.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=30.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=30.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=30.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "30.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "30.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "30.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "30.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "30.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "30.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "30.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=30.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=30.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=30.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=30.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=30.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=30.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "30.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=30.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=30.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=30.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=30.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=30.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=30.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=30.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=30.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=30.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=30.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "30.0.1", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "30.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "30.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "30.0.1" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "30.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "30.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "30.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=30.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=30.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=30.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=30.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=30.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=30.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=30.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=30.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=30.0.0", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=30.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=30.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=30.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=30.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=30.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=30.0.0" }
-wasmtime-math = { path = "crates/math", version = "=30.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=30.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=30.0.1" }
+wasmtime-math = { path = "crates/math", version = "=30.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-pulley-interpreter = { path = 'pulley', version = "=30.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=30.0.1" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-codegen = { path = "cranelift/codegen", version = "0.117.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.117.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.117.0" }
-cranelift-native = { path = "cranelift/native", version = "0.117.0" }
-cranelift-module = { path = "cranelift/module", version = "0.117.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.117.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.117.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.117.1", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.117.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.117.1" }
+cranelift-native = { path = "cranelift/native", version = "0.117.1" }
+cranelift-module = { path = "cranelift/module", version = "0.117.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.117.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.117.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.117.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.117.0" }
+cranelift-object = { path = "cranelift/object", version = "0.117.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.117.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.117.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.117.0" }
-cranelift-control = { path = "cranelift/control", version = "0.117.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.117.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.117.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.117.1" }
+cranelift-control = { path = "cranelift/control", version = "0.117.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.117.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=30.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=30.0.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.117.0"
+version = "0.117.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -13,7 +13,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 arbtest = "0.3.1"
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.117.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.117.1" }
 
 [lints.clippy]
 all = "deny"

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.117.0"
+version = "0.117.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.117.0"
+version = "0.117.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.117.0"
+version = "0.117.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.117.0"
+version = "0.117.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,8 +25,8 @@ arbitrary = { version = "1.3.2", features = ["derive"] }
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-assembler-x64 = { path = "../assembler-x64", version = "0.117.0" }
-cranelift-codegen-shared = { path = "./shared", version = "0.117.0" }
+cranelift-assembler-x64 = { path = "../assembler-x64", version = "0.117.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.117.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -55,8 +55,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.117.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.117.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.117.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.117.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.117.0"
+version = "0.117.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,8 +16,8 @@ workspace = true
 rustdoc-args = ["--document-private-items"]
 
 [dependencies]
-cranelift-assembler-x64 = { path = "../../assembler-x64", version = "0.117.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.117.0" }
+cranelift-assembler-x64 = { path = "../../assembler-x64", version = "0.117.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.117.1" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.117.0"
+version = "0.117.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.117.0"
+version = "0.117.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.117.0"
+version = "0.117.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.117.0"
+version = "0.117.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.117.0"
+version = "0.117.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.117.0"
+version = "0.117.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.117.0"
+version = "0.117.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.117.0"
+version = "0.117.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "30.0.0"
+#define WASMTIME_VERSION "30.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -14,11 +14,23 @@ version = "0.117.0"
 audited_as = "0.115.0"
 
 [[unpublished.cranelift]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
+[[unpublished.cranelift]]
 version = "0.118.0"
 audited_as = "0.116.1"
 
 [[unpublished.cranelift-assembler-x64]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
+[[unpublished.cranelift-assembler-x64]]
 version = "0.118.0"
+audited_as = "0.117.0"
+
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.117.1"
 audited_as = "0.117.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
@@ -37,6 +49,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-bforest]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-bitset]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -48,6 +64,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-bitset]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-bitset]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-codegen]]
 version = "0.115.0"
@@ -61,6 +81,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -72,6 +96,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.115.0"
@@ -85,6 +113,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-control]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -96,6 +128,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-control]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-control]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-entity]]
 version = "0.115.0"
@@ -109,6 +145,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -120,6 +160,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-frontend]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.115.0"
@@ -133,6 +177,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -144,6 +192,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-isle]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-jit]]
 version = "0.115.0"
@@ -157,6 +209,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-module]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -168,6 +224,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-module]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-module]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-native]]
 version = "0.115.0"
@@ -181,6 +241,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-native]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-object]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -192,6 +256,10 @@ audited_as = "0.114.0"
 [[unpublished.cranelift-object]]
 version = "0.117.0"
 audited_as = "0.115.0"
+
+[[unpublished.cranelift-object]]
+version = "0.117.1"
+audited_as = "0.117.0"
 
 [[unpublished.cranelift-reader]]
 version = "0.115.0"
@@ -205,6 +273,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.115.0"
 audited_as = "0.113.1"
@@ -217,6 +289,10 @@ audited_as = "0.114.0"
 version = "0.117.0"
 audited_as = "0.115.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.117.1"
+audited_as = "0.117.0"
+
 [[unpublished.pulley-interpreter]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -228,6 +304,10 @@ audited_as = "27.0.0"
 [[unpublished.pulley-interpreter]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasi-common]]
 version = "28.0.0"
@@ -241,6 +321,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasi-common]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -252,6 +336,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "28.0.0"
@@ -265,6 +353,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-cache]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -276,6 +368,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-cache]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-cache]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-cli]]
 version = "28.0.0"
@@ -289,6 +385,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-cli]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -300,6 +400,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-cli-flags]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-component-macro]]
 version = "28.0.0"
@@ -313,6 +417,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-component-macro]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-component-util]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -324,6 +432,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-component-util]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-component-util]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-cranelift]]
 version = "28.0.0"
@@ -337,6 +449,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-cranelift]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -348,6 +464,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-environ]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "28.0.0"
@@ -361,6 +481,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -372,6 +496,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-fiber]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "28.0.0"
@@ -385,6 +513,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -396,11 +528,19 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-math]]
 version = "30.0.0"
 audited_as = "29.0.0"
 
+[[unpublished.wasmtime-math]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -412,6 +552,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-slab]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-slab]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "28.0.0"
@@ -425,6 +569,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "28.0.0"
 audited_as = "27.0.0"
@@ -436,6 +584,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "28.0.0"
@@ -448,10 +600,18 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-http]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "31.0.0"
 audited_as = "29.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "31.0.0"
@@ -469,6 +629,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -480,6 +644,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "28.0.0"
@@ -493,6 +661,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -504,6 +676,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wast]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "28.0.0"
@@ -517,6 +693,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-winch]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -528,6 +708,10 @@ audited_as = "27.0.0"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "28.0.0"
@@ -541,6 +725,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wiggle]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -552,6 +740,10 @@ audited_as = "27.0.0"
 [[unpublished.wiggle]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wiggle]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "28.0.0"
@@ -565,6 +757,10 @@ audited_as = "27.0.0"
 version = "30.0.0"
 audited_as = "28.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "30.0.1"
+audited_as = "30.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "28.0.0"
 audited_as = "26.0.1"
@@ -576,6 +772,10 @@ audited_as = "27.0.0"
 [[unpublished.wiggle-macro]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -592,6 +792,10 @@ audited_as = "27.0.0"
 [[unpublished.winch-codegen]]
 version = "30.0.0"
 audited_as = "28.0.0"
+
+[[unpublished.winch-codegen]]
+version = "30.0.1"
+audited_as = "30.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -797,8 +1001,8 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -815,98 +1019,98 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.115.0"
-when = "2024-12-20"
+version = "0.117.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1121,8 +1325,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1371,8 +1575,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1442,110 +1646,110 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-math]]
-version = "29.0.0"
-when = "2025-01-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1556,44 +1760,44 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1617,20 +1821,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1649,8 +1853,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "28.0.0"
-when = "2024-12-20"
+version = "30.0.0"
+when = "2025-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 30.0.1, requested by @abrown.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-30.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
