### PR TITLE
Improve rendering of errors in `wasmtime serve`

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -515,7 +515,7 @@ async fn handle_request(
             .call_handle(store, req, out)
             .await
         {
-            log::error!("[{req_id}] :: {:#?}", e);
+            log::error!("[{req_id}] :: {:?}", e);
             return Err(e);
         }
 
@@ -537,7 +537,7 @@ async fn handle_request(
                 Ok(r) => r.expect_err("if the receiver has an error, the task must have failed"),
                 Err(e) => e.into(),
             };
-            bail!("guest never invoked `response-outparam::set` method: {e:?}")
+            return Err(e.context("guest never invoked `response-outparam::set` method"));
         }
     }
 }


### PR DESCRIPTION
For the error from `handle_request` use `e.context(...)` instead of stringifying `e` into a message. Additionally when logging a guest error use `:?` instead of `:#?` to give a more standard `anyhow` rendering of the error.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
