### PR TITLE
Disable shuffling allocator during benchmarks by default.

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -35,5 +35,5 @@ clap = { workspace = true }
 wat = { workspace = true }
 
 [features]
-default = ["shuffling-allocator", "wasi-nn"]
+default = ["wasi-nn"]
 wasi-nn = ["wasmtime-wasi-nn"]


### PR DESCRIPTION
The slowness of the shuffling obscured performance signal (by dwarfing it) more than the accidental localities it was meant to avoid. Closes https://github.com/bytecodealliance/sightglass/issues/280.

This issue came up in https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/regalloc3.20benchmarks/near/502160547. I'm just packaging up Amanieu's one-liner.