### PR TITLE
Add a missing `apt-get update` before install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -588,7 +588,7 @@ jobs:
       if: ${{ matrix.cross }}
     - name: Install apt packages
       if: ${{ matrix.apt_packages }}
-      run: sudo apt-get install -y ${{ matrix.apt_packages }}
+      run: sudo apt-get update && sudo apt-get install -y ${{ matrix.apt_packages }}
     - run: ${{ matrix.test }}
       env:
         CARGO_BUILD_TARGET: ${{ matrix.target }}


### PR DESCRIPTION
I always forget this and it always bites us within a few months. Alas.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
