### PR TITLE
Enable the GC proposal during general fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -41,8 +41,8 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         let _ = config.relaxed_simd_enabled;
         let _ = config.tail_call_enabled;
         let _ = config.extended_const_enabled;
+        let _ = config.gc_enabled;
         config.exceptions_enabled = false;
-        config.gc_enabled = false;
         config.custom_page_sizes_enabled = u.arbitrary()?;
         config.wide_arithmetic_enabled = u.arbitrary()?;
         config.memory64_enabled = u.ratio(1, 20)?;

--- a/crates/fuzzing/src/generators/value.rs
+++ b/crates/fuzzing/src/generators/value.rs
@@ -267,6 +267,7 @@ impl PartialEq for DiffValue {
             }
             (Self::FuncRef { null: a }, Self::FuncRef { null: b }) => a == b,
             (Self::ExternRef { null: a }, Self::ExternRef { null: b }) => a == b,
+            (Self::AnyRef { null: a }, Self::AnyRef { null: b }) => a == b,
             _ => false,
         }
     }
@@ -302,7 +303,7 @@ impl TryFrom<wasmtime::ValType> for DiffValueType {
                 (true, HeapType::Any) => Ok(Self::AnyRef),
                 (true, HeapType::I31) => Ok(Self::AnyRef),
                 (true, HeapType::None) => Ok(Self::AnyRef),
-                _ => Err("non-funcref and non-externref reference types are not supported yet"),
+                _ => Err("non-null reference types are not supported yet"),
             },
         }
     }

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -49,7 +49,7 @@ impl DiffEngine for SpecInterpreter {
         let _ = (trap, err);
     }
 
-    fn is_stack_overflow(&self, err: &Error) -> bool {
+    fn is_non_deterministic_error(&self, err: &Error) -> bool {
         err.to_string().contains("(Isabelle) call stack exhausted")
     }
 }

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -145,7 +145,7 @@ impl DiffEngine for V8Engine {
         verify_wasmtime("not possibly present in an error, just panic please");
     }
 
-    fn is_stack_overflow(&self, err: &Error) -> bool {
+    fn is_non_deterministic_error(&self, err: &Error) -> bool {
         err.to_string().contains("Maximum call stack size exceeded")
     }
 }

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -85,7 +85,7 @@ impl DiffEngine for WasmiEngine {
         }
     }
 
-    fn is_stack_overflow(&self, err: &Error) -> bool {
+    fn is_non_deterministic_error(&self, err: &Error) -> bool {
         matches!(
             self.trap_code(err),
             Some(wasmi::core::TrapCode::StackOverflow)

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -61,9 +61,12 @@ pub trait DiffEngine {
     /// generated.
     fn assert_error_match(&self, err: &Error, trap: &Trap);
 
-    /// Returns whether the error specified from this engine might be stack
-    /// overflow.
-    fn is_stack_overflow(&self, err: &Error) -> bool;
+    /// Returns whether the error specified from this engine is
+    /// non-deterministic, like a stack overflow or an attempt to allocate an
+    /// object that is too large (which is non-deterministic because it may
+    /// depend on which collector it was configured with or memory available on
+    /// the system).
+    fn is_non_deterministic_error(&self, err: &Error) -> bool;
 }
 
 /// Provide a way to evaluate Wasm functions--a Wasm instance implemented by a

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -8,7 +8,7 @@ use crate::{
     Instance, Module, StoreContextMut, Val, ValRaw, ValType,
 };
 use alloc::sync::Arc;
-use core::fmt;
+use core::fmt::{self, Debug};
 use core::marker;
 #[cfg(feature = "async")]
 use core::{future::Future, pin::Pin};
@@ -88,6 +88,12 @@ pub struct Linker<T> {
     allow_shadowing: bool,
     allow_unknown_exports: bool,
     _marker: marker::PhantomData<fn() -> T>,
+}
+
+impl<T> Debug for Linker<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Linker").finish_non_exhaustive()
+    }
 }
 
 impl<T> Clone for Linker<T> {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/free_list.rs
@@ -310,14 +310,6 @@ fn blocks_are_contiguous(prev_index: u32, prev_len: u32, next_index: u32) -> boo
     // the size of the `Layout` given to us upon deallocation (aka `prev_len`)
     // is smaller than the actual size of the block we allocated.
     let end_of_prev = prev_index + prev_len;
-    log::trace!(
-        "checking for overlapping blocks: \n\
-         \t prev_index = {prev_index:#x}\n\
-         \t   prev_len = {prev_len:#x}\n\
-         \tend_of_prev = {end_of_prev:#x}\n\
-         \t next_index = {next_index:#x}\n\
-         `next_index` should be >= `end_of_prev`"
-    );
     debug_assert!(
         next_index >= end_of_prev,
         "overlapping blocks: \n\

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -33,7 +33,6 @@ pub use self::tls::{AsyncWasmCallState, PreviousAsyncWasmCallState};
 
 pub use traphandlers::SignalHandler;
 
-#[derive(Debug)]
 pub(crate) struct TrapRegisters {
     pub pc: usize,
     pub fp: usize,
@@ -669,11 +668,8 @@ impl CallThreadState {
         faulting_addr: Option<usize>,
         call_handler: impl Fn(&SignalHandler) -> bool,
     ) -> TrapTest {
-        log::trace!("testing if trap: {faulting_addr:?}, {regs:?}");
-
         // If we haven't even started to handle traps yet, bail out.
         if self.jmp_buf.get().is_null() {
-            log::trace!("not a trap: have not entered wasm");
             return TrapTest::NotWasm;
         }
 
@@ -684,30 +680,25 @@ impl CallThreadState {
         #[cfg(all(has_native_signals, not(miri)))]
         if let Some(handler) = self.signal_handler {
             if unsafe { call_handler(&*handler) } {
-                log::trace!("not a trap: handled by embedder");
                 return TrapTest::HandledByEmbedder;
             }
         }
 
         // If this fault wasn't in wasm code, then it's not our problem
         let Some((code, text_offset)) = lookup_code(regs.pc) else {
-            log::trace!("not a trap: PC not in loaded code memory range");
             return TrapTest::NotWasm;
         };
-        log::trace!("faulting PC's text section offset is {text_offset:#x}");
 
         // If the fault was at a location that was not marked as potentially
         // trapping, then that's a bug in Cranelift/Winch/etc. Don't try to
         // catch the trap and pretend this isn't wasm so the program likely
         // aborts.
         let Some(trap) = code.lookup_trap_code(text_offset) else {
-            log::trace!("not a trap: no trap code registered for text offset");
             return TrapTest::NotWasm;
         };
 
         // If all that passed then this is indeed a wasm trap, so return the
         // `jmp_buf` passed to `wasmtime_longjmp` to resume.
-        log::trace!("is a trap: {trap:?}");
         self.set_jit_trap(regs, faulting_addr, trap);
         TrapTest::Trap {
             #[cfg(has_host_compiler_backend)]


### PR DESCRIPTION
This allows us to fuzz Wasm GC in our fuzz targets that use the common config-generation infrastructure, such as the differential fuzz target.

Fixes #10328

---------------

I've been running this locally for about 20 minutes since I last hit a bug. Let's let it run longer before we merge it, just in case. Figured that there was no reason I couldn't make the PR now and optimistically and speculatively pipeline with review and CI potentially and all that.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
