### PR TITLE
Add "pure" flag to `ir::MemFlags`

### DIFF
--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -42,14 +42,14 @@ fn has_side_effect(func: &Function, inst: Inst) -> bool {
 /// aegraph semantics?
 ///
 /// - Actual pure nodes (arithmetic, etc)
-/// - Loads with the `readonly` flag set
+/// - Loads with the `readonly`, `notrap`, and `pure` flags set
 pub fn is_pure_for_egraph(func: &Function, inst: Inst) -> bool {
     let is_readonly_load = match func.dfg.insts[inst] {
         InstructionData::Load {
             opcode: Opcode::Load,
             flags,
             ..
-        } => flags.readonly() && flags.notrap(),
+        } => flags.readonly() && flags.notrap() && flags.pure(),
         _ => false,
     };
 

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -41,15 +41,15 @@ fn has_side_effect(func: &Function, inst: Inst) -> bool {
 /// Does the given instruction behave as a "pure" node with respect to
 /// aegraph semantics?
 ///
-/// - Actual pure nodes (arithmetic, etc)
-/// - Loads with the `readonly`, `notrap`, and `pure` flags set
+/// - Trivially pure nodes (bitwise arithmetic, etc)
+/// - Loads with the `readonly`, `notrap`, and `can_move` flags set
 pub fn is_pure_for_egraph(func: &Function, inst: Inst) -> bool {
-    let is_readonly_load = match func.dfg.insts[inst] {
+    let is_pure_load = match func.dfg.insts[inst] {
         InstructionData::Load {
             opcode: Opcode::Load,
             flags,
             ..
-        } => flags.readonly() && flags.notrap() && flags.pure(),
+        } => flags.readonly() && flags.notrap() && flags.can_move(),
         _ => false,
     };
 
@@ -65,7 +65,7 @@ pub fn is_pure_for_egraph(func: &Function, inst: Inst) -> bool {
 
     let op = func.dfg.insts[inst].opcode();
 
-    has_one_result && (is_readonly_load || (!op.can_load() && !trivially_has_side_effects(op)))
+    has_one_result && (is_pure_load || (!op.can_load() && !trivially_has_side_effects(op)))
 }
 
 /// Can the given instruction be merged into another copy of itself?

--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -73,7 +73,7 @@ pub struct MemFlags {
     // * 4 - checked flag
     // * 5/6 - alias region
     // * 7/8/9/10/11/12/13/14 - trap code
-    // * 15 - pure flag
+    // * 15 - can_move flag
     //
     // Current properties upheld are:
     //
@@ -112,11 +112,12 @@ const ALIAS_REGION_OFFSET: u16 = 5;
 const MASK_TRAP_CODE: u16 = 0b1111_1111 << TRAP_CODE_OFFSET;
 const TRAP_CODE_OFFSET: u16 = 7;
 
-/// Whether the load's/store's safety is purely a function of its data
-/// dependencies (i.e. operands) and is not guarded by
-/// outside-the-data-flow-graph properties, like implicit bounds-checking
+/// Whether this memory operation may be freely moved by the optimizer so long
+/// as its data dependencies are satisfied. That is, by setting this flag, the
+/// producer is guaranteeing that this memory operation's safety is not guarded
+/// by outside-the-data-flow-graph properties, like implicit bounds-checking
 /// control dependencies.
-const BIT_PURE: u16 = 1 << 15;
+const BIT_CAN_MOVE: u16 = 1 << 15;
 
 impl MemFlags {
     /// Create a new empty set of flags.
@@ -204,7 +205,7 @@ impl MemFlags {
                 self.with_alias_region(Some(AliasRegion::Vmctx))
             }
             "checked" => self.with_checked(),
-            "pure" => self.with_pure(),
+            "can_move" => self.with_can_move(),
 
             other => match TrapCode::from_str(other) {
                 Ok(code) => self.with_trap_code(Some(code)),
@@ -272,7 +273,7 @@ impl MemFlags {
     /// This flag does *not* mean that the associated instruction can be
     /// code-motioned to arbitrary places in the function so long as its data
     /// dependencies are met. This only means that, given its current location
-    /// in the function, it will never trap. See the `pure` method for more
+    /// in the function, it will never trap. See the `can_move` method for more
     /// details.
     pub const fn notrap(self) -> bool {
         self.trap_code().is_none()
@@ -289,8 +290,8 @@ impl MemFlags {
         self.with_trap_code(None)
     }
 
-    /// Is this memory operation's safety (e.g. the validity of its `notrap` and
-    /// `readonly` claims) purely a function of its data dependencies?
+    /// Is this memory operation safe to move so long as its data dependencies
+    /// remain satisfied?
     ///
     /// If this is `true`, then it is okay to code motion this instruction to
     /// arbitrary locations, in the function, including across blocks and
@@ -304,18 +305,18 @@ impl MemFlags {
     /// bounds check, which is not reflected in its operands, and it would be
     /// unsafe to code motion it above the bounds check, even if its data
     /// dependencies would still be satisfied.
-    pub const fn pure(self) -> bool {
-        self.read_bit(BIT_PURE)
+    pub const fn can_move(self) -> bool {
+        self.read_bit(BIT_CAN_MOVE)
     }
 
-    /// Set the `pure` flag.
-    pub const fn set_pure(&mut self) {
-        *self = self.with_pure();
+    /// Set the `can_move` flag.
+    pub const fn set_can_move(&mut self) {
+        *self = self.with_can_move();
     }
 
-    /// Set the `pure` flag, returning new flags.
-    pub const fn with_pure(self) -> Self {
-        self.with_bit(BIT_PURE)
+    /// Set the `can_move` flag, returning new flags.
+    pub const fn with_can_move(self) -> Self {
+        self.with_bit(BIT_CAN_MOVE)
     }
 
     /// Test if the `aligned` flag is set.
@@ -424,8 +425,8 @@ impl fmt::Display for MemFlags {
         if self.readonly() {
             write!(f, " readonly")?;
         }
-        if self.pure() {
-            write!(f, " pure")?;
+        if self.can_move() {
+            write!(f, " can_move")?;
         }
         if self.read_bit(BIT_BIG_ENDIAN) {
             write!(f, " big")?;

--- a/cranelift/filetests/filetests/egraph/load-hoist.clif
+++ b/cranelift/filetests/filetests/egraph/load-hoist.clif
@@ -2,7 +2,7 @@ test optimize
 set opt_level=speed_and_size
 target x86_64
 
-function %pure_hoists(i64 vmctx, i64, i32, i32) -> i32 fast {
+function %can_move_hoists(i64 vmctx, i64, i32, i32) -> i32 fast {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned readonly gv0+8
     gv2 = load.i64 notrap aligned gv1
@@ -15,7 +15,7 @@ function %pure_hoists(i64 vmctx, i64, i32, i32) -> i32 fast {
         jump block2(v5, v2, v3)  ; v5 = 0
 
     block2(v6: i32, v7: i32, v15: i32):
-        v9 = load.i64 notrap aligned readonly pure v0+80
+        v9 = load.i64 notrap aligned readonly can_move v0+80
         v8 = uextend.i64 v7
         v10 = iadd v9, v8
         v11 = load.i32 little heap v10
@@ -37,13 +37,13 @@ function %pure_hoists(i64 vmctx, i64, i32, i32) -> i32 fast {
         return v12
 }
 
-; check:    v9 = load.i64 notrap aligned readonly pure v0+80
+; check:    v9 = load.i64 notrap aligned readonly can_move v0+80
 ; check: block2(v6: i32, v7: i32, v15: i32):
 ; check:    v10 = iadd.i64 v9, v8
 ; check:    v11 = load.i32 little heap v10
 ; check:    brif v19, block2(v12, v21, v19), block4
 
-function %non_pure_does_not_hoist(i64 vmctx, i64, i32, i32) -> i32 fast {
+function %non_can_move_does_not_hoist(i64 vmctx, i64, i32, i32) -> i32 fast {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned readonly gv0+8
     gv2 = load.i64 notrap aligned gv1

--- a/cranelift/filetests/filetests/egraph/load-hoist.clif
+++ b/cranelift/filetests/filetests/egraph/load-hoist.clif
@@ -2,7 +2,48 @@ test optimize
 set opt_level=speed_and_size
 target x86_64
 
-function %foo(i64 vmctx, i64, i32, i32) -> i32 fast {
+function %pure_hoists(i64 vmctx, i64, i32, i32) -> i32 fast {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned readonly gv0+8
+    gv2 = load.i64 notrap aligned gv1
+    gv3 = vmctx
+    gv4 = load.i64 notrap aligned readonly gv3+80
+    stack_limit = gv2
+
+    block0(v0: i64, v1: i64, v2: i32, v3: i32):
+        v5 = iconst.i32 0
+        jump block2(v5, v2, v3)  ; v5 = 0
+
+    block2(v6: i32, v7: i32, v15: i32):
+        v9 = load.i64 notrap aligned readonly pure v0+80
+        v8 = uextend.i64 v7
+        v10 = iadd v9, v8
+        v11 = load.i32 little heap v10
+        v16 = iconst.i32 1
+        v17 = isub v15, v16  ; v16 = 1
+        v12 = iadd v6, v11
+        v4 -> v12
+        v13 = iconst.i32 4
+        v14 = iadd v7, v13  ; v13 = 4
+        brif v17, block2(v12, v14, v17), block4
+
+    block4:
+        jump block3
+
+    block3:
+        jump block1
+
+    block1:
+        return v12
+}
+
+; check:    v9 = load.i64 notrap aligned readonly pure v0+80
+; check: block2(v6: i32, v7: i32, v15: i32):
+; check:    v10 = iadd.i64 v9, v8
+; check:    v11 = load.i32 little heap v10
+; check:    brif v19, block2(v12, v21, v19), block4
+
+function %non_pure_does_not_hoist(i64 vmctx, i64, i32, i32) -> i32 fast {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned readonly gv0+8
     gv2 = load.i64 notrap aligned gv1
@@ -37,8 +78,5 @@ function %foo(i64 vmctx, i64, i32, i32) -> i32 fast {
         return v12
 }
 
-; check:    v9 = load.i64 notrap aligned readonly v0+80
-; check: block2(v6: i32, v7: i32, v15: i32):
-; check:    v10 = iadd.i64 v9, v8
-; check:    v11 = load.i32 little heap v10
-; check:    brif v19, block2(v12, v21, v19), block4
+; check:  block2(v6: i32, v7: i32, v15: i32):
+; nextln:   v9 = load.i64 notrap aligned readonly v0+80

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -298,7 +298,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                 base: vmctx,
                 offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                 global_type: pointer_type,
-                flags: MemFlags::trusted().with_readonly(),
+                flags: MemFlags::trusted().with_readonly().with_pure(),
             });
             (global, 0)
         }
@@ -314,10 +314,12 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let base = builder.ins().global_value(pointer_type, vmctx);
         let offset = i32::from(self.offsets.ptr.vmctx_runtime_limits());
         debug_assert!(self.vmstore_context_ptr.is_reserved_value());
-        self.vmstore_context_ptr =
-            builder
-                .ins()
-                .load(pointer_type, ir::MemFlags::trusted(), base, offset);
+        self.vmstore_context_ptr = builder.ins().load(
+            pointer_type,
+            ir::MemFlags::trusted().with_readonly().with_pure(),
+            base,
+            offset,
+        );
     }
 
     fn fuel_function_entry(&mut self, builder: &mut FunctionBuilder<'_>) {
@@ -808,7 +810,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     base: vmctx,
                     offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                     global_type: pointer_type,
-                    flags: MemFlags::trusted().with_readonly(),
+                    flags: MemFlags::trusted().with_readonly().with_pure(),
                 });
                 let base_offset = i32::from(self.offsets.vmtable_definition_base());
                 let current_elements_offset =
@@ -832,7 +834,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             flags: if Some(table.limits.min) == table.limits.max {
                 // A fixed-size table can't be resized so its base address won't
                 // change.
-                MemFlags::trusted().with_readonly()
+                MemFlags::trusted().with_readonly().with_pure()
             } else {
                 MemFlags::trusted()
             },
@@ -1008,18 +1010,18 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     /// memtypes are in use, add a field to the original struct and
     /// generate a new memtype for the pointee.
     fn load_pointer_with_memtypes(
-        &self,
+        &mut self,
         func: &mut ir::Function,
-        value: ir::GlobalValue,
         offset: u32,
         readonly: bool,
         memtype: Option<ir::MemoryType>,
     ) -> (ir::GlobalValue, Option<ir::MemoryType>) {
+        let vmctx = self.vmctx(func);
         let pointee = func.create_global_value(ir::GlobalValueData::Load {
-            base: value,
+            base: vmctx,
             offset: Offset32::new(i32::try_from(offset).unwrap()),
             global_type: self.pointer_type(),
-            flags: MemFlags::trusted().with_readonly(),
+            flags: MemFlags::trusted().with_readonly().with_pure(),
         });
 
         let mt = memtype.map(|mt| {
@@ -1153,7 +1155,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     ) -> ir::Value {
         let vmctx = self.vmctx_val(pos);
         let pointer_type = self.pointer_type();
-        let mem_flags = ir::MemFlags::trusted().with_readonly();
+        let mem_flags = ir::MemFlags::trusted().with_readonly().with_pure();
 
         // Load the base pointer of the array of `VMSharedTypeIndex`es.
         let shared_indices = pos.ins().load(
@@ -1270,7 +1272,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         let vmctx = self.env.vmctx(self.builder.func);
         let base = self.builder.ins().global_value(pointer_type, vmctx);
 
-        let mem_flags = ir::MemFlags::trusted().with_readonly();
+        let mem_flags = ir::MemFlags::trusted().with_readonly().with_pure();
 
         // Load the callee address.
         let body_offset = i32::try_from(
@@ -1426,10 +1428,11 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                     // anyway.
                     if table.ref_type.nullable {
                         if self.env.clif_memory_traps_enabled() {
-                            let mem_flags = ir::MemFlags::trusted().with_readonly();
                             self.builder.ins().load(
                                 sig_id_type,
-                                mem_flags.with_trap_code(Some(crate::TRAP_INDIRECT_CALL_TO_NULL)),
+                                ir::MemFlags::trusted()
+                                    .with_readonly()
+                                    .with_trap_code(Some(crate::TRAP_INDIRECT_CALL_TO_NULL)),
                                 funcref_ptr,
                                 i32::from(self.env.offsets.ptr.vm_func_ref_type_index()),
                             );
@@ -2252,12 +2255,13 @@ impl FuncEnvironment<'_> {
         builder: &mut FunctionBuilder,
         index: GlobalIndex,
     ) -> WasmResult<ir::Value> {
-        let ty = self.module.globals[index].wasm_ty;
+        let global_ty = self.module.globals[index];
+        let wasm_ty = global_ty.wasm_ty;
         debug_assert!(
-            ty.is_vmgcref_type(),
+            wasm_ty.is_vmgcref_type(),
             "We only use GlobalVariable::Custom for VMGcRef types"
         );
-        let WasmValType::Ref(ty) = ty else {
+        let WasmValType::Ref(ref_ty) = wasm_ty else {
             unreachable!()
         };
 
@@ -2268,9 +2272,13 @@ impl FuncEnvironment<'_> {
         gc::gc_compiler(self)?.translate_read_gc_reference(
             self,
             builder,
-            ty,
+            ref_ty,
             src,
-            ir::MemFlags::trusted(),
+            if global_ty.mutability {
+                ir::MemFlags::trusted()
+            } else {
+                ir::MemFlags::trusted().with_readonly().with_pure()
+            },
         )
     }
 
@@ -2319,7 +2327,6 @@ impl FuncEnvironment<'_> {
                     let from_offset = self.offsets.vmctx_vmmemory_pointer(def_index);
                     let (memory, def_mt) = self.load_pointer_with_memtypes(
                         func,
-                        vmctx,
                         from_offset,
                         true,
                         self.pcc_vmctx_memtype,
@@ -2348,7 +2355,6 @@ impl FuncEnvironment<'_> {
                 let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
                 let (memory, def_mt) = self.load_pointer_with_memtypes(
                     func,
-                    vmctx,
                     from_offset,
                     true,
                     self.pcc_vmctx_memtype,
@@ -2474,7 +2480,7 @@ impl FuncEnvironment<'_> {
             }
         };
 
-        let mut flags = MemFlags::trusted().with_checked();
+        let mut flags = MemFlags::trusted().with_checked().with_pure();
         if !memory.memory_may_move(self.tunables) {
             flags.set_readonly();
         }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -298,7 +298,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                 base: vmctx,
                 offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                 global_type: pointer_type,
-                flags: MemFlags::trusted().with_readonly().with_pure(),
+                flags: MemFlags::trusted().with_readonly().with_can_move(),
             });
             (global, 0)
         }
@@ -316,7 +316,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         debug_assert!(self.vmstore_context_ptr.is_reserved_value());
         self.vmstore_context_ptr = builder.ins().load(
             pointer_type,
-            ir::MemFlags::trusted().with_readonly().with_pure(),
+            ir::MemFlags::trusted().with_readonly().with_can_move(),
             base,
             offset,
         );
@@ -810,7 +810,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     base: vmctx,
                     offset: Offset32::new(i32::try_from(from_offset).unwrap()),
                     global_type: pointer_type,
-                    flags: MemFlags::trusted().with_readonly().with_pure(),
+                    flags: MemFlags::trusted().with_readonly().with_can_move(),
                 });
                 let base_offset = i32::from(self.offsets.vmtable_definition_base());
                 let current_elements_offset =
@@ -834,7 +834,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             flags: if Some(table.limits.min) == table.limits.max {
                 // A fixed-size table can't be resized so its base address won't
                 // change.
-                MemFlags::trusted().with_readonly().with_pure()
+                MemFlags::trusted().with_readonly().with_can_move()
             } else {
                 MemFlags::trusted()
             },
@@ -1021,7 +1021,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             base: vmctx,
             offset: Offset32::new(i32::try_from(offset).unwrap()),
             global_type: self.pointer_type(),
-            flags: MemFlags::trusted().with_readonly().with_pure(),
+            flags: MemFlags::trusted().with_readonly().with_can_move(),
         });
 
         let mt = memtype.map(|mt| {
@@ -1155,7 +1155,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     ) -> ir::Value {
         let vmctx = self.vmctx_val(pos);
         let pointer_type = self.pointer_type();
-        let mem_flags = ir::MemFlags::trusted().with_readonly().with_pure();
+        let mem_flags = ir::MemFlags::trusted().with_readonly().with_can_move();
 
         // Load the base pointer of the array of `VMSharedTypeIndex`es.
         let shared_indices = pos.ins().load(
@@ -1272,7 +1272,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         let vmctx = self.env.vmctx(self.builder.func);
         let base = self.builder.ins().global_value(pointer_type, vmctx);
 
-        let mem_flags = ir::MemFlags::trusted().with_readonly().with_pure();
+        let mem_flags = ir::MemFlags::trusted().with_readonly().with_can_move();
 
         // Load the callee address.
         let body_offset = i32::try_from(
@@ -2277,7 +2277,7 @@ impl FuncEnvironment<'_> {
             if global_ty.mutability {
                 ir::MemFlags::trusted()
             } else {
-                ir::MemFlags::trusted().with_readonly().with_pure()
+                ir::MemFlags::trusted().with_readonly().with_can_move()
             },
         )
     }
@@ -2480,7 +2480,7 @@ impl FuncEnvironment<'_> {
             }
         };
 
-        let mut flags = MemFlags::trusted().with_checked().with_pure();
+        let mut flags = MemFlags::trusted().with_checked().with_can_move();
         if !memory.memory_may_move(self.tunables) {
             flags.set_readonly();
         }

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -1244,7 +1244,7 @@ impl FuncEnvironment<'_> {
     /// Get the GC heap's base pointer.
     fn get_gc_heap_base(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let ptr_ty = self.pointer_type();
-        let flags = ir::MemFlags::trusted().with_readonly().with_pure();
+        let flags = ir::MemFlags::trusted().with_readonly().with_can_move();
 
         let vmctx = self.vmctx(builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);
@@ -1258,7 +1258,7 @@ impl FuncEnvironment<'_> {
     /// Get the GC heap's bound.
     fn get_gc_heap_bound(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let ptr_ty = self.pointer_type();
-        let flags = ir::MemFlags::trusted().with_readonly().with_pure();
+        let flags = ir::MemFlags::trusted().with_readonly().with_can_move();
 
         let vmctx = self.vmctx(builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);

--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -680,9 +680,12 @@ pub fn translate_array_len(
         // don't know its length yet. Chicken and egg problem.
         BoundsCheck::Access(ir::types::I32.bytes()),
     );
-    let result = builder
-        .ins()
-        .load(ir::types::I32, ir::MemFlags::trusted(), len_field, 0);
+    let result = builder.ins().load(
+        ir::types::I32,
+        ir::MemFlags::trusted().with_readonly(),
+        len_field,
+        0,
+    );
     log::trace!("translate_array_len(..) -> {result:?}");
     Ok(result)
 }
@@ -1241,7 +1244,7 @@ impl FuncEnvironment<'_> {
     /// Get the GC heap's base pointer.
     fn get_gc_heap_base(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let ptr_ty = self.pointer_type();
-        let flags = ir::MemFlags::trusted().with_readonly();
+        let flags = ir::MemFlags::trusted().with_readonly().with_pure();
 
         let vmctx = self.vmctx(builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);
@@ -1255,7 +1258,7 @@ impl FuncEnvironment<'_> {
     /// Get the GC heap's bound.
     fn get_gc_heap_bound(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let ptr_ty = self.pointer_type();
-        let flags = ir::MemFlags::trusted().with_readonly();
+        let flags = ir::MemFlags::trusted().with_readonly().with_pure();
 
         let vmctx = self.vmctx(builder.func);
         let vmctx = builder.ins().global_value(ptr_ty, vmctx);

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -15,16 +15,16 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0021                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0021                               v7 = iadd v6, v5
 ;; @0021                               v8 = load.i32 little heap v7
 ;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0026                               v10 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0026                               v11 = iadd v10, v9
 ;; @0026                               v12 = load.i32 little heap v11
 ;; @0029                               v13 = iadd v8, v12

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -15,16 +15,16 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0021                               v5 = uextend.i64 v2
-;; @0021                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0021                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0021                               v7 = iadd v6, v5
 ;; @0021                               v8 = load.i32 little heap v7
 ;; @0026                               v9 = uextend.i64 v3
-;; @0026                               v10 = load.i64 notrap aligned readonly checked v0+88
+;; @0026                               v10 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0026                               v11 = iadd v10, v9
 ;; @0026                               v12 = load.i32 little heap v11
 ;; @0029                               v13 = iadd v8, v12

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -28,12 +28,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0057                               v6 = load.i64 notrap aligned v0+96
-;; @0057                               v8 = load.i64 notrap aligned checked v0+88
+;; @0057                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = icmp ugt v5, v6
 ;; @0057                               v10 = iconst.i64 0
@@ -52,12 +52,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0064                               v6 = load.i64 notrap aligned v0+96
-;; @0064                               v8 = load.i64 notrap aligned checked v0+88
+;; @0064                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = icmp ugt v5, v6
 ;; @0064                               v12 = iconst.i64 0

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -28,12 +28,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0057                               v6 = load.i64 notrap aligned v0+96
-;; @0057                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0057                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = icmp ugt v5, v6
 ;; @0057                               v10 = iconst.i64 0
@@ -52,12 +52,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0064                               v6 = load.i64 notrap aligned v0+96
-;; @0064                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0064                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = icmp ugt v5, v6
 ;; @0064                               v12 = iconst.i64 0

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -23,11 +23,11 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0057                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
 ;; @0057                               v8 = load.i32 little heap v7
@@ -43,11 +43,11 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0064                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -23,11 +23,11 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0057                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0057                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
 ;; @0057                               v8 = load.i32 little heap v7
@@ -43,11 +43,11 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0064                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0064                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -41,7 +41,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -49,7 +49,7 @@
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               trapnz v8, heap_oob
-;; @0047                               v9 = load.i64 notrap aligned checked v0+88
+;; @0047                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v11 = load.i32 little heap v10
 ;; @004c                               v17 = iconst.i64 4
@@ -74,7 +74,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -82,7 +82,7 @@
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               trapnz v8, heap_oob
-;; @005d                               v9 = load.i64 notrap aligned checked v0+88
+;; @005d                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               store little heap v3, v10
 ;; @0064                               v16 = iconst.i64 4

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -41,7 +41,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -49,7 +49,7 @@
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               trapnz v8, heap_oob
-;; @0047                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0047                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v11 = load.i32 little heap v10
 ;; @004c                               v17 = iconst.i64 4
@@ -74,7 +74,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -82,7 +82,7 @@
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               trapnz v8, heap_oob
-;; @005d                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @005d                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @005d                               v10 = iadd v9, v6
 ;; @005d                               store little heap v3, v10
 ;; @0064                               v16 = iconst.i64 4

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -37,12 +37,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0047                               v7 = load.i64 notrap aligned v0+96
-;; @0047                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0047                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               v11 = iconst.i64 0
@@ -72,12 +72,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @005d                               v7 = load.i64 notrap aligned v0+96
-;; @005d                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @005d                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               v11 = iconst.i64 0

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -37,12 +37,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0047                               v7 = load.i64 notrap aligned v0+96
-;; @0047                               v9 = load.i64 notrap aligned checked v0+88
+;; @0047                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
 ;; @0047                               v11 = iconst.i64 0
@@ -72,12 +72,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @005d                               v7 = load.i64 notrap aligned v0+96
-;; @005d                               v9 = load.i64 notrap aligned checked v0+88
+;; @005d                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7
 ;; @005d                               v11 = iconst.i64 0

--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -16,21 +16,21 @@
 ;;       movq    %rbx, (%rsp)
 ;;       movq    %r12, 8(%rsp)
 ;;       movq    %r13, 0x10(%rsp)
-;;       movq    8(%rdi), %r12
-;;       movq    0x20(%rdi), %rbx
+;;       movq    0x20(%rdi), %r12
+;;       movq    (%r12), %r9
+;;       movq    8(%rdi), %rbx
 ;;       movq    %rdi, %r13
-;;       movq    (%rbx), %r9
-;;       movq    8(%r12), %rax
+;;       movq    8(%rbx), %rax
 ;;       cmpq    %rax, %r9
-;;       jae     0x58
-;;   47: movq    (%rbx), %rdi
+;;       jae     0x59
+;;   47: movq    (%r12), %rdi
 ;;       cmpq    %rax, %rdi
-;;       jae     0x65
+;;       jae     0x66
 ;;       jmp     0x47
-;;   58: movq    %r13, %rdi
+;;   59: movq    %r13, %rdi
 ;;       callq   0x107
 ;;       jmp     0x47
-;;   65: movq    8(%r12), %rax
+;;   66: movq    8(%rbx), %rax
 ;;       cmpq    %rax, %rdi
 ;;       jb      0x47
 ;;   73: movq    %r13, %rdi

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -16,7 +16,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0016                               v5 = load.i64 notrap aligned v0+32
 ;; @0016                               v6 = load.i64 notrap aligned v5
-;; @0016                               v3 = load.i64 notrap aligned readonly pure v0+8
+;; @0016                               v3 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0016                               v7 = load.i64 notrap aligned v3+8
 ;; @0016                               v8 = icmp uge v6, v7
 ;; @0016                               brif v8, block3, block2(v7)

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -14,9 +14,9 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0016                               v3 = load.i64 notrap aligned v0+8
 ;; @0016                               v5 = load.i64 notrap aligned v0+32
 ;; @0016                               v6 = load.i64 notrap aligned v5
+;; @0016                               v3 = load.i64 notrap aligned readonly pure v0+8
 ;; @0016                               v7 = load.i64 notrap aligned v3+8
 ;; @0016                               v8 = icmp uge v6, v7
 ;; @0016                               brif v8, block3, block2(v7)

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -12,12 +12,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f32 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -12,12 +12,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f32 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f64 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.f64 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -29,7 +29,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -55,7 +55,7 @@
 ;;                                 block2:
 ;; @0056                               v16 = iconst.i32 0
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
-;; @005a                               v18 = load.i64 notrap aligned readonly checked v0+88
+;; @005a                               v18 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @005a                               v19 = iadd v18, v17
 ;; @005a                               store.i32 little heap v11, v19
 ;; @005d                               jump block1

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -29,7 +29,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -55,7 +55,7 @@
 ;;                                 block2:
 ;; @0056                               v16 = iconst.i32 0
 ;; @005a                               v17 = uextend.i64 v16  ; v16 = 0
-;; @005a                               v18 = load.i64 notrap aligned readonly pure checked v0+88
+;; @005a                               v18 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @005a                               v19 = iadd v18, v17
 ;; @005a                               store.i32 little heap v11, v19
 ;; @005d                               jump block1

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -26,7 +26,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0041                               v5 = iconst.i64 0x0001_0000
 ;; @0041                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0041                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0x0001_0000
 ;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
 ;; @004c                               jump block1

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -26,7 +26,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0041                               v5 = iconst.i64 0x0001_0000
 ;; @0041                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned checked v0+88
+;; @0041                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0x0001_0000
 ;; @0049                               v6 = icmp uge v4, v5  ; v5 = 0x0001_0000
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
 ;; @004c                               jump block1

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -23,10 +23,10 @@
 ;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
 ;; @0027                               v13 = iconst.i64 4
 ;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
-;; @0027                               v9 = load.i64 notrap aligned readonly pure v0+48
+;; @0027                               v9 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0027                               v15 = icmp ule v14, v9
 ;; @0027                               trapz v15, user1
-;; @0027                               v7 = load.i64 notrap aligned readonly pure v0+40
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0027                               v16 = iadd v7, v12
 ;; @0027                               v17 = load.i32 notrap aligned readonly v16
 ;; @0027                               v18 = uadd_overflow_trap v3, v5, user17

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -23,12 +23,12 @@
 ;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
 ;; @0027                               v13 = iconst.i64 4
 ;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
-;; @0027                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0027                               v9 = load.i64 notrap aligned readonly pure v0+48
 ;; @0027                               v15 = icmp ule v14, v9
 ;; @0027                               trapz v15, user1
-;; @0027                               v7 = load.i64 notrap aligned readonly v0+40
+;; @0027                               v7 = load.i64 notrap aligned readonly pure v0+40
 ;; @0027                               v16 = iadd v7, v12
-;; @0027                               v17 = load.i32 notrap aligned v16
+;; @0027                               v17 = load.i32 notrap aligned readonly v16
 ;; @0027                               v18 = uadd_overflow_trap v3, v5, user17
 ;; @0027                               v19 = icmp ugt v18, v17
 ;; @0027                               trapnz v19, user17

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -23,12 +23,12 @@
 ;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
 ;; @001f                               v11 = iconst.i64 4
 ;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @001f                               v7 = load.i64 notrap aligned readonly v0+48
+;; @001f                               v7 = load.i64 notrap aligned readonly pure v0+48
 ;; @001f                               v13 = icmp ule v12, v7
 ;; @001f                               trapz v13, user1
-;; @001f                               v5 = load.i64 notrap aligned readonly v0+40
+;; @001f                               v5 = load.i64 notrap aligned readonly pure v0+40
 ;; @001f                               v14 = iadd v5, v10
-;; @001f                               v15 = load.i32 notrap aligned v14
+;; @001f                               v15 = load.i32 notrap aligned readonly v14
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -23,10 +23,10 @@
 ;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
 ;; @001f                               v11 = iconst.i64 4
 ;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @001f                               v7 = load.i64 notrap aligned readonly pure v0+48
+;; @001f                               v7 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001f                               v13 = icmp ule v12, v7
 ;; @001f                               trapz v13, user1
-;; @001f                               v5 = load.i64 notrap aligned readonly pure v0+40
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v14 = iadd v5, v10
 ;; @001f                               v15 = load.i32 notrap aligned readonly v14
 ;; @0021                               jump block1

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -28,7 +28,7 @@
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
 ;; @0025                               v7 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly pure v0+40
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v18 = ireduce.i32 v17
 ;; @0025                               v21 = uextend.i64 v18
 ;; @0025                               v22 = iadd v20, v21

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -28,7 +28,7 @@
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
 ;; @0025                               v7 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly v0+40
+;; @0025                               v20 = load.i64 notrap aligned readonly pure v0+40
 ;; @0025                               v18 = ireduce.i32 v17
 ;; @0025                               v21 = uextend.i64 v18
 ;; @0025                               v22 = iadd v20, v21

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -33,7 +33,7 @@
 ;; @0022                               v13 = iconst.i32 0
 ;;                                     v40 = iconst.i32 8
 ;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
-;; @0022                               v18 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v18 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v16 = ireduce.i32 v15
 ;; @0022                               v19 = uextend.i64 v16
 ;; @0022                               v20 = iadd v18, v19

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -33,7 +33,7 @@
 ;; @0022                               v13 = iconst.i32 0
 ;;                                     v40 = iconst.i32 8
 ;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
-;; @0022                               v18 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v16 = ireduce.i32 v15
 ;; @0022                               v19 = uextend.i64 v16
 ;; @0022                               v20 = iadd v18, v19

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -23,10 +23,10 @@
 ;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0024                               v12 = iconst.i64 4
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0024                               v14 = icmp ule v13, v8
 ;; @0024                               trapz v14, user1
-;; @0024                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0024                               v15 = iadd v6, v11
 ;; @0024                               v16 = load.i32 notrap aligned readonly v15
 ;; @0024                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -23,12 +23,12 @@
 ;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;; @0024                               v12 = iconst.i64 4
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0024                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0024                               v14 = icmp ule v13, v8
 ;; @0024                               trapz v14, user1
-;; @0024                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0024                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0024                               v15 = iadd v6, v11
-;; @0024                               v16 = load.i32 notrap aligned v15
+;; @0024                               v16 = load.i32 notrap aligned readonly v15
 ;; @0024                               v17 = icmp ult v3, v16
 ;; @0024                               trapz v17, user17
 ;; @0024                               v19 = uextend.i64 v16

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -49,14 +49,14 @@
 ;; @002e                               v18 = iconst.i64 4
 ;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002e                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @002e                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002e                               v22 = icmp ule v21, v16
 ;; @002e                               trapz v22, user1
-;; @002e                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002e                               v23 = iadd v14, v19
 ;; @002e                               v24 = load.i32 notrap aligned readonly v23
-;; @002e                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @002e                               v12 = load.i32 notrap aligned readonly pure v11
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v25 = icmp eq v24, v12
 ;; @002e                               v26 = uextend.i32 v25
 ;; @002e                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v32 = load.i64 notrap aligned readonly pure v0+80
-;; @0034                               v33 = load.i64 notrap aligned readonly pure v0+96
+;; @0034                               v32 = load.i64 notrap aligned readonly can_move v0+80
+;; @0034                               v33 = load.i64 notrap aligned readonly can_move v0+96
 ;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v35 = load.i64 notrap aligned readonly pure v0+104
-;; @0038                               v36 = load.i64 notrap aligned readonly pure v0+120
+;; @0038                               v35 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               v36 = load.i64 notrap aligned readonly can_move v0+120
 ;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -49,14 +49,14 @@
 ;; @002e                               v18 = iconst.i64 4
 ;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002e                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @002e                               v22 = icmp ule v21, v16
 ;; @002e                               trapz v22, user1
-;; @002e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002e                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002e                               v23 = iadd v14, v19
 ;; @002e                               v24 = load.i32 notrap aligned readonly v23
-;; @002e                               v11 = load.i64 notrap aligned readonly v0+64
-;; @002e                               v12 = load.i32 notrap aligned readonly v11
+;; @002e                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @002e                               v25 = icmp eq v24, v12
 ;; @002e                               v26 = uextend.i32 v25
 ;; @002e                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v32 = load.i64 notrap aligned readonly v0+80
-;; @0034                               v33 = load.i64 notrap aligned readonly v0+96
+;; @0034                               v32 = load.i64 notrap aligned readonly pure v0+80
+;; @0034                               v33 = load.i64 notrap aligned readonly pure v0+96
 ;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v35 = load.i64 notrap aligned readonly v0+104
-;; @0038                               v36 = load.i64 notrap aligned readonly v0+120
+;; @0038                               v35 = load.i64 notrap aligned readonly pure v0+104
+;; @0038                               v36 = load.i64 notrap aligned readonly pure v0+120
 ;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -49,14 +49,14 @@
 ;; @002f                               v18 = iconst.i64 4
 ;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002f                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002f                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @002f                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002f                               v22 = icmp ule v21, v16
 ;; @002f                               trapz v22, user1
-;; @002f                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002f                               v23 = iadd v14, v19
 ;; @002f                               v24 = load.i32 notrap aligned readonly v23
-;; @002f                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @002f                               v12 = load.i32 notrap aligned readonly pure v11
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v25 = icmp eq v24, v12
 ;; @002f                               v26 = uextend.i32 v25
 ;; @002f                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v32 = load.i64 notrap aligned readonly pure v0+80
-;; @0035                               v33 = load.i64 notrap aligned readonly pure v0+96
+;; @0035                               v32 = load.i64 notrap aligned readonly can_move v0+80
+;; @0035                               v33 = load.i64 notrap aligned readonly can_move v0+96
 ;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v35 = load.i64 notrap aligned readonly pure v0+104
-;; @0039                               v36 = load.i64 notrap aligned readonly pure v0+120
+;; @0039                               v35 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               v36 = load.i64 notrap aligned readonly can_move v0+120
 ;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -49,14 +49,14 @@
 ;; @002f                               v18 = iconst.i64 4
 ;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002f                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002f                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002f                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @002f                               v22 = icmp ule v21, v16
 ;; @002f                               trapz v22, user1
-;; @002f                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002f                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002f                               v23 = iadd v14, v19
 ;; @002f                               v24 = load.i32 notrap aligned readonly v23
-;; @002f                               v11 = load.i64 notrap aligned readonly v0+64
-;; @002f                               v12 = load.i32 notrap aligned readonly v11
+;; @002f                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @002f                               v25 = icmp eq v24, v12
 ;; @002f                               v26 = uextend.i32 v25
 ;; @002f                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v32 = load.i64 notrap aligned readonly v0+80
-;; @0035                               v33 = load.i64 notrap aligned readonly v0+96
+;; @0035                               v32 = load.i64 notrap aligned readonly pure v0+80
+;; @0035                               v33 = load.i64 notrap aligned readonly pure v0+96
 ;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v35 = load.i64 notrap aligned readonly v0+104
-;; @0039                               v36 = load.i64 notrap aligned readonly v0+120
+;; @0039                               v35 = load.i64 notrap aligned readonly pure v0+104
+;; @0039                               v36 = load.i64 notrap aligned readonly pure v0+120
 ;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+128
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+128
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly v0+128
+;; @005c                               v6 = load.i64 notrap aligned readonly pure v0+128
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3
@@ -51,8 +51,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @005c                               v21 = load.i32 user6 aligned readonly v13+16
-;; @005c                               v19 = load.i64 notrap aligned readonly v0+64
-;; @005c                               v20 = load.i32 notrap aligned readonly v19
+;; @005c                               v19 = load.i64 notrap aligned readonly pure v0+64
+;; @005c                               v20 = load.i32 notrap aligned readonly pure v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22
 ;; @005c                               brif v23, block5(v23), block4

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+128
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+128
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly pure v0+128
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+128
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3
@@ -51,8 +51,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @005c                               v21 = load.i32 user6 aligned readonly v13+16
-;; @005c                               v19 = load.i64 notrap aligned readonly pure v0+64
-;; @005c                               v20 = load.i32 notrap aligned readonly pure v19
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+64
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22
 ;; @005c                               brif v23, block5(v23), block4

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -44,10 +44,10 @@
 ;; @0034                               v17 = iconst.i64 8
 ;; @0034                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 8
 ;; @0034                               v20 = uadd_overflow_trap v18, v17, user1  ; v17 = 8
-;; @0034                               v15 = load.i64 notrap aligned readonly pure v0+48
+;; @0034                               v15 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0034                               v21 = icmp ule v20, v15
 ;; @0034                               trapz v21, user1
-;; @0034                               v13 = load.i64 notrap aligned readonly pure v0+40
+;; @0034                               v13 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0034                               v22 = iadd v13, v18
 ;; @0034                               v23 = load.i64 notrap aligned v22
 ;;                                     v50 = iconst.i64 1
@@ -94,10 +94,10 @@
 ;; @003b                               v37 = iconst.i64 8
 ;; @003b                               v13 = uadd_overflow_trap v11, v37, user1  ; v37 = 8
 ;; @003b                               v15 = uadd_overflow_trap v13, v37, user1  ; v37 = 8
-;; @003b                               v35 = load.i64 notrap aligned readonly pure v0+48
+;; @003b                               v35 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003b                               v16 = icmp ule v15, v35
 ;; @003b                               trapz v16, user1
-;; @003b                               v33 = load.i64 notrap aligned readonly pure v0+40
+;; @003b                               v33 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003b                               v17 = iadd v33, v13
 ;; @003b                               v18 = load.i64 notrap aligned v17
 ;;                                     v60 = iconst.i64 1
@@ -117,10 +117,10 @@
 ;;                                     v67 = iconst.i64 8
 ;; @003b                               v38 = uadd_overflow_trap v36, v67, user1  ; v67 = 8
 ;; @003b                               v40 = uadd_overflow_trap v38, v67, user1  ; v67 = 8
-;;                                     v68 = load.i64 notrap aligned readonly pure v0+48
+;;                                     v68 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003b                               v41 = icmp ule v40, v68
 ;; @003b                               trapz v41, user1
-;;                                     v69 = load.i64 notrap aligned readonly pure v0+40
+;;                                     v69 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003b                               v42 = iadd v69, v38
 ;; @003b                               v43 = load.i64 notrap aligned v42
 ;;                                     v62 = iconst.i64 -1

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -44,10 +44,10 @@
 ;; @0034                               v17 = iconst.i64 8
 ;; @0034                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 8
 ;; @0034                               v20 = uadd_overflow_trap v18, v17, user1  ; v17 = 8
-;; @0034                               v15 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v15 = load.i64 notrap aligned readonly pure v0+48
 ;; @0034                               v21 = icmp ule v20, v15
 ;; @0034                               trapz v21, user1
-;; @0034                               v13 = load.i64 notrap aligned readonly v0+40
+;; @0034                               v13 = load.i64 notrap aligned readonly pure v0+40
 ;; @0034                               v22 = iadd v13, v18
 ;; @0034                               v23 = load.i64 notrap aligned v22
 ;;                                     v50 = iconst.i64 1
@@ -94,10 +94,10 @@
 ;; @003b                               v37 = iconst.i64 8
 ;; @003b                               v13 = uadd_overflow_trap v11, v37, user1  ; v37 = 8
 ;; @003b                               v15 = uadd_overflow_trap v13, v37, user1  ; v37 = 8
-;; @003b                               v35 = load.i64 notrap aligned readonly v0+48
+;; @003b                               v35 = load.i64 notrap aligned readonly pure v0+48
 ;; @003b                               v16 = icmp ule v15, v35
 ;; @003b                               trapz v16, user1
-;; @003b                               v33 = load.i64 notrap aligned readonly v0+40
+;; @003b                               v33 = load.i64 notrap aligned readonly pure v0+40
 ;; @003b                               v17 = iadd v33, v13
 ;; @003b                               v18 = load.i64 notrap aligned v17
 ;;                                     v60 = iconst.i64 1
@@ -117,10 +117,10 @@
 ;;                                     v67 = iconst.i64 8
 ;; @003b                               v38 = uadd_overflow_trap v36, v67, user1  ; v67 = 8
 ;; @003b                               v40 = uadd_overflow_trap v38, v67, user1  ; v67 = 8
-;;                                     v68 = load.i64 notrap aligned readonly v0+48
+;;                                     v68 = load.i64 notrap aligned readonly pure v0+48
 ;; @003b                               v41 = icmp ule v40, v68
 ;; @003b                               trapz v41, user1
-;;                                     v69 = load.i64 notrap aligned readonly v0+40
+;;                                     v69 = load.i64 notrap aligned readonly pure v0+40
 ;; @003b                               v42 = iadd v69, v38
 ;; @003b                               v43 = load.i64 notrap aligned v42
 ;;                                     v62 = iconst.i64 -1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -25,10 +25,10 @@
 ;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v20 = iconst.i64 24
 ;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 24
-;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0020                               v14 = icmp ule v13, v8
 ;; @0020                               trapz v14, user1
-;; @0020                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v15 = iadd v6, v11
 ;; @0020                               v18 = load.i32 notrap aligned little v15
 ;; @0020                               v16 = iconst.i32 -1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -25,10 +25,10 @@
 ;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v20 = iconst.i64 24
 ;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 24
-;; @0020                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0020                               v14 = icmp ule v13, v8
 ;; @0020                               trapz v14, user1
-;; @0020                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0020                               v15 = iadd v6, v11
 ;; @0020                               v18 = load.i32 notrap aligned little v15
 ;; @0020                               v16 = iconst.i32 -1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -32,7 +32,7 @@
 ;;                                     store notrap v10, v21
 ;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v18 = ireduce.i32 v17
-;; @0020                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v13 = uextend.i64 v10
 ;; @0020                               v14 = iadd v12, v13
 ;;                                     v23 = iconst.i64 16

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -32,7 +32,7 @@
 ;;                                     store notrap v10, v21
 ;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v18 = ireduce.i32 v17
-;; @0020                               v12 = load.i64 notrap aligned readonly v0+40
+;; @0020                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @0020                               v13 = uextend.i64 v10
 ;; @0020                               v14 = iadd v12, v13
 ;;                                     v23 = iconst.i64 16

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -25,12 +25,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v19 = iconst.i64 24
 ;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 24
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
 ;; @0022                               v18 = ireduce.i32 v17
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -25,12 +25,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v19 = iconst.i64 24
 ;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 24
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
 ;; @0022                               v18 = ireduce.i32 v17
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -24,10 +24,10 @@
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 16
 ;; @0024                               v14 = iconst.i64 4
 ;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
-;; @0024                               v10 = load.i64 notrap aligned readonly pure v0+48
+;; @0024                               v10 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0024                               v16 = icmp ule v15, v10
 ;; @0024                               trapz v16, user1
-;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+40
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0024                               v17 = iadd v8, v13
 ;; @0024                               v18 = load.i32 notrap aligned readonly v17
 ;; @0024                               v19 = icmp ult v3, v18

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -24,12 +24,12 @@
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 16
 ;; @0024                               v14 = iconst.i64 4
 ;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
-;; @0024                               v10 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v10 = load.i64 notrap aligned readonly pure v0+48
 ;; @0024                               v16 = icmp ule v15, v10
 ;; @0024                               trapz v16, user1
-;; @0024                               v8 = load.i64 notrap aligned readonly v0+40
+;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+40
 ;; @0024                               v17 = iadd v8, v13
-;; @0024                               v18 = load.i32 notrap aligned v17
+;; @0024                               v18 = load.i32 notrap aligned readonly v17
 ;; @0024                               v19 = icmp ult v3, v18
 ;; @0024                               trapz v19, user17
 ;; @0024                               v21 = uextend.i64 v18

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -25,10 +25,10 @@
 ;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
 ;;                                     v32 = iconst.i64 24
 ;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 24
-;; @0023                               v9 = load.i64 notrap aligned readonly pure v0+48
+;; @0023                               v9 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0023                               v15 = icmp ule v14, v9
 ;; @0023                               trapz v15, user1
-;; @0023                               v7 = load.i64 notrap aligned readonly pure v0+40
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
 ;; @0029                               v24 = iconst.i64 20

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -25,10 +25,10 @@
 ;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
 ;;                                     v32 = iconst.i64 24
 ;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 24
-;; @0023                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0023                               v9 = load.i64 notrap aligned readonly pure v0+48
 ;; @0023                               v15 = icmp ule v14, v9
 ;; @0023                               trapz v15, user1
-;; @0023                               v7 = load.i64 notrap aligned readonly v0+40
+;; @0023                               v7 = load.i64 notrap aligned readonly pure v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
 ;; @0029                               v24 = iconst.i64 20

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -37,14 +37,14 @@
 ;; @001e                               v18 = iconst.i64 4
 ;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001e                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @001e                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001e                               v22 = icmp ule v21, v16
 ;; @001e                               trapz v22, user1
-;; @001e                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001e                               v23 = iadd v14, v19
 ;; @001e                               v24 = load.i32 notrap aligned readonly v23
-;; @001e                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @001e                               v12 = load.i32 notrap aligned readonly pure v11
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v25 = icmp eq v24, v12
 ;; @001e                               v26 = uextend.i32 v25
 ;; @001e                               brif v26, block6(v26), block5

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -37,14 +37,14 @@
 ;; @001e                               v18 = iconst.i64 4
 ;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001e                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @001e                               v22 = icmp ule v21, v16
 ;; @001e                               trapz v22, user1
-;; @001e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001e                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @001e                               v23 = iadd v14, v19
 ;; @001e                               v24 = load.i32 notrap aligned readonly v23
-;; @001e                               v11 = load.i64 notrap aligned readonly v0+64
-;; @001e                               v12 = load.i32 notrap aligned readonly v11
+;; @001e                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @001e                               v25 = icmp eq v24, v12
 ;; @001e                               v26 = uextend.i32 v25
 ;; @001e                               brif v26, block6(v26), block5

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1476395008

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1476395008

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -29,8 +29,8 @@
 ;;
 ;;                                 block3:
 ;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly v0+64
-;; @0020                               v9 = load.i32 notrap aligned readonly v8
+;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly pure v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11
 ;; @0020                               brif v12, block6(v12), block5

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -29,8 +29,8 @@
 ;;
 ;;                                 block3:
 ;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+64
-;; @0020                               v9 = load.i32 notrap aligned readonly pure v8
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11
 ;; @0020                               brif v12, block6(v12), block5

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -34,14 +34,14 @@
 ;; @001d                               v18 = iconst.i64 4
 ;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001d                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001d                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001d                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @001d                               v22 = icmp ule v21, v16
 ;; @001d                               trapz v22, user1
-;; @001d                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001d                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @001d                               v23 = iadd v14, v19
 ;; @001d                               v24 = load.i32 notrap aligned readonly v23
-;; @001d                               v11 = load.i64 notrap aligned readonly v0+64
-;; @001d                               v12 = load.i32 notrap aligned readonly v11
+;; @001d                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @001d                               v25 = icmp eq v24, v12
 ;; @001d                               v26 = uextend.i32 v25
 ;; @001d                               brif v26, block6(v26), block5

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -34,14 +34,14 @@
 ;; @001d                               v18 = iconst.i64 4
 ;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001d                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001d                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @001d                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001d                               v22 = icmp ule v21, v16
 ;; @001d                               trapz v22, user1
-;; @001d                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001d                               v23 = iadd v14, v19
 ;; @001d                               v24 = load.i32 notrap aligned readonly v23
-;; @001d                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @001d                               v12 = load.i32 notrap aligned readonly pure v11
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v25 = icmp eq v24, v12
 ;; @001d                               v26 = uextend.i32 v25
 ;; @001d                               brif v26, block6(v26), block5

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -31,10 +31,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1610612736

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -31,10 +31,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1610612736

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1342177280

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1342177280

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -37,10 +37,10 @@
 ;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v17 = iconst.i64 32
 ;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 32
-;; @0033                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0033                               v14 = icmp ule v13, v8
 ;; @0033                               trapz v14, user1
-;; @0033                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0033                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0033                               v15 = iadd v6, v11
 ;; @0033                               v16 = load.f32 notrap aligned little v15
 ;; @0037                               jump block1
@@ -63,10 +63,10 @@
 ;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v18 = iconst.i64 32
 ;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
-;; @003c                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003c                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @003c                               v14 = icmp ule v13, v8
 ;; @003c                               trapz v14, user1
-;; @003c                               v6 = load.i64 notrap aligned readonly v0+40
+;; @003c                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @003c                               v15 = iadd v6, v11
 ;; @003c                               v16 = load.i8 notrap aligned little v15
 ;; @0040                               jump block1
@@ -90,10 +90,10 @@
 ;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v18 = iconst.i64 32
 ;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
-;; @0045                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0045                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0045                               v14 = icmp ule v13, v8
 ;; @0045                               trapz v14, user1
-;; @0045                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0045                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0045                               v15 = iadd v6, v11
 ;; @0045                               v16 = load.i8 notrap aligned little v15
 ;; @0049                               jump block1
@@ -120,10 +120,10 @@
 ;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;;                                     v72 = iconst.i64 32
 ;; @004e                               v13 = uadd_overflow_trap v9, v72, user1  ; v72 = 32
-;; @004e                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004e                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @004e                               v14 = icmp ule v13, v8
 ;; @004e                               trapz v14, user1
-;; @004e                               v6 = load.i64 notrap aligned readonly v0+40
+;; @004e                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @004e                               v15 = iadd v6, v11
 ;; @004e                               v16 = load.i32 notrap aligned little v15
 ;;                                     v60 = stack_addr.i64 ss0

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -37,10 +37,10 @@
 ;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v17 = iconst.i64 32
 ;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 32
-;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0033                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0033                               v14 = icmp ule v13, v8
 ;; @0033                               trapz v14, user1
-;; @0033                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0033                               v15 = iadd v6, v11
 ;; @0033                               v16 = load.f32 notrap aligned little v15
 ;; @0037                               jump block1
@@ -63,10 +63,10 @@
 ;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v18 = iconst.i64 32
 ;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
-;; @003c                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @003c                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003c                               v14 = icmp ule v13, v8
 ;; @003c                               trapz v14, user1
-;; @003c                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003c                               v15 = iadd v6, v11
 ;; @003c                               v16 = load.i8 notrap aligned little v15
 ;; @0040                               jump block1
@@ -90,10 +90,10 @@
 ;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v18 = iconst.i64 32
 ;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
-;; @0045                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0045                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0045                               v14 = icmp ule v13, v8
 ;; @0045                               trapz v14, user1
-;; @0045                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0045                               v15 = iadd v6, v11
 ;; @0045                               v16 = load.i8 notrap aligned little v15
 ;; @0049                               jump block1
@@ -120,10 +120,10 @@
 ;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;;                                     v72 = iconst.i64 32
 ;; @004e                               v13 = uadd_overflow_trap v9, v72, user1  ; v72 = 32
-;; @004e                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @004e                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004e                               v14 = icmp ule v13, v8
 ;; @004e                               trapz v14, user1
-;; @004e                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @004e                               v15 = iadd v6, v11
 ;; @004e                               v16 = load.i32 notrap aligned little v15
 ;;                                     v60 = stack_addr.i64 ss0

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -27,7 +27,7 @@
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @0021                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0021                               v12 = ireduce.i32 v11
 ;; @0021                               v15 = uextend.i64 v12
 ;; @0021                               v16 = iadd v14, v15
@@ -45,7 +45,7 @@
 ;; @0021                               v29 = iconst.i64 8
 ;; @0021                               v30 = uadd_overflow_trap v73, v29, user1  ; v73 = 0, v29 = 8
 ;; @0021                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @0021                               v27 = load.i64 notrap aligned readonly pure v0+48
+;; @0021                               v27 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0021                               v33 = icmp ule v32, v27
 ;; @0021                               trapz v33, user1
 ;; @0021                               v34 = iadd.i64 v14, v30

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -27,7 +27,7 @@
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v14 = load.i64 notrap aligned readonly v0+40
+;; @0021                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @0021                               v12 = ireduce.i32 v11
 ;; @0021                               v15 = uextend.i64 v12
 ;; @0021                               v16 = iadd v14, v15
@@ -45,7 +45,7 @@
 ;; @0021                               v29 = iconst.i64 8
 ;; @0021                               v30 = uadd_overflow_trap v73, v29, user1  ; v73 = 0, v29 = 8
 ;; @0021                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @0021                               v27 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v27 = load.i64 notrap aligned readonly pure v0+48
 ;; @0021                               v33 = icmp ule v32, v27
 ;; @0021                               trapz v33, user1
 ;; @0021                               v34 = iadd.i64 v14, v30

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -29,7 +29,7 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002a                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v12 = ireduce.i32 v11
 ;; @002a                               v15 = uextend.i64 v12
 ;; @002a                               v16 = iadd v14, v15
@@ -52,7 +52,7 @@
 ;; @002a                               v29 = iconst.i64 8
 ;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
 ;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly pure v0+48
+;; @002a                               v27 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002a                               v33 = icmp ule v32, v27
 ;; @002a                               trapz v33, user1
 ;; @002a                               v34 = iadd.i64 v14, v30

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -29,7 +29,7 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002a                               v12 = ireduce.i32 v11
 ;; @002a                               v15 = uextend.i64 v12
 ;; @002a                               v16 = iadd v14, v15
@@ -52,7 +52,7 @@
 ;; @002a                               v29 = iconst.i64 8
 ;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
 ;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v27 = load.i64 notrap aligned readonly pure v0+48
 ;; @002a                               v33 = icmp ule v32, v27
 ;; @002a                               trapz v33, user1
 ;; @002a                               v34 = iadd.i64 v14, v30

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -33,10 +33,10 @@
 ;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v16 = iconst.i64 32
 ;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
-;; @0034                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0034                               v14 = icmp ule v13, v8
 ;; @0034                               trapz v14, user1
-;; @0034                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0034                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0034                               v15 = iadd v6, v11
 ;; @0034                               store notrap aligned little v3, v15
 ;; @0038                               jump block1
@@ -59,10 +59,10 @@
 ;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v16 = iconst.i64 32
 ;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
-;; @003f                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003f                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @003f                               v14 = icmp ule v13, v8
 ;; @003f                               trapz v14, user1
-;; @003f                               v6 = load.i64 notrap aligned readonly v0+40
+;; @003f                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @003f                               v15 = iadd v6, v11
 ;; @003f                               istore8 notrap aligned little v3, v15
 ;; @0043                               jump block1
@@ -87,10 +87,10 @@
 ;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;;                                     v82 = iconst.i64 32
 ;; @004a                               v13 = uadd_overflow_trap v9, v82, user1  ; v82 = 32
-;; @004a                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004a                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @004a                               v14 = icmp ule v13, v8
 ;; @004a                               trapz v14, user1
-;; @004a                               v6 = load.i64 notrap aligned readonly v0+40
+;; @004a                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @004a                               v15 = iadd v6, v11
 ;; @004a                               v16 = load.i32 notrap aligned little v15
 ;;                                     v75 = iconst.i32 1

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -33,10 +33,10 @@
 ;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v16 = iconst.i64 32
 ;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
-;; @0034                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0034                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0034                               v14 = icmp ule v13, v8
 ;; @0034                               trapz v14, user1
-;; @0034                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0034                               v15 = iadd v6, v11
 ;; @0034                               store notrap aligned little v3, v15
 ;; @0038                               jump block1
@@ -59,10 +59,10 @@
 ;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
 ;;                                     v16 = iconst.i64 32
 ;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
-;; @003f                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003f                               v14 = icmp ule v13, v8
 ;; @003f                               trapz v14, user1
-;; @003f                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003f                               v15 = iadd v6, v11
 ;; @003f                               istore8 notrap aligned little v3, v15
 ;; @0043                               jump block1
@@ -87,10 +87,10 @@
 ;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;;                                     v82 = iconst.i64 32
 ;; @004a                               v13 = uadd_overflow_trap v9, v82, user1  ; v82 = 32
-;; @004a                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @004a                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004a                               v14 = icmp ule v13, v8
 ;; @004a                               trapz v14, user1
-;; @004a                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @004a                               v15 = iadd v6, v11
 ;; @004a                               v16 = load.i32 notrap aligned little v15
 ;;                                     v75 = iconst.i32 1

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -23,10 +23,10 @@
 ;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 8
 ;; @0027                               v13 = iconst.i64 4
 ;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
-;; @0027                               v9 = load.i64 notrap aligned readonly pure v0+48
+;; @0027                               v9 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0027                               v15 = icmp ule v14, v9
 ;; @0027                               trapz v15, user1
-;; @0027                               v7 = load.i64 notrap aligned readonly pure v0+40
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0027                               v16 = iadd v7, v12
 ;; @0027                               v17 = load.i32 notrap aligned readonly v16
 ;; @0027                               v18 = uadd_overflow_trap v3, v5, user17

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -23,12 +23,12 @@
 ;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 8
 ;; @0027                               v13 = iconst.i64 4
 ;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
-;; @0027                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0027                               v9 = load.i64 notrap aligned readonly pure v0+48
 ;; @0027                               v15 = icmp ule v14, v9
 ;; @0027                               trapz v15, user1
-;; @0027                               v7 = load.i64 notrap aligned readonly v0+40
+;; @0027                               v7 = load.i64 notrap aligned readonly pure v0+40
 ;; @0027                               v16 = iadd v7, v12
-;; @0027                               v17 = load.i32 notrap aligned v16
+;; @0027                               v17 = load.i32 notrap aligned readonly v16
 ;; @0027                               v18 = uadd_overflow_trap v3, v5, user17
 ;; @0027                               v19 = icmp ugt v18, v17
 ;; @0027                               trapnz v19, user17

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -23,12 +23,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
-;; @0022                               v16 = load.i32 notrap aligned v15
+;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16
 ;; @0022                               trapz v17, user17
 ;; @0022                               v19 = uextend.i64 v16

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -23,10 +23,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i32 notrap aligned readonly v15
 ;; @0022                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -23,10 +23,10 @@
 ;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 8
 ;; @001f                               v11 = iconst.i64 4
 ;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @001f                               v7 = load.i64 notrap aligned readonly pure v0+48
+;; @001f                               v7 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001f                               v13 = icmp ule v12, v7
 ;; @001f                               trapz v13, user1
-;; @001f                               v5 = load.i64 notrap aligned readonly pure v0+40
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v14 = iadd v5, v10
 ;; @001f                               v15 = load.i32 notrap aligned readonly v14
 ;; @0021                               jump block1

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -23,12 +23,12 @@
 ;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 8
 ;; @001f                               v11 = iconst.i64 4
 ;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
-;; @001f                               v7 = load.i64 notrap aligned readonly v0+48
+;; @001f                               v7 = load.i64 notrap aligned readonly pure v0+48
 ;; @001f                               v13 = icmp ule v12, v7
 ;; @001f                               trapz v13, user1
-;; @001f                               v5 = load.i64 notrap aligned readonly v0+40
+;; @001f                               v5 = load.i64 notrap aligned readonly pure v0+40
 ;; @001f                               v14 = iadd v5, v10
-;; @001f                               v15 = load.i32 notrap aligned v14
+;; @001f                               v15 = load.i32 notrap aligned readonly v14
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -33,17 +33,17 @@
 ;; @0025                               v23 = band v21, v67  ; v67 = -8
 ;; @0025                               v24 = uadd_overflow_trap v23, v12, user18
 ;; @0025                               v25 = uextend.i64 v24
-;; @0025                               v29 = load.i64 notrap aligned readonly pure v0+48
+;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0025                               v30 = icmp ule v25, v29
 ;; @0025                               trapz v30, user18
 ;; @0025                               v33 = iconst.i32 -1476395008
 ;;                                     v68 = bor v12, v33  ; v33 = -1476395008
-;; @0025                               v27 = load.i64 notrap aligned readonly pure v0+40
+;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v31 = uextend.i64 v23
 ;; @0025                               v32 = iadd v27, v31
 ;; @0025                               store notrap aligned v68, v32
-;; @0025                               v36 = load.i64 notrap aligned readonly pure v0+64
-;; @0025                               v37 = load.i32 notrap aligned readonly pure v36
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move v0+64
+;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
 ;; @0025                               store notrap aligned v37, v32+4
 ;; @0025                               store notrap aligned v24, v17
 ;; @0025                               v7 = iconst.i32 3

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -33,17 +33,17 @@
 ;; @0025                               v23 = band v21, v67  ; v67 = -8
 ;; @0025                               v24 = uadd_overflow_trap v23, v12, user18
 ;; @0025                               v25 = uextend.i64 v24
-;; @0025                               v29 = load.i64 notrap aligned readonly v0+48
+;; @0025                               v29 = load.i64 notrap aligned readonly pure v0+48
 ;; @0025                               v30 = icmp ule v25, v29
 ;; @0025                               trapz v30, user18
 ;; @0025                               v33 = iconst.i32 -1476395008
 ;;                                     v68 = bor v12, v33  ; v33 = -1476395008
-;; @0025                               v27 = load.i64 notrap aligned readonly v0+40
+;; @0025                               v27 = load.i64 notrap aligned readonly pure v0+40
 ;; @0025                               v31 = uextend.i64 v23
 ;; @0025                               v32 = iadd v27, v31
 ;; @0025                               store notrap aligned v68, v32
-;; @0025                               v36 = load.i64 notrap aligned readonly v0+64
-;; @0025                               v37 = load.i32 notrap aligned readonly v36
+;; @0025                               v36 = load.i64 notrap aligned readonly pure v0+64
+;; @0025                               v37 = load.i32 notrap aligned readonly pure v36
 ;; @0025                               store notrap aligned v37, v32+4
 ;; @0025                               store notrap aligned v24, v17
 ;; @0025                               v7 = iconst.i32 3

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -38,17 +38,17 @@
 ;; @0022                               v21 = band v19, v68  ; v68 = -8
 ;; @0022                               v22 = uadd_overflow_trap v21, v10, user18
 ;; @0022                               v23 = uextend.i64 v22
-;; @0022                               v27 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v27 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v28 = icmp ule v23, v27
 ;; @0022                               trapz v28, user18
 ;; @0022                               v31 = iconst.i32 -1476395008
 ;;                                     v69 = bor v10, v31  ; v31 = -1476395008
-;; @0022                               v25 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v25 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v29 = uextend.i64 v21
 ;; @0022                               v30 = iadd v25, v29
 ;; @0022                               store notrap aligned v69, v30
-;; @0022                               v34 = load.i64 notrap aligned readonly pure v0+64
-;; @0022                               v35 = load.i32 notrap aligned readonly pure v34
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+64
+;; @0022                               v35 = load.i32 notrap aligned readonly can_move v34
 ;; @0022                               store notrap aligned v35, v30+4
 ;; @0022                               store notrap aligned v22, v15
 ;;                                     v47 = iconst.i64 8

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -38,17 +38,17 @@
 ;; @0022                               v21 = band v19, v68  ; v68 = -8
 ;; @0022                               v22 = uadd_overflow_trap v21, v10, user18
 ;; @0022                               v23 = uextend.i64 v22
-;; @0022                               v27 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v27 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v28 = icmp ule v23, v27
 ;; @0022                               trapz v28, user18
 ;; @0022                               v31 = iconst.i32 -1476395008
 ;;                                     v69 = bor v10, v31  ; v31 = -1476395008
-;; @0022                               v25 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v25 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v29 = uextend.i64 v21
 ;; @0022                               v30 = iadd v25, v29
 ;; @0022                               store notrap aligned v69, v30
-;; @0022                               v34 = load.i64 notrap aligned readonly v0+64
-;; @0022                               v35 = load.i32 notrap aligned readonly v34
+;; @0022                               v34 = load.i64 notrap aligned readonly pure v0+64
+;; @0022                               v35 = load.i32 notrap aligned readonly pure v34
 ;; @0022                               store notrap aligned v35, v30+4
 ;; @0022                               store notrap aligned v22, v15
 ;;                                     v47 = iconst.i64 8

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -23,12 +23,12 @@
 ;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0024                               v12 = iconst.i64 4
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0024                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0024                               v14 = icmp ule v13, v8
 ;; @0024                               trapz v14, user1
-;; @0024                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0024                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0024                               v15 = iadd v6, v11
-;; @0024                               v16 = load.i32 notrap aligned v15
+;; @0024                               v16 = load.i32 notrap aligned readonly v15
 ;; @0024                               v17 = icmp ult v3, v16
 ;; @0024                               trapz v17, user17
 ;; @0024                               v19 = uextend.i64 v16

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -23,10 +23,10 @@
 ;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;; @0024                               v12 = iconst.i64 4
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
-;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0024                               v14 = icmp ule v13, v8
 ;; @0024                               trapz v14, user1
-;; @0024                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0024                               v15 = iadd v6, v11
 ;; @0024                               v16 = load.i32 notrap aligned readonly v15
 ;; @0024                               v17 = icmp ult v3, v16

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -49,14 +49,14 @@
 ;; @002e                               v18 = iconst.i64 4
 ;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002e                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @002e                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002e                               v22 = icmp ule v21, v16
 ;; @002e                               trapz v22, user1
-;; @002e                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002e                               v23 = iadd v14, v19
 ;; @002e                               v24 = load.i32 notrap aligned readonly v23
-;; @002e                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @002e                               v12 = load.i32 notrap aligned readonly pure v11
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002e                               v25 = icmp eq v24, v12
 ;; @002e                               v26 = uextend.i32 v25
 ;; @002e                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v32 = load.i64 notrap aligned readonly pure v0+80
-;; @0034                               v33 = load.i64 notrap aligned readonly pure v0+96
+;; @0034                               v32 = load.i64 notrap aligned readonly can_move v0+80
+;; @0034                               v33 = load.i64 notrap aligned readonly can_move v0+96
 ;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v35 = load.i64 notrap aligned readonly pure v0+104
-;; @0038                               v36 = load.i64 notrap aligned readonly pure v0+120
+;; @0038                               v35 = load.i64 notrap aligned readonly can_move v0+104
+;; @0038                               v36 = load.i64 notrap aligned readonly can_move v0+120
 ;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -49,14 +49,14 @@
 ;; @002e                               v18 = iconst.i64 4
 ;; @002e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002e                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @002e                               v22 = icmp ule v21, v16
 ;; @002e                               trapz v22, user1
-;; @002e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002e                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002e                               v23 = iadd v14, v19
 ;; @002e                               v24 = load.i32 notrap aligned readonly v23
-;; @002e                               v11 = load.i64 notrap aligned readonly v0+64
-;; @002e                               v12 = load.i32 notrap aligned readonly v11
+;; @002e                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @002e                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @002e                               v25 = icmp eq v24, v12
 ;; @002e                               v26 = uextend.i32 v25
 ;; @002e                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002e                               brif v30, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v32 = load.i64 notrap aligned readonly v0+80
-;; @0034                               v33 = load.i64 notrap aligned readonly v0+96
+;; @0034                               v32 = load.i64 notrap aligned readonly pure v0+80
+;; @0034                               v33 = load.i64 notrap aligned readonly pure v0+96
 ;; @0034                               call_indirect sig1, v32(v33, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v35 = load.i64 notrap aligned readonly v0+104
-;; @0038                               v36 = load.i64 notrap aligned readonly v0+120
+;; @0038                               v35 = load.i64 notrap aligned readonly pure v0+104
+;; @0038                               v36 = load.i64 notrap aligned readonly pure v0+120
 ;; @0038                               call_indirect sig2, v35(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -49,14 +49,14 @@
 ;; @002f                               v18 = iconst.i64 4
 ;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002f                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002f                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @002f                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002f                               v22 = icmp ule v21, v16
 ;; @002f                               trapz v22, user1
-;; @002f                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002f                               v23 = iadd v14, v19
 ;; @002f                               v24 = load.i32 notrap aligned readonly v23
-;; @002f                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @002f                               v12 = load.i32 notrap aligned readonly pure v11
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @002f                               v25 = icmp eq v24, v12
 ;; @002f                               v26 = uextend.i32 v25
 ;; @002f                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v32 = load.i64 notrap aligned readonly pure v0+80
-;; @0035                               v33 = load.i64 notrap aligned readonly pure v0+96
+;; @0035                               v32 = load.i64 notrap aligned readonly can_move v0+80
+;; @0035                               v33 = load.i64 notrap aligned readonly can_move v0+96
 ;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v35 = load.i64 notrap aligned readonly pure v0+104
-;; @0039                               v36 = load.i64 notrap aligned readonly pure v0+120
+;; @0039                               v35 = load.i64 notrap aligned readonly can_move v0+104
+;; @0039                               v36 = load.i64 notrap aligned readonly can_move v0+120
 ;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -49,14 +49,14 @@
 ;; @002f                               v18 = iconst.i64 4
 ;; @002f                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @002f                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @002f                               v16 = load.i64 notrap aligned readonly v0+48
+;; @002f                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @002f                               v22 = icmp ule v21, v16
 ;; @002f                               trapz v22, user1
-;; @002f                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002f                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002f                               v23 = iadd v14, v19
 ;; @002f                               v24 = load.i32 notrap aligned readonly v23
-;; @002f                               v11 = load.i64 notrap aligned readonly v0+64
-;; @002f                               v12 = load.i32 notrap aligned readonly v11
+;; @002f                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @002f                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @002f                               v25 = icmp eq v24, v12
 ;; @002f                               v26 = uextend.i32 v25
 ;; @002f                               brif v26, block7(v26), block6
@@ -73,14 +73,14 @@
 ;; @002f                               brif v30, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v32 = load.i64 notrap aligned readonly v0+80
-;; @0035                               v33 = load.i64 notrap aligned readonly v0+96
+;; @0035                               v32 = load.i64 notrap aligned readonly pure v0+80
+;; @0035                               v33 = load.i64 notrap aligned readonly pure v0+96
 ;; @0035                               call_indirect sig1, v32(v33, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v35 = load.i64 notrap aligned readonly v0+104
-;; @0039                               v36 = load.i64 notrap aligned readonly v0+120
+;; @0039                               v35 = load.i64 notrap aligned readonly pure v0+104
+;; @0039                               v36 = load.i64 notrap aligned readonly pure v0+120
 ;; @0039                               call_indirect sig2, v35(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+128
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+128
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly v0+128
+;; @005c                               v6 = load.i64 notrap aligned readonly pure v0+128
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3
@@ -51,8 +51,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @005c                               v21 = load.i32 user6 aligned readonly v13+16
-;; @005c                               v19 = load.i64 notrap aligned readonly v0+64
-;; @005c                               v20 = load.i32 notrap aligned readonly v19
+;; @005c                               v19 = load.i64 notrap aligned readonly pure v0+64
+;; @005c                               v20 = load.i32 notrap aligned readonly pure v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22
 ;; @005c                               brif v23, block5(v23), block4

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+128
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+128
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly pure v0+128
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+128
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3
@@ -51,8 +51,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @005c                               v21 = load.i32 user6 aligned readonly v13+16
-;; @005c                               v19 = load.i64 notrap aligned readonly pure v0+64
-;; @005c                               v20 = load.i32 notrap aligned readonly pure v19
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+64
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @005c                               v22 = icmp eq v21, v20
 ;; @005c                               v23 = uextend.i32 v22
 ;; @005c                               brif v23, block5(v23), block4

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -25,10 +25,10 @@
 ;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v20 = iconst.i64 16
 ;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 16
-;; @0020                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0020                               v14 = icmp ule v13, v8
 ;; @0020                               trapz v14, user1
-;; @0020                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0020                               v15 = iadd v6, v11
 ;; @0020                               v18 = load.i32 notrap aligned little v15
 ;; @0020                               v16 = iconst.i32 -1

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -25,10 +25,10 @@
 ;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v20 = iconst.i64 16
 ;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 16
-;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0020                               v14 = icmp ule v13, v8
 ;; @0020                               trapz v14, user1
-;; @0020                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v15 = iadd v6, v11
 ;; @0020                               v18 = load.i32 notrap aligned little v15
 ;; @0020                               v16 = iconst.i32 -1

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -30,16 +30,16 @@
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v16 = uadd_overflow_trap v15, v4, user18  ; v4 = 16
 ;; @0020                               v17 = uextend.i64 v16
-;; @0020                               v21 = load.i64 notrap aligned readonly v0+48
+;; @0020                               v21 = load.i64 notrap aligned readonly pure v0+48
 ;; @0020                               v22 = icmp ule v17, v21
 ;; @0020                               trapz v22, user18
 ;;                                     v50 = iconst.i32 -1342177264
-;; @0020                               v19 = load.i64 notrap aligned readonly v0+40
+;; @0020                               v19 = load.i64 notrap aligned readonly pure v0+40
 ;; @0020                               v23 = uextend.i64 v15
 ;; @0020                               v24 = iadd v19, v23
 ;; @0020                               store notrap aligned v50, v24  ; v50 = -1342177264
-;; @0020                               v28 = load.i64 notrap aligned readonly v0+64
-;; @0020                               v29 = load.i32 notrap aligned readonly v28
+;; @0020                               v28 = load.i64 notrap aligned readonly pure v0+64
+;; @0020                               v29 = load.i32 notrap aligned readonly pure v28
 ;; @0020                               store notrap aligned v29, v24+4
 ;; @0020                               store notrap aligned v16, v9
 ;; @0020                               v32 = call fn0(v0, v2)

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -30,16 +30,16 @@
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v16 = uadd_overflow_trap v15, v4, user18  ; v4 = 16
 ;; @0020                               v17 = uextend.i64 v16
-;; @0020                               v21 = load.i64 notrap aligned readonly pure v0+48
+;; @0020                               v21 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0020                               v22 = icmp ule v17, v21
 ;; @0020                               trapz v22, user18
 ;;                                     v50 = iconst.i32 -1342177264
-;; @0020                               v19 = load.i64 notrap aligned readonly pure v0+40
+;; @0020                               v19 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v23 = uextend.i64 v15
 ;; @0020                               v24 = iadd v19, v23
 ;; @0020                               store notrap aligned v50, v24  ; v50 = -1342177264
-;; @0020                               v28 = load.i64 notrap aligned readonly pure v0+64
-;; @0020                               v29 = load.i32 notrap aligned readonly pure v28
+;; @0020                               v28 = load.i64 notrap aligned readonly can_move v0+64
+;; @0020                               v29 = load.i32 notrap aligned readonly can_move v28
 ;; @0020                               store notrap aligned v29, v24+4
 ;; @0020                               store notrap aligned v16, v9
 ;; @0020                               v32 = call fn0(v0, v2)

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -25,12 +25,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v19 = iconst.i64 16
 ;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 16
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
 ;; @0022                               v18 = ireduce.i32 v17
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -25,12 +25,12 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v19 = iconst.i64 16
 ;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 16
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
 ;; @0022                               v17 = call fn0(v0, v3)
 ;; @0022                               v18 = ireduce.i32 v17
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               store notrap aligned little v18, v15
 ;; @0026                               jump block1

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -24,10 +24,10 @@
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 8
 ;; @0024                               v14 = iconst.i64 4
 ;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
-;; @0024                               v10 = load.i64 notrap aligned readonly pure v0+48
+;; @0024                               v10 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0024                               v16 = icmp ule v15, v10
 ;; @0024                               trapz v16, user1
-;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+40
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0024                               v17 = iadd v8, v13
 ;; @0024                               v18 = load.i32 notrap aligned readonly v17
 ;; @0024                               v19 = icmp ult v3, v18

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -24,12 +24,12 @@
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 8
 ;; @0024                               v14 = iconst.i64 4
 ;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
-;; @0024                               v10 = load.i64 notrap aligned readonly v0+48
+;; @0024                               v10 = load.i64 notrap aligned readonly pure v0+48
 ;; @0024                               v16 = icmp ule v15, v10
 ;; @0024                               trapz v16, user1
-;; @0024                               v8 = load.i64 notrap aligned readonly v0+40
+;; @0024                               v8 = load.i64 notrap aligned readonly pure v0+40
 ;; @0024                               v17 = iadd v8, v13
-;; @0024                               v18 = load.i32 notrap aligned v17
+;; @0024                               v18 = load.i32 notrap aligned readonly v17
 ;; @0024                               v19 = icmp ult v3, v18
 ;; @0024                               trapz v19, user17
 ;; @0024                               v21 = uextend.i64 v18

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -25,10 +25,10 @@
 ;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 8
 ;;                                     v32 = iconst.i64 16
 ;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 16
-;; @0023                               v9 = load.i64 notrap aligned readonly pure v0+48
+;; @0023                               v9 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0023                               v15 = icmp ule v14, v9
 ;; @0023                               trapz v15, user1
-;; @0023                               v7 = load.i64 notrap aligned readonly pure v0+40
+;; @0023                               v7 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
 ;; @0029                               v24 = iconst.i64 12

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -25,10 +25,10 @@
 ;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 8
 ;;                                     v32 = iconst.i64 16
 ;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 16
-;; @0023                               v9 = load.i64 notrap aligned readonly v0+48
+;; @0023                               v9 = load.i64 notrap aligned readonly pure v0+48
 ;; @0023                               v15 = icmp ule v14, v9
 ;; @0023                               trapz v15, user1
-;; @0023                               v7 = load.i64 notrap aligned readonly v0+40
+;; @0023                               v7 = load.i64 notrap aligned readonly pure v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
 ;; @0029                               v24 = iconst.i64 12

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -37,14 +37,14 @@
 ;; @001e                               v18 = iconst.i64 4
 ;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001e                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @001e                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001e                               v22 = icmp ule v21, v16
 ;; @001e                               trapz v22, user1
-;; @001e                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001e                               v23 = iadd v14, v19
 ;; @001e                               v24 = load.i32 notrap aligned readonly v23
-;; @001e                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @001e                               v12 = load.i32 notrap aligned readonly pure v11
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001e                               v25 = icmp eq v24, v12
 ;; @001e                               v26 = uextend.i32 v25
 ;; @001e                               brif v26, block6(v26), block5

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -37,14 +37,14 @@
 ;; @001e                               v18 = iconst.i64 4
 ;; @001e                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001e                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001e                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001e                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @001e                               v22 = icmp ule v21, v16
 ;; @001e                               trapz v22, user1
-;; @001e                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001e                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @001e                               v23 = iadd v14, v19
 ;; @001e                               v24 = load.i32 notrap aligned readonly v23
-;; @001e                               v11 = load.i64 notrap aligned readonly v0+64
-;; @001e                               v12 = load.i32 notrap aligned readonly v11
+;; @001e                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @001e                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @001e                               v25 = icmp eq v24, v12
 ;; @001e                               v26 = uextend.i32 v25
 ;; @001e                               brif v26, block6(v26), block5

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1476395008

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1476395008

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -29,8 +29,8 @@
 ;;
 ;;                                 block3:
 ;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly v0+64
-;; @0020                               v9 = load.i32 notrap aligned readonly v8
+;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly pure v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11
 ;; @0020                               brif v12, block6(v12), block5

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -29,8 +29,8 @@
 ;;
 ;;                                 block3:
 ;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
-;; @0020                               v8 = load.i64 notrap aligned readonly pure v0+64
-;; @0020                               v9 = load.i32 notrap aligned readonly pure v8
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+64
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
 ;; @0020                               v11 = icmp eq v10, v9
 ;; @0020                               v12 = uextend.i32 v11
 ;; @0020                               brif v12, block6(v12), block5

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -34,14 +34,14 @@
 ;; @001d                               v18 = iconst.i64 4
 ;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001d                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001d                               v16 = load.i64 notrap aligned readonly v0+48
+;; @001d                               v16 = load.i64 notrap aligned readonly pure v0+48
 ;; @001d                               v22 = icmp ule v21, v16
 ;; @001d                               trapz v22, user1
-;; @001d                               v14 = load.i64 notrap aligned readonly v0+40
+;; @001d                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @001d                               v23 = iadd v14, v19
 ;; @001d                               v24 = load.i32 notrap aligned readonly v23
-;; @001d                               v11 = load.i64 notrap aligned readonly v0+64
-;; @001d                               v12 = load.i32 notrap aligned readonly v11
+;; @001d                               v11 = load.i64 notrap aligned readonly pure v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly pure v11
 ;; @001d                               v25 = icmp eq v24, v12
 ;; @001d                               v26 = uextend.i32 v25
 ;; @001d                               brif v26, block6(v26), block5

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -34,14 +34,14 @@
 ;; @001d                               v18 = iconst.i64 4
 ;; @001d                               v19 = uadd_overflow_trap v17, v18, user1  ; v18 = 4
 ;; @001d                               v21 = uadd_overflow_trap v19, v18, user1  ; v18 = 4
-;; @001d                               v16 = load.i64 notrap aligned readonly pure v0+48
+;; @001d                               v16 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001d                               v22 = icmp ule v21, v16
 ;; @001d                               trapz v22, user1
-;; @001d                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001d                               v23 = iadd v14, v19
 ;; @001d                               v24 = load.i32 notrap aligned readonly v23
-;; @001d                               v11 = load.i64 notrap aligned readonly pure v0+64
-;; @001d                               v12 = load.i32 notrap aligned readonly pure v11
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+64
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
 ;; @001d                               v25 = icmp eq v24, v12
 ;; @001d                               v26 = uextend.i32 v25
 ;; @001d                               brif v26, block6(v26), block5

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -31,10 +31,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1610612736

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -31,10 +31,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1610612736

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1342177280

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -32,10 +32,10 @@
 ;; @001b                               v17 = uadd_overflow_trap v15, v16, user1  ; v16 = 0
 ;;                                     v29 = iconst.i64 8
 ;; @001b                               v19 = uadd_overflow_trap v15, v29, user1  ; v29 = 8
-;; @001b                               v14 = load.i64 notrap aligned readonly pure v0+48
+;; @001b                               v14 = load.i64 notrap aligned readonly can_move v0+48
 ;; @001b                               v20 = icmp ule v19, v14
 ;; @001b                               trapz v20, user1
-;; @001b                               v12 = load.i64 notrap aligned readonly pure v0+40
+;; @001b                               v12 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001b                               v21 = iadd v12, v17
 ;; @001b                               v22 = load.i32 notrap aligned readonly v21
 ;; @001b                               v23 = iconst.i32 -1342177280

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -37,10 +37,10 @@
 ;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v17 = iconst.i64 24
 ;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 24
-;; @0033                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0033                               v14 = icmp ule v13, v8
 ;; @0033                               trapz v14, user1
-;; @0033                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0033                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0033                               v15 = iadd v6, v11
 ;; @0033                               v16 = load.f32 notrap aligned little v15
 ;; @0037                               jump block1
@@ -63,10 +63,10 @@
 ;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v18 = iconst.i64 24
 ;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
-;; @003c                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003c                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @003c                               v14 = icmp ule v13, v8
 ;; @003c                               trapz v14, user1
-;; @003c                               v6 = load.i64 notrap aligned readonly v0+40
+;; @003c                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @003c                               v15 = iadd v6, v11
 ;; @003c                               v16 = load.i8 notrap aligned little v15
 ;; @0040                               jump block1
@@ -90,10 +90,10 @@
 ;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v18 = iconst.i64 24
 ;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
-;; @0045                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0045                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0045                               v14 = icmp ule v13, v8
 ;; @0045                               trapz v14, user1
-;; @0045                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0045                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0045                               v15 = iadd v6, v11
 ;; @0045                               v16 = load.i8 notrap aligned little v15
 ;; @0049                               jump block1
@@ -117,10 +117,10 @@
 ;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v17 = iconst.i64 24
 ;; @004e                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 24
-;; @004e                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004e                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @004e                               v14 = icmp ule v13, v8
 ;; @004e                               trapz v14, user1
-;; @004e                               v6 = load.i64 notrap aligned readonly v0+40
+;; @004e                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @004e                               v15 = iadd v6, v11
 ;; @004e                               v16 = load.i32 notrap aligned little v15
 ;; @0052                               jump block1

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -37,10 +37,10 @@
 ;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v17 = iconst.i64 24
 ;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 24
-;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0033                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0033                               v14 = icmp ule v13, v8
 ;; @0033                               trapz v14, user1
-;; @0033                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0033                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0033                               v15 = iadd v6, v11
 ;; @0033                               v16 = load.f32 notrap aligned little v15
 ;; @0037                               jump block1
@@ -63,10 +63,10 @@
 ;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v18 = iconst.i64 24
 ;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
-;; @003c                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @003c                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003c                               v14 = icmp ule v13, v8
 ;; @003c                               trapz v14, user1
-;; @003c                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @003c                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003c                               v15 = iadd v6, v11
 ;; @003c                               v16 = load.i8 notrap aligned little v15
 ;; @0040                               jump block1
@@ -90,10 +90,10 @@
 ;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v18 = iconst.i64 24
 ;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 24
-;; @0045                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0045                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0045                               v14 = icmp ule v13, v8
 ;; @0045                               trapz v14, user1
-;; @0045                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0045                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0045                               v15 = iadd v6, v11
 ;; @0045                               v16 = load.i8 notrap aligned little v15
 ;; @0049                               jump block1
@@ -117,10 +117,10 @@
 ;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v17 = iconst.i64 24
 ;; @004e                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 24
-;; @004e                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @004e                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004e                               v14 = icmp ule v13, v8
 ;; @004e                               trapz v14, user1
-;; @004e                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @004e                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @004e                               v15 = iadd v6, v11
 ;; @004e                               v16 = load.i32 notrap aligned little v15
 ;; @0052                               jump block1

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -30,16 +30,16 @@
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
 ;; @0021                               v19 = uextend.i64 v18
-;; @0021                               v23 = load.i64 notrap aligned readonly pure v0+48
+;; @0021                               v23 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0021                               v24 = icmp ule v19, v23
 ;; @0021                               trapz v24, user18
 ;;                                     v52 = iconst.i32 -1342177256
-;; @0021                               v21 = load.i64 notrap aligned readonly pure v0+40
+;; @0021                               v21 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0021                               v25 = uextend.i64 v17
 ;; @0021                               v26 = iadd v21, v25
 ;; @0021                               store notrap aligned v52, v26  ; v52 = -1342177256
-;; @0021                               v30 = load.i64 notrap aligned readonly pure v0+64
-;; @0021                               v31 = load.i32 notrap aligned readonly pure v30
+;; @0021                               v30 = load.i64 notrap aligned readonly can_move v0+64
+;; @0021                               v31 = load.i32 notrap aligned readonly can_move v30
 ;; @0021                               store notrap aligned v31, v26+4
 ;; @0021                               store notrap aligned v18, v11
 ;; @0021                               v3 = f32const 0.0

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -30,16 +30,16 @@
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
 ;; @0021                               v19 = uextend.i64 v18
-;; @0021                               v23 = load.i64 notrap aligned readonly v0+48
+;; @0021                               v23 = load.i64 notrap aligned readonly pure v0+48
 ;; @0021                               v24 = icmp ule v19, v23
 ;; @0021                               trapz v24, user18
 ;;                                     v52 = iconst.i32 -1342177256
-;; @0021                               v21 = load.i64 notrap aligned readonly v0+40
+;; @0021                               v21 = load.i64 notrap aligned readonly pure v0+40
 ;; @0021                               v25 = uextend.i64 v17
 ;; @0021                               v26 = iadd v21, v25
 ;; @0021                               store notrap aligned v52, v26  ; v52 = -1342177256
-;; @0021                               v30 = load.i64 notrap aligned readonly v0+64
-;; @0021                               v31 = load.i32 notrap aligned readonly v30
+;; @0021                               v30 = load.i64 notrap aligned readonly pure v0+64
+;; @0021                               v31 = load.i32 notrap aligned readonly pure v30
 ;; @0021                               store notrap aligned v31, v26+4
 ;; @0021                               store notrap aligned v18, v11
 ;; @0021                               v3 = f32const 0.0

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -30,16 +30,16 @@
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
 ;; @002a                               v19 = uextend.i64 v18
-;; @002a                               v23 = load.i64 notrap aligned readonly pure v0+48
+;; @002a                               v23 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002a                               v24 = icmp ule v19, v23
 ;; @002a                               trapz v24, user18
 ;;                                     v53 = iconst.i32 -1342177256
-;; @002a                               v21 = load.i64 notrap aligned readonly pure v0+40
+;; @002a                               v21 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v25 = uextend.i64 v17
 ;; @002a                               v26 = iadd v21, v25
 ;; @002a                               store notrap aligned v53, v26  ; v53 = -1342177256
-;; @002a                               v30 = load.i64 notrap aligned readonly pure v0+64
-;; @002a                               v31 = load.i32 notrap aligned readonly pure v30
+;; @002a                               v30 = load.i64 notrap aligned readonly can_move v0+64
+;; @002a                               v31 = load.i32 notrap aligned readonly can_move v30
 ;; @002a                               store notrap aligned v31, v26+4
 ;; @002a                               store notrap aligned v18, v11
 ;;                                     v35 = iconst.i64 8

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -30,16 +30,16 @@
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
 ;; @002a                               v19 = uextend.i64 v18
-;; @002a                               v23 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v23 = load.i64 notrap aligned readonly pure v0+48
 ;; @002a                               v24 = icmp ule v19, v23
 ;; @002a                               trapz v24, user18
 ;;                                     v53 = iconst.i32 -1342177256
-;; @002a                               v21 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v21 = load.i64 notrap aligned readonly pure v0+40
 ;; @002a                               v25 = uextend.i64 v17
 ;; @002a                               v26 = iadd v21, v25
 ;; @002a                               store notrap aligned v53, v26  ; v53 = -1342177256
-;; @002a                               v30 = load.i64 notrap aligned readonly v0+64
-;; @002a                               v31 = load.i32 notrap aligned readonly v30
+;; @002a                               v30 = load.i64 notrap aligned readonly pure v0+64
+;; @002a                               v31 = load.i32 notrap aligned readonly pure v30
 ;; @002a                               store notrap aligned v31, v26+4
 ;; @002a                               store notrap aligned v18, v11
 ;;                                     v35 = iconst.i64 8

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -33,10 +33,10 @@
 ;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v16 = iconst.i64 24
 ;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @0034                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0034                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0034                               v14 = icmp ule v13, v8
 ;; @0034                               trapz v14, user1
-;; @0034                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0034                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0034                               v15 = iadd v6, v11
 ;; @0034                               store notrap aligned little v3, v15
 ;; @0038                               jump block1
@@ -59,10 +59,10 @@
 ;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v16 = iconst.i64 24
 ;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @003f                               v8 = load.i64 notrap aligned readonly v0+48
+;; @003f                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @003f                               v14 = icmp ule v13, v8
 ;; @003f                               trapz v14, user1
-;; @003f                               v6 = load.i64 notrap aligned readonly v0+40
+;; @003f                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @003f                               v15 = iadd v6, v11
 ;; @003f                               istore8 notrap aligned little v3, v15
 ;; @0043                               jump block1
@@ -85,10 +85,10 @@
 ;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v16 = iconst.i64 24
 ;; @004a                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @004a                               v8 = load.i64 notrap aligned readonly v0+48
+;; @004a                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @004a                               v14 = icmp ule v13, v8
 ;; @004a                               trapz v14, user1
-;; @004a                               v6 = load.i64 notrap aligned readonly v0+40
+;; @004a                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @004a                               v15 = iadd v6, v11
 ;; @004a                               store notrap aligned little v3, v15
 ;; @004e                               jump block1

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -33,10 +33,10 @@
 ;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 8
 ;;                                     v16 = iconst.i64 24
 ;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @0034                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0034                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0034                               v14 = icmp ule v13, v8
 ;; @0034                               trapz v14, user1
-;; @0034                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0034                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0034                               v15 = iadd v6, v11
 ;; @0034                               store notrap aligned little v3, v15
 ;; @0038                               jump block1
@@ -59,10 +59,10 @@
 ;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 12
 ;;                                     v16 = iconst.i64 24
 ;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @003f                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @003f                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003f                               v14 = icmp ule v13, v8
 ;; @003f                               trapz v14, user1
-;; @003f                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @003f                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @003f                               v15 = iadd v6, v11
 ;; @003f                               istore8 notrap aligned little v3, v15
 ;; @0043                               jump block1
@@ -85,10 +85,10 @@
 ;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v16 = iconst.i64 24
 ;; @004a                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 24
-;; @004a                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @004a                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004a                               v14 = icmp ule v13, v8
 ;; @004a                               trapz v14, user1
-;; @004a                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @004a                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @004a                               v15 = iadd v6, v11
 ;; @004a                               store notrap aligned little v3, v15
 ;; @004e                               jump block1

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -25,10 +25,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v31 = iconst.i64 48
 ;; @0022                               v13 = uadd_overflow_trap v9, v31, user1  ; v31 = 48
-;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i8x16 notrap aligned little v15
 ;; @002e                               jump block1

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -25,10 +25,10 @@
 ;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
 ;;                                     v31 = iconst.i64 48
 ;; @0022                               v13 = uadd_overflow_trap v9, v31, user1  ; v31 = 48
-;; @0022                               v8 = load.i64 notrap aligned readonly v0+48
+;; @0022                               v8 = load.i64 notrap aligned readonly pure v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1
-;; @0022                               v6 = load.i64 notrap aligned readonly v0+40
+;; @0022                               v6 = load.i64 notrap aligned readonly pure v0+40
 ;; @0022                               v15 = iadd v6, v11
 ;; @0022                               v16 = load.i8x16 notrap aligned little v15
 ;; @002e                               jump block1

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -29,7 +29,7 @@
 ;; @0023                               v11 = iconst.i32 16
 ;; @0023                               v12 = call fn0(v0, v9, v4, v7, v11)  ; v9 = -1342177280, v4 = 0, v7 = 48, v11 = 16
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v15 = load.i64 notrap aligned readonly pure v0+40
+;; @0023                               v15 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0023                               v13 = ireduce.i32 v12
 ;; @0023                               v16 = uextend.i64 v13
 ;; @0023                               v17 = iadd v15, v16
@@ -47,7 +47,7 @@
 ;; @0023                               v30 = iconst.i64 8
 ;; @0023                               v31 = uadd_overflow_trap v76, v30, user1  ; v76 = 0, v30 = 8
 ;; @0023                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
-;; @0023                               v28 = load.i64 notrap aligned readonly pure v0+48
+;; @0023                               v28 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0023                               v34 = icmp ule v33, v28
 ;; @0023                               trapz v34, user1
 ;; @0023                               v35 = iadd.i64 v15, v31

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -29,7 +29,7 @@
 ;; @0023                               v11 = iconst.i32 16
 ;; @0023                               v12 = call fn0(v0, v9, v4, v7, v11)  ; v9 = -1342177280, v4 = 0, v7 = 48, v11 = 16
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v15 = load.i64 notrap aligned readonly v0+40
+;; @0023                               v15 = load.i64 notrap aligned readonly pure v0+40
 ;; @0023                               v13 = ireduce.i32 v12
 ;; @0023                               v16 = uextend.i64 v13
 ;; @0023                               v17 = iadd v15, v16
@@ -47,7 +47,7 @@
 ;; @0023                               v30 = iconst.i64 8
 ;; @0023                               v31 = uadd_overflow_trap v76, v30, user1  ; v76 = 0, v30 = 8
 ;; @0023                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
-;; @0023                               v28 = load.i64 notrap aligned readonly v0+48
+;; @0023                               v28 = load.i64 notrap aligned readonly pure v0+48
 ;; @0023                               v34 = icmp ule v33, v28
 ;; @0023                               trapz v34, user1
 ;; @0023                               v35 = iadd.i64 v15, v31

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -29,7 +29,7 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly pure v0+40
+;; @002a                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v12 = ireduce.i32 v11
 ;; @002a                               v15 = uextend.i64 v12
 ;; @002a                               v16 = iadd v14, v15
@@ -52,7 +52,7 @@
 ;; @002a                               v29 = iconst.i64 8
 ;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
 ;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly pure v0+48
+;; @002a                               v27 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002a                               v33 = icmp ule v32, v27
 ;; @002a                               trapz v33, user1
 ;; @002a                               v34 = iadd.i64 v14, v30

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -29,7 +29,7 @@
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly v0+40
+;; @002a                               v14 = load.i64 notrap aligned readonly pure v0+40
 ;; @002a                               v12 = ireduce.i32 v11
 ;; @002a                               v15 = uextend.i64 v12
 ;; @002a                               v16 = iadd v14, v15
@@ -52,7 +52,7 @@
 ;; @002a                               v29 = iconst.i64 8
 ;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
 ;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly v0+48
+;; @002a                               v27 = load.i64 notrap aligned readonly pure v0+48
 ;; @002a                               v33 = icmp ule v32, v27
 ;; @002a                               trapz v33, user1
 ;; @002a                               v34 = iadd.i64 v14, v30

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -15,7 +15,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -23,7 +23,7 @@
 ;; @0029                               v3 = iconst.i32 0
 ;; @002b                               v5 = load.i32 notrap aligned table v0+112
 ;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002d                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002d                               v8 = iadd v7, v6
 ;; @002d                               store little heap v5, v8
 ;; @0030                               jump block1

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -15,7 +15,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -23,7 +23,7 @@
 ;; @0029                               v3 = iconst.i32 0
 ;; @002b                               v5 = load.i32 notrap aligned table v0+112
 ;; @002d                               v6 = uextend.i64 v3  ; v3 = 0
-;; @002d                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @002d                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002d                               v8 = iadd v7, v6
 ;; @002d                               store little heap v5, v8
 ;; @0030                               jump block1

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i32 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i32 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i32 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i32 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i32 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i32 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i32 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i32 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i32 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i32 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i64 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @002e                               v4 = uextend.i64 v2
-;; @002e                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @002e                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002e                               v6 = iadd v5, v4
 ;; @002e                               v7 = load.i64 little heap v6
 ;; @0031                               jump block1

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i64 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = sload16.i64 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i64 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               v7 = uload16.i64 little heap v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i64 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = sload8.i64 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i64 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -14,12 +14,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               v7 = uload8.i64 little heap v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0031                               v4 = uextend.i64 v2
-;; @0031                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0031                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0031                               v6 = iadd v5, v4
 ;; @0031                               store little heap v3, v6
 ;; @0034                               jump block1

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore16 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore32 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0033                               v4 = uextend.i64 v2
-;; @0033                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0033                               v6 = iadd v5, v4
 ;; @0033                               istore32 little heap v3, v6
 ;; @0036                               jump block1

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -15,12 +15,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0032                               v4 = uextend.i64 v2
-;; @0032                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0032                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0032                               v6 = iadd v5, v4
 ;; @0032                               istore8 little heap v3, v6
 ;; @0035                               jump block1

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -27,7 +27,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -37,7 +37,7 @@
 ;; @002b                               v4 = iconst.i32 2
 ;; @002b                               v5 = icmp uge v2, v4  ; v4 = 2
 ;; @002b                               v10 = iconst.i64 0
-;; @002b                               v7 = load.i64 notrap aligned readonly v0+80
+;; @002b                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;; @002b                               v6 = uextend.i64 v2
 ;;                                     v29 = iconst.i64 3
 ;; @002b                               v8 = ishl v6, v29  ; v29 = 3
@@ -45,8 +45,8 @@
 ;; @002b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;;                                     v30 = iconst.i64 -2
 ;; @002b                               v15 = iconst.i32 0
-;; @002b                               v20 = load.i64 notrap aligned readonly v0+64
-;; @002b                               v21 = load.i32 notrap aligned readonly v20
+;; @002b                               v20 = load.i64 notrap aligned readonly pure v0+64
+;; @002b                               v21 = load.i32 notrap aligned readonly pure v20
 ;; @0027                               jump block2
 ;;
 ;;                                 block2:
@@ -75,21 +75,21 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0038                               v6 = load.i64 notrap aligned readonly v0+80
+;; @0038                               v6 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v37 = iconst.i64 8
 ;; @0038                               v8 = iadd v6, v37  ; v37 = 8
 ;;                                     v28 = iconst.i64 -2
 ;; @0038                               v14 = iconst.i32 0
 ;;                                     v36 = iconst.i64 1
-;; @0038                               v19 = load.i64 notrap aligned readonly v0+64
-;; @0038                               v20 = load.i32 notrap aligned readonly v19
+;; @0038                               v19 = load.i64 notrap aligned readonly pure v0+64
+;; @0038                               v20 = load.i32 notrap aligned readonly pure v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -27,7 +27,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -37,7 +37,7 @@
 ;; @002b                               v4 = iconst.i32 2
 ;; @002b                               v5 = icmp uge v2, v4  ; v4 = 2
 ;; @002b                               v10 = iconst.i64 0
-;; @002b                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @002b                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;; @002b                               v6 = uextend.i64 v2
 ;;                                     v29 = iconst.i64 3
 ;; @002b                               v8 = ishl v6, v29  ; v29 = 3
@@ -45,8 +45,8 @@
 ;; @002b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;;                                     v30 = iconst.i64 -2
 ;; @002b                               v15 = iconst.i32 0
-;; @002b                               v20 = load.i64 notrap aligned readonly pure v0+64
-;; @002b                               v21 = load.i32 notrap aligned readonly pure v20
+;; @002b                               v20 = load.i64 notrap aligned readonly can_move v0+64
+;; @002b                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0027                               jump block2
 ;;
 ;;                                 block2:
@@ -75,21 +75,21 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0038                               v6 = load.i64 notrap aligned readonly pure v0+80
+;; @0038                               v6 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v37 = iconst.i64 8
 ;; @0038                               v8 = iadd v6, v37  ; v37 = 8
 ;;                                     v28 = iconst.i64 -2
 ;; @0038                               v14 = iconst.i32 0
 ;;                                     v36 = iconst.i64 1
-;; @0038                               v19 = load.i64 notrap aligned readonly pure v0+64
-;; @0038                               v20 = load.i32 notrap aligned readonly pure v19
+;; @0038                               v19 = load.i64 notrap aligned readonly can_move v0+64
+;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -23,7 +23,7 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+80
+;; @0033                               v8 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v29 = iconst.i64 3
 ;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
@@ -41,8 +41,8 @@
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly pure v0+64
-;; @0033                               v22 = load.i32 notrap aligned readonly pure v21
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+64
+;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
 ;; @0033                               trapz v24, user7

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -23,7 +23,7 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly v0+80
+;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v29 = iconst.i64 3
 ;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
@@ -41,8 +41,8 @@
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly v0+64
-;; @0033                               v22 = load.i32 notrap aligned readonly v21
+;; @0033                               v21 = load.i64 notrap aligned readonly pure v0+64
+;; @0033                               v22 = load.i32 notrap aligned readonly pure v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
 ;; @0033                               trapz v24, user7

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -23,7 +23,7 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+80
+;; @0033                               v8 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v29 = iconst.i64 3
 ;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
@@ -41,8 +41,8 @@
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly pure v0+64
-;; @0033                               v22 = load.i32 notrap aligned readonly pure v21
+;; @0033                               v21 = load.i64 notrap aligned readonly can_move v0+64
+;; @0033                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
 ;; @0033                               trapz v24, user7

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -13,7 +13,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -23,7 +23,7 @@
 ;; @0033                               v5 = iconst.i32 23
 ;; @0033                               v6 = icmp uge v2, v5  ; v5 = 23
 ;; @0033                               v7 = uextend.i64 v2
-;; @0033                               v8 = load.i64 notrap aligned readonly v0+80
+;; @0033                               v8 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v29 = iconst.i64 3
 ;; @0033                               v9 = ishl v7, v29  ; v29 = 3
 ;; @0033                               v10 = iadd v8, v9
@@ -41,8 +41,8 @@
 ;; @0033                               jump block3(v19)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               v21 = load.i64 notrap aligned readonly v0+64
-;; @0033                               v22 = load.i32 notrap aligned readonly v21
+;; @0033                               v21 = load.i64 notrap aligned readonly pure v0+64
+;; @0033                               v22 = load.i32 notrap aligned readonly pure v21
 ;; @0033                               v23 = load.i32 user6 aligned readonly v15+16
 ;; @0033                               v24 = icmp eq v23, v22
 ;; @0033                               trapz v24, user7

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -25,7 +25,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0058                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0058                               v9 = iadd v8, v7
 ;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -25,7 +25,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
-;; @0058                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0058                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0058                               v9 = iadd v8, v7
 ;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -48,7 +48,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -60,7 +60,7 @@
 ;;
 ;;                                 block4:
 ;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
-;; @004b                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004b                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004b                               v9 = iadd v8, v7
 ;; @004b                               v10 = sload16.i64 little heap v9
 ;; @004e                               trap user11

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -48,7 +48,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -60,7 +60,7 @@
 ;;
 ;;                                 block4:
 ;; @004b                               v7 = uextend.i64 v3  ; v3 = 35
-;; @004b                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @004b                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004b                               v9 = iadd v8, v7
 ;; @004b                               v10 = sload16.i64 little heap v9
 ;; @004e                               trap user11

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -67,7 +67,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -77,7 +77,7 @@
 ;; @0050                               v4 = iconst.i32 10
 ;; @0050                               v5 = icmp uge v2, v4  ; v4 = 10
 ;; @0050                               v6 = uextend.i64 v2
-;; @0050                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @0050                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v28 = iconst.i64 3
 ;; @0050                               v8 = ishl v6, v28  ; v28 = 3
 ;; @0050                               v9 = iadd v7, v8
@@ -95,8 +95,8 @@
 ;; @0050                               jump block3(v18)
 ;;
 ;;                                 block3(v14: i64):
-;; @0050                               v20 = load.i64 notrap aligned readonly pure v0+64
-;; @0050                               v21 = load.i32 notrap aligned readonly pure v20
+;; @0050                               v20 = load.i64 notrap aligned readonly can_move v0+64
+;; @0050                               v21 = load.i32 notrap aligned readonly can_move v20
 ;; @0050                               v22 = load.i32 user6 aligned readonly v14+16
 ;; @0050                               v23 = icmp eq v22, v21
 ;; @0050                               trapz v23, user7

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -67,7 +67,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -77,7 +77,7 @@
 ;; @0050                               v4 = iconst.i32 10
 ;; @0050                               v5 = icmp uge v2, v4  ; v4 = 10
 ;; @0050                               v6 = uextend.i64 v2
-;; @0050                               v7 = load.i64 notrap aligned readonly v0+80
+;; @0050                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v28 = iconst.i64 3
 ;; @0050                               v8 = ishl v6, v28  ; v28 = 3
 ;; @0050                               v9 = iadd v7, v8
@@ -95,8 +95,8 @@
 ;; @0050                               jump block3(v18)
 ;;
 ;;                                 block3(v14: i64):
-;; @0050                               v20 = load.i64 notrap aligned readonly v0+64
-;; @0050                               v21 = load.i32 notrap aligned readonly v20
+;; @0050                               v20 = load.i64 notrap aligned readonly pure v0+64
+;; @0050                               v21 = load.i32 notrap aligned readonly pure v20
 ;; @0050                               v22 = load.i32 user6 aligned readonly v14+16
 ;; @0050                               v23 = icmp eq v22, v21
 ;; @0050                               trapz v23, user7

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +59,7 @@
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
 ;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = load.i32 little heap v10
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               store little heap v3, v10
 ;; @0043                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +59,7 @@
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
 ;; @0048                               trapnz v8, heap_oob
-;; @0048                               v9 = load.i64 notrap aligned checked v0+88
+;; @0048                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = load.i32 little heap v10
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
 ;; @0049                               trapnz v8, heap_oob
-;; @0049                               v9 = load.i64 notrap aligned checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
 ;; @0040                               trapnz v8, heap_oob
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
 ;; @004c                               trapnz v8, heap_oob
-;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +59,7 @@
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               v9 = load.i64 notrap aligned checked v0+88
+;; @0048                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0
 ;; @0040                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -59,7 +59,7 @@
 ;; @0048                               v6 = iconst.i64 4
 ;; @0048                               v7 = isub v5, v6  ; v6 = 4
 ;; @0048                               v8 = icmp ugt v4, v7
-;; @0048                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v10 = iadd v9, v4
 ;; @0048                               v11 = iconst.i64 0
 ;; @0048                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4100
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v6 = iconst.i64 4100
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4100
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0004
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = iconst.i64 4097
 ;; @0040                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0040                               v8 = icmp ugt v4, v7
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 4096
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 4096
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @0049                               v6 = iconst.i64 4097
 ;; @0049                               v7 = isub v5, v6  ; v6 = 4097
 ;; @0049                               v8 = icmp ugt v4, v7
-;; @0049                               v9 = load.i64 notrap aligned checked v0+88
+;; @0049                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v10 = iadd v9, v4
 ;; @0049                               v11 = iconst.i64 4096
 ;; @0049                               v12 = iadd v10, v11  ; v11 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
 ;; @0040                               v7 = load.i64 notrap aligned v0+96
 ;; @0040                               v8 = icmp ugt v6, v7
-;; @0040                               v9 = load.i64 notrap aligned checked v0+88
+;; @0040                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v10 = iadd v9, v4
 ;; @0040                               v11 = iconst.i64 0xffff_0000
 ;; @0040                               v12 = iadd v10, v11  ; v11 = 0xffff_0000
@@ -52,7 +52,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -61,7 +61,7 @@
 ;; @004c                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 0xffff_0001
 ;; @004c                               v7 = load.i64 notrap aligned v0+96
 ;; @004c                               v8 = icmp ugt v6, v7
-;; @004c                               v9 = load.i64 notrap aligned checked v0+88
+;; @004c                               v9 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v10 = iadd v9, v4
 ;; @004c                               v11 = iconst.i64 0xffff_0000
 ;; @004c                               v12 = iadd v10, v11  ; v11 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp ugt v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp ugt v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               istore8 little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = uload8.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp ugt v4, v5
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp uge v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = load.i64 notrap aligned v0+96
 ;; @0048                               v6 = icmp uge v4, v5
-;; @0048                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp ugt v4, v5
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = load.i64 notrap aligned v0+96
 ;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = load.i64 notrap aligned v0+96
 ;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
@@ -48,7 +48,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +57,7 @@
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
 ;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = load.i32 little heap v9
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               store little heap v3, v9
 ;; @0043                               jump block1
@@ -48,7 +48,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +57,7 @@
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
 ;; @0048                               trapnz v7, heap_oob
-;; @0048                               v8 = load.i64 notrap aligned checked v0+88
+;; @0048                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = load.i32 little heap v9
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
 ;; @0049                               trapnz v7, heap_oob
-;; @0049                               v8 = load.i64 notrap aligned checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -33,7 +33,7 @@
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
 ;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -50,7 +50,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
 ;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +57,7 @@
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = load.i64 notrap aligned checked v0+88
+;; @0048                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0
 ;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -57,7 +57,7 @@
 ;; @0048                               v5 = iconst.i64 4
 ;; @0048                               v6 = isub v4, v5  ; v5 = 4
 ;; @0048                               v7 = icmp ugt v2, v6
-;; @0048                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v9 = iadd v8, v2
 ;; @0048                               v10 = iconst.i64 0
 ;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4100
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v5 = iconst.i64 4100
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4100
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0004
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 4097
 ;; @0040                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0040                               v7 = icmp ugt v2, v6
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 4096
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @0049                               v5 = iconst.i64 4097
 ;; @0049                               v6 = isub v4, v5  ; v5 = 4097
 ;; @0049                               v7 = icmp ugt v2, v6
-;; @0049                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v9 = iadd v8, v2
 ;; @0049                               v10 = iconst.i64 4096
 ;; @0049                               v11 = iadd v9, v10  ; v10 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
 ;; @0040                               v6 = load.i64 notrap aligned v0+96
 ;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v9 = iadd v8, v2
 ;; @0040                               v10 = iconst.i64 0xffff_0000
 ;; @0040                               v11 = iadd v9, v10  ; v10 = 0xffff_0000
@@ -51,7 +51,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
@@ -59,7 +59,7 @@
 ;; @004c                               v5 = uadd_overflow_trap v2, v4, heap_oob  ; v4 = 0xffff_0001
 ;; @004c                               v6 = load.i64 notrap aligned v0+96
 ;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               v8 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v8 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v9 = iadd v8, v2
 ;; @004c                               v10 = iconst.i64 0xffff_0000
 ;; @004c                               v11 = iadd v9, v10  ; v10 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp ugt v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp ugt v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp ugt v2, v4
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp uge v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = load.i64 notrap aligned v0+96
 ;; @0048                               v5 = icmp uge v2, v4
-;; @0048                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = load.i64 notrap aligned v0+96
 ;; @0049                               v5 = icmp ugt v2, v4
-;; @0049                               v6 = load.i64 notrap aligned checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = load.i64 notrap aligned v0+96
 ;; @0040                               v5 = icmp ugt v2, v4
-;; @0040                               v6 = load.i64 notrap aligned checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = load.i64 notrap aligned v0+96
 ;; @004c                               v5 = icmp ugt v2, v4
-;; @004c                               v6 = load.i64 notrap aligned checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               store little heap v3, v8
 ;; @0043                               jump block1
@@ -47,7 +47,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -55,7 +55,7 @@
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
 ;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = load.i32 little heap v8
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,7 +24,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -32,7 +32,7 @@
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
 ;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_fffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0
 ;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
 ;; @0048                               v5 = iconst.i64 0xffff_fffc
 ;; @0048                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_fffc
-;; @0048                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v8 = iadd v7, v4
 ;; @0048                               v9 = iconst.i64 0
 ;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_effc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_effc
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_effc
-;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xfffc
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xfffc
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xfffc
-;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff_efff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 4096
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
 ;; @0049                               v5 = iconst.i64 0xffff_efff
 ;; @0049                               v6 = icmp ugt v4, v5  ; v5 = 0xffff_efff
-;; @0049                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = iconst.i64 4096
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @0040                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
 ;; @0040                               v5 = iconst.i64 0xffff
 ;; @0040                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @0040                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v8 = iadd v7, v4
 ;; @0040                               v9 = iconst.i64 0xffff_0000
 ;; @0040                               v10 = iadd v8, v9  ; v9 = 0xffff_0000
@@ -50,14 +50,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
 ;; @004c                               v5 = iconst.i64 0xffff
 ;; @004c                               v6 = icmp ugt v4, v5  ; v5 = 0xffff
-;; @004c                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v8 = iadd v7, v4
 ;; @004c                               v9 = iconst.i64 0xffff_0000
 ;; @004c                               v10 = iadd v8, v9  ; v9 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               store little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = load.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               istore8 little heap v3, v6
 ;; @0043                               jump block1
@@ -44,12 +44,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0048                               v4 = uextend.i64 v2
-;; @0048                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v6 = iadd v5, v4
 ;; @0048                               v7 = uload8.i32 little heap v6
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 4096
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0049                               v4 = uextend.i64 v2
-;; @0049                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v6 = iadd v5, v4
 ;; @0049                               v7 = iconst.i64 4096
 ;; @0049                               v8 = iadd v6, v7  ; v7 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,12 +24,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0040                               v4 = uextend.i64 v2
-;; @0040                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v6 = iadd v5, v4
 ;; @0040                               v7 = iconst.i64 0xffff_0000
 ;; @0040                               v8 = iadd v6, v7  ; v7 = 0xffff_0000
@@ -46,12 +46,12 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004c                               v4 = uextend.i64 v2
-;; @004c                               v5 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v5 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v6 = iadd v5, v4
 ;; @004c                               v7 = iconst.i64 0xffff_0000
 ;; @004c                               v8 = iadd v6, v7  ; v7 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               store little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = load.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               istore8 little heap v3, v7
 ;; @0043                               jump block1
@@ -46,14 +46,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
 ;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = uload8.i32 little heap v7
 ;; @004b                               jump block1

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
 ;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,14 +24,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -48,14 +48,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
 ;; @004c                               trapnz v5, heap_oob
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_fffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_fffc
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_effc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_effc
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_effc
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xfffc
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xfffc
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xfffc
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_ffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0
 ;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
@@ -47,13 +47,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0048                               v4 = iconst.i64 0xffff_ffff
 ;; @0048                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_ffff
-;; @0048                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0048                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0048                               v7 = iadd v6, v2
 ;; @0048                               v8 = iconst.i64 0
 ;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff_efff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 4096
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0049                               v4 = iconst.i64 0xffff_efff
 ;; @0049                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_efff
-;; @0049                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0049                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0049                               v7 = iadd v6, v2
 ;; @0049                               v8 = iconst.i64 4096
 ;; @0049                               v9 = iadd v7, v8  ; v8 = 4096

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -24,13 +24,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0040                               v4 = iconst.i64 0xffff
 ;; @0040                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @0040                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v7 = iadd v6, v2
 ;; @0040                               v8 = iconst.i64 0xffff_0000
 ;; @0040                               v9 = iadd v7, v8  ; v8 = 0xffff_0000
@@ -49,13 +49,13 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @004c                               v4 = iconst.i64 0xffff
 ;; @004c                               v5 = icmp ugt v2, v4  ; v4 = 0xffff
-;; @004c                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @004c                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004c                               v7 = iadd v6, v2
 ;; @004c                               v8 = iconst.i64 0xffff_0000
 ;; @004c                               v9 = iadd v7, v8  ; v8 = 0xffff_0000

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -18,7 +18,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -26,12 +26,12 @@
 ;; @0021                               v3 = iconst.i32 0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0025                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0025                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0025                               v7 = iadd v6, v5
 ;; @0025                               store little heap v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
-;; @002a                               v10 = load.i64 notrap aligned readonly pure checked v0+88
+;; @002a                               v10 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @002a                               v11 = iadd v10, v9
 ;; @002a                               v12 = load.i32 little heap v11
 ;; @002d                               brif v12, block2, block4
@@ -40,7 +40,7 @@
 ;; @002f                               v13 = iconst.i32 0
 ;; @0031                               v14 = iconst.i32 10
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
-;; @0033                               v16 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0033                               v16 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0033                               v17 = iadd v16, v15
 ;; @0033                               store little heap v14, v17  ; v14 = 10
 ;; @0036                               jump block3
@@ -49,7 +49,7 @@
 ;; @0037                               v18 = iconst.i32 0
 ;; @0039                               v19 = iconst.i32 11
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
-;; @003b                               v21 = load.i64 notrap aligned readonly pure checked v0+88
+;; @003b                               v21 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @003b                               v22 = iadd v21, v20
 ;; @003b                               store little heap v19, v22  ; v19 = 11
 ;; @003e                               jump block3

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -18,7 +18,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -26,12 +26,12 @@
 ;; @0021                               v3 = iconst.i32 0
 ;; @0023                               v4 = iconst.i32 0
 ;; @0025                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0025                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0025                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0025                               v7 = iadd v6, v5
 ;; @0025                               store little heap v4, v7  ; v4 = 0
 ;; @0028                               v8 = iconst.i32 0
 ;; @002a                               v9 = uextend.i64 v8  ; v8 = 0
-;; @002a                               v10 = load.i64 notrap aligned readonly checked v0+88
+;; @002a                               v10 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @002a                               v11 = iadd v10, v9
 ;; @002a                               v12 = load.i32 little heap v11
 ;; @002d                               brif v12, block2, block4
@@ -40,7 +40,7 @@
 ;; @002f                               v13 = iconst.i32 0
 ;; @0031                               v14 = iconst.i32 10
 ;; @0033                               v15 = uextend.i64 v13  ; v13 = 0
-;; @0033                               v16 = load.i64 notrap aligned readonly checked v0+88
+;; @0033                               v16 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0033                               v17 = iadd v16, v15
 ;; @0033                               store little heap v14, v17  ; v14 = 10
 ;; @0036                               jump block3
@@ -49,7 +49,7 @@
 ;; @0037                               v18 = iconst.i32 0
 ;; @0039                               v19 = iconst.i32 11
 ;; @003b                               v20 = uextend.i64 v18  ; v18 = 0
-;; @003b                               v21 = load.i64 notrap aligned readonly checked v0+88
+;; @003b                               v21 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @003b                               v22 = iadd v21, v20
 ;; @003b                               store little heap v19, v22  ; v19 = 11
 ;; @003e                               jump block3

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -26,7 +26,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0041                               v5 = load.i64 notrap aligned v0+96
 ;; @0041                               v6 = icmp uge v4, v5
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned checked v0+88
+;; @0041                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned checked gv3+88
+;;     gv5 = load.i64 notrap aligned pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp uge v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
 ;; @004c                               jump block1

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -26,7 +26,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -34,7 +34,7 @@
 ;; @0041                               v5 = load.i64 notrap aligned v0+96
 ;; @0041                               v6 = icmp uge v4, v5
 ;; @0041                               trapnz v6, heap_oob
-;; @0041                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0041                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0041                               v8 = iadd v7, v4
 ;; @0041                               istore8 little heap v3, v8
 ;; @0044                               jump block1
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -57,7 +57,7 @@
 ;; @0049                               v5 = load.i64 notrap aligned v0+96
 ;; @0049                               v6 = icmp uge v4, v5
 ;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = load.i64 notrap aligned pure checked v0+88
+;; @0049                               v7 = load.i64 notrap aligned can_move checked v0+88
 ;; @0049                               v8 = iadd v7, v4
 ;; @0049                               v9 = uload8.i32 little heap v8
 ;; @004c                               jump block1

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -19,7 +19,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     sig0 = (i64 vmctx, i32, i32, i64, i32, i32) -> i8 tail
 ;;     fn0 = colocated u1:6 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -19,7 +19,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     sig0 = (i64 vmctx, i32, i32, i64, i32, i32) -> i8 tail
 ;;     fn0 = colocated u1:6 sig0
 ;;     stack_limit = gv2

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -22,19 +22,19 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0036                               v3 = iconst.i32 48
 ;; @0038                               v4 = iconst.i32 0
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
-;; @003a                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @003a                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @003a                               v7 = iadd v6, v5
 ;; @003a                               v8 = load.i8x16 little heap v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
-;; @0040                               v11 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0040                               v11 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0040                               v12 = iadd v11, v10
 ;; @0040                               v13 = load.i8x16 little heap v12
 ;; @0046                               brif v2, block2, block4
@@ -45,7 +45,7 @@
 ;; @0048                               v18 = iadd v16, v17
 ;; @004b                               v19 = iconst.i32 32
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = load.i64 notrap aligned readonly pure checked v0+88
+;; @004d                               v21 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @004d                               v22 = iadd v21, v20
 ;; @004d                               v23 = load.i8x16 little heap v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
@@ -57,7 +57,7 @@
 ;; @0052                               v29 = isub v27, v28
 ;; @0055                               v30 = iconst.i32 0
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0057                               v32 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0057                               v33 = iadd v32, v31
 ;; @0057                               v34 = load.i8x16 little heap v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
@@ -68,7 +68,7 @@
 ;; @005c                               v37 = bitcast.i16x8 little v15
 ;; @005c                               v38 = imul v36, v37
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = load.i64 notrap aligned readonly pure checked v0+88
+;; @005f                               v40 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @005f                               v41 = iadd v40, v39
 ;; @005f                               store little heap v38, v41
 ;; @0063                               jump block1

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -22,19 +22,19 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0036                               v3 = iconst.i32 48
 ;; @0038                               v4 = iconst.i32 0
 ;; @003a                               v5 = uextend.i64 v4  ; v4 = 0
-;; @003a                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @003a                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @003a                               v7 = iadd v6, v5
 ;; @003a                               v8 = load.i8x16 little heap v7
 ;; @003e                               v9 = iconst.i32 16
 ;; @0040                               v10 = uextend.i64 v9  ; v9 = 16
-;; @0040                               v11 = load.i64 notrap aligned readonly checked v0+88
+;; @0040                               v11 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0040                               v12 = iadd v11, v10
 ;; @0040                               v13 = load.i8x16 little heap v12
 ;; @0046                               brif v2, block2, block4
@@ -45,7 +45,7 @@
 ;; @0048                               v18 = iadd v16, v17
 ;; @004b                               v19 = iconst.i32 32
 ;; @004d                               v20 = uextend.i64 v19  ; v19 = 32
-;; @004d                               v21 = load.i64 notrap aligned readonly checked v0+88
+;; @004d                               v21 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @004d                               v22 = iadd v21, v20
 ;; @004d                               v23 = load.i8x16 little heap v22
 ;; @0051                               v26 = bitcast.i8x16 little v18
@@ -57,7 +57,7 @@
 ;; @0052                               v29 = isub v27, v28
 ;; @0055                               v30 = iconst.i32 0
 ;; @0057                               v31 = uextend.i64 v30  ; v30 = 0
-;; @0057                               v32 = load.i64 notrap aligned readonly checked v0+88
+;; @0057                               v32 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0057                               v33 = iadd v32, v31
 ;; @0057                               v34 = load.i8x16 little heap v33
 ;; @005b                               v35 = bitcast.i8x16 little v29
@@ -68,7 +68,7 @@
 ;; @005c                               v37 = bitcast.i16x8 little v15
 ;; @005c                               v38 = imul v36, v37
 ;; @005f                               v39 = uextend.i64 v3  ; v3 = 48
-;; @005f                               v40 = load.i64 notrap aligned readonly checked v0+88
+;; @005f                               v40 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @005f                               v41 = iadd v40, v39
 ;; @005f                               store little heap v38, v41
 ;; @0063                               jump block1

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -7,11 +7,11 @@
 )
 ;; wasm[0]::function[0]:
 ;;       push_frame
-;;       xload64le_o32 x6, x0, 8
-;;       xload64le_o32 x7, x0, 32
-;;       xload64le_o32 x7, x7, 0
-;;       xload64le_o32 x6, x6, 8
-;;       br_if_xulteq64 x6, x7, 0x9    // target = 0x26
+;;       xload64le_o32 x6, x0, 32
+;;       xload64le_o32 x6, x6, 0
+;;       xload64le_o32 x7, x0, 8
+;;       xload64le_o32 x7, x7, 8
+;;       br_if_xulteq64 x7, x6, 0x9    // target = 0x26
 ;;   24: pop_frame
 ;;       ret
 ;;   26: call 0x9e    // target = 0xc4

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -36,7 +36,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -46,7 +46,7 @@
 ;; @0031                               v3 = iconst.i32 2
 ;; @0031                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @0031                               v9 = iconst.i64 0
-;; @0031                               v6 = load.i64 notrap aligned readonly v0+80
+;; @0031                               v6 = load.i64 notrap aligned readonly pure v0+80
 ;; @0031                               v5 = uextend.i64 v2
 ;;                                     v26 = iconst.i64 3
 ;; @0031                               v7 = ishl v5, v26  ; v26 = 3
@@ -64,8 +64,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @0031                               v21 = load.i32 user6 aligned readonly v13+16
-;; @0031                               v19 = load.i64 notrap aligned readonly v0+64
-;; @0031                               v20 = load.i32 notrap aligned readonly v19
+;; @0031                               v19 = load.i64 notrap aligned readonly pure v0+64
+;; @0031                               v20 = load.i32 notrap aligned readonly pure v19
 ;; @0031                               v22 = icmp eq v21, v20
 ;; @0031                               trapz v22, user7
 ;; @0031                               v23 = load.i64 notrap aligned readonly v13+8

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -36,7 +36,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
@@ -46,7 +46,7 @@
 ;; @0031                               v3 = iconst.i32 2
 ;; @0031                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @0031                               v9 = iconst.i64 0
-;; @0031                               v6 = load.i64 notrap aligned readonly pure v0+80
+;; @0031                               v6 = load.i64 notrap aligned readonly can_move v0+80
 ;; @0031                               v5 = uextend.i64 v2
 ;;                                     v26 = iconst.i64 3
 ;; @0031                               v7 = ishl v5, v26  ; v26 = 3
@@ -64,8 +64,8 @@
 ;;
 ;;                                 block3(v13: i64):
 ;; @0031                               v21 = load.i32 user6 aligned readonly v13+16
-;; @0031                               v19 = load.i64 notrap aligned readonly pure v0+64
-;; @0031                               v20 = load.i32 notrap aligned readonly pure v19
+;; @0031                               v19 = load.i64 notrap aligned readonly can_move v0+64
+;; @0031                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0031                               v22 = icmp eq v21, v20
 ;; @0031                               trapz v22, user7
 ;; @0031                               v23 = load.i64 notrap aligned readonly v13+8

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -13,7 +13,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -21,7 +21,7 @@
 ;; @0020                               v5 = iconst.i64 0x0001_fffc
 ;; @0020                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0020                               v9 = iconst.i64 0
-;; @0020                               v7 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0020                               v7 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0020                               v8 = iadd v7, v4
 ;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0020                               v11 = load.i32 little heap v10

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -13,7 +13,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -21,7 +21,7 @@
 ;; @0020                               v5 = iconst.i64 0x0001_fffc
 ;; @0020                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0020                               v9 = iconst.i64 0
-;; @0020                               v7 = load.i64 notrap aligned readonly checked v0+88
+;; @0020                               v7 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0020                               v8 = iadd v7, v4
 ;; @0020                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0020                               v11 = load.i32 little heap v10

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -12,9 +12,9 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     gv5 = load.i64 notrap aligned gv4+8
-;;     gv6 = load.i64 notrap aligned readonly checked gv4
+;;     gv6 = load.i64 notrap aligned readonly pure checked gv4
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -22,8 +22,8 @@
 ;; @0022                               v5 = iconst.i64 0x0001_fffc
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0022                               v9 = iconst.i64 0
-;; @0022                               v12 = load.i64 notrap aligned readonly v0+80
-;; @0022                               v7 = load.i64 notrap aligned readonly checked v12
+;; @0022                               v12 = load.i64 notrap aligned readonly pure v0+80
+;; @0022                               v7 = load.i64 notrap aligned readonly pure checked v12
 ;; @0022                               v8 = iadd v7, v4
 ;; @0022                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0022                               v11 = load.i32 little heap v10

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -12,9 +12,9 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     gv5 = load.i64 notrap aligned gv4+8
-;;     gv6 = load.i64 notrap aligned readonly pure checked gv4
+;;     gv6 = load.i64 notrap aligned readonly can_move checked gv4
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -22,8 +22,8 @@
 ;; @0022                               v5 = iconst.i64 0x0001_fffc
 ;; @0022                               v6 = icmp ugt v4, v5  ; v5 = 0x0001_fffc
 ;; @0022                               v9 = iconst.i64 0
-;; @0022                               v12 = load.i64 notrap aligned readonly pure v0+80
-;; @0022                               v7 = load.i64 notrap aligned readonly pure checked v12
+;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0022                               v7 = load.i64 notrap aligned readonly can_move checked v12
 ;; @0022                               v8 = iadd v7, v4
 ;; @0022                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
 ;; @0022                               v11 = load.i32 little heap v10

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -13,14 +13,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = iconst.i64 0xffff_fffc
 ;; @0020                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0020                               v8 = iconst.i64 0
-;; @0020                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0020                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0020                               v7 = iadd v6, v2
 ;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0020                               v10 = load.i32 little heap v9

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -13,14 +13,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v4 = iconst.i64 0xffff_fffc
 ;; @0020                               v5 = icmp ugt v2, v4  ; v4 = 0xffff_fffc
 ;; @0020                               v8 = iconst.i64 0
-;; @0020                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0020                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0020                               v7 = iadd v6, v2
 ;; @0020                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
 ;; @0020                               v10 = load.i32 little heap v9

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -27,7 +27,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;;                                     v94 = iconst.i64 112
 ;; @008f                               v7 = iadd v0, v94  ; v94 = 112
-;; @008f                               v8 = load.i32 notrap aligned v7
+;; @008f                               v8 = load.i32 notrap aligned readonly pure v7
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v8, v95
 ;;                                     v96 = stack_addr.i64 ss0
@@ -44,8 +44,8 @@
 ;; @008f                               brif v14, block3, block4
 ;;
 ;;                                 block4:
-;; @008f                               v16 = load.i64 notrap aligned readonly v0+40
-;; @008f                               v18 = load.i64 notrap aligned readonly v0+48
+;; @008f                               v16 = load.i64 notrap aligned readonly pure v0+40
+;; @008f                               v18 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v98 = stack_addr.i64 ss0
 ;;                                     v92 = load.i32 notrap v98
 ;; @008f                               v19 = uextend.i64 v92
@@ -59,8 +59,8 @@
 ;; @008f                               v26 = load.i64 notrap aligned v25
 ;;                                     v99 = iconst.i64 1
 ;; @008f                               v27 = iadd v26, v99  ; v99 = 1
-;; @008f                               v29 = load.i64 notrap aligned readonly v0+40
-;; @008f                               v31 = load.i64 notrap aligned readonly v0+48
+;; @008f                               v29 = load.i64 notrap aligned readonly pure v0+40
+;; @008f                               v31 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v100 = stack_addr.i64 ss0
 ;;                                     v91 = load.i32 notrap v100
 ;; @008f                               v32 = uextend.i64 v91
@@ -89,7 +89,7 @@
 ;;                                 block5:
 ;;                                     v104 = iconst.i64 128
 ;; @0091                               v43 = iadd.i64 v0, v104  ; v104 = 128
-;; @0091                               v44 = load.i32 notrap aligned v43
+;; @0091                               v44 = load.i32 notrap aligned readonly pure v43
 ;;                                     v105 = stack_addr.i64 ss1
 ;;                                     store notrap v44, v105
 ;;                                     v106 = stack_addr.i64 ss1
@@ -106,8 +106,8 @@
 ;; @0091                               brif v50, block7, block8
 ;;
 ;;                                 block8:
-;; @0091                               v52 = load.i64 notrap aligned readonly v0+40
-;; @0091                               v54 = load.i64 notrap aligned readonly v0+48
+;; @0091                               v52 = load.i64 notrap aligned readonly pure v0+40
+;; @0091                               v54 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v108 = stack_addr.i64 ss1
 ;;                                     v87 = load.i32 notrap v108
 ;; @0091                               v55 = uextend.i64 v87
@@ -121,8 +121,8 @@
 ;; @0091                               v62 = load.i64 notrap aligned v61
 ;;                                     v109 = iconst.i64 1
 ;; @0091                               v63 = iadd v62, v109  ; v109 = 1
-;; @0091                               v65 = load.i64 notrap aligned readonly v0+40
-;; @0091                               v67 = load.i64 notrap aligned readonly v0+48
+;; @0091                               v65 = load.i64 notrap aligned readonly pure v0+40
+;; @0091                               v67 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v110 = stack_addr.i64 ss1
 ;;                                     v86 = load.i32 notrap v110
 ;; @0091                               v68 = uextend.i64 v86

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -27,7 +27,7 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;;                                     v94 = iconst.i64 112
 ;; @008f                               v7 = iadd v0, v94  ; v94 = 112
-;; @008f                               v8 = load.i32 notrap aligned readonly pure v7
+;; @008f                               v8 = load.i32 notrap aligned readonly can_move v7
 ;;                                     v95 = stack_addr.i64 ss0
 ;;                                     store notrap v8, v95
 ;;                                     v96 = stack_addr.i64 ss0
@@ -44,8 +44,8 @@
 ;; @008f                               brif v14, block3, block4
 ;;
 ;;                                 block4:
-;; @008f                               v16 = load.i64 notrap aligned readonly pure v0+40
-;; @008f                               v18 = load.i64 notrap aligned readonly pure v0+48
+;; @008f                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @008f                               v18 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v98 = stack_addr.i64 ss0
 ;;                                     v92 = load.i32 notrap v98
 ;; @008f                               v19 = uextend.i64 v92
@@ -59,8 +59,8 @@
 ;; @008f                               v26 = load.i64 notrap aligned v25
 ;;                                     v99 = iconst.i64 1
 ;; @008f                               v27 = iadd v26, v99  ; v99 = 1
-;; @008f                               v29 = load.i64 notrap aligned readonly pure v0+40
-;; @008f                               v31 = load.i64 notrap aligned readonly pure v0+48
+;; @008f                               v29 = load.i64 notrap aligned readonly can_move v0+40
+;; @008f                               v31 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v100 = stack_addr.i64 ss0
 ;;                                     v91 = load.i32 notrap v100
 ;; @008f                               v32 = uextend.i64 v91
@@ -89,7 +89,7 @@
 ;;                                 block5:
 ;;                                     v104 = iconst.i64 128
 ;; @0091                               v43 = iadd.i64 v0, v104  ; v104 = 128
-;; @0091                               v44 = load.i32 notrap aligned readonly pure v43
+;; @0091                               v44 = load.i32 notrap aligned readonly can_move v43
 ;;                                     v105 = stack_addr.i64 ss1
 ;;                                     store notrap v44, v105
 ;;                                     v106 = stack_addr.i64 ss1
@@ -106,8 +106,8 @@
 ;; @0091                               brif v50, block7, block8
 ;;
 ;;                                 block8:
-;; @0091                               v52 = load.i64 notrap aligned readonly pure v0+40
-;; @0091                               v54 = load.i64 notrap aligned readonly pure v0+48
+;; @0091                               v52 = load.i64 notrap aligned readonly can_move v0+40
+;; @0091                               v54 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v108 = stack_addr.i64 ss1
 ;;                                     v87 = load.i32 notrap v108
 ;; @0091                               v55 = uextend.i64 v87
@@ -121,8 +121,8 @@
 ;; @0091                               v62 = load.i64 notrap aligned v61
 ;;                                     v109 = iconst.i64 1
 ;; @0091                               v63 = iadd v62, v109  ; v109 = 1
-;; @0091                               v65 = load.i64 notrap aligned readonly pure v0+40
-;; @0091                               v67 = load.i64 notrap aligned readonly pure v0+48
+;; @0091                               v65 = load.i64 notrap aligned readonly can_move v0+40
+;; @0091                               v67 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v110 = stack_addr.i64 ss1
 ;;                                     v86 = load.i32 notrap v110
 ;; @0091                               v68 = uextend.i64 v86

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -90,14 +90,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @003f                               v3 = iconst.i32 0
 ;; @0045                               v4 = icmp eq v2, v2
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0047                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0047                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0047                               v7 = iadd v6, v5
 ;; @0047                               store little heap v4, v7
 ;; @004b                               jump block1
@@ -112,7 +112,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -121,7 +121,7 @@
 ;; @0054                               v5 = bitcast.i16x8 little v2
 ;; @0054                               v6 = icmp eq v4, v5
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0056                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0056                               v9 = iadd v8, v7
 ;; @0056                               store little heap v6, v9
 ;; @005a                               jump block1
@@ -136,7 +136,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -145,7 +145,7 @@
 ;; @0063                               v5 = bitcast.i32x4 little v2
 ;; @0063                               v6 = icmp eq v4, v5
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0065                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0065                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0065                               v9 = iadd v8, v7
 ;; @0065                               store little heap v6, v9
 ;; @0069                               jump block1
@@ -160,7 +160,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -169,7 +169,7 @@
 ;; @0072                               v5 = bitcast.i64x2 little v2
 ;; @0072                               v6 = icmp eq v4, v5
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0075                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0075                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0075                               v9 = iadd v8, v7
 ;; @0075                               store little heap v6, v9
 ;; @0079                               jump block1
@@ -184,14 +184,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @007c                               v3 = iconst.i32 0
 ;; @0082                               v4 = icmp ne v2, v2
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0084                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0084                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0084                               v7 = iadd v6, v5
 ;; @0084                               store little heap v4, v7
 ;; @0088                               jump block1
@@ -206,7 +206,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -215,7 +215,7 @@
 ;; @0091                               v5 = bitcast.i16x8 little v2
 ;; @0091                               v6 = icmp ne v4, v5
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0093                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0093                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0093                               v9 = iadd v8, v7
 ;; @0093                               store little heap v6, v9
 ;; @0097                               jump block1
@@ -230,7 +230,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -239,7 +239,7 @@
 ;; @00a0                               v5 = bitcast.i32x4 little v2
 ;; @00a0                               v6 = icmp ne v4, v5
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00a2                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @00a2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00a2                               v9 = iadd v8, v7
 ;; @00a2                               store little heap v6, v9
 ;; @00a6                               jump block1
@@ -254,7 +254,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -263,7 +263,7 @@
 ;; @00af                               v5 = bitcast.i64x2 little v2
 ;; @00af                               v6 = icmp ne v4, v5
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00b2                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @00b2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00b2                               v9 = iadd v8, v7
 ;; @00b2                               store little heap v6, v9
 ;; @00b6                               jump block1
@@ -278,14 +278,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00b9                               v3 = iconst.i32 0
 ;; @00bf                               v4 = icmp slt v2, v2
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00c1                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @00c1                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00c1                               v7 = iadd v6, v5
 ;; @00c1                               store little heap v4, v7
 ;; @00c5                               jump block1
@@ -300,7 +300,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -309,7 +309,7 @@
 ;; @00ce                               v5 = bitcast.i16x8 little v2
 ;; @00ce                               v6 = icmp slt v4, v5
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00d0                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @00d0                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00d0                               v9 = iadd v8, v7
 ;; @00d0                               store little heap v6, v9
 ;; @00d4                               jump block1
@@ -324,7 +324,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -333,7 +333,7 @@
 ;; @00dd                               v5 = bitcast.i32x4 little v2
 ;; @00dd                               v6 = icmp slt v4, v5
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00df                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @00df                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00df                               v9 = iadd v8, v7
 ;; @00df                               store little heap v6, v9
 ;; @00e3                               jump block1
@@ -348,7 +348,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -357,7 +357,7 @@
 ;; @00ec                               v5 = bitcast.i64x2 little v2
 ;; @00ec                               v6 = icmp slt v4, v5
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00ef                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @00ef                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00ef                               v9 = iadd v8, v7
 ;; @00ef                               store little heap v6, v9
 ;; @00f3                               jump block1
@@ -372,14 +372,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00f6                               v3 = iconst.i32 0
 ;; @00fc                               v4 = icmp ult v2, v2
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00fe                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @00fe                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @00fe                               v7 = iadd v6, v5
 ;; @00fe                               store little heap v4, v7
 ;; @0102                               jump block1
@@ -394,7 +394,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -403,7 +403,7 @@
 ;; @010b                               v5 = bitcast.i16x8 little v2
 ;; @010b                               v6 = icmp ult v4, v5
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @010d                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @010d                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @010d                               v9 = iadd v8, v7
 ;; @010d                               store little heap v6, v9
 ;; @0111                               jump block1
@@ -418,7 +418,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -427,7 +427,7 @@
 ;; @011a                               v5 = bitcast.i32x4 little v2
 ;; @011a                               v6 = icmp ult v4, v5
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @011c                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @011c                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @011c                               v9 = iadd v8, v7
 ;; @011c                               store little heap v6, v9
 ;; @0120                               jump block1
@@ -442,14 +442,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0123                               v3 = iconst.i32 0
 ;; @0129                               v4 = icmp sgt v2, v2
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
-;; @012b                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @012b                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @012b                               v7 = iadd v6, v5
 ;; @012b                               store little heap v4, v7
 ;; @012f                               jump block1
@@ -464,7 +464,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -473,7 +473,7 @@
 ;; @0138                               v5 = bitcast.i16x8 little v2
 ;; @0138                               v6 = icmp sgt v4, v5
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @013a                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @013a                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @013a                               v9 = iadd v8, v7
 ;; @013a                               store little heap v6, v9
 ;; @013e                               jump block1
@@ -488,7 +488,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -497,7 +497,7 @@
 ;; @0147                               v5 = bitcast.i32x4 little v2
 ;; @0147                               v6 = icmp sgt v4, v5
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0149                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0149                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0149                               v9 = iadd v8, v7
 ;; @0149                               store little heap v6, v9
 ;; @014d                               jump block1
@@ -512,7 +512,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -521,7 +521,7 @@
 ;; @0156                               v5 = bitcast.i64x2 little v2
 ;; @0156                               v6 = icmp sgt v4, v5
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0159                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0159                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0159                               v9 = iadd v8, v7
 ;; @0159                               store little heap v6, v9
 ;; @015d                               jump block1
@@ -536,14 +536,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0160                               v3 = iconst.i32 0
 ;; @0166                               v4 = icmp ugt v2, v2
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0168                               v6 = load.i64 notrap aligned readonly checked v0+88
+;; @0168                               v6 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0168                               v7 = iadd v6, v5
 ;; @0168                               store little heap v4, v7
 ;; @016c                               jump block1
@@ -558,7 +558,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -567,7 +567,7 @@
 ;; @0175                               v5 = bitcast.i16x8 little v2
 ;; @0175                               v6 = icmp ugt v4, v5
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0177                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0177                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0177                               v9 = iadd v8, v7
 ;; @0177                               store little heap v6, v9
 ;; @017b                               jump block1
@@ -582,7 +582,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -591,7 +591,7 @@
 ;; @0184                               v5 = bitcast.i32x4 little v2
 ;; @0184                               v6 = icmp ugt v4, v5
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0186                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0186                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0186                               v9 = iadd v8, v7
 ;; @0186                               store little heap v6, v9
 ;; @018a                               jump block1
@@ -606,7 +606,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -615,7 +615,7 @@
 ;; @0193                               v5 = bitcast.f32x4 little v2
 ;; @0193                               v6 = fcmp eq v4, v5
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0195                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @0195                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @0195                               v9 = iadd v8, v7
 ;; @0195                               store little heap v6, v9
 ;; @0199                               jump block1
@@ -630,7 +630,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -639,7 +639,7 @@
 ;; @01a2                               v5 = bitcast.f64x2 little v2
 ;; @01a2                               v6 = fcmp eq v4, v5
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01a4                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01a4                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01a4                               v9 = iadd v8, v7
 ;; @01a4                               store little heap v6, v9
 ;; @01a8                               jump block1
@@ -654,7 +654,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -663,7 +663,7 @@
 ;; @01b1                               v5 = bitcast.f32x4 little v2
 ;; @01b1                               v6 = fcmp ne v4, v5
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01b3                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01b3                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01b3                               v9 = iadd v8, v7
 ;; @01b3                               store little heap v6, v9
 ;; @01b7                               jump block1
@@ -678,7 +678,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -687,7 +687,7 @@
 ;; @01c0                               v5 = bitcast.f64x2 little v2
 ;; @01c0                               v6 = fcmp ne v4, v5
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01c2                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01c2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01c2                               v9 = iadd v8, v7
 ;; @01c2                               store little heap v6, v9
 ;; @01c6                               jump block1
@@ -702,7 +702,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -711,7 +711,7 @@
 ;; @01cf                               v5 = bitcast.f32x4 little v2
 ;; @01cf                               v6 = fcmp lt v4, v5
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01d1                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01d1                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01d1                               v9 = iadd v8, v7
 ;; @01d1                               store little heap v6, v9
 ;; @01d5                               jump block1
@@ -726,7 +726,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -735,7 +735,7 @@
 ;; @01de                               v5 = bitcast.f64x2 little v2
 ;; @01de                               v6 = fcmp lt v4, v5
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01e0                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01e0                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01e0                               v9 = iadd v8, v7
 ;; @01e0                               store little heap v6, v9
 ;; @01e4                               jump block1
@@ -750,7 +750,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -759,7 +759,7 @@
 ;; @01ed                               v5 = bitcast.f32x4 little v2
 ;; @01ed                               v6 = fcmp le v4, v5
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01ef                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01ef                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01ef                               v9 = iadd v8, v7
 ;; @01ef                               store little heap v6, v9
 ;; @01f3                               jump block1
@@ -774,7 +774,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -783,7 +783,7 @@
 ;; @01fc                               v5 = bitcast.f64x2 little v2
 ;; @01fc                               v6 = fcmp le v4, v5
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01fe                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @01fe                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @01fe                               v9 = iadd v8, v7
 ;; @01fe                               store little heap v6, v9
 ;; @0202                               jump block1
@@ -798,7 +798,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -807,7 +807,7 @@
 ;; @020b                               v5 = bitcast.f32x4 little v2
 ;; @020b                               v6 = fcmp gt v4, v5
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @020d                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @020d                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @020d                               v9 = iadd v8, v7
 ;; @020d                               store little heap v6, v9
 ;; @0211                               jump block1
@@ -822,7 +822,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -831,7 +831,7 @@
 ;; @021a                               v5 = bitcast.f64x2 little v2
 ;; @021a                               v6 = fcmp gt v4, v5
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @021c                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @021c                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @021c                               v9 = iadd v8, v7
 ;; @021c                               store little heap v6, v9
 ;; @0220                               jump block1
@@ -846,7 +846,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -855,7 +855,7 @@
 ;; @0229                               v5 = bitcast.f32x4 little v2
 ;; @0229                               v6 = fcmp ge v4, v5
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
-;; @022b                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @022b                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @022b                               v9 = iadd v8, v7
 ;; @022b                               store little heap v6, v9
 ;; @022f                               jump block1
@@ -870,7 +870,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -879,7 +879,7 @@
 ;; @0238                               v5 = bitcast.f64x2 little v2
 ;; @0238                               v6 = fcmp ge v4, v5
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @023a                               v8 = load.i64 notrap aligned readonly checked v0+88
+;; @023a                               v8 = load.i64 notrap aligned readonly pure checked v0+88
 ;; @023a                               v9 = iadd v8, v7
 ;; @023a                               store little heap v6, v9
 ;; @023e                               jump block1

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -90,14 +90,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @003f                               v3 = iconst.i32 0
 ;; @0045                               v4 = icmp eq v2, v2
 ;; @0047                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0047                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0047                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0047                               v7 = iadd v6, v5
 ;; @0047                               store little heap v4, v7
 ;; @004b                               jump block1
@@ -112,7 +112,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -121,7 +121,7 @@
 ;; @0054                               v5 = bitcast.i16x8 little v2
 ;; @0054                               v6 = icmp eq v4, v5
 ;; @0056                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0056                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0056                               v9 = iadd v8, v7
 ;; @0056                               store little heap v6, v9
 ;; @005a                               jump block1
@@ -136,7 +136,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -145,7 +145,7 @@
 ;; @0063                               v5 = bitcast.i32x4 little v2
 ;; @0063                               v6 = icmp eq v4, v5
 ;; @0065                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0065                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0065                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0065                               v9 = iadd v8, v7
 ;; @0065                               store little heap v6, v9
 ;; @0069                               jump block1
@@ -160,7 +160,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -169,7 +169,7 @@
 ;; @0072                               v5 = bitcast.i64x2 little v2
 ;; @0072                               v6 = icmp eq v4, v5
 ;; @0075                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0075                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0075                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0075                               v9 = iadd v8, v7
 ;; @0075                               store little heap v6, v9
 ;; @0079                               jump block1
@@ -184,14 +184,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @007c                               v3 = iconst.i32 0
 ;; @0082                               v4 = icmp ne v2, v2
 ;; @0084                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0084                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0084                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0084                               v7 = iadd v6, v5
 ;; @0084                               store little heap v4, v7
 ;; @0088                               jump block1
@@ -206,7 +206,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -215,7 +215,7 @@
 ;; @0091                               v5 = bitcast.i16x8 little v2
 ;; @0091                               v6 = icmp ne v4, v5
 ;; @0093                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0093                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0093                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0093                               v9 = iadd v8, v7
 ;; @0093                               store little heap v6, v9
 ;; @0097                               jump block1
@@ -230,7 +230,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -239,7 +239,7 @@
 ;; @00a0                               v5 = bitcast.i32x4 little v2
 ;; @00a0                               v6 = icmp ne v4, v5
 ;; @00a2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00a2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00a2                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00a2                               v9 = iadd v8, v7
 ;; @00a2                               store little heap v6, v9
 ;; @00a6                               jump block1
@@ -254,7 +254,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -263,7 +263,7 @@
 ;; @00af                               v5 = bitcast.i64x2 little v2
 ;; @00af                               v6 = icmp ne v4, v5
 ;; @00b2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00b2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00b2                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00b2                               v9 = iadd v8, v7
 ;; @00b2                               store little heap v6, v9
 ;; @00b6                               jump block1
@@ -278,14 +278,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00b9                               v3 = iconst.i32 0
 ;; @00bf                               v4 = icmp slt v2, v2
 ;; @00c1                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00c1                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00c1                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00c1                               v7 = iadd v6, v5
 ;; @00c1                               store little heap v4, v7
 ;; @00c5                               jump block1
@@ -300,7 +300,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -309,7 +309,7 @@
 ;; @00ce                               v5 = bitcast.i16x8 little v2
 ;; @00ce                               v6 = icmp slt v4, v5
 ;; @00d0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00d0                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00d0                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00d0                               v9 = iadd v8, v7
 ;; @00d0                               store little heap v6, v9
 ;; @00d4                               jump block1
@@ -324,7 +324,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -333,7 +333,7 @@
 ;; @00dd                               v5 = bitcast.i32x4 little v2
 ;; @00dd                               v6 = icmp slt v4, v5
 ;; @00df                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00df                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00df                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00df                               v9 = iadd v8, v7
 ;; @00df                               store little heap v6, v9
 ;; @00e3                               jump block1
@@ -348,7 +348,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -357,7 +357,7 @@
 ;; @00ec                               v5 = bitcast.i64x2 little v2
 ;; @00ec                               v6 = icmp slt v4, v5
 ;; @00ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @00ef                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00ef                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00ef                               v9 = iadd v8, v7
 ;; @00ef                               store little heap v6, v9
 ;; @00f3                               jump block1
@@ -372,14 +372,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @00f6                               v3 = iconst.i32 0
 ;; @00fc                               v4 = icmp ult v2, v2
 ;; @00fe                               v5 = uextend.i64 v3  ; v3 = 0
-;; @00fe                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @00fe                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @00fe                               v7 = iadd v6, v5
 ;; @00fe                               store little heap v4, v7
 ;; @0102                               jump block1
@@ -394,7 +394,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -403,7 +403,7 @@
 ;; @010b                               v5 = bitcast.i16x8 little v2
 ;; @010b                               v6 = icmp ult v4, v5
 ;; @010d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @010d                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @010d                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @010d                               v9 = iadd v8, v7
 ;; @010d                               store little heap v6, v9
 ;; @0111                               jump block1
@@ -418,7 +418,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -427,7 +427,7 @@
 ;; @011a                               v5 = bitcast.i32x4 little v2
 ;; @011a                               v6 = icmp ult v4, v5
 ;; @011c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @011c                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @011c                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @011c                               v9 = iadd v8, v7
 ;; @011c                               store little heap v6, v9
 ;; @0120                               jump block1
@@ -442,14 +442,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0123                               v3 = iconst.i32 0
 ;; @0129                               v4 = icmp sgt v2, v2
 ;; @012b                               v5 = uextend.i64 v3  ; v3 = 0
-;; @012b                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @012b                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @012b                               v7 = iadd v6, v5
 ;; @012b                               store little heap v4, v7
 ;; @012f                               jump block1
@@ -464,7 +464,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -473,7 +473,7 @@
 ;; @0138                               v5 = bitcast.i16x8 little v2
 ;; @0138                               v6 = icmp sgt v4, v5
 ;; @013a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @013a                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @013a                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @013a                               v9 = iadd v8, v7
 ;; @013a                               store little heap v6, v9
 ;; @013e                               jump block1
@@ -488,7 +488,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -497,7 +497,7 @@
 ;; @0147                               v5 = bitcast.i32x4 little v2
 ;; @0147                               v6 = icmp sgt v4, v5
 ;; @0149                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0149                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0149                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0149                               v9 = iadd v8, v7
 ;; @0149                               store little heap v6, v9
 ;; @014d                               jump block1
@@ -512,7 +512,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -521,7 +521,7 @@
 ;; @0156                               v5 = bitcast.i64x2 little v2
 ;; @0156                               v6 = icmp sgt v4, v5
 ;; @0159                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0159                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0159                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0159                               v9 = iadd v8, v7
 ;; @0159                               store little heap v6, v9
 ;; @015d                               jump block1
@@ -536,14 +536,14 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0160                               v3 = iconst.i32 0
 ;; @0166                               v4 = icmp ugt v2, v2
 ;; @0168                               v5 = uextend.i64 v3  ; v3 = 0
-;; @0168                               v6 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0168                               v6 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0168                               v7 = iadd v6, v5
 ;; @0168                               store little heap v4, v7
 ;; @016c                               jump block1
@@ -558,7 +558,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -567,7 +567,7 @@
 ;; @0175                               v5 = bitcast.i16x8 little v2
 ;; @0175                               v6 = icmp ugt v4, v5
 ;; @0177                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0177                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0177                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0177                               v9 = iadd v8, v7
 ;; @0177                               store little heap v6, v9
 ;; @017b                               jump block1
@@ -582,7 +582,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -591,7 +591,7 @@
 ;; @0184                               v5 = bitcast.i32x4 little v2
 ;; @0184                               v6 = icmp ugt v4, v5
 ;; @0186                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0186                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0186                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0186                               v9 = iadd v8, v7
 ;; @0186                               store little heap v6, v9
 ;; @018a                               jump block1
@@ -606,7 +606,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -615,7 +615,7 @@
 ;; @0193                               v5 = bitcast.f32x4 little v2
 ;; @0193                               v6 = fcmp eq v4, v5
 ;; @0195                               v7 = uextend.i64 v3  ; v3 = 0
-;; @0195                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @0195                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @0195                               v9 = iadd v8, v7
 ;; @0195                               store little heap v6, v9
 ;; @0199                               jump block1
@@ -630,7 +630,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -639,7 +639,7 @@
 ;; @01a2                               v5 = bitcast.f64x2 little v2
 ;; @01a2                               v6 = fcmp eq v4, v5
 ;; @01a4                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01a4                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01a4                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01a4                               v9 = iadd v8, v7
 ;; @01a4                               store little heap v6, v9
 ;; @01a8                               jump block1
@@ -654,7 +654,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -663,7 +663,7 @@
 ;; @01b1                               v5 = bitcast.f32x4 little v2
 ;; @01b1                               v6 = fcmp ne v4, v5
 ;; @01b3                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01b3                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01b3                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01b3                               v9 = iadd v8, v7
 ;; @01b3                               store little heap v6, v9
 ;; @01b7                               jump block1
@@ -678,7 +678,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -687,7 +687,7 @@
 ;; @01c0                               v5 = bitcast.f64x2 little v2
 ;; @01c0                               v6 = fcmp ne v4, v5
 ;; @01c2                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01c2                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01c2                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01c2                               v9 = iadd v8, v7
 ;; @01c2                               store little heap v6, v9
 ;; @01c6                               jump block1
@@ -702,7 +702,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -711,7 +711,7 @@
 ;; @01cf                               v5 = bitcast.f32x4 little v2
 ;; @01cf                               v6 = fcmp lt v4, v5
 ;; @01d1                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01d1                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01d1                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01d1                               v9 = iadd v8, v7
 ;; @01d1                               store little heap v6, v9
 ;; @01d5                               jump block1
@@ -726,7 +726,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -735,7 +735,7 @@
 ;; @01de                               v5 = bitcast.f64x2 little v2
 ;; @01de                               v6 = fcmp lt v4, v5
 ;; @01e0                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01e0                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01e0                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01e0                               v9 = iadd v8, v7
 ;; @01e0                               store little heap v6, v9
 ;; @01e4                               jump block1
@@ -750,7 +750,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -759,7 +759,7 @@
 ;; @01ed                               v5 = bitcast.f32x4 little v2
 ;; @01ed                               v6 = fcmp le v4, v5
 ;; @01ef                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01ef                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01ef                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01ef                               v9 = iadd v8, v7
 ;; @01ef                               store little heap v6, v9
 ;; @01f3                               jump block1
@@ -774,7 +774,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -783,7 +783,7 @@
 ;; @01fc                               v5 = bitcast.f64x2 little v2
 ;; @01fc                               v6 = fcmp le v4, v5
 ;; @01fe                               v7 = uextend.i64 v3  ; v3 = 0
-;; @01fe                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @01fe                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @01fe                               v9 = iadd v8, v7
 ;; @01fe                               store little heap v6, v9
 ;; @0202                               jump block1
@@ -798,7 +798,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -807,7 +807,7 @@
 ;; @020b                               v5 = bitcast.f32x4 little v2
 ;; @020b                               v6 = fcmp gt v4, v5
 ;; @020d                               v7 = uextend.i64 v3  ; v3 = 0
-;; @020d                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @020d                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @020d                               v9 = iadd v8, v7
 ;; @020d                               store little heap v6, v9
 ;; @0211                               jump block1
@@ -822,7 +822,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -831,7 +831,7 @@
 ;; @021a                               v5 = bitcast.f64x2 little v2
 ;; @021a                               v6 = fcmp gt v4, v5
 ;; @021c                               v7 = uextend.i64 v3  ; v3 = 0
-;; @021c                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @021c                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @021c                               v9 = iadd v8, v7
 ;; @021c                               store little heap v6, v9
 ;; @0220                               jump block1
@@ -846,7 +846,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -855,7 +855,7 @@
 ;; @0229                               v5 = bitcast.f32x4 little v2
 ;; @0229                               v6 = fcmp ge v4, v5
 ;; @022b                               v7 = uextend.i64 v3  ; v3 = 0
-;; @022b                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @022b                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @022b                               v9 = iadd v8, v7
 ;; @022b                               store little heap v6, v9
 ;; @022f                               jump block1
@@ -870,7 +870,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned gv3+96
-;;     gv5 = load.i64 notrap aligned readonly pure checked gv3+88
+;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+88
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
@@ -879,7 +879,7 @@
 ;; @0238                               v5 = bitcast.f64x2 little v2
 ;; @0238                               v6 = fcmp ge v4, v5
 ;; @023a                               v7 = uextend.i64 v3  ; v3 = 0
-;; @023a                               v8 = load.i64 notrap aligned readonly pure checked v0+88
+;; @023a                               v8 = load.i64 notrap aligned readonly can_move checked v0+88
 ;; @023a                               v9 = iadd v8, v7
 ;; @023a                               store little heap v6, v9
 ;; @023e                               jump block1

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
@@ -31,7 +31,7 @@
 ;; @0054                               v4 = iconst.i32 7
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0054                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @0054                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v53 = iconst.i64 2
 ;; @0054                               v8 = ishl v6, v53  ; v53 = 2
 ;; @0054                               v9 = iadd v7, v8
@@ -54,8 +54,8 @@
 ;; @0054                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @0054                               v20 = load.i64 notrap aligned readonly pure v0+40
-;; @0054                               v22 = load.i64 notrap aligned readonly pure v0+48
+;; @0054                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0054                               v22 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v57 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v57
 ;; @0054                               v23 = uextend.i64 v50
@@ -69,8 +69,8 @@
 ;; @0054                               v30 = load.i64 notrap aligned v29
 ;;                                     v58 = iconst.i64 1
 ;; @0054                               v31 = iadd v30, v58  ; v58 = 1
-;; @0054                               v33 = load.i64 notrap aligned readonly pure v0+40
-;; @0054                               v35 = load.i64 notrap aligned readonly pure v0+48
+;; @0054                               v33 = load.i64 notrap aligned readonly can_move v0+40
+;; @0054                               v35 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v49 = load.i32 notrap v59
 ;; @0054                               v36 = uextend.i64 v49
@@ -111,7 +111,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
@@ -120,7 +120,7 @@
 ;; @005b                               v4 = iconst.i32 7
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
-;; @005b                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @005b                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v53 = iconst.i64 2
 ;; @005b                               v8 = ishl v6, v53  ; v53 = 2
 ;; @005b                               v9 = iadd v7, v8
@@ -143,8 +143,8 @@
 ;; @005b                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @005b                               v20 = load.i64 notrap aligned readonly pure v0+40
-;; @005b                               v22 = load.i64 notrap aligned readonly pure v0+48
+;; @005b                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @005b                               v22 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v57 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v57
 ;; @005b                               v23 = uextend.i64 v50
@@ -158,8 +158,8 @@
 ;; @005b                               v30 = load.i64 notrap aligned v29
 ;;                                     v58 = iconst.i64 1
 ;; @005b                               v31 = iadd v30, v58  ; v58 = 1
-;; @005b                               v33 = load.i64 notrap aligned readonly pure v0+40
-;; @005b                               v35 = load.i64 notrap aligned readonly pure v0+48
+;; @005b                               v33 = load.i64 notrap aligned readonly can_move v0+40
+;; @005b                               v35 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v49 = load.i32 notrap v59
 ;; @005b                               v36 = uextend.i64 v49

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
@@ -31,7 +31,7 @@
 ;; @0054                               v4 = iconst.i32 7
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0054                               v7 = load.i64 notrap aligned readonly v0+80
+;; @0054                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v53 = iconst.i64 2
 ;; @0054                               v8 = ishl v6, v53  ; v53 = 2
 ;; @0054                               v9 = iadd v7, v8
@@ -54,8 +54,8 @@
 ;; @0054                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @0054                               v20 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v22 = load.i64 notrap aligned readonly v0+48
+;; @0054                               v20 = load.i64 notrap aligned readonly pure v0+40
+;; @0054                               v22 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v57 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v57
 ;; @0054                               v23 = uextend.i64 v50
@@ -69,8 +69,8 @@
 ;; @0054                               v30 = load.i64 notrap aligned v29
 ;;                                     v58 = iconst.i64 1
 ;; @0054                               v31 = iadd v30, v58  ; v58 = 1
-;; @0054                               v33 = load.i64 notrap aligned readonly v0+40
-;; @0054                               v35 = load.i64 notrap aligned readonly v0+48
+;; @0054                               v33 = load.i64 notrap aligned readonly pure v0+40
+;; @0054                               v35 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v49 = load.i32 notrap v59
 ;; @0054                               v36 = uextend.i64 v49
@@ -111,7 +111,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u1:26 sig0
 ;;     stack_limit = gv2
@@ -120,7 +120,7 @@
 ;; @005b                               v4 = iconst.i32 7
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
-;; @005b                               v7 = load.i64 notrap aligned readonly v0+80
+;; @005b                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v53 = iconst.i64 2
 ;; @005b                               v8 = ishl v6, v53  ; v53 = 2
 ;; @005b                               v9 = iadd v7, v8
@@ -143,8 +143,8 @@
 ;; @005b                               brif v18, block3, block4
 ;;
 ;;                                 block4:
-;; @005b                               v20 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v22 = load.i64 notrap aligned readonly v0+48
+;; @005b                               v20 = load.i64 notrap aligned readonly pure v0+40
+;; @005b                               v22 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v57 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v57
 ;; @005b                               v23 = uextend.i64 v50
@@ -158,8 +158,8 @@
 ;; @005b                               v30 = load.i64 notrap aligned v29
 ;;                                     v58 = iconst.i64 1
 ;; @005b                               v31 = iadd v30, v58  ; v58 = 1
-;; @005b                               v33 = load.i64 notrap aligned readonly v0+40
-;; @005b                               v35 = load.i64 notrap aligned readonly v0+48
+;; @005b                               v33 = load.i64 notrap aligned readonly pure v0+40
+;; @005b                               v35 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v49 = load.i32 notrap v59
 ;; @005b                               v36 = uextend.i64 v49

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -55,8 +55,8 @@
 ;; @0053                               brif v19, block3, block4
 ;;
 ;;                                 block4:
-;; @0053                               v21 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v23 = load.i64 notrap aligned readonly v0+48
+;; @0053                               v21 = load.i64 notrap aligned readonly pure v0+40
+;; @0053                               v23 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v51 = load.i32 notrap v59
 ;; @0053                               v24 = uextend.i64 v51
@@ -70,8 +70,8 @@
 ;; @0053                               v31 = load.i64 notrap aligned v30
 ;;                                     v60 = iconst.i64 1
 ;; @0053                               v32 = iadd v31, v60  ; v60 = 1
-;; @0053                               v34 = load.i64 notrap aligned readonly v0+40
-;; @0053                               v36 = load.i64 notrap aligned readonly v0+48
+;; @0053                               v34 = load.i64 notrap aligned readonly pure v0+40
+;; @0053                               v36 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v61 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v61
 ;; @0053                               v37 = uextend.i64 v50
@@ -146,8 +146,8 @@
 ;; @005a                               brif v19, block3, block4
 ;;
 ;;                                 block4:
-;; @005a                               v21 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v23 = load.i64 notrap aligned readonly v0+48
+;; @005a                               v21 = load.i64 notrap aligned readonly pure v0+40
+;; @005a                               v23 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v51 = load.i32 notrap v59
 ;; @005a                               v24 = uextend.i64 v51
@@ -161,8 +161,8 @@
 ;; @005a                               v31 = load.i64 notrap aligned v30
 ;;                                     v60 = iconst.i64 1
 ;; @005a                               v32 = iadd v31, v60  ; v60 = 1
-;; @005a                               v34 = load.i64 notrap aligned readonly v0+40
-;; @005a                               v36 = load.i64 notrap aligned readonly v0+48
+;; @005a                               v34 = load.i64 notrap aligned readonly pure v0+40
+;; @005a                               v36 = load.i64 notrap aligned readonly pure v0+48
 ;;                                     v61 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v61
 ;; @005a                               v37 = uextend.i64 v50

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -55,8 +55,8 @@
 ;; @0053                               brif v19, block3, block4
 ;;
 ;;                                 block4:
-;; @0053                               v21 = load.i64 notrap aligned readonly pure v0+40
-;; @0053                               v23 = load.i64 notrap aligned readonly pure v0+48
+;; @0053                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0053                               v23 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v51 = load.i32 notrap v59
 ;; @0053                               v24 = uextend.i64 v51
@@ -70,8 +70,8 @@
 ;; @0053                               v31 = load.i64 notrap aligned v30
 ;;                                     v60 = iconst.i64 1
 ;; @0053                               v32 = iadd v31, v60  ; v60 = 1
-;; @0053                               v34 = load.i64 notrap aligned readonly pure v0+40
-;; @0053                               v36 = load.i64 notrap aligned readonly pure v0+48
+;; @0053                               v34 = load.i64 notrap aligned readonly can_move v0+40
+;; @0053                               v36 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v61 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v61
 ;; @0053                               v37 = uextend.i64 v50
@@ -146,8 +146,8 @@
 ;; @005a                               brif v19, block3, block4
 ;;
 ;;                                 block4:
-;; @005a                               v21 = load.i64 notrap aligned readonly pure v0+40
-;; @005a                               v23 = load.i64 notrap aligned readonly pure v0+48
+;; @005a                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @005a                               v23 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v59 = stack_addr.i64 ss0
 ;;                                     v51 = load.i32 notrap v59
 ;; @005a                               v24 = uextend.i64 v51
@@ -161,8 +161,8 @@
 ;; @005a                               v31 = load.i64 notrap aligned v30
 ;;                                     v60 = iconst.i64 1
 ;; @005a                               v32 = iadd v31, v60  ; v60 = 1
-;; @005a                               v34 = load.i64 notrap aligned readonly pure v0+40
-;; @005a                               v36 = load.i64 notrap aligned readonly pure v0+48
+;; @005a                               v34 = load.i64 notrap aligned readonly can_move v0+40
+;; @005a                               v36 = load.i64 notrap aligned readonly can_move v0+48
 ;;                                     v61 = stack_addr.i64 ss0
 ;;                                     v50 = load.i32 notrap v61
 ;; @005a                               v37 = uextend.i64 v50

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
@@ -31,7 +31,7 @@
 ;; @0056                               v4 = iconst.i32 7
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @0056                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v66 = iconst.i64 2
 ;; @0056                               v8 = ishl v6, v66  ; v66 = 2
 ;; @0056                               v9 = iadd v7, v8
@@ -43,8 +43,8 @@
 ;; @0056                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0056                               v15 = load.i64 notrap aligned readonly pure v0+40
-;; @0056                               v17 = load.i64 notrap aligned readonly pure v0+48
+;; @0056                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v17 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0056                               v18 = uextend.i64 v2
 ;; @0056                               v19 = iconst.i64 8
 ;; @0056                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
@@ -56,8 +56,8 @@
 ;; @0056                               v25 = load.i64 notrap aligned v24
 ;;                                     v68 = iconst.i64 1
 ;; @0056                               v26 = iadd v25, v68  ; v68 = 1
-;; @0056                               v28 = load.i64 notrap aligned readonly pure v0+40
-;; @0056                               v30 = load.i64 notrap aligned readonly pure v0+48
+;; @0056                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v30 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0056                               v31 = uextend.i64 v2
 ;; @0056                               v32 = iconst.i64 8
 ;; @0056                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
@@ -76,8 +76,8 @@
 ;; @0056                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @0056                               v40 = load.i64 notrap aligned readonly pure v0+40
-;; @0056                               v42 = load.i64 notrap aligned readonly pure v0+48
+;; @0056                               v40 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v42 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0056                               v43 = uextend.i64 v12
 ;; @0056                               v44 = iconst.i64 8
 ;; @0056                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
@@ -98,8 +98,8 @@
 ;; @0056                               jump block7
 ;;
 ;;                                 block6:
-;; @0056                               v55 = load.i64 notrap aligned readonly pure v0+40
-;; @0056                               v57 = load.i64 notrap aligned readonly pure v0+48
+;; @0056                               v55 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v57 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0056                               v58 = uextend.i64 v12
 ;; @0056                               v59 = iconst.i64 8
 ;; @0056                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
@@ -123,7 +123,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
@@ -132,7 +132,7 @@
 ;; @005f                               v4 = iconst.i32 7
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
-;; @005f                               v7 = load.i64 notrap aligned readonly pure v0+80
+;; @005f                               v7 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v66 = iconst.i64 2
 ;; @005f                               v8 = ishl v6, v66  ; v66 = 2
 ;; @005f                               v9 = iadd v7, v8
@@ -144,8 +144,8 @@
 ;; @005f                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005f                               v15 = load.i64 notrap aligned readonly pure v0+40
-;; @005f                               v17 = load.i64 notrap aligned readonly pure v0+48
+;; @005f                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v17 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005f                               v18 = uextend.i64 v3
 ;; @005f                               v19 = iconst.i64 8
 ;; @005f                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
@@ -157,8 +157,8 @@
 ;; @005f                               v25 = load.i64 notrap aligned v24
 ;;                                     v68 = iconst.i64 1
 ;; @005f                               v26 = iadd v25, v68  ; v68 = 1
-;; @005f                               v28 = load.i64 notrap aligned readonly pure v0+40
-;; @005f                               v30 = load.i64 notrap aligned readonly pure v0+48
+;; @005f                               v28 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v30 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005f                               v31 = uextend.i64 v3
 ;; @005f                               v32 = iconst.i64 8
 ;; @005f                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
@@ -177,8 +177,8 @@
 ;; @005f                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @005f                               v40 = load.i64 notrap aligned readonly pure v0+40
-;; @005f                               v42 = load.i64 notrap aligned readonly pure v0+48
+;; @005f                               v40 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v42 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005f                               v43 = uextend.i64 v12
 ;; @005f                               v44 = iconst.i64 8
 ;; @005f                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
@@ -199,8 +199,8 @@
 ;; @005f                               jump block7
 ;;
 ;;                                 block6:
-;; @005f                               v55 = load.i64 notrap aligned readonly pure v0+40
-;; @005f                               v57 = load.i64 notrap aligned readonly pure v0+48
+;; @005f                               v55 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v57 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005f                               v58 = uextend.i64 v12
 ;; @005f                               v59 = iconst.i64 8
 ;; @005f                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
@@ -31,7 +31,7 @@
 ;; @0056                               v4 = iconst.i32 7
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v7 = load.i64 notrap aligned readonly v0+80
+;; @0056                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v66 = iconst.i64 2
 ;; @0056                               v8 = ishl v6, v66  ; v66 = 2
 ;; @0056                               v9 = iadd v7, v8
@@ -43,8 +43,8 @@
 ;; @0056                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @0056                               v15 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v17 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v15 = load.i64 notrap aligned readonly pure v0+40
+;; @0056                               v17 = load.i64 notrap aligned readonly pure v0+48
 ;; @0056                               v18 = uextend.i64 v2
 ;; @0056                               v19 = iconst.i64 8
 ;; @0056                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
@@ -56,8 +56,8 @@
 ;; @0056                               v25 = load.i64 notrap aligned v24
 ;;                                     v68 = iconst.i64 1
 ;; @0056                               v26 = iadd v25, v68  ; v68 = 1
-;; @0056                               v28 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v30 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v28 = load.i64 notrap aligned readonly pure v0+40
+;; @0056                               v30 = load.i64 notrap aligned readonly pure v0+48
 ;; @0056                               v31 = uextend.i64 v2
 ;; @0056                               v32 = iconst.i64 8
 ;; @0056                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
@@ -76,8 +76,8 @@
 ;; @0056                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @0056                               v40 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v42 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v40 = load.i64 notrap aligned readonly pure v0+40
+;; @0056                               v42 = load.i64 notrap aligned readonly pure v0+48
 ;; @0056                               v43 = uextend.i64 v12
 ;; @0056                               v44 = iconst.i64 8
 ;; @0056                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
@@ -98,8 +98,8 @@
 ;; @0056                               jump block7
 ;;
 ;;                                 block6:
-;; @0056                               v55 = load.i64 notrap aligned readonly v0+40
-;; @0056                               v57 = load.i64 notrap aligned readonly v0+48
+;; @0056                               v55 = load.i64 notrap aligned readonly pure v0+40
+;; @0056                               v57 = load.i64 notrap aligned readonly pure v0+48
 ;; @0056                               v58 = uextend.i64 v12
 ;; @0056                               v59 = iconst.i64 8
 ;; @0056                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
@@ -123,7 +123,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i32) tail
 ;;     fn0 = colocated u1:25 sig0
 ;;     stack_limit = gv2
@@ -132,7 +132,7 @@
 ;; @005f                               v4 = iconst.i32 7
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
-;; @005f                               v7 = load.i64 notrap aligned readonly v0+80
+;; @005f                               v7 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v66 = iconst.i64 2
 ;; @005f                               v8 = ishl v6, v66  ; v66 = 2
 ;; @005f                               v9 = iadd v7, v8
@@ -144,8 +144,8 @@
 ;; @005f                               brif v13, block3, block2
 ;;
 ;;                                 block2:
-;; @005f                               v15 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v17 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v15 = load.i64 notrap aligned readonly pure v0+40
+;; @005f                               v17 = load.i64 notrap aligned readonly pure v0+48
 ;; @005f                               v18 = uextend.i64 v3
 ;; @005f                               v19 = iconst.i64 8
 ;; @005f                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
@@ -157,8 +157,8 @@
 ;; @005f                               v25 = load.i64 notrap aligned v24
 ;;                                     v68 = iconst.i64 1
 ;; @005f                               v26 = iadd v25, v68  ; v68 = 1
-;; @005f                               v28 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v30 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v28 = load.i64 notrap aligned readonly pure v0+40
+;; @005f                               v30 = load.i64 notrap aligned readonly pure v0+48
 ;; @005f                               v31 = uextend.i64 v3
 ;; @005f                               v32 = iconst.i64 8
 ;; @005f                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
@@ -177,8 +177,8 @@
 ;; @005f                               brif v38, block7, block4
 ;;
 ;;                                 block4:
-;; @005f                               v40 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v42 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v40 = load.i64 notrap aligned readonly pure v0+40
+;; @005f                               v42 = load.i64 notrap aligned readonly pure v0+48
 ;; @005f                               v43 = uextend.i64 v12
 ;; @005f                               v44 = iconst.i64 8
 ;; @005f                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
@@ -199,8 +199,8 @@
 ;; @005f                               jump block7
 ;;
 ;;                                 block6:
-;; @005f                               v55 = load.i64 notrap aligned readonly v0+40
-;; @005f                               v57 = load.i64 notrap aligned readonly v0+48
+;; @005f                               v55 = load.i64 notrap aligned readonly pure v0+40
+;; @005f                               v57 = load.i64 notrap aligned readonly pure v0+48
 ;; @005f                               v58 = uextend.i64 v12
 ;; @005f                               v59 = iconst.i64 8
 ;; @005f                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -45,8 +45,8 @@
 ;; @0055                               brif v14, block3, block2
 ;;
 ;;                                 block2:
-;; @0055                               v16 = load.i64 notrap aligned readonly pure v0+40
-;; @0055                               v18 = load.i64 notrap aligned readonly pure v0+48
+;; @0055                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v18 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0055                               v19 = uextend.i64 v2
 ;; @0055                               v20 = iconst.i64 8
 ;; @0055                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
@@ -58,8 +58,8 @@
 ;; @0055                               v26 = load.i64 notrap aligned v25
 ;;                                     v70 = iconst.i64 1
 ;; @0055                               v27 = iadd v26, v70  ; v70 = 1
-;; @0055                               v29 = load.i64 notrap aligned readonly pure v0+40
-;; @0055                               v31 = load.i64 notrap aligned readonly pure v0+48
+;; @0055                               v29 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v31 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0055                               v32 = uextend.i64 v2
 ;; @0055                               v33 = iconst.i64 8
 ;; @0055                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
@@ -78,8 +78,8 @@
 ;; @0055                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @0055                               v41 = load.i64 notrap aligned readonly pure v0+40
-;; @0055                               v43 = load.i64 notrap aligned readonly pure v0+48
+;; @0055                               v41 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v43 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0055                               v44 = uextend.i64 v13
 ;; @0055                               v45 = iconst.i64 8
 ;; @0055                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
@@ -100,8 +100,8 @@
 ;; @0055                               jump block7
 ;;
 ;;                                 block6:
-;; @0055                               v56 = load.i64 notrap aligned readonly pure v0+40
-;; @0055                               v58 = load.i64 notrap aligned readonly pure v0+48
+;; @0055                               v56 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v58 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0055                               v59 = uextend.i64 v13
 ;; @0055                               v60 = iconst.i64 8
 ;; @0055                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
@@ -148,8 +148,8 @@
 ;; @005e                               brif v14, block3, block2
 ;;
 ;;                                 block2:
-;; @005e                               v16 = load.i64 notrap aligned readonly pure v0+40
-;; @005e                               v18 = load.i64 notrap aligned readonly pure v0+48
+;; @005e                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v18 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005e                               v19 = uextend.i64 v3
 ;; @005e                               v20 = iconst.i64 8
 ;; @005e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
@@ -161,8 +161,8 @@
 ;; @005e                               v26 = load.i64 notrap aligned v25
 ;;                                     v70 = iconst.i64 1
 ;; @005e                               v27 = iadd v26, v70  ; v70 = 1
-;; @005e                               v29 = load.i64 notrap aligned readonly pure v0+40
-;; @005e                               v31 = load.i64 notrap aligned readonly pure v0+48
+;; @005e                               v29 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v31 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005e                               v32 = uextend.i64 v3
 ;; @005e                               v33 = iconst.i64 8
 ;; @005e                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
@@ -181,8 +181,8 @@
 ;; @005e                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @005e                               v41 = load.i64 notrap aligned readonly pure v0+40
-;; @005e                               v43 = load.i64 notrap aligned readonly pure v0+48
+;; @005e                               v41 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v43 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005e                               v44 = uextend.i64 v13
 ;; @005e                               v45 = iconst.i64 8
 ;; @005e                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
@@ -203,8 +203,8 @@
 ;; @005e                               jump block7
 ;;
 ;;                                 block6:
-;; @005e                               v56 = load.i64 notrap aligned readonly pure v0+40
-;; @005e                               v58 = load.i64 notrap aligned readonly pure v0+48
+;; @005e                               v56 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v58 = load.i64 notrap aligned readonly can_move v0+48
 ;; @005e                               v59 = uextend.i64 v13
 ;; @005e                               v60 = iconst.i64 8
 ;; @005e                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -45,8 +45,8 @@
 ;; @0055                               brif v14, block3, block2
 ;;
 ;;                                 block2:
-;; @0055                               v16 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v18 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v16 = load.i64 notrap aligned readonly pure v0+40
+;; @0055                               v18 = load.i64 notrap aligned readonly pure v0+48
 ;; @0055                               v19 = uextend.i64 v2
 ;; @0055                               v20 = iconst.i64 8
 ;; @0055                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
@@ -58,8 +58,8 @@
 ;; @0055                               v26 = load.i64 notrap aligned v25
 ;;                                     v70 = iconst.i64 1
 ;; @0055                               v27 = iadd v26, v70  ; v70 = 1
-;; @0055                               v29 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v31 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v29 = load.i64 notrap aligned readonly pure v0+40
+;; @0055                               v31 = load.i64 notrap aligned readonly pure v0+48
 ;; @0055                               v32 = uextend.i64 v2
 ;; @0055                               v33 = iconst.i64 8
 ;; @0055                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
@@ -78,8 +78,8 @@
 ;; @0055                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @0055                               v41 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v43 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v41 = load.i64 notrap aligned readonly pure v0+40
+;; @0055                               v43 = load.i64 notrap aligned readonly pure v0+48
 ;; @0055                               v44 = uextend.i64 v13
 ;; @0055                               v45 = iconst.i64 8
 ;; @0055                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
@@ -100,8 +100,8 @@
 ;; @0055                               jump block7
 ;;
 ;;                                 block6:
-;; @0055                               v56 = load.i64 notrap aligned readonly v0+40
-;; @0055                               v58 = load.i64 notrap aligned readonly v0+48
+;; @0055                               v56 = load.i64 notrap aligned readonly pure v0+40
+;; @0055                               v58 = load.i64 notrap aligned readonly pure v0+48
 ;; @0055                               v59 = uextend.i64 v13
 ;; @0055                               v60 = iconst.i64 8
 ;; @0055                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
@@ -148,8 +148,8 @@
 ;; @005e                               brif v14, block3, block2
 ;;
 ;;                                 block2:
-;; @005e                               v16 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v18 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v16 = load.i64 notrap aligned readonly pure v0+40
+;; @005e                               v18 = load.i64 notrap aligned readonly pure v0+48
 ;; @005e                               v19 = uextend.i64 v3
 ;; @005e                               v20 = iconst.i64 8
 ;; @005e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
@@ -161,8 +161,8 @@
 ;; @005e                               v26 = load.i64 notrap aligned v25
 ;;                                     v70 = iconst.i64 1
 ;; @005e                               v27 = iadd v26, v70  ; v70 = 1
-;; @005e                               v29 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v31 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v29 = load.i64 notrap aligned readonly pure v0+40
+;; @005e                               v31 = load.i64 notrap aligned readonly pure v0+48
 ;; @005e                               v32 = uextend.i64 v3
 ;; @005e                               v33 = iconst.i64 8
 ;; @005e                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
@@ -181,8 +181,8 @@
 ;; @005e                               brif v39, block7, block4
 ;;
 ;;                                 block4:
-;; @005e                               v41 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v43 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v41 = load.i64 notrap aligned readonly pure v0+40
+;; @005e                               v43 = load.i64 notrap aligned readonly pure v0+48
 ;; @005e                               v44 = uextend.i64 v13
 ;; @005e                               v45 = iconst.i64 8
 ;; @005e                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
@@ -203,8 +203,8 @@
 ;; @005e                               jump block7
 ;;
 ;;                                 block6:
-;; @005e                               v56 = load.i64 notrap aligned readonly v0+40
-;; @005e                               v58 = load.i64 notrap aligned readonly v0+48
+;; @005e                               v56 = load.i64 notrap aligned readonly pure v0+40
+;; @005e                               v58 = load.i64 notrap aligned readonly pure v0+48
 ;; @005e                               v59 = uextend.i64 v13
 ;; @005e                               v60 = iconst.i64 8
 ;; @005e                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -131,12 +131,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly pure v0+80
+;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v48 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
@@ -161,12 +161,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly pure v0+80
+;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v48 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -131,12 +131,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly v0+80
+;; @0048                               v12 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v48 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
@@ -161,12 +161,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly v0+80
+;; @0075                               v12 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v48 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -131,14 +131,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:9 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly pure v0+80
+;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v68 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
@@ -185,14 +185,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly pure v0+80
+;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+80
 ;;                                     v68 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -131,14 +131,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:9 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0048                               v12 = load.i64 notrap aligned readonly v0+80
+;; @0048                               v12 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v68 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
@@ -185,14 +185,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly gv3+80
+;;     gv4 = load.i64 notrap aligned readonly pure gv3+80
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0075                               v12 = load.i64 notrap aligned readonly v0+80
+;; @0075                               v12 = load.i64 notrap aligned readonly pure v0+80
 ;;                                     v68 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -146,7 +146,7 @@
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x984
+;;       callq   0x988
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -158,7 +158,7 @@
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x984
+;;       callq   0x988
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c3
+;;       callq   0x9c7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c3
+;;       callq   0x9c7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c3
+;;       callq   0x9c7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x9c3
+;;       callq   0x9c7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c3
+;;       callq   0x9c7
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xa1e
+;;       callq   0xa26
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/misc_testsuite/gc/fuzz-segfault.wast
+++ b/tests/misc_testsuite/gc/fuzz-segfault.wast
@@ -1,0 +1,13 @@
+;;! gc = true
+
+(module
+  (func (export "")
+    loop
+      ref.null 0
+      ref.test (ref 0)
+      br_if 0
+    end
+  )
+)
+
+(assert_return (invoke ""))


### PR DESCRIPTION
This flag represents whether the memory operation's safety (e.g. the validity of its `notrap` and `readonly` claims) is purely a function of its data dependencies.

If this flag is `true`, then it is okay to code motion this instruction to arbitrary locations, in the function, including across blocks and conditional branches, so long as data dependencies (and trap ordering, if relevant) are upheld.

If this flag is `false`, then the memory operation's safety potentially relies upon invariants that are not reflected in its data dependencies, and therefore it is not safe to code motion this operation. For example, this operation could be in a block that is dominated by a control-flow bounds check that makes this operation safe, and that invariant is not reflected in its operands. It would be unsafe to code motion such an instruction above its associated bounds check, even if its data dependencies would still be satisfied.

I've added this flag because we were doing exactly that kind of code motion where we moved a `readonly` and `notrap` memory operation past its associated null-check and therefore it was no longer safe to perform and we would get a segfault. This could only be triggered when the Wasm typed-function-references proposal was enabled, which is not a tier-1 proposal, so it is not considered a vulnerability. Nonetheless, it is a pretty scary kind of bug, and other code paths weren't affected due to pretty subtle interactions. And this is the motivation for the new "pure" flag: without needing to explicitly opt into data-dependency-based code motion (i.e. set the "pure" flag), it is too easy to accidentally move loads past their control-flow-based safety guards.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
