### PR TITLE
Winch: Turn on SIMD for Winch fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -622,11 +622,21 @@ impl WasmtimeConfig {
                 // at this time, so if winch is selected be sure to disable wasm
                 // proposals in `Config` to ensure that Winch can compile the
                 // module that wasm-smith generates.
-                config.simd_enabled = false;
                 config.relaxed_simd_enabled = false;
                 config.gc_enabled = false;
                 config.tail_call_enabled = false;
                 config.reference_types_enabled = false;
+
+                // Winch's SIMD implementations require AVX and AVX2.
+                if self
+                    .codegen_flag("has_avx")
+                    .is_some_and(|value| value == "false")
+                    || self
+                        .codegen_flag("has_avx2")
+                        .is_some_and(|value| value == "false")
+                {
+                    config.simd_enabled = false;
+                }
 
                 // Tuning  the following engine options is currently not supported
                 // by Winch.


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Part of #8093. Enables emitting modules with SIMD instructions for Winch when performing differential fuzzing if AVX and AVX2 extensions are available.