### PR TITLE
Mention the filename when a module can't be opened

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -160,7 +160,8 @@ impl RunCommon {
             Some("-") => "/dev/stdin".as_ref(),
             _ => path,
         };
-        let file = File::open(path)?;
+        let file =
+            File::open(path).with_context(|| format!("failed to open wasm module {path:?}"))?;
 
         // First attempt to load the module as an mmap. If this succeeds then
         // detection can be done with the contents of the mmap and if a

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2255,3 +2255,12 @@ fn config_cli_flag() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn invalid_subcommand() -> Result<()> {
+    let output = run_wasmtime_for_output(&["invalid-subcommand"], None)?;
+    dbg!(&output);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("invalid-subcommand"));
+    Ok(())
+}


### PR DESCRIPTION
This commit improves the error message of the `wasmtime` CLI when running a file that can't be opened. This can happen for example when an invalid subcommand is passed such as `wasmtime foo` by accident.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
