### PR TITLE
Rename `VMRuntimeLimits` to `VMStoreContext`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -856,17 +856,17 @@ impl ComponentCompiler for Compiler {
                 wasmtime_environ::component::VMCOMPONENT_MAGIC,
             );
             if let Abi::Wasm = abi {
-                let limits = c.builder.ins().load(
+                let vm_store_context = c.builder.ins().load(
                     pointer_type,
                     MemFlags::trusted(),
                     vmctx,
-                    i32::try_from(c.offsets.limits()).unwrap(),
+                    i32::try_from(c.offsets.vm_store_context()).unwrap(),
                 );
                 super::save_last_wasm_exit_fp_and_pc(
                     &mut c.builder,
                     pointer_type,
                     &c.offsets.ptr,
-                    limits,
+                    vm_store_context,
                 );
             }
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -116,7 +116,7 @@ macro_rules! foreach_builtin_function {
             // Wasm code, so that it doesn't need to make a libcall to go from
             // id to `VMFuncRef`. That will be a little tricky: it will also
             // require updating the pointer to the slab in the `VMContext` (or
-            // `VMRuntimeLimits` or wherever we put it) when the slab is
+            // `VMStoreContext` or wherever we put it) when the slab is
             // resized.
             #[cfg(feature = "gc")]
             get_interned_func_ref(

--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -3,7 +3,7 @@
 // struct VMComponentContext {
 //      magic: u32,
 //      builtins: &'static VMComponentBuiltins,
-//      limits: *const VMRuntimeLimits,
+//      limits: *const VMStoreContext,
 //      flags: [VMGlobalDefinition; component.num_runtime_component_instances],
 //      trampoline_func_refs: [VMFuncRef; component.num_trampolines],
 //      lowerings: [VMLowering; component.num_lowerings],
@@ -61,7 +61,7 @@ pub struct VMComponentOffsets<P> {
     // precalculated offsets of various member fields
     magic: u32,
     builtins: u32,
-    limits: u32,
+    vm_store_context: u32,
     flags: u32,
     trampoline_func_refs: u32,
     lowerings: u32,
@@ -98,7 +98,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             num_resources: component.num_resources,
             magic: 0,
             builtins: 0,
-            limits: 0,
+            vm_store_context: 0,
             flags: 0,
             trampoline_func_refs: 0,
             lowerings: 0,
@@ -138,7 +138,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             size(magic) = 4u32,
             align(u32::from(ret.ptr.size())),
             size(builtins) = ret.ptr.size(),
-            size(limits) = ret.ptr.size(),
+            size(vm_store_context) = ret.ptr.size(),
             align(16),
             size(flags) = cmul(ret.num_runtime_component_instances, ret.ptr.size_of_vmglobal_definition()),
             align(u32::from(ret.ptr.size())),
@@ -186,10 +186,10 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.flags + index.as_u32() * u32::from(self.ptr.size_of_vmglobal_definition())
     }
 
-    /// The offset of the `limits` field.
+    /// The offset of the `vm_store_context` field.
     #[inline]
-    pub fn limits(&self) -> u32 {
-        self.limits
+    pub fn vm_store_context(&self) -> u32 {
+        self.vm_store_context
     }
 
     /// The offset of the `trampoline_func_refs` field.

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -8,7 +8,7 @@
 //      // these fields is a compile-time constant when using `HostPtr`.
 //      magic: u32,
 //      _padding: u32, // (On 64-bit systems)
-//      runtime_limits: *const VMRuntimeLimits,
+//      vm_store_context: *const VMStoreContext,
 //      builtin_functions: *mut VMBuiltinFunctionsArray,
 //      callee: *mut VMFunctionBody,
 //      epoch_ptr: *mut AtomicU64,
@@ -109,7 +109,7 @@ pub trait PtrSize {
     fn size(&self) -> u8;
 
     /// The offset of the `VMContext::runtime_limits` field
-    fn vmcontext_runtime_limits(&self) -> u8 {
+    fn vmcontext_store_context(&self) -> u8 {
         u8::try_from(align(
             u32::try_from(core::mem::size_of::<u32>()).unwrap(),
             u32::from(self.size()),
@@ -119,7 +119,7 @@ pub trait PtrSize {
 
     /// The offset of the `VMContext::builtin_functions` field
     fn vmcontext_builtin_functions(&self) -> u8 {
-        self.vmcontext_runtime_limits() + self.size()
+        self.vmcontext_store_context() + self.size()
     }
 
     /// The offset of the `array_call` field.
@@ -165,39 +165,39 @@ pub trait PtrSize {
         4
     }
 
-    // Offsets within `VMRuntimeLimits`
+    // Offsets within `VMStoreContext`
 
-    /// Return the offset of the `fuel_consumed` field of `VMRuntimeLimits`
+    /// Return the offset of the `fuel_consumed` field of `VMStoreContext`
     #[inline]
-    fn vmruntime_limits_fuel_consumed(&self) -> u8 {
+    fn vmstore_context_fuel_consumed(&self) -> u8 {
         0
     }
 
-    /// Return the offset of the `epoch_deadline` field of `VMRuntimeLimits`
+    /// Return the offset of the `epoch_deadline` field of `VMStoreContext`
     #[inline]
-    fn vmruntime_limits_epoch_deadline(&self) -> u8 {
-        self.vmruntime_limits_fuel_consumed() + 8
+    fn vmstore_context_epoch_deadline(&self) -> u8 {
+        self.vmstore_context_fuel_consumed() + 8
     }
 
-    /// Return the offset of the `stack_limit` field of `VMRuntimeLimits`
+    /// Return the offset of the `stack_limit` field of `VMStoreContext`
     #[inline]
-    fn vmruntime_limits_stack_limit(&self) -> u8 {
-        self.vmruntime_limits_epoch_deadline() + 8
+    fn vmstore_context_stack_limit(&self) -> u8 {
+        self.vmstore_context_epoch_deadline() + 8
     }
 
-    /// Return the offset of the `last_wasm_exit_fp` field of `VMRuntimeLimits`.
-    fn vmruntime_limits_last_wasm_exit_fp(&self) -> u8 {
-        self.vmruntime_limits_stack_limit() + self.size()
+    /// Return the offset of the `last_wasm_exit_fp` field of `VMStoreContext`.
+    fn vmstore_context_last_wasm_exit_fp(&self) -> u8 {
+        self.vmstore_context_stack_limit() + self.size()
     }
 
-    /// Return the offset of the `last_wasm_exit_pc` field of `VMRuntimeLimits`.
-    fn vmruntime_limits_last_wasm_exit_pc(&self) -> u8 {
-        self.vmruntime_limits_last_wasm_exit_fp() + self.size()
+    /// Return the offset of the `last_wasm_exit_pc` field of `VMStoreContext`.
+    fn vmstore_context_last_wasm_exit_pc(&self) -> u8 {
+        self.vmstore_context_last_wasm_exit_fp() + self.size()
     }
 
-    /// Return the offset of the `last_wasm_entry_fp` field of `VMRuntimeLimits`.
-    fn vmruntime_limits_last_wasm_entry_fp(&self) -> u8 {
-        self.vmruntime_limits_last_wasm_exit_pc() + self.size()
+    /// Return the offset of the `last_wasm_entry_fp` field of `VMStoreContext`.
+    fn vmstore_context_last_wasm_entry_fp(&self) -> u8 {
+        self.vmstore_context_last_wasm_exit_pc() + self.size()
     }
 
     // Offsets within `VMMemoryDefinition`
@@ -246,7 +246,7 @@ pub trait PtrSize {
         0
     }
 
-    /// Return the offset to the `VMRuntimeLimits` structure
+    /// Return the offset to the `VMStoreContext` structure
     #[inline]
     fn vmctx_runtime_limits(&self) -> u8 {
         self.vmctx_magic() + self.size()

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1632,7 +1632,7 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
     // For asynchronous stores then each call happens on a separate native
     // stack. This means that the previous stack limit is no longer relevant
     // because we're on a separate stack.
-    if unsafe { *store.0.runtime_limits().stack_limit.get() } != usize::MAX
+    if unsafe { *store.0.vm_store_context().stack_limit.get() } != usize::MAX
         && !store.0.async_support()
     {
         return None;
@@ -1676,7 +1676,7 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
     let wasm_stack_limit = stack_pointer - store.engine().config().max_wasm_stack;
     let prev_stack = unsafe {
         mem::replace(
-            &mut *store.0.runtime_limits().stack_limit.get(),
+            &mut *store.0.vm_store_context().stack_limit.get(),
             wasm_stack_limit,
         )
     };
@@ -1693,7 +1693,7 @@ fn exit_wasm<T>(store: &mut StoreContextMut<'_, T>, prev_stack: Option<usize>) {
     };
 
     unsafe {
-        *store.0.runtime_limits().stack_limit.get() = prev_stack;
+        *store.0.vm_store_context().stack_limit.get() = prev_stack;
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -93,7 +93,7 @@ pub use crate::runtime::vm::unwind::*;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMRuntimeLimits, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMStoreContext, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -468,8 +468,8 @@ impl ComponentInstance {
         *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
         *self.vmctx_plus_offset_mut(self.offsets.builtins()) =
             VmPtr::from(NonNull::from(&libcalls::VMComponentBuiltins::INIT));
-        *self.vmctx_plus_offset_mut(self.offsets.limits()) =
-            VmPtr::from(self.store.0.as_ref().vmruntime_limits());
+        *self.vmctx_plus_offset_mut(self.offsets.vm_store_context()) =
+            VmPtr::from(self.store.0.as_ref().vm_store_context_ptr());
 
         for i in 0..self.offsets.num_runtime_component_instances {
             let i = RuntimeComponentInstanceIndex::from_u32(i);

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -8,7 +8,7 @@ use crate::runtime::vm::memory::{Memory, RuntimeMemoryCreator};
 use crate::runtime::vm::table::{Table, TableElement, TableElementType};
 use crate::runtime::vm::vmcontext::{
     VMBuiltinFunctionsArray, VMContext, VMFuncRef, VMFunctionImport, VMGlobalDefinition,
-    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext, VMRuntimeLimits,
+    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext, VMStoreContext,
     VMTableDefinition, VMTableImport, VMTagDefinition, VMTagImport,
 };
 use crate::runtime::vm::{
@@ -582,7 +582,7 @@ impl Instance {
 
     /// Return a pointer to the interrupts structure
     #[inline]
-    pub fn runtime_limits(&mut self) -> NonNull<Option<VmPtr<VMRuntimeLimits>>> {
+    pub fn vm_store_context(&mut self) -> NonNull<Option<VmPtr<VMStoreContext>>> {
         unsafe { self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_runtime_limits()) }
     }
 
@@ -611,14 +611,14 @@ impl Instance {
         self.store = store.map(VMStoreRawPtr);
         if let Some(mut store) = store {
             let store = store.as_mut();
-            self.runtime_limits()
-                .write(Some(store.vmruntime_limits().into()));
+            self.vm_store_context()
+                .write(Some(store.vm_store_context_ptr().into()));
             #[cfg(target_has_atomic = "64")]
             self.epoch_ptr()
                 .write(Some(NonNull::from(store.engine().epoch_counter()).into()));
             self.set_gc_heap(store.gc_store_mut().ok());
         } else {
-            self.runtime_limits().write(None);
+            self.vm_store_context().write(None);
             #[cfg(target_has_atomic = "64")]
             self.epoch_ptr().write(None);
             self.set_gc_heap(None);

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -11,7 +11,7 @@
 //! pointer (FP) and program counter (PC) each time we call into Wasm and Wasm
 //! calls into the host via trampolines (see
 //! `crates/wasmtime/src/runtime/vm/trampolines`). The most recent entry is
-//! stored in `VMRuntimeLimits` and older entries are saved in
+//! stored in `VMStoreContext` and older entries are saved in
 //! `CallThreadState`. This lets us identify ranges of contiguous Wasm frames on
 //! the stack.
 //!
@@ -25,7 +25,7 @@ use crate::prelude::*;
 use crate::runtime::store::StoreOpaque;
 use crate::runtime::vm::{
     traphandlers::{tls, CallThreadState},
-    Unwind, VMRuntimeLimits,
+    Unwind, VMStoreContext,
 };
 use core::ops::ControlFlow;
 
@@ -65,10 +65,12 @@ impl Backtrace {
 
     /// Capture the current Wasm stack in a backtrace.
     pub fn new(store: &StoreOpaque) -> Backtrace {
-        let limits = store.runtime_limits();
+        let vm_store_context = store.vm_store_context();
         let unwind = store.unwinder();
         tls::with(|state| match state {
-            Some(state) => unsafe { Self::new_with_trap_state(limits, unwind, state, None) },
+            Some(state) => unsafe {
+                Self::new_with_trap_state(vm_store_context, unwind, state, None)
+            },
             None => Backtrace(vec![]),
         })
     }
@@ -77,15 +79,15 @@ impl Backtrace {
     ///
     /// If Wasm hit a trap, and we calling this from the trap handler, then the
     /// Wasm exit trampoline didn't run, and we use the provided PC and FP
-    /// instead of looking them up in `VMRuntimeLimits`.
+    /// instead of looking them up in `VMStoreContext`.
     pub(crate) unsafe fn new_with_trap_state(
-        limits: *const VMRuntimeLimits,
+        vm_store_context: *const VMStoreContext,
         unwind: &dyn Unwind,
         state: &CallThreadState,
         trap_pc_and_fp: Option<(usize, usize)>,
     ) -> Backtrace {
         let mut frames = vec![];
-        Self::trace_with_trap_state(limits, unwind, state, trap_pc_and_fp, |frame| {
+        Self::trace_with_trap_state(vm_store_context, unwind, state, trap_pc_and_fp, |frame| {
             frames.push(frame);
             ControlFlow::Continue(())
         });
@@ -95,10 +97,12 @@ impl Backtrace {
     /// Walk the current Wasm stack, calling `f` for each frame we walk.
     #[cfg(feature = "gc")]
     pub fn trace(store: &StoreOpaque, f: impl FnMut(Frame) -> ControlFlow<()>) {
-        let limits = store.runtime_limits();
+        let vm_store_context = store.vm_store_context();
         let unwind = store.unwinder();
         tls::with(|state| match state {
-            Some(state) => unsafe { Self::trace_with_trap_state(limits, unwind, state, None, f) },
+            Some(state) => unsafe {
+                Self::trace_with_trap_state(vm_store_context, unwind, state, None, f)
+            },
             None => {}
         });
     }
@@ -107,9 +111,9 @@ impl Backtrace {
     ///
     /// If Wasm hit a trap, and we calling this from the trap handler, then the
     /// Wasm exit trampoline didn't run, and we use the provided PC and FP
-    /// instead of looking them up in `VMRuntimeLimits`.
+    /// instead of looking them up in `VMStoreContext`.
     pub(crate) unsafe fn trace_with_trap_state(
-        limits: *const VMRuntimeLimits,
+        vm_store_context: *const VMStoreContext,
         unwind: &dyn Unwind,
         state: &CallThreadState,
         trap_pc_and_fp: Option<(usize, usize)>,
@@ -122,14 +126,17 @@ impl Backtrace {
             // trampoline did not get a chance to save the last Wasm PC and FP,
             // and we need to use the plumbed-through values instead.
             Some((pc, fp)) => {
-                assert!(core::ptr::eq(limits, state.limits.as_ptr()));
+                assert!(core::ptr::eq(
+                    vm_store_context,
+                    state.vm_store_context.as_ptr()
+                ));
                 (pc, fp)
             }
             // Either there is no Wasm currently on the stack, or we exited Wasm
             // through the Wasm-to-host trampoline.
             None => {
-                let pc = *(*limits).last_wasm_exit_pc.get();
-                let fp = *(*limits).last_wasm_exit_fp.get();
+                let pc = *(*vm_store_context).last_wasm_exit_pc.get();
+                let fp = *(*vm_store_context).last_wasm_exit_fp.get();
                 (pc, fp)
             }
         };
@@ -137,12 +144,12 @@ impl Backtrace {
         let activations = core::iter::once((
             last_wasm_exit_pc,
             last_wasm_exit_fp,
-            *(*limits).last_wasm_entry_fp.get(),
+            *(*vm_store_context).last_wasm_entry_fp.get(),
         ))
         .chain(
             state
                 .iter()
-                .filter(|state| core::ptr::eq(limits, state.limits.as_ptr()))
+                .filter(|state| core::ptr::eq(vm_store_context, state.vm_store_context.as_ptr()))
                 .map(|state| {
                     (
                         state.old_last_wasm_exit_pc(),

--- a/crates/wasmtime/src/runtime/vm/traphandlers/coredump_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/coredump_disabled.rs
@@ -1,5 +1,5 @@
 use crate::runtime::vm::traphandlers::CallThreadState;
-use crate::runtime::vm::VMRuntimeLimits;
+use crate::runtime::vm::VMStoreContext;
 
 /// A WebAssembly Coredump
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub enum CoreDumpStack {}
 impl CallThreadState {
     pub(super) fn capture_coredump(
         &self,
-        _limits: *const VMRuntimeLimits,
+        _ctx: *const VMStoreContext,
         _trap_pc_and_fp: Option<(usize, usize)>,
     ) -> Option<CoreDumpStack> {
         None

--- a/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
@@ -1,6 +1,6 @@
 use super::CallThreadState;
 use crate::prelude::*;
-use crate::runtime::vm::{Backtrace, VMRuntimeLimits};
+use crate::runtime::vm::{Backtrace, VMStoreContext};
 use wasm_encoder::CoreDumpValue;
 
 /// A WebAssembly Coredump
@@ -25,14 +25,15 @@ pub struct CoreDumpStack {
 impl CallThreadState {
     pub(super) fn capture_coredump(
         &self,
-        limits: *const VMRuntimeLimits,
+        vm_store_context: *const VMStoreContext,
         trap_pc_and_fp: Option<(usize, usize)>,
     ) -> Option<CoreDumpStack> {
         if !self.capture_coredump {
             return None;
         }
-        let bt =
-            unsafe { Backtrace::new_with_trap_state(limits, self.unwinder, self, trap_pc_and_fp) };
+        let bt = unsafe {
+            Backtrace::new_with_trap_state(vm_store_context, self.unwinder, self, trap_pc_and_fp)
+        };
 
         Some(CoreDumpStack {
             bt,

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1515,7 +1515,7 @@ fn dont_see_stale_stack_walking_registers() -> Result<()> {
                 (export "get_trap" (func $host_get_trap))
 
                 ;; We enter and exit Wasm, which saves registers in the
-                ;; `VMRuntimeLimits`. Later, when we call a re-exported host
+                ;; `VMStoreContext`. Later, when we call a re-exported host
                 ;; function, we should not accidentally reuse those saved
                 ;; registers.
                 (start $start)

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -92,7 +92,7 @@ pub(crate) struct MacroAssembler {
     asm: Assembler,
     /// ISA flags.
     flags: x64_settings::Flags,
-    /// Shared flags.
+    /// Shared flags.vmcontext_store_context
     shared_flags: settings::Flags,
     /// The target pointer size.
     ptr_size: OperandSize,
@@ -126,12 +126,12 @@ impl Masm for MacroAssembler {
         let scratch = regs::scratch();
 
         self.load_ptr(
-            self.address_at_reg(vmctx, ptr_size.vmcontext_runtime_limits().into())?,
+            self.address_at_reg(vmctx, ptr_size.vmcontext_store_context().into())?,
             writable!(scratch),
         )?;
 
         self.load_ptr(
-            Address::offset(scratch, ptr_size.vmruntime_limits_stack_limit().into()),
+            Address::offset(scratch, ptr_size.vmstore_context_stack_limit().into()),
             writable!(scratch),
         )?;
 


### PR DESCRIPTION
Way back in time, this struct originally contained the stack and fuel limits. Then it also got the epoch deadline. Then it also got the exit FP/PC and entry FP. Now it is just the place where we put per-store mutable data that is accessed by JIT code and must be shared between all `VMContext`s. So it is time to rename it.

This commit is purely mechanical and just renames the type and various methods and variables that use/access it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
