### PR TITLE
wasmtime-wit-bindgen: gen is a reserved keyword in the lexer starting in 2024 edition

### DIFF
--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -431,6 +431,7 @@ pub fn to_rust_ident(name: &str) -> String {
         "virtual" => "virtual_".into(),
         "yield" => "yield_".into(),
         "try" => "try_".into(),
+        "gen" => "gen_".into(),
         s => s.to_snake_case(),
     }
 }


### PR DESCRIPTION
`gen` is now escaped to `gen_` when used as a rust identifier in wasmtime-wit-bindgen.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
