### PR TITLE
pulley: Fix a panic compiling with debug info

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -18,6 +18,8 @@
     ;; A pseudo-instruction that moves vregs to return registers.
     (Rets (rets VecRetPair))
 
+    (DummyUse (reg Reg))
+
     ;; Implementation of `br_table`, uses `idx` to jump to one of `targets` or
     ;; jumps to `default` if it's out-of-bounds.
     (BrTable

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -126,7 +126,7 @@ fn pulley_emit<P>(
 {
     match inst {
         // Pseduo-instructions that don't actually encode to anything.
-        Inst::Args { .. } | Inst::Rets { .. } => {}
+        Inst::Args { .. } | Inst::Rets { .. } | Inst::DummyUse { .. } => {}
 
         Inst::TrapIf { cond, code } => {
             let trap = sink.defer_trap(*code);

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -126,6 +126,10 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             }
         }
 
+        Inst::DummyUse { reg } => {
+            collector.reg_use(reg);
+        }
+
         Inst::Nop => {}
 
         Inst::TrapIf { cond, code: _ } => {
@@ -373,8 +377,8 @@ where
 
     const TRAP_OPCODE: &'static [u8] = TRAP_OPCODE;
 
-    fn gen_dummy_use(_reg: Reg) -> Self {
-        todo!()
+    fn gen_dummy_use(reg: Reg) -> Self {
+        Inst::DummyUse { reg }.into()
     }
 
     fn canonical_type_for_rc(rc: RegClass) -> Type {
@@ -596,6 +600,11 @@ impl Inst {
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
+            }
+
+            Inst::DummyUse { reg } => {
+                let reg = format_reg(*reg);
+                format!("dummy_use {reg}")
             }
 
             Inst::TrapIf { cond, code } => {

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -172,3 +172,13 @@ fn pulley_provenance_test() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(not(miri))]
+fn enabling_debug_info_doesnt_break_anything() -> Result<()> {
+    let mut config = pulley_config();
+    config.debug_info(true);
+    let engine = Engine::new(&config)?;
+    assert!(Module::from_file(&engine, "./tests/all/cli_tests/greeter_command.wat").is_err());
+    Ok(())
+}


### PR DESCRIPTION
Debug into doesn't work on Pulley anyway but it's better to return a first-class error rather than a panic. This commit fills out a simple missing instruction in the Pulley backend to ensure that compilation gets far enough to the DWARF transform where there's no pulley support and an error is returned.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
