### PR TITLE
Test natively on AArch64, not emulated

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -95,12 +95,8 @@ const FULL_MATRIX = [
     "filter": "mingw-x64"
   },
   {
-    "os": ubuntu,
+    "os": ubuntu + '-arm',
     "target": "aarch64-unknown-linux-gnu",
-    "gcc_package": "gcc-aarch64-linux-gnu",
-    "gcc": "aarch64-linux-gnu-gcc",
-    "qemu": "qemu-aarch64 -L /usr/aarch64-linux-gnu",
-    "qemu_target": "aarch64-linux-user",
     "name": "Test Linux arm64",
     "filter": "linux-arm64",
     "isa": "aarch64",


### PR DESCRIPTION
This commit updates the aarch64 tests to use the new `*-arm` images from GitHub instead of running through QEMU emulation. This should be a bit faster but primarily helps build confidence that it runs on real hardware.

I'll note that release builds aren't updated at this time to run on native hardware since that's moreso about glibc compatibility and it's a bit easier to keep the setup we currently have for that. If `*-arm` machines are noticably faster than the default x64 machines then we could in theory move everything over to an aarch64-based machine as opposed to just the aarch64 build.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
