### PR TITLE
[30.0.0] Upgrade Windows builder to `windows-2025` 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -774,7 +774,7 @@ jobs:
       run: sysctl hw
       if: runner.os == 'macOS'
     - name: CPU information
-      run: wmic cpu list /format:list
+      run: Get-WmiObject Win32_Processor
       shell: pwsh
       if: runner.os == 'Windows'
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,16 @@
+## 30.0.2
+
+Released 2025-02-25.
+
+### Fixed
+
+* MinGW C API builds are now built with a newer version of GCC which seems to
+  fix an issue caused by #9929.
+  [#10290](https://github.com/bytecodealliance/wasmtime/pull/10290)
+
+
+--------------------------------------------------------------------------------
+
 ## 30.0.1
 
 Released 2025-02-21.

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -5,7 +5,7 @@
 // targets/platforms once and then duplicate them all with a "min" build.
 
 const ubuntu = 'ubuntu-24.04';
-const windows = 'windows-2022';
+const windows = 'windows-2025';
 const macos = 'macos-14';
 
 const array = [

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -16,7 +16,7 @@ const GENERIC_BUCKETS = 3;
 const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
 const ubuntu = 'ubuntu-24.04';
-const windows = 'windows-2022';
+const windows = 'windows-2025';
 const macos = 'macos-14';
 
 // This is the small, fast-to-execute matrix we use for PRs before they enter


### PR DESCRIPTION
This is a backport of #10290 to the 30.0.x release branch after testing that the `dev` artifacts work with the upgrade in https://github.com/bytecodealliance/wasmtime-go/pull/241.