### PR TITLE
Winch: Fix extadd implementations

### DIFF
--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -438,6 +438,7 @@ impl WastTest {
                     "misc_testsuite/simd/issue6725-no-egraph-panic.wast",
                     "misc_testsuite/simd/replace-lane-preserve.wast",
                     "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
+                    "misc_testsuite/winch/issue-10331.wast",
                     "spec_testsuite/simd_align.wast",
                     "spec_testsuite/simd_boolean.wast",
                     "spec_testsuite/simd_conversions.wast",

--- a/tests/disas/winch/x64/i16x8/extadd/extadd_s.wat
+++ b/tests/disas/winch/x64/i16x8/extadd/extadd_s.wat
@@ -14,18 +14,25 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x51
+;;       ja      0x4b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movdqu  %xmm0, (%rsp)
 ;;       movdqu  (%rsp), %xmm0
-;;       vpmovsxbw %xmm0, %xmm15
-;;       vpalignr $8, %xmm0, %xmm0, %xmm0
-;;       vpmovsxbw %xmm0, %xmm0
-;;       vpaddw  %xmm0, %xmm0, %xmm0
+;;       movdqu  0x10(%rip), %xmm15
+;;       vpmaddubsw %xmm0, %xmm15, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: ud2
+;;   4b: ud2
+;;   4d: addb    %al, (%rax)
+;;   4f: addb    %al, (%rcx)
+;;   51: addl    %eax, (%rcx)
+;;   53: addl    %eax, (%rcx)
+;;   55: addl    %eax, (%rcx)
+;;   57: addl    %eax, (%rcx)
+;;   59: addl    %eax, (%rcx)
+;;   5b: addl    %eax, (%rcx)
+;;   5d: addl    %eax, (%rcx)

--- a/tests/disas/winch/x64/i16x8/extadd/extadd_u.wat
+++ b/tests/disas/winch/x64/i16x8/extadd/extadd_u.wat
@@ -14,18 +14,27 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x50
+;;       ja      0x46
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movdqu  %xmm0, (%rsp)
 ;;       movdqu  (%rsp), %xmm0
-;;       vpmovzxbw %xmm0, %xmm15
-;;       vpxor   %xmm15, %xmm15, %xmm15
-;;       vpunpckhbw %xmm15, %xmm0, %xmm0
-;;       vpaddw  %xmm0, %xmm0, %xmm0
+;;       vpmaddubsw 0x10(%rip), %xmm0, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   50: ud2
+;;   46: ud2
+;;   48: addb    %al, (%rax)
+;;   4a: addb    %al, (%rax)
+;;   4c: addb    %al, (%rax)
+;;   4e: addb    %al, (%rax)
+;;   50: addl    %eax, (%rcx)
+;;   52: addl    %eax, (%rcx)
+;;   54: addl    %eax, (%rcx)
+;;   56: addl    %eax, (%rcx)
+;;   58: addl    %eax, (%rcx)
+;;   5a: addl    %eax, (%rcx)
+;;   5c: addl    %eax, (%rcx)
+;;   5e: addl    %eax, (%rcx)

--- a/tests/disas/winch/x64/i32x4/extadd/extadd_s.wat
+++ b/tests/disas/winch/x64/i32x4/extadd/extadd_s.wat
@@ -14,18 +14,27 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x51
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movdqu  %xmm0, (%rsp)
 ;;       movdqu  (%rsp), %xmm0
-;;       vpmovsxwd %xmm0, %xmm15
-;;       vpalignr $8, %xmm0, %xmm0, %xmm0
-;;       vpmovsxwd %xmm0, %xmm0
-;;       vpaddd  %xmm0, %xmm0, %xmm0
+;;       vpmaddwd 0x11(%rip), %xmm0, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   51: ud2
+;;   45: ud2
+;;   47: addb    %al, (%rax)
+;;   49: addb    %al, (%rax)
+;;   4b: addb    %al, (%rax)
+;;   4d: addb    %al, (%rax)
+;;   4f: addb    %al, (%rcx)
+;;   51: addb    %al, (%rcx)
+;;   53: addb    %al, (%rcx)
+;;   55: addb    %al, (%rcx)
+;;   57: addb    %al, (%rcx)
+;;   59: addb    %al, (%rcx)
+;;   5b: addb    %al, (%rcx)
+;;   5d: addb    %al, (%rcx)

--- a/tests/disas/winch/x64/i32x4/extadd/extadd_u.wat
+++ b/tests/disas/winch/x64/i32x4/extadd/extadd_u.wat
@@ -14,18 +14,41 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x50
+;;       ja      0x55
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movdqu  %xmm0, (%rsp)
 ;;       movdqu  (%rsp), %xmm0
-;;       vpmovzxwd %xmm0, %xmm15
-;;       vpxor   %xmm15, %xmm15, %xmm15
-;;       vpunpckhwd %xmm15, %xmm0, %xmm0
-;;       vpaddd  %xmm0, %xmm0, %xmm0
+;;       vpxor   0x21(%rip), %xmm0, %xmm0
+;;       vpmaddwd 0x29(%rip), %xmm0, %xmm0
+;;       vpaddd  0x31(%rip), %xmm0, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   50: ud2
+;;   55: ud2
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rax)
+;;   61: addb    $0x80, (%rax)
+;;   64: addb    %al, -0x7fff8000(%rax)
+;;   6a: addb    %al, -0x7fff8000(%rax)
+;;   70: addl    %eax, (%rax)
+;;   72: addl    %eax, (%rax)
+;;   74: addl    %eax, (%rax)
+;;   76: addl    %eax, (%rax)
+;;   78: addl    %eax, (%rax)
+;;   7a: addl    %eax, (%rax)
+;;   7c: addl    %eax, (%rax)
+;;   7e: addl    %eax, (%rax)
+;;   80: addb    %al, (%rax)
+;;   82: addl    %eax, (%rax)
+;;   84: addb    %al, (%rax)
+;;   86: addl    %eax, (%rax)
+;;   88: addb    %al, (%rax)
+;;   8a: addl    %eax, (%rax)
+;;   8c: addb    %al, (%rax)
+;;   8e: addl    %eax, (%rax)

--- a/tests/misc_testsuite/winch/issue-10331.wast
+++ b/tests/misc_testsuite/winch/issue-10331.wast
@@ -1,0 +1,16 @@
+;;! simd = true
+
+;; See https://github.com/bytecodealliance/wasmtime/issues/10331
+
+(module
+  (func (export "test") (result v128)
+    v128.const i8x16 0 128 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    call 1
+  )
+  (func (param v128) (result v128)
+    local.get 0
+    i16x8.extadd_pairwise_i8x16_s
+  )
+)
+
+(assert_return (invoke "test") (v128.const i16x8 65408 0 0 0 0 0 0 0))

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -915,15 +915,6 @@ pub(crate) enum V128ExtAddKind {
     I16x8U,
 }
 
-impl From<V128ExtAddKind> for V128AddKind {
-    fn from(value: V128ExtAddKind) -> Self {
-        match value {
-            V128ExtAddKind::I8x16S | V128ExtAddKind::I8x16U => Self::I16x8,
-            V128ExtAddKind::I16x8S | V128ExtAddKind::I16x8U => Self::I32x4,
-        }
-    }
-}
-
 /// Kinds of vector extended multiplication supported by WebAssembly.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum V128ExtMulKind {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fixes #10331. The existing approach used the macroassembler `v128.extend` method to perform extensions but this can lead subtly incorrect results because it's designed to select values from the top half or bottom half of the vector and not from pairs of lanes within vectors. This PR changes the implementation to use machine instructions directly.