### PR TITLE
Expose GC refs to Wasm in `gc_alloc_raw` libcall

### DIFF
--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -529,7 +529,14 @@ unsafe fn gc_alloc_raw(
         }
     };
 
-    Ok(gc_ref.as_raw_u32())
+    let raw = gc_ref.as_raw_u32();
+
+    store
+        .store_opaque_mut()
+        .unwrap_gc_store_mut()
+        .expose_gc_ref_to_wasm(gc_ref);
+
+    Ok(raw)
 }
 
 // Intern a `funcref` into the GC heap, returning its `FuncRefTableId`.

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1003,3 +1003,52 @@ fn ref_matches() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn issue_9669() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+    config.collector(Collector::DeferredReferenceCounting);
+
+    let engine = Engine::new(&config)?;
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $empty (struct))
+                (type $thing (struct
+                    (field $field1 (ref $empty))
+                    (field $field2 (ref $empty))
+                ))
+
+                (func (export "run")
+                    (local $object (ref $thing))
+
+                    struct.new $empty
+                    struct.new $empty
+                    struct.new $thing
+
+                    local.tee $object
+                    struct.get $thing $field1
+                    drop
+
+                    local.get $object
+                    struct.get $thing $field2
+                    drop
+                )
+            )
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    let func = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+    func.call(&mut store, ())?;
+
+    Ok(())
+}

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1005,6 +1005,7 @@ fn ref_matches() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn issue_9669() -> Result<()> {
     let _ = env_logger::try_init();
 


### PR DESCRIPTION
As we are returning a GC reference to Wasm, we need to mark that GC reference as exposed to Wasm.

Fixes https://github.com/bytecodealliance/wasmtime/issues/9669

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
