### PR TITLE
chore: fix parenthesis balance

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -41,7 +41,7 @@ the real code [here](https://github.com/bytecodealliance/wasmtime/blob/main/cran
       (value_reg (add
                    (put_in_reg x)
                    ;; `y` is a `RegMemImm.Imm`.
-                   y)))
+                   y))))
 ```
 
 ISLE lets the compiler backend developer express this information in a


### PR DESCRIPTION
parentheses are not balanced here

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
