### PR TITLE
Winch: Fix v128 consts and multivalue returns

### DIFF
--- a/tests/disas/winch/x64/v128_const/multivalue.wat
+++ b/tests/disas/winch/x64/v128_const/multivalue.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x68
+;;       ja      0x67
 ;;   1c: movq    %rsi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rsi, 0x18(%rsp)
@@ -23,7 +23,7 @@
 ;;       movdqu  0x36(%rip), %xmm0
 ;;       subq    $0x10, %rsp
 ;;       movdqu  0x29(%rip), %xmm15
-;;       movdqu  %xmm15, 0x30(%rsp)
+;;       movdqu  %xmm15, (%rsp)
 ;;       movq    0x18(%rsp), %rax
 ;;       movdqu  (%rsp), %xmm15
 ;;       addq    $0x10, %rsp
@@ -31,15 +31,15 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
-;;   70: addb    %al, (%rax)
-;;   72: addb    %al, (%rax)
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
-;;   78: addb    %al, (%rax)
-;;   7a: addb    %al, (%rax)
-;;   7c: addb    %al, (%rax)
-;;   7e: addb    %al, (%rax)
+;;   67: ud2
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)
+;;   6f: addb    %al, (%rax)
+;;   71: addb    %al, (%rax)
+;;   73: addb    %al, (%rax)
+;;   75: addb    %al, (%rax)
+;;   77: addb    %al, (%rax)
+;;   79: addb    %al, (%rax)
+;;   7b: addb    %al, (%rax)
+;;   7d: addb    %al, (%rax)

--- a/tests/misc_testsuite/winch/simd_multivalue.wast
+++ b/tests/misc_testsuite/winch/simd_multivalue.wast
@@ -3,3 +3,7 @@
 ;; test that swapping the parameters results in swapped return values
 (module (func (export "f") (param v128) (param v128) (result v128) (result v128) (local.get 1) (local.get 0)))
 (assert_return (invoke "f" (v128.const i64x2 2 1) (v128.const i64x2 1 2)) (v128.const i64x2 1 2) (v128.const i64x2 2 1))
+
+;; test 0 consts
+(module (func (export "consts") (result v128) (result v128) (v128.const i64x2 0 0) (v128.const i64x2 0 0)))
+(assert_return (invoke "consts") (v128.const i64x2 0 0) (v128.const i64x2 0 0))

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -932,8 +932,8 @@ impl ControlStackFrame {
                     masm.store(RegImm::f64(v.bits()), addr, (*ty).try_into()?)?;
                 }
                 (ABIOperand::Stack { ty, offset, .. }, Val::V128(v)) => {
-                    let addr =
-                        masm.address_at_sp(SPOffset::from_u32(results_offset.as_u32() - *offset))?;
+                    let addr = masm
+                        .address_from_sp(SPOffset::from_u32(results_offset.as_u32() - *offset))?;
                     masm.store(RegImm::v128(*v), addr, (*ty).try_into()?)?;
                 }
                 (_, v) => debug_assert!(v.is_mem()),


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fixes #10301. The existing approach didn't take the stack pointer offset into account for v128 values unlike the branches for the other Wasm types.