### PR TITLE
winch(aarch64): ABI integration

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1123,8 +1123,11 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
-    fn get_regs_clobbered_by_call(_call_conv: isa::CallConv) -> PRegSet {
-        DEFAULT_AAPCS_CLOBBERS
+    fn get_regs_clobbered_by_call(call_conv: isa::CallConv) -> PRegSet {
+        match call_conv {
+            isa::CallConv::Winch => WINCH_CLOBBERS,
+            _ => DEFAULT_AAPCS_CLOBBERS,
+        }
     }
 
     fn get_ext_mode(
@@ -1438,7 +1441,78 @@ const fn default_aapcs_clobbers() -> PRegSet {
         .with(vreg_preg(31))
 }
 
+const fn winch_clobbers() -> PRegSet {
+    PRegSet::empty()
+        .with(xreg_preg(0))
+        .with(xreg_preg(1))
+        .with(xreg_preg(2))
+        .with(xreg_preg(3))
+        .with(xreg_preg(4))
+        .with(xreg_preg(5))
+        .with(xreg_preg(6))
+        .with(xreg_preg(7))
+        .with(xreg_preg(8))
+        .with(xreg_preg(9))
+        .with(xreg_preg(10))
+        .with(xreg_preg(11))
+        .with(xreg_preg(12))
+        .with(xreg_preg(13))
+        .with(xreg_preg(14))
+        .with(xreg_preg(15))
+        .with(xreg_preg(16))
+        .with(xreg_preg(17))
+        // x18 is used to carry platform state and is not allocatable by Winch.
+        //
+        // x19 - x27 are considered caller-saved in Winch's calling convention.
+        .with(xreg_preg(19))
+        .with(xreg_preg(20))
+        .with(xreg_preg(21))
+        .with(xreg_preg(22))
+        .with(xreg_preg(23))
+        .with(xreg_preg(24))
+        .with(xreg_preg(25))
+        .with(xreg_preg(26))
+        .with(xreg_preg(27))
+        // x28 is used as the shadow stack pointer and is considered
+        // callee-saved.
+        //
+        // All vregs are considered caller-saved.
+        .with(vreg_preg(0))
+        .with(vreg_preg(1))
+        .with(vreg_preg(2))
+        .with(vreg_preg(3))
+        .with(vreg_preg(4))
+        .with(vreg_preg(5))
+        .with(vreg_preg(6))
+        .with(vreg_preg(7))
+        .with(vreg_preg(8))
+        .with(vreg_preg(9))
+        .with(vreg_preg(10))
+        .with(vreg_preg(11))
+        .with(vreg_preg(12))
+        .with(vreg_preg(13))
+        .with(vreg_preg(14))
+        .with(vreg_preg(15))
+        .with(vreg_preg(16))
+        .with(vreg_preg(17))
+        .with(vreg_preg(18))
+        .with(vreg_preg(19))
+        .with(vreg_preg(20))
+        .with(vreg_preg(21))
+        .with(vreg_preg(22))
+        .with(vreg_preg(23))
+        .with(vreg_preg(24))
+        .with(vreg_preg(25))
+        .with(vreg_preg(26))
+        .with(vreg_preg(27))
+        .with(vreg_preg(28))
+        .with(vreg_preg(29))
+        .with(vreg_preg(30))
+        .with(vreg_preg(31))
+}
+
 const DEFAULT_AAPCS_CLOBBERS: PRegSet = default_aapcs_clobbers();
+const WINCH_CLOBBERS: PRegSet = winch_clobbers();
 
 fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
     fn preg(r: Reg) -> PReg {

--- a/tests/disas/winch/aarch64/br/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_br_if_cond.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -17,5 +18,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br/as_br_value.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,5 +20,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br/as_if_cond.wat
@@ -13,6 +13,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_else.wat
+++ b/tests/disas/winch/aarch64/br/as_if_else.wat
@@ -13,6 +13,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -23,14 +24,15 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       tst     w0, w0
-;;       b.eq    #0x40
-;;       b       #0x38
-;;   38: ldur    w0, [x28]
-;;       b       #0x48
-;;   40: mov     x16, #4
+;;       b.eq    #0x44
+;;       b       #0x3c
+;;   3c: ldur    w0, [x28]
+;;       b       #0x4c
+;;   44: mov     x16, #4
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_if_then.wat
+++ b/tests/disas/winch/aarch64/br/as_if_then.wat
@@ -13,6 +13,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -23,14 +24,15 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28, #4]
 ;;       tst     w0, w0
-;;       b.eq    #0x44
-;;       b       #0x38
-;;   38: mov     x16, #3
+;;       b.eq    #0x48
+;;       b       #0x3c
+;;   3c: mov     x16, #3
 ;;       mov     w0, w16
-;;       b       #0x48
-;;   44: ldur    w0, [x28]
+;;       b       #0x4c
+;;   48: ldur    w0, [x28]
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/as_loop_first.wat
+++ b/tests/disas/winch/aarch64/br/as_loop_first.wat
@@ -9,6 +9,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -20,5 +21,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br/br_jump.wat
+++ b/tests/disas/winch/aarch64/br/br_jump.wat
@@ -16,6 +16,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -34,9 +35,10 @@
 ;;       stur    w16, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       b       #0x38
-;;   54: add     x28, x28, #0x18
+;;       b       #0x3c
+;;   58: add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_if_cond.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -17,15 +18,16 @@
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       tst     w0, w0
-;;       b.ne    #0x48
-;;       b       #0x34
-;;   34: mov     x16, #1
+;;       b.ne    #0x4c
+;;       b       #0x38
+;;   38: mov     x16, #1
 ;;       mov     w0, w16
 ;;       tst     w0, w0
-;;       b.ne    #0x48
-;;       b       #0x48
-;;   48: add     x28, x28, #0x10
+;;       b.ne    #0x4c
+;;       b       #0x4c
+;;   4c: add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_br_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_br_value.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,10 +20,11 @@
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       tst     w1, w1
-;;       b.ne    #0x3c
-;;       b       #0x3c
-;;   3c: add     x28, x28, #0x10
+;;       b.ne    #0x40
+;;       b       #0x40
+;;   40: add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_if_cond.wat
+++ b/tests/disas/winch/aarch64/br_if/as_if_cond.wat
@@ -14,6 +14,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,18 +26,19 @@
 ;;       mov     x16, #1
 ;;       mov     w0, w16
 ;;       tst     w1, w1
-;;       b.ne    #0x5c
-;;       b       #0x3c
-;;   3c: tst     w0, w0
-;;       b.eq    #0x54
-;;       b       #0x48
-;;   48: mov     x16, #2
+;;       b.ne    #0x60
+;;       b       #0x40
+;;   40: tst     w0, w0
+;;       b.eq    #0x58
+;;       b       #0x4c
+;;   4c: mov     x16, #2
 ;;       mov     w0, w16
-;;       b       #0x5c
-;;   54: mov     x16, #3
+;;       b       #0x60
+;;   58: mov     x16, #3
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
+++ b/tests/disas/winch/aarch64/br_if/as_local_set_value.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,13 +27,14 @@
 ;;       mov     x16, #0x11
 ;;       mov     w0, w16
 ;;       tst     w1, w1
-;;       b.ne    #0x54
-;;       b       #0x48
-;;   48: stur    w0, [x28, #4]
+;;       b.ne    #0x58
+;;       b       #0x4c
+;;   4c: stur    w0, [x28, #4]
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/large.wat
+++ b/tests/disas/winch/aarch64/br_table/large.wat
@@ -741,6 +741,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -751,14 +752,14 @@
 ;;       ldur    w0, [x28, #4]
 ;;       mov     x16, #0x6027
 ;;       cmp     x0, x16, uxtx
-;;       b.hs    #0x180f4
-;;   34: csel    x1, xzr, x0, hs
+;;       b.hs    #0x180f8
+;;   38: csel    x1, xzr, x0, hs
 ;;       csdb
-;;       adr     x16, #0x4c
+;;       adr     x16, #0x50
 ;;       ldrsw   x1, [x16, w1, uxtw #2]
 ;;       add     x16, x16, x1
 ;;       br      x16
-;;   4c: .byte   0x9c, 0x80, 0x01, 0x00
+;;   50: .byte   0x9c, 0x80, 0x01, 0x00
 ;;       .byte   0xa8, 0x80, 0x01, 0x00
 ;;       .byte   0x9c, 0x80, 0x01, 0x00
 ;;       .byte   0xa8, 0x80, 0x01, 0x00
@@ -25375,11 +25376,12 @@
 ;;       .byte   0x9c, 0x80, 0x01, 0x00
 ;;       mov     x16, #0
 ;;       mov     w0, w16
-;;       b       #0x180fc
-;; 180f4: mov     x16, #1
+;;       b       #0x18100
+;; 180f8: mov     x16, #1
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
+++ b/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
@@ -21,6 +21,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -30,34 +31,35 @@
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       cmp     x0, #2
-;;       b.hs    #0x54
-;;   30: csel    x1, xzr, x0, hs
+;;       b.hs    #0x58
+;;   34: csel    x1, xzr, x0, hs
 ;;       csdb
-;;       adr     x16, #0x48
+;;       adr     x16, #0x4c
 ;;       ldrsw   x1, [x16, w1, uxtw #2]
 ;;       add     x16, x16, x1
 ;;       br      x16
-;;   48: .byte   0xdc, 0xff, 0xff, 0xff
+;;   4c: .byte   0xdc, 0xff, 0xff, 0xff
 ;;       .byte   0x0c, 0x00, 0x00, 0x00
-;;       b       #0x24
-;;   54: mov     x16, #0
+;;       b       #0x28
+;;   58: mov     x16, #0
 ;;       mov     w0, w16
 ;;       stur    w0, [x28, #4]
 ;;       ldur    w0, [x28, #4]
 ;;       cmp     x0, #2
-;;       b.hs    #0x60
-;;   6c: csel    x1, xzr, x0, hs
+;;       b.hs    #0x64
+;;   70: csel    x1, xzr, x0, hs
 ;;       csdb
-;;       adr     x16, #0x84
+;;       adr     x16, #0x88
 ;;       ldrsw   x1, [x16, w1, uxtw #2]
 ;;       add     x16, x16, x1
 ;;       br      x16
-;;   84: .byte   0x08, 0x00, 0x00, 0x00
+;;   88: .byte   0x08, 0x00, 0x00, 0x00
 ;;       .byte   0xdc, 0xff, 0xff, 0xff
 ;;       mov     x16, #3
 ;;       mov     w0, w16
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/multi.wat
+++ b/tests/disas/winch/aarch64/call/multi.wat
@@ -13,6 +13,7 @@
 ;; wasm[0]::function[0]::multi:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x1
 ;;       sub     x28, x28, #0x18
@@ -34,12 +35,14 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]::start:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -54,7 +57,7 @@
 ;;       mov     x2, x9
 ;;       add     x0, x28, #0xc
 ;;       bl      #0
-;;   c0: add     x28, x28, #0xc
+;;   c4: add     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0xc]
 ;;       add     x28, x28, #4
@@ -62,5 +65,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/params.wat
+++ b/tests/disas/winch/aarch64/call/params.wat
@@ -40,6 +40,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -79,7 +80,7 @@
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
 ;;       bl      #0x180
-;;   a4: add     x28, x28, #0x24
+;;   a8: add     x28, x28, #0x24
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -117,7 +118,7 @@
 ;;       mov     w16, w16
 ;;       stur    w16, [x28, #0x10]
 ;;       bl      #0x180
-;;  13c: add     x28, x28, #0x20
+;;  140: add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       add     x28, x28, #8
 ;;       mov     sp, x28
@@ -125,12 +126,14 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]::add:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x28
@@ -164,5 +167,6 @@
 ;;       add     x28, x28, #0x28
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/recursive.wat
+++ b/tests/disas/winch/aarch64/call/recursive.wat
@@ -27,6 +27,7 @@
 ;; wasm[0]::function[0]::fibonacci8:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -38,11 +39,11 @@
 ;;       cmp     w0, #1
 ;;       cset    x0, le
 ;;       tst     w0, w0
-;;       b.eq    #0x44
-;;       b       #0x3c
-;;   3c: ldur    w0, [x28, #4]
-;;       b       #0xd4
-;;   44: ldur    w0, [x28, #4]
+;;       b.eq    #0x48
+;;       b       #0x40
+;;   40: ldur    w0, [x28, #4]
+;;       b       #0xd8
+;;   48: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #1
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
@@ -53,7 +54,7 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       bl      #0
-;;   70: add     x28, x28, #4
+;;   74: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -70,7 +71,7 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       bl      #0
-;;   b4: add     x28, x28, #4
+;;   b8: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
@@ -81,5 +82,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/reg_on_stack.wat
+++ b/tests/disas/winch/aarch64/call/reg_on_stack.wat
@@ -16,6 +16,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -34,7 +35,7 @@
 ;;       mov     x16, #1
 ;;       mov     w2, w16
 ;;       bl      #0
-;;   50: add     x28, x28, #4
+;;   54: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       sub     x28, x28, #4
@@ -45,7 +46,7 @@
 ;;       mov     x16, #1
 ;;       mov     w2, w16
 ;;       bl      #0
-;;   7c: ldur    x9, [x28, #0x18]
+;;   80: ldur    x9, [x28, #0x18]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
@@ -56,14 +57,15 @@
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       tst     w1, w1
-;;       b.eq    #0xbc
-;;       b       #0xb0
-;;   b0: add     x28, x28, #4
+;;       b.eq    #0xc0
+;;       b       #0xb4
+;;   b4: add     x28, x28, #4
 ;;       mov     sp, x28
-;;       b       #0xc0
-;;   bc: .byte   0x1f, 0xc1, 0x00, 0x00
+;;       b       #0xc4
+;;   c0: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call/simple.wat
+++ b/tests/disas/winch/aarch64/call/simple.wat
@@ -18,6 +18,7 @@
 ;; wasm[0]::function[0]::main:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -34,8 +35,8 @@
 ;;       mov     w2, w16
 ;;       mov     x16, #0x50
 ;;       mov     w3, w16
-;;       bl      #0x80
-;;   4c: add     x28, x28, #8
+;;       bl      #0xa0
+;;   50: add     x28, x28, #8
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x10]
 ;;       mov     x16, #2
@@ -46,12 +47,14 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]::add:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -67,5 +70,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -32,6 +32,7 @@
 ;; wasm[0]::function[0]::fib-i32:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,12 +44,12 @@
 ;;       cmp     w0, #1
 ;;       cset    x0, ls
 ;;       tst     w0, w0
-;;       b.eq    #0x48
-;;       b       #0x3c
-;;   3c: mov     x16, #1
+;;       b.eq    #0x4c
+;;       b       #0x40
+;;   40: mov     x16, #1
 ;;       mov     w0, w16
-;;       b       #0x268
-;;   48: ldur    w0, [x28, #4]
+;;       b       #0x26c
+;;   4c: ldur    w0, [x28, #4]
 ;;       sub     w0, w0, #2
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
@@ -59,8 +60,8 @@
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
 ;;       sub     sp, x28, #4
-;;       b.hs    #0x27c
-;;   78: mov     sp, x28
+;;       b.hs    #0x284
+;;   7c: mov     sp, x28
 ;;       mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
@@ -71,31 +72,31 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xdc
-;;       b       #0xac
-;;   ac: sub     x28, x28, #4
+;;       b.ne    #0xe0
+;;       b       #0xb0
+;;   b0: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x0, x9
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x3b4
-;;   cc: add     x28, x28, #4
+;;       bl      #0x3fc
+;;   d0: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xe0
-;;   dc: and     x0, x0, #0xfffffffffffffffe
+;;       b       #0xe4
+;;   e0: and     x0, x0, #0xfffffffffffffffe
 ;;       sub     sp, x28, #4
-;;       cbz     x0, #0x280
-;;   e8: mov     sp, x28
+;;       cbz     x0, #0x288
+;;   ec: mov     sp, x28
 ;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
 ;;       sub     sp, x28, #4
-;;       b.ne    #0x284
-;;  104: mov     sp, x28
+;;       b.ne    #0x28c
+;;  108: mov     sp, x28
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
@@ -110,7 +111,7 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  140: add     x28, x28, #4
+;;  144: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -128,8 +129,8 @@
 ;;       mov     x2, x9
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
-;;       b.hs    #0x288
-;;  18c: mov     x16, x1
+;;       b.hs    #0x290
+;;  190: mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
 ;;       ldur    x2, [x2, #0x50]
@@ -139,9 +140,9 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0x1fc
-;;       b       #0x1bc
-;;  1bc: sub     x28, x28, #4
+;;       b.ne    #0x200
+;;       b       #0x1c0
+;;  1c0: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       sub     x28, x28, #0xc
@@ -150,21 +151,21 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28, #0xc]
-;;       bl      #0x3b4
-;;  1e4: add     x28, x28, #0xc
+;;       bl      #0x3fc
+;;  1e8: add     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x18]
-;;       b       #0x200
-;;  1fc: and     x0, x0, #0xfffffffffffffffe
-;;       cbz     x0, #0x28c
-;;  204: ldur    x16, [x9, #0x40]
+;;       b       #0x204
+;;  200: and     x0, x0, #0xfffffffffffffffe
+;;       cbz     x0, #0x294
+;;  208: ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
-;;       b.ne    #0x290
-;;  218: sub     x28, x28, #8
+;;       b.ne    #0x298
+;;  21c: sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       ldur    x3, [x28]
@@ -176,7 +177,7 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28]
 ;;       blr     x4
-;;  248: add     x28, x28, #4
+;;  24c: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
 ;;       ldur    w1, [x28]
@@ -187,11 +188,12 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  27c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  280: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  284: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  288: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  28c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  290: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  294: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  298: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]::param-i32:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -30,12 +31,14 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -54,8 +57,8 @@
 ;;       ldur    x3, [x2, #0x58]
 ;;       cmp     x1, x3, uxtx
 ;;       sub     sp, x28, #4
-;;       b.hs    #0x184
-;;   94: mov     sp, x28
+;;       b.hs    #0x18c
+;;   98: mov     sp, x28
 ;;       mov     x16, x1
 ;;       mov     x16, #8
 ;;       mul     x16, x16, x16
@@ -66,31 +69,31 @@
 ;;       csel    x2, x4, x4, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
-;;       b.ne    #0xf8
-;;       b       #0xc8
-;;   c8: sub     x28, x28, #4
+;;       b.ne    #0xfc
+;;       b       #0xcc
+;;   cc: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
 ;;       mov     x0, x9
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x394
-;;   e8: add     x28, x28, #4
+;;       bl      #0x424
+;;   ec: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
-;;       b       #0xfc
-;;   f8: and     x0, x0, #0xfffffffffffffffe
+;;       b       #0x100
+;;   fc: and     x0, x0, #0xfffffffffffffffe
 ;;       sub     sp, x28, #4
-;;       cbz     x0, #0x188
-;;  104: mov     sp, x28
+;;       cbz     x0, #0x190
+;;  108: mov     sp, x28
 ;;       ldur    x16, [x9, #0x40]
 ;;       ldur    w1, [x16]
 ;;       ldur    w2, [x0, #0x10]
 ;;       cmp     w1, w2, uxtx
 ;;       sub     sp, x28, #4
-;;       b.ne    #0x18c
-;;  120: mov     sp, x28
+;;       b.ne    #0x194
+;;  124: mov     sp, x28
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
@@ -105,7 +108,7 @@
 ;;       mov     x1, x9
 ;;       ldur    w2, [x28, #4]
 ;;       blr     x4
-;;  15c: add     x28, x28, #4
+;;  160: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -113,8 +116,9 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  184: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  188: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  18c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  190: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  194: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
+++ b/tests/disas/winch/aarch64/f32_abs/f32_abs_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/const.wat
+++ b/tests/disas/winch/aarch64/f32_add/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/locals.wat
+++ b/tests/disas/winch/aarch64/f32_add/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_add/params.wat
+++ b/tests/disas/winch/aarch64/f32_add/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f32_ceil/f32_ceil_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_s/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i32_u/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_s/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_convert_i64_u/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -29,5 +30,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -44,5 +45,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f32_copysign/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/const.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_demote_f64/params.wat
+++ b/tests/disas/winch/aarch64/f32_demote_f64/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/const.wat
+++ b/tests/disas/winch/aarch64/f32_div/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/locals.wat
+++ b/tests/disas/winch/aarch64/f32_div/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_div/params.wat
+++ b/tests/disas/winch/aarch64/f32_div/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/const.wat
+++ b/tests/disas/winch/aarch64/f32_eq/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/aarch64/f32_floor/f32_floor_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/const.wat
+++ b/tests/disas/winch/aarch64/f32_ge/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/const.wat
+++ b/tests/disas/winch/aarch64/f32_gt/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/const.wat
+++ b/tests/disas/winch/aarch64/f32_le/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/const.wat
+++ b/tests/disas/winch/aarch64/f32_lt/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/const.wat
+++ b/tests/disas/winch/aarch64/f32_max/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/locals.wat
+++ b/tests/disas/winch/aarch64/f32_max/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_max/params.wat
+++ b/tests/disas/winch/aarch64/f32_max/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/const.wat
+++ b/tests/disas/winch/aarch64/f32_min/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/locals.wat
+++ b/tests/disas/winch/aarch64/f32_min/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_min/params.wat
+++ b/tests/disas/winch/aarch64/f32_min/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/const.wat
+++ b/tests/disas/winch/aarch64/f32_mul/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f32_mul/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_mul/params.wat
+++ b/tests/disas/winch/aarch64/f32_mul/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/const.wat
+++ b/tests/disas/winch/aarch64/f32_ne/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f32_nearest/f32_nearest_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
+++ b/tests/disas/winch/aarch64/f32_neg/f32_neg_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/ret_int.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
+++ b/tests/disas/winch/aarch64/f32_reinterpret_i32/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f32_sqrt/f32_sqrt_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/const.wat
+++ b/tests/disas/winch/aarch64/f32_sub/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f32_sub/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_sub/params.wat
+++ b/tests/disas/winch/aarch64/f32_sub/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f32_trunc/f32_trunc_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
+++ b/tests/disas/winch/aarch64/f64_abs/f64_abs_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/const.wat
+++ b/tests/disas/winch/aarch64/f64_add/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/locals.wat
+++ b/tests/disas/winch/aarch64/f64_add/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_add/params.wat
+++ b/tests/disas/winch/aarch64/f64_add/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/aarch64/f64_ceil/f64_ceil_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_s/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i32_u/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_s/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_convert_i64_u/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/const.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -33,5 +34,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/locals.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -49,5 +50,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_copysign/params.wat
+++ b/tests/disas/winch/aarch64/f64_copysign/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/const.wat
+++ b/tests/disas/winch/aarch64/f64_div/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/locals.wat
+++ b/tests/disas/winch/aarch64/f64_div/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_div/params.wat
+++ b/tests/disas/winch/aarch64/f64_div/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/const.wat
+++ b/tests/disas/winch/aarch64/f64_eq/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/aarch64/f64_floor/f64_floor_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/const.wat
+++ b/tests/disas/winch/aarch64/f64_ge/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/const.wat
+++ b/tests/disas/winch/aarch64/f64_gt/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/const.wat
+++ b/tests/disas/winch/aarch64/f64_le/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/const.wat
+++ b/tests/disas/winch/aarch64/f64_lt/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/const.wat
+++ b/tests/disas/winch/aarch64/f64_max/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/locals.wat
+++ b/tests/disas/winch/aarch64/f64_max/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_max/params.wat
+++ b/tests/disas/winch/aarch64/f64_max/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/const.wat
+++ b/tests/disas/winch/aarch64/f64_min/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/locals.wat
+++ b/tests/disas/winch/aarch64/f64_min/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_min/params.wat
+++ b/tests/disas/winch/aarch64/f64_min/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/const.wat
+++ b/tests/disas/winch/aarch64/f64_mul/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f64_mul/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_mul/params.wat
+++ b/tests/disas/winch/aarch64/f64_mul/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/const.wat
+++ b/tests/disas/winch/aarch64/f64_ne/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/aarch64/f64_nearest/f64_nearest_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
+++ b/tests/disas/winch/aarch64/f64_neg/f64_neg_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/const.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_promote_f32/params.wat
+++ b/tests/disas/winch/aarch64/f64_promote_f32/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/ret_int.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
+++ b/tests/disas/winch/aarch64/f64_reinterpret_i64/spilled.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
+++ b/tests/disas/winch/aarch64/f64_sqrt/f64_sqrt_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/const.wat
+++ b/tests/disas/winch/aarch64/f64_sub/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -32,5 +33,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f64_sub/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -48,5 +49,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_sub/params.wat
+++ b/tests/disas/winch/aarch64/f64_sub/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/aarch64/f64_trunc/f64_trunc_param.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/const.wat
+++ b/tests/disas/winch/aarch64/i32_add/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/locals.wat
+++ b/tests/disas/winch/aarch64/i32_add/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max.wat
+++ b/tests/disas/winch/aarch64/i32_add/max.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_add/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_add/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/params.wat
+++ b/tests/disas/winch/aarch64/i32_add/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/signed.wat
+++ b/tests/disas/winch/aarch64/i32_add/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_add/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/const.wat
+++ b/tests/disas/winch/aarch64/i32_and/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/locals.wat
+++ b/tests/disas/winch/aarch64/i32_and/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_and/params.wat
+++ b/tests/disas/winch/aarch64/i32_and/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/const.wat
+++ b/tests/disas/winch/aarch64/i32_clz/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_clz/locals.wat
@@ -14,6 +14,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -29,5 +30,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_clz/params.wat
+++ b/tests/disas/winch/aarch64/i32_clz/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -28,5 +29,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i32_ctz/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_divs/const.wat
+++ b/tests/disas/winch/aarch64/i32_divs/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,18 +23,19 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     w0, #0x64
-;;   34: cmn     w0, #1
+;;       cbz     w0, #0x6c
+;;   38: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x68
-;;   40: sxtw    x0, w0
+;;       b.vs    #0x70
+;;   44: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,18 +23,19 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x64
-;;   34: cmn     w0, #1
+;;       cbz     w0, #0x6c
+;;   38: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x68
-;;   40: sxtw    x0, w0
+;;       b.vs    #0x70
+;;   44: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_divs/overflow.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,18 +23,19 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     w0, #0x64
-;;   34: cmn     w0, #1
+;;       cbz     w0, #0x6c
+;;   38: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x68
-;;   40: sxtw    x0, w0
+;;       b.vs    #0x70
+;;   44: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/params.wat
+++ b/tests/disas/winch/aarch64/i32_divs/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,18 +23,19 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x64
-;;   34: cmn     w0, #1
+;;       cbz     w0, #0x6c
+;;   38: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x68
-;;   40: sxtw    x0, w0
+;;       b.vs    #0x70
+;;   44: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divs/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,18 +23,19 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x64
-;;   34: cmn     w0, #1
+;;       cbz     w0, #0x6c
+;;   38: cmn     w0, #1
 ;;       ccmp    w1, #1, #0, eq
-;;       b.vs    #0x68
-;;   40: sxtw    x0, w0
+;;       b.vs    #0x70
+;;   44: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x1, x1, x0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/const.wat
+++ b/tests/disas/winch/aarch64/i32_divu/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x14
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
-;;   34: udiv    w1, w1, w0
+;;       cbz     w0, #0x58
+;;   38: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
-;;   34: udiv    w1, w1, w0
+;;       cbz     w0, #0x58
+;;   38: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/params.wat
+++ b/tests/disas/winch/aarch64/i32_divu/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,12 +23,13 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x50
-;;   34: udiv    w1, w1, w0
+;;       cbz     w0, #0x58
+;;   38: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_divu/signed.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
-;;   34: udiv    w1, w1, w0
+;;       cbz     w0, #0x58
+;;   38: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_divu/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x50
-;;   34: udiv    w1, w1, w0
+;;       cbz     w0, #0x58
+;;   38: udiv    w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_eq/const.wat
+++ b/tests/disas/winch/aarch64/i32_eq/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i32_eq/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_eq/params.wat
+++ b/tests/disas/winch/aarch64/i32_eq/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_16_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_extend_8_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_ge_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_gt_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_le_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_lt_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/const.wat
+++ b/tests/disas/winch/aarch64/i32_mul/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i32_mul/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_mul/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/params.wat
+++ b/tests/disas/winch/aarch64/i32_mul/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i32_mul/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_mul/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/const.wat
+++ b/tests/disas/winch/aarch64/i32_ne/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i32_ne/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_ne/params.wat
+++ b/tests/disas/winch/aarch64/i32_ne/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/const.wat
+++ b/tests/disas/winch/aarch64/i32_or/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/locals.wat
+++ b/tests/disas/winch/aarch64/i32_or/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_or/params.wat
+++ b/tests/disas/winch/aarch64/i32_or/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i32_popcnt/reg.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
+++ b/tests/disas/winch/aarch64/i32_reinterpret_f32/ret_float.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rems/const.wat
+++ b/tests/disas/winch/aarch64/i32_rems/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,8 +23,8 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     w0, #0x5c
-;;   34: sxtw    x0, w0
+;;       cbz     w0, #0x64
+;;   38: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
@@ -31,6 +32,7 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,8 +23,8 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x5c
-;;   34: sxtw    x0, w0
+;;       cbz     w0, #0x64
+;;   38: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
@@ -31,6 +32,7 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i32_rems/overflow.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,8 +23,8 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0x80000000
 ;;       mov     w1, w16
-;;       cbz     w0, #0x5c
-;;   34: sxtw    x0, w0
+;;       cbz     w0, #0x64
+;;   38: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
@@ -31,6 +32,7 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/params.wat
+++ b/tests/disas/winch/aarch64/i32_rems/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,8 +23,8 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x5c
-;;   34: sxtw    x0, w0
+;;       cbz     w0, #0x64
+;;   38: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
@@ -31,6 +32,7 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_rems/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,8 +23,8 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x5c
-;;   34: sxtw    x0, w0
+;;       cbz     w0, #0x64
+;;   38: sxtw    x0, w0
 ;;       sxtw    x1, w1
 ;;       sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
@@ -31,6 +32,7 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/const.wat
+++ b/tests/disas/winch/aarch64/i32_remu/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #7
 ;;       mov     w1, w16
-;;       cbz     w0, #0x54
-;;   34: udiv    w16, w1, w0
+;;       cbz     w0, #0x5c
+;;   38: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #1
 ;;       mov     w1, w16
-;;       cbz     w0, #0x54
-;;   34: udiv    w16, w1, w0
+;;       cbz     w0, #0x5c
+;;   38: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/params.wat
+++ b/tests/disas/winch/aarch64/i32_remu/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,13 +23,14 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       cbz     w0, #0x54
-;;   34: udiv    w16, w1, w0
+;;       cbz     w0, #0x5c
+;;   38: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i32_remu/signed.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     w0, w16
 ;;       orr     x16, xzr, #0xffffffff
 ;;       mov     w1, w16
-;;       cbz     w0, #0x54
-;;   34: udiv    w16, w1, w0
+;;       cbz     w0, #0x5c
+;;   38: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i32_remu/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     w0, w16
 ;;       mov     x16, #0
 ;;       mov     w1, w16
-;;       cbz     w0, #0x54
-;;   34: udiv    w16, w1, w0
+;;       cbz     w0, #0x5c
+;;   38: udiv    w16, w1, w0
 ;;       msub    w1, w0, w16, w1
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotr/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/16_const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shl/8_const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shl/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shl/params.wat
+++ b/tests/disas/winch/aarch64/i32_shl/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_shr_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/const.wat
+++ b/tests/disas/winch/aarch64/i32_sub/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i32_sub/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i32_sub/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/params.wat
+++ b/tests/disas/winch/aarch64/i32_sub/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i32_sub/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i32_sub/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,21 +20,22 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   30: mov     x16, #0xcf000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x4f000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzs  w0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,21 +23,22 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x6c
-;;   34: mov     x16, #0xcf000000
+;;       b.vs    #0x74
+;;   38: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x70
-;;   44: mov     x16, #0x4f000000
+;;       b.le    #0x78
+;;   48: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x74
-;;   54: fcvtzs  w0, s0
+;;       b.ge    #0x7c
+;;   58: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,21 +20,22 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   30: mov     x16, #0xcf000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x4f000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzs  w0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,20 +20,21 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
-;;   30: fmov    s31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x4f800000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  w0, s0
+;;       b.ge    #0x74
+;;   50: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,20 +23,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   34: fmov    s31, #-1.00000000
+;;       b.vs    #0x70
+;;   38: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x4f800000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzu  w0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,20 +20,21 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
-;;   30: fmov    s31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x4f800000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  w0, s0
+;;       b.ge    #0x74
+;;   50: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,22 +20,23 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x6c
-;;   30: mov     x16, #0x200000
+;;       b.vs    #0x74
+;;   34: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x70
-;;   44: mov     x16, #0x41e0000000000000
+;;       b.le    #0x78
+;;   48: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x74
-;;   54: fcvtzs  w0, d0
+;;       b.ge    #0x7c
+;;   58: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,22 +23,23 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x70
-;;   34: mov     x16, #0x200000
+;;       b.vs    #0x78
+;;   38: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x74
-;;   48: mov     x16, #0x41e0000000000000
+;;       b.le    #0x7c
+;;   4c: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x78
-;;   58: fcvtzs  w0, d0
+;;       b.ge    #0x80
+;;   5c: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   80: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,22 +20,23 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x6c
-;;   30: mov     x16, #0x200000
+;;       b.vs    #0x74
+;;   34: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x70
-;;   44: mov     x16, #0x41e0000000000000
+;;       b.le    #0x78
+;;   48: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x74
-;;   54: fcvtzs  w0, d0
+;;       b.ge    #0x7c
+;;   58: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,20 +20,21 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
-;;   30: fmov    d31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x41f0000000000000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  w0, d0
+;;       b.ge    #0x74
+;;   50: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,20 +23,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
-;;   34: fmov    d31, #-1.00000000
+;;       b.vs    #0x70
+;;   38: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x41f0000000000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
-;;   50: fcvtzu  w0, d0
+;;       b.ge    #0x78
+;;   54: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,20 +20,21 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
-;;   30: fmov    d31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x41f0000000000000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  w0, d0
+;;       b.ge    #0x74
+;;   50: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
+++ b/tests/disas/winch/aarch64/i32_wrap_i64/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/const.wat
+++ b/tests/disas/winch/aarch64/i32_xor/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i32_xor/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i32_xor/params.wat
+++ b/tests/disas/winch/aarch64/i32_xor/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/const.wat
+++ b/tests/disas/winch/aarch64/i64_add/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/locals.wat
+++ b/tests/disas/winch/aarch64/i64_add/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max.wat
+++ b/tests/disas/winch/aarch64/i64_add/max.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_add/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_add/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/params.wat
+++ b/tests/disas/winch/aarch64/i64_add/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/signed.wat
+++ b/tests/disas/winch/aarch64/i64_add/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_add/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/32_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_and/64_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/locals.wat
+++ b/tests/disas/winch/aarch64/i64_and/locals.wat
@@ -19,6 +19,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_and/params.wat
+++ b/tests/disas/winch/aarch64/i64_and/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/const.wat
+++ b/tests/disas/winch/aarch64/i64_clz/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_clz/locals.wat
@@ -14,6 +14,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -29,5 +30,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_clz/params.wat
+++ b/tests/disas/winch/aarch64/i64_clz/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/const.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/locals.wat
@@ -14,6 +14,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -30,5 +31,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ctz/params.wat
+++ b/tests/disas/winch/aarch64/i64_ctz/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_divs/const.wat
+++ b/tests/disas/winch/aarch64/i64_divs/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,16 +23,17 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0x14
 ;;       mov     x1, x16
-;;       cbz     x0, #0x5c
-;;   34: cmn     x0, #1
+;;       cbz     x0, #0x64
+;;   38: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x60
-;;   40: sdiv    x1, x1, x0
+;;       b.vs    #0x68
+;;   44: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,16 +23,17 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x5c
-;;   34: cmn     x0, #1
+;;       cbz     x0, #0x64
+;;   38: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x60
-;;   40: sdiv    x1, x1, x0
+;;       b.vs    #0x68
+;;   44: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_divs/overflow.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,16 +23,17 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x1, x16
-;;       cbz     x0, #0x5c
-;;   34: cmn     x0, #1
+;;       cbz     x0, #0x64
+;;   38: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x60
-;;   40: sdiv    x1, x1, x0
+;;       b.vs    #0x68
+;;   44: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/params.wat
+++ b/tests/disas/winch/aarch64/i64_divs/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -22,16 +23,17 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x5c
-;;   34: cmn     x0, #1
+;;       cbz     x0, #0x64
+;;   38: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x60
-;;   40: sdiv    x1, x1, x0
+;;       b.vs    #0x68
+;;   44: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divs/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,16 +23,17 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x5c
-;;   34: cmn     x0, #1
+;;       cbz     x0, #0x64
+;;   38: cmn     x0, #1
 ;;       ccmp    x1, #1, #0, eq
-;;       b.vs    #0x60
-;;   40: sdiv    x1, x1, x0
+;;       b.vs    #0x68
+;;   44: sdiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   60: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/const.wat
+++ b/tests/disas/winch/aarch64/i64_divu/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0x14
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
-;;   34: udiv    x1, x1, x0
+;;       cbz     x0, #0x58
+;;   38: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
-;;   34: udiv    x1, x1, x0
+;;       cbz     x0, #0x58
+;;   38: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/params.wat
+++ b/tests/disas/winch/aarch64/i64_divu/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -22,12 +23,13 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x50
-;;   34: udiv    x1, x1, x0
+;;       cbz     x0, #0x58
+;;   38: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_divu/signed.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
-;;   34: udiv    x1, x1, x0
+;;       cbz     x0, #0x58
+;;   38: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_divu/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,12 +23,13 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x50
-;;   34: udiv    x1, x1, x0
+;;       cbz     x0, #0x58
+;;   38: udiv    x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   50: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_eq/const.wat
+++ b/tests/disas/winch/aarch64/i64_eq/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/i64_eq/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_eq/params.wat
+++ b/tests/disas/winch/aarch64/i64_eq/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_16_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_8_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_extend_i32_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ge_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_ge_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_gt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_gt_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_le_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_le_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_lt_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_lt_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/const.wat
+++ b/tests/disas/winch/aarch64/i64_mul/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/locals.wat
+++ b/tests/disas/winch/aarch64/i64_mul/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_mul/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/params.wat
+++ b/tests/disas/winch/aarch64/i64_mul/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/signed.wat
+++ b/tests/disas/winch/aarch64/i64_mul/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_mul/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/const.wat
+++ b/tests/disas/winch/aarch64/i64_ne/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/i64_ne/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_ne/params.wat
+++ b/tests/disas/winch/aarch64/i64_ne/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/32_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_or/64_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/locals.wat
+++ b/tests/disas/winch/aarch64/i64_or/locals.wat
@@ -19,6 +19,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_or/params.wat
+++ b/tests/disas/winch/aarch64/i64_or/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/const.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_popcnt/reg.wat
+++ b/tests/disas/winch/aarch64/i64_popcnt/reg.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
+++ b/tests/disas/winch/aarch64/i64_reinterpret_f64/ret_float.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rems/const.wat
+++ b/tests/disas/winch/aarch64/i64_rems/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #7
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: sdiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: sdiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/overflow.wat
+++ b/tests/disas/winch/aarch64/i64_rems/overflow.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-0x8000000000000000
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: sdiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/params.wat
+++ b/tests/disas/winch/aarch64/i64_rems/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -22,13 +23,14 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x54
-;;   34: sdiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_rems/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: sdiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: sdiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/const.wat
+++ b/tests/disas/winch/aarch64/i64_remu/const.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #7
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: udiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/one_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/one_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: udiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/params.wat
+++ b/tests/disas/winch/aarch64/i64_remu/params.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -22,13 +23,14 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       cbz     x0, #0x54
-;;   34: udiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/signed.wat
+++ b/tests/disas/winch/aarch64/i64_remu/signed.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #-1
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: udiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
+++ b/tests/disas/winch/aarch64/i64_remu/zero_zero.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,13 +23,14 @@
 ;;       mov     x0, x16
 ;;       mov     x16, #0
 ;;       mov     x1, x16
-;;       cbz     x0, #0x54
-;;   34: udiv    x16, x1, x0
+;;       cbz     x0, #0x5c
+;;   38: udiv    x16, x1, x0
 ;;       msub    x1, x0, x16, x1
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   54: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   5c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -43,5 +44,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -27,5 +28,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_rotr/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotr/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shl/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shl/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shl/params.wat
+++ b/tests/disas/winch/aarch64/i64_shl/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_s/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/16_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/8_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_shr_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_shr_u/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/const.wat
+++ b/tests/disas/winch/aarch64/i64_sub/const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/locals.wat
+++ b/tests/disas/winch/aarch64/i64_sub/locals.wat
@@ -20,6 +20,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -42,5 +43,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/max_one.wat
+++ b/tests/disas/winch/aarch64/i64_sub/max_one.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/mixed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/mixed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/params.wat
+++ b/tests/disas/winch/aarch64/i64_sub/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/signed.wat
+++ b/tests/disas/winch/aarch64/i64_sub/signed.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/aarch64/i64_sub/unsigned_with_zero.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,21 +20,22 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   30: mov     x16, #0xdf000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x5f000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzs  x0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,21 +23,22 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x6c
-;;   34: mov     x16, #0xdf000000
+;;       b.vs    #0x74
+;;   38: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x70
-;;   44: mov     x16, #0x5f000000
+;;       b.le    #0x78
+;;   48: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x74
-;;   54: fcvtzs  x0, s0
+;;       b.ge    #0x7c
+;;   58: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,21 +20,22 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   30: mov     x16, #0xdf000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x5f000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzs  x0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,20 +20,21 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
-;;   30: fmov    s31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x5f800000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  x0, s0
+;;       b.ge    #0x74
+;;   50: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,20 +23,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x68
-;;   34: fmov    s31, #-1.00000000
+;;       b.vs    #0x70
+;;   38: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x5f800000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x70
-;;   50: fcvtzu  x0, s0
+;;       b.ge    #0x78
+;;   54: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,20 +20,21 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x64
-;;   30: fmov    s31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    s31, #-1.00000000
 ;;       fcmp    s31, s0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x5f800000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
 ;;       fcmp    s31, s0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  x0, s0
+;;       b.ge    #0x74
+;;   50: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,21 +20,22 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
-;;   30: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x43e0000000000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
-;;   50: fcvtzs  x0, d0
+;;       b.ge    #0x78
+;;   54: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,21 +23,22 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x6c
-;;   34: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x74
+;;   38: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x70
-;;   44: mov     x16, #0x43e0000000000000
+;;       b.le    #0x78
+;;   48: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x74
-;;   54: fcvtzs  x0, d0
+;;       b.ge    #0x7c
+;;   58: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,21 +20,22 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
-;;   30: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x70
+;;   34: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x43e0000000000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
-;;   50: fcvtzs  x0, d0
+;;       b.ge    #0x78
+;;   54: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -19,20 +20,21 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
-;;   30: fmov    d31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x43f0000000000000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  x0, d0
+;;       b.ge    #0x74
+;;   50: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -22,20 +23,21 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x68
-;;   34: fmov    d31, #-1.00000000
+;;       b.vs    #0x70
+;;   38: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x6c
-;;   40: mov     x16, #0x43f0000000000000
+;;       b.le    #0x74
+;;   44: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x70
-;;   50: fcvtzu  x0, d0
+;;       b.ge    #0x78
+;;   54: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -19,20 +20,21 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x64
-;;   30: fmov    d31, #-1.00000000
+;;       b.vs    #0x6c
+;;   34: fmov    d31, #-1.00000000
 ;;       fcmp    d31, d0
-;;       b.le    #0x68
-;;   3c: mov     x16, #0x43f0000000000000
+;;       b.le    #0x70
+;;   40: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d31, d0
-;;       b.ge    #0x6c
-;;   4c: fcvtzu  x0, d0
+;;       b.ge    #0x74
+;;   50: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   64: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   68: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_xor/32_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/32_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/64_const.wat
+++ b/tests/disas/winch/aarch64/i64_xor/64_const.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/locals.wat
+++ b/tests/disas/winch/aarch64/i64_xor/locals.wat
@@ -19,6 +19,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -41,5 +42,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/i64_xor/params.wat
+++ b/tests/disas/winch/aarch64/i64_xor/params.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -22,6 +22,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x1
 ;;       sub     x28, x28, #0x20
@@ -34,10 +35,10 @@
 ;;       ldur    x1, [x9, #0x60]
 ;;       mov     w2, w0
 ;;       add     x2, x2, #4
-;;       b.hs    #0x138
-;;   3c: cmp     x2, x1, uxtx
-;;       b.hi    #0x13c
-;;   44: ldur    x3, [x9, #0x58]
+;;       b.hs    #0x140
+;;   40: cmp     x2, x1, uxtx
+;;       b.hi    #0x144
+;;   48: ldur    x3, [x9, #0x58]
 ;;       add     x3, x3, x0, uxtx
 ;;       mov     x16, #0
 ;;       mov     x4, x16
@@ -48,10 +49,10 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.hs    #0x140
-;;   74: cmp     x3, x2, uxtx
-;;       b.hi    #0x144
-;;   7c: ldur    x4, [x9, #0x58]
+;;       b.hs    #0x148
+;;   78: cmp     x3, x2, uxtx
+;;       b.hi    #0x14c
+;;   80: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
 ;;       mov     x16, #0
@@ -65,10 +66,10 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x4, x4, x16, uxtx
-;;       b.hs    #0x148
-;;   b8: cmp     x4, x3, uxtx
-;;       b.hi    #0x14c
-;;   c0: ldur    x5, [x9, #0x58]
+;;       b.hs    #0x150
+;;   bc: cmp     x4, x3, uxtx
+;;       b.hi    #0x154
+;;   c4: ldur    x5, [x9, #0x58]
 ;;       add     x5, x5, x2, uxtx
 ;;       orr     x16, xzr, #0xfffff
 ;;       add     x5, x5, x16, uxtx
@@ -96,11 +97,12 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  138: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  13c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  140: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  144: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  148: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  14c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  150: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  154: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/load/f32.wat
+++ b/tests/disas/winch/aarch64/load/f32.wat
@@ -9,6 +9,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/f64.wat
+++ b/tests/disas/winch/aarch64/load/f64.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i32.wat
+++ b/tests/disas/winch/aarch64/load/i32.wat
@@ -9,6 +9,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -23,5 +24,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/load/i64.wat
+++ b/tests/disas/winch/aarch64/load/i64.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x18
@@ -35,5 +36,6 @@
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/nop/nop.wat
+++ b/tests/disas/winch/aarch64/nop/nop.wat
@@ -9,6 +9,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -18,5 +19,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/400_params.wat
+++ b/tests/disas/winch/aarch64/params/400_params.wat
@@ -52,6 +52,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x28
@@ -68,5 +69,6 @@
 ;;       add     x28, x28, #0x28
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/params/multi_values.wat
+++ b/tests/disas/winch/aarch64/params/multi_values.wat
@@ -12,6 +12,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x1
 ;;       sub     x28, x28, #0x28
@@ -52,5 +53,6 @@
 ;;       add     x28, x28, #0x28
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -22,6 +22,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x20
@@ -37,10 +38,10 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #4
-;;       b.hs    #0x10c
-;;   48: cmp     x3, x2, uxtx
-;;       b.hi    #0x110
-;;   50: ldur    x4, [x9, #0x58]
+;;       b.hs    #0x114
+;;   4c: cmp     x3, x2, uxtx
+;;       b.hi    #0x118
+;;   54: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       mov     x16, #0
 ;;       mov     x5, x16
@@ -52,10 +53,10 @@
 ;;       ldur    x2, [x9, #0x60]
 ;;       mov     w3, w1
 ;;       add     x3, x3, #8
-;;       b.hs    #0x114
-;;   84: cmp     x3, x2, uxtx
-;;       b.hi    #0x118
-;;   8c: ldur    x4, [x9, #0x58]
+;;       b.hs    #0x11c
+;;   88: cmp     x3, x2, uxtx
+;;       b.hi    #0x120
+;;   90: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       add     x4, x4, #4
 ;;       mov     x16, #0
@@ -70,10 +71,10 @@
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
 ;;       add     x3, x3, x16, uxtx
-;;       b.hs    #0x11c
-;;   cc: cmp     x3, x2, uxtx
-;;       b.hi    #0x120
-;;   d4: ldur    x4, [x9, #0x58]
+;;       b.hs    #0x124
+;;   d0: cmp     x3, x2, uxtx
+;;       b.hi    #0x128
+;;   d8: ldur    x4, [x9, #0x58]
 ;;       add     x4, x4, x1, uxtx
 ;;       orr     x16, xzr, #0xfffff
 ;;       add     x4, x4, x16, uxtx
@@ -85,11 +86,12 @@
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  10c: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  110: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  114: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  118: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  11c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  120: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  124: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  128: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/store/f32.wat
+++ b/tests/disas/winch/aarch64/store/f32.wat
@@ -8,6 +8,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -24,5 +25,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/f64.wat
+++ b/tests/disas/winch/aarch64/store/f64.wat
@@ -9,6 +9,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -25,5 +26,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i32.wat
+++ b/tests/disas/winch/aarch64/store/i32.wat
@@ -10,6 +10,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -26,5 +27,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/winch/aarch64/store/i64.wat
+++ b/tests/disas/winch/aarch64/store/i64.wat
@@ -11,6 +11,7 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
 ;;       mov     x28, sp
 ;;       mov     x9, x0
 ;;       sub     x28, x28, #0x10
@@ -22,5 +23,6 @@
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -114,6 +114,12 @@ pub(crate) trait ABI {
     /// The offset to the argument base, relative to the frame pointer.
     fn arg_base_offset() -> u8;
 
+    /// The initial size in bytes of the function's frame.
+    ///
+    /// This amount is constant and accounts for all the stack space allocated
+    /// at the frame setup.
+    fn initial_frame_size() -> u8;
+
     /// Construct the ABI-specific signature from a WebAssembly
     /// function type.
     #[cfg(test)]

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -33,6 +33,12 @@ impl ABI for X64ABI {
         16
     }
 
+    fn initial_frame_size() -> u8 {
+        // The initial frame size is equal to the space allocated to save the
+        // return address and the frame pointer.
+        Self::arg_base_offset()
+    }
+
     fn word_bits() -> u8 {
         64
     }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -310,7 +310,7 @@ impl Masm for MacroAssembler {
         mut load_callee: impl FnMut(&mut Self) -> Result<(CalleeKind, CallingConvention)>,
     ) -> Result<u32> {
         let alignment: u32 = <Self::ABI as abi::ABI>::call_stack_align().into();
-        let addend: u32 = <Self::ABI as abi::ABI>::arg_base_offset().into();
+        let addend: u32 = <Self::ABI as abi::ABI>::initial_frame_size().into();
         let delta = calculate_frame_adjustment(self.sp_offset()?.as_u32(), addend, alignment);
         let aligned_args_size = align_to(stack_args_size, alignment);
         let total_stack = delta + aligned_args_size;


### PR DESCRIPTION
This commit finalizes the ABI integration between Winch and Cranelift, notably:

* Updates the Cranelift ABI to ensure that all the Winch register clobbers are taken into account.
* Updates the Winch ABI to treat x28 as callee-saved, since it's used as the shadow stack pointer.

The alternative to treating x28 as callee-saved is to treat it as caller-saved and save it when required e.g., at call-sites, even though this approach works, it's probably more efficient to perform a store/pop once per function, to minimize the number of move instructions required.

There are still some changes needed in order to fully enable running spec tests for aarch64, however, this change is one step further. If interested, you can run the call.wast test via:

    cargo run -- wast -Ccompiler=winch tests/spec_testsuite/call.wast

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
