### PR TITLE
Upgrade Windows builder to `windows-2025`

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -5,7 +5,7 @@
 // targets/platforms once and then duplicate them all with a "min" build.
 
 const ubuntu = 'ubuntu-24.04';
-const windows = 'windows-2022';
+const windows = 'windows-2025';
 const macos = 'macos-14';
 
 const array = [

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -16,7 +16,7 @@ const GENERIC_BUCKETS = 3;
 const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
 const ubuntu = 'ubuntu-24.04';
-const windows = 'windows-2022';
+const windows = 'windows-2025';
 const macos = 'macos-14';
 
 // This is the small, fast-to-execute matrix we use for PRs before they enter


### PR DESCRIPTION
This is an attempt to address #10289 and unblock the upgrade of Wasmtime in the wasmtime-go bindings. Honestly I'm lost in the number of MinGW bugs we're dodging at this point. Regardless though this is something that will need to be done at some point anyway and theoretically shouldn't cause any other regressions, so I figured I might as well go ahead and do this and hopefully fix some MinGW issues while I'm at it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
