### PR TITLE
Improve rebuild detection of test-programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ examples/.cache
 cranelift/isle/veri/veri_engine/test_output
 crates/explorer/node_modules
 tests/all/pulley_provenance_test.cwasm
-artifacts
+/artifacts


### PR DESCRIPTION
This commit improves the logic of detecting when to rebuild the `test-programs` artifacts used during test by parsing the `*.d` files that Cargo emits as part of its compilation and using that as the `cargo:rerun-if-changed` directive. This not only includes what was previously depended on but additionally includes features such as `path` dependencies which might temporarily be used during development.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
