### PR TITLE
wasmtime-wit-bindgen: emit a definition for all types in a wit interface

### DIFF
--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -248,6 +248,56 @@ pub mod a {
         pub mod interface_with_dead_type {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            pub type LiveType = super::super::super::a::b::interface_with_live_type::LiveType;
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DeadType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for DeadType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DeadType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < DeadType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < DeadType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum V {
+                #[component(name = "a")]
+                A(LiveType),
+                #[component(name = "b")]
+                B(DeadType),
+            }
+            impl core::fmt::Debug for V {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V::A(e) => f.debug_tuple("V::A").field(e).finish(),
+                        V::B(e) => f.debug_tuple("V::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
+            };
             pub trait Host {}
             pub trait GetHost<
                 T,

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -262,6 +262,56 @@ pub mod a {
         pub mod interface_with_dead_type {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            pub type LiveType = super::super::super::a::b::interface_with_live_type::LiveType;
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DeadType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for DeadType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DeadType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < DeadType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < DeadType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum V {
+                #[component(name = "a")]
+                A(LiveType),
+                #[component(name = "b")]
+                B(DeadType),
+            }
+            impl core::fmt::Debug for V {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V::A(e) => f.debug_tuple("V::A").field(e).finish(),
+                        V::B(e) => f.debug_tuple("V::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
+            };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             pub trait GetHost<

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -301,6 +301,56 @@ pub mod a {
         pub mod interface_with_dead_type {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            pub type LiveType = super::super::super::a::b::interface_with_live_type::LiveType;
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DeadType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for DeadType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DeadType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < DeadType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < DeadType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum V {
+                #[component(name = "a")]
+                A(LiveType),
+                #[component(name = "b")]
+                B(DeadType),
+            }
+            impl core::fmt::Debug for V {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V::A(e) => f.debug_tuple("V::A").field(e).finish(),
+                        V::B(e) => f.debug_tuple("V::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
+            };
             pub trait Host {}
             pub trait GetHost<
                 T,

--- a/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
@@ -275,6 +275,56 @@ pub mod a {
         pub mod interface_with_dead_type {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            pub type LiveType = super::super::super::a::b::interface_with_live_type::LiveType;
+            const _: () = {
+                assert!(4 == < LiveType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < LiveType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct DeadType {
+                #[component(name = "a")]
+                pub a: u32,
+            }
+            impl core::fmt::Debug for DeadType {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("DeadType").field("a", &self.a).finish()
+                }
+            }
+            const _: () = {
+                assert!(4 == < DeadType as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < DeadType as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone, Copy)]
+            pub enum V {
+                #[component(name = "a")]
+                A(LiveType),
+                #[component(name = "b")]
+                B(DeadType),
+            }
+            impl core::fmt::Debug for V {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        V::A(e) => f.debug_tuple("V::A").field(e).finish(),
+                        V::B(e) => f.debug_tuple("V::B").field(e).finish(),
+                    }
+                }
+            }
+            const _: () = {
+                assert!(8 == < V as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < V as wasmtime::component::ComponentType >::ALIGN32);
+            };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             pub trait GetHost<

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -314,6 +314,15 @@ pub mod foo {
                     4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
+            pub type TupleTypedef = (i32,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub type IntTypedef = i32;
             const _: () = {
                 assert!(
@@ -677,6 +686,17 @@ pub mod exports {
                     );
                     assert!(
                         4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef = (i32,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
                         >::ALIGN32
                     );
                 };

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -321,6 +321,15 @@ pub mod foo {
                     4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
+            pub type TupleTypedef = (i32,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub type IntTypedef = i32;
             const _: () = {
                 assert!(
@@ -711,6 +720,17 @@ pub mod exports {
                     );
                     assert!(
                         4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef = (i32,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
                         >::ALIGN32
                     );
                 };

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -321,6 +321,15 @@ pub mod foo {
                     4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
+            pub type TupleTypedef = (i32,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub type IntTypedef = i32;
             const _: () = {
                 assert!(
@@ -1131,6 +1140,17 @@ pub mod exports {
                     );
                     assert!(
                         4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef = (i32,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
                         >::ALIGN32
                     );
                 };

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -321,6 +321,15 @@ pub mod foo {
                     4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
                 );
             };
+            pub type TupleTypedef = (i32,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub type IntTypedef = i32;
             const _: () = {
                 assert!(
@@ -872,6 +881,17 @@ pub mod exports {
                     );
                     assert!(
                         4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef = (i32,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
                         >::ALIGN32
                     );
                 };

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -300,6 +300,25 @@ pub mod foo {
         pub mod wall_clock {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct WallClock {}
+            impl core::fmt::Debug for WallClock {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("WallClock").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < WallClock as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub trait Host {}
             pub trait GetHost<
                 T,

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -316,6 +316,25 @@ pub mod foo {
         pub mod wall_clock {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct WallClock {}
+            impl core::fmt::Debug for WallClock {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("WallClock").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < WallClock as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             pub trait GetHost<

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -397,6 +397,25 @@ pub mod foo {
         pub mod wall_clock {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct WallClock {}
+            impl core::fmt::Debug for WallClock {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("WallClock").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < WallClock as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             pub trait Host {}
             pub trait GetHost<
                 T,

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -342,6 +342,25 @@ pub mod foo {
         pub mod wall_clock {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct WallClock {}
+            impl core::fmt::Debug for WallClock {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("WallClock").finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    0 == < WallClock as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < WallClock as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             pub trait GetHost<

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -293,8 +293,16 @@ pub trait RustGenerator<'a> {
 
     fn modes_of(&self, ty: TypeId) -> Vec<(String, TypeMode)> {
         let info = self.info(ty);
+        // Info only populated for types that are passed to and from functions. For
+        // types which are not, default to the ownership setting.
         if !info.owned && !info.borrowed {
-            return Vec::new();
+            return vec![(
+                self.param_name(ty),
+                match self.ownership() {
+                    Ownership::Owning => TypeMode::Owned,
+                    Ownership::Borrowing { .. } => TypeMode::AllBorrowed("'a"),
+                },
+            )];
         }
         let mut result = Vec::new();
         let first_mode =


### PR DESCRIPTION
Rust type definitions for wit types are created for the set returned by `modes_of`, when an empty list is returned the type never gets a definition in Rust.

The calculation of TypeInfo only reaches types which are passed to or from a function. For types which are not reachable, default to the defining them according to the ownership setting given to bindgen.

I have my doubts that `with`-reuse of bindgen types actually works properly when bindgen is set to Ownership::Borrowing but thats out of scope for this PR, which is to fix #10090

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
