### PR TITLE
feat: Add hexadecimal integer parsing in CLI arguments

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -526,11 +526,9 @@ impl RunCommand {
                 .to_str()
                 .ok_or_else(|| anyhow!("argument is not valid utf-8: {val:?}"))?;
             values.push(match ty {
-                // TODO: integer parsing here should handle hexadecimal notation
-                // like `0x0...`, but the Rust standard library currently only
-                // parses base-10 representations.
-                ValType::I32 => Val::I32(val.parse()?),
-                ValType::I64 => Val::I64(val.parse()?),
+                // Supports both decimal and hexadecimal notation (with 0x prefix)
+                ValType::I32 => Val::I32(val.parse::<i32>().or_else(|_| i32::from_str_radix(&val.trim_start_matches("0x"), 16))?),
+                ValType::I64 => Val::I64(val.parse::<i64>().or_else(|_| i64::from_str_radix(&val.trim_start_matches("0x"), 16))?),
                 ValType::F32 => Val::F32(val.parse::<f32>()?.to_bits()),
                 ValType::F64 => Val::F64(val.parse::<f64>()?.to_bits()),
                 t => bail!("unsupported argument type {:?}", t),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -528,12 +528,18 @@ impl RunCommand {
             values.push(match ty {
                 // Supports both decimal and hexadecimal notation (with 0x prefix)
                 ValType::I32 => Val::I32(
-                    val.parse::<i32>()
-                        .or_else(|_| i32::from_str_radix(&val.trim_start_matches("0x"), 16))?,
+                    if val.starts_with("0x") || val.starts_with("0X") {
+                        i32::from_str_radix(&val[2..], 16)?
+                    } else {
+                        val.parse::<i32>()?
+                    }
                 ),
                 ValType::I64 => Val::I64(
-                    val.parse::<i64>()
-                        .or_else(|_| i64::from_str_radix(&val.trim_start_matches("0x"), 16))?,
+                    if val.starts_with("0x") || val.starts_with("0X") {
+                        i64::from_str_radix(&val[2..], 16)?
+                    } else {
+                        val.parse::<i64>()?
+                    }
                 ),
                 ValType::F32 => Val::F32(val.parse::<f32>()?.to_bits()),
                 ValType::F64 => Val::F64(val.parse::<f64>()?.to_bits()),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -527,8 +527,14 @@ impl RunCommand {
                 .ok_or_else(|| anyhow!("argument is not valid utf-8: {val:?}"))?;
             values.push(match ty {
                 // Supports both decimal and hexadecimal notation (with 0x prefix)
-                ValType::I32 => Val::I32(val.parse::<i32>().or_else(|_| i32::from_str_radix(&val.trim_start_matches("0x"), 16))?),
-                ValType::I64 => Val::I64(val.parse::<i64>().or_else(|_| i64::from_str_radix(&val.trim_start_matches("0x"), 16))?),
+                ValType::I32 => Val::I32(
+                    val.parse::<i32>()
+                        .or_else(|_| i32::from_str_radix(&val.trim_start_matches("0x"), 16))?,
+                ),
+                ValType::I64 => Val::I64(
+                    val.parse::<i64>()
+                        .or_else(|_| i64::from_str_radix(&val.trim_start_matches("0x"), 16))?,
+                ),
                 ValType::F32 => Val::F32(val.parse::<f32>()?.to_bits()),
                 ValType::F64 => Val::F64(val.parse::<f64>()?.to_bits()),
                 t => bail!("unsupported argument type {:?}", t),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -527,20 +527,16 @@ impl RunCommand {
                 .ok_or_else(|| anyhow!("argument is not valid utf-8: {val:?}"))?;
             values.push(match ty {
                 // Supports both decimal and hexadecimal notation (with 0x prefix)
-                ValType::I32 => Val::I32(
-                    if val.starts_with("0x") || val.starts_with("0X") {
-                        i32::from_str_radix(&val[2..], 16)?
-                    } else {
-                        val.parse::<i32>()?
-                    }
-                ),
-                ValType::I64 => Val::I64(
-                    if val.starts_with("0x") || val.starts_with("0X") {
-                        i64::from_str_radix(&val[2..], 16)?
-                    } else {
-                        val.parse::<i64>()?
-                    }
-                ),
+                ValType::I32 => Val::I32(if val.starts_with("0x") || val.starts_with("0X") {
+                    i32::from_str_radix(&val[2..], 16)?
+                } else {
+                    val.parse::<i32>()?
+                }),
+                ValType::I64 => Val::I64(if val.starts_with("0x") || val.starts_with("0X") {
+                    i64::from_str_radix(&val[2..], 16)?
+                } else {
+                    val.parse::<i64>()?
+                }),
                 ValType::F32 => Val::F32(val.parse::<f32>()?.to_bits()),
                 ValType::F64 => Val::F64(val.parse::<f64>()?.to_bits()),
                 t => bail!("unsupported argument type {:?}", t),

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2264,3 +2264,66 @@ fn invalid_subcommand() -> Result<()> {
     assert!(String::from_utf8_lossy(&output.stderr).contains("invalid-subcommand"));
     Ok(())
 }
+
+#[test]
+fn numeric_args() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/numeric_args.wat")?;
+    
+    // Test decimal i32
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i32_test",
+            wasm.path().to_str().unwrap(),
+            "42",
+        ],
+        None,
+    )?;
+    assert_eq!(output.status.success(), true);
+    assert_eq!(output.stdout, b"42\n");
+    
+    // Test hexadecimal i32
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i32_test",
+            wasm.path().to_str().unwrap(),
+            "0x2A",
+        ],
+        None,
+    )?;
+    assert_eq!(output.status.success(), true);
+    assert_eq!(output.stdout, b"42\n");
+    
+    // Test decimal i64
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i64_test",
+            wasm.path().to_str().unwrap(),
+            "42",
+        ],
+        None,
+    )?;
+    assert_eq!(output.status.success(), true);
+    assert_eq!(output.stdout, b"42\n");
+    
+    // Test hexadecimal i64
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i64_test",
+            wasm.path().to_str().unwrap(),
+            "0x2A",
+        ],
+        None,
+    )?;
+    assert_eq!(output.status.success(), true);
+    assert_eq!(output.stdout, b"42\n");
+    
+    Ok(())
+}

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2281,7 +2281,7 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
-    // Test hexadecimal i32
+    // Test hexadecimal i32 with lowercase prefix
     let output = run_wasmtime_for_output(
         &[
             "run",
@@ -2294,6 +2294,31 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
+    // Test hexadecimal i32 with uppercase prefix
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i32_test",
+            wasm.path().to_str().unwrap(),
+            "0X2a",
+        ],
+        None,
+    )?;
+    assert_eq!(output.status.success(), true);
+    assert_eq!(output.stdout, b"42\n");
+    // Test that non-prefixed hex strings are not interpreted as hex
+    let output = run_wasmtime_for_output(
+        &[
+            "run",
+            "--invoke",
+            "i32_test",
+            wasm.path().to_str().unwrap(),
+            "ff",
+        ],
+        None,
+    )?;
+    assert!(!output.status.success()); // Should fail as "ff" is not a valid decimal number
     // Test decimal i64
     let output = run_wasmtime_for_output(
         &[

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2319,6 +2319,7 @@ fn numeric_args() -> Result<()> {
         None,
     )?;
     assert!(!output.status.success()); // Should fail as "ff" is not a valid decimal number
+    
     // Test decimal i64
     let output = run_wasmtime_for_output(
         &[

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2319,7 +2319,7 @@ fn numeric_args() -> Result<()> {
         None,
     )?;
     assert!(!output.status.success()); // Should fail as "ff" is not a valid decimal number
-    
+
     // Test decimal i64
     let output = run_wasmtime_for_output(
         &[

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2268,7 +2268,6 @@ fn invalid_subcommand() -> Result<()> {
 #[test]
 fn numeric_args() -> Result<()> {
     let wasm = build_wasm("tests/all/cli_tests/numeric_args.wat")?;
-    
     // Test decimal i32
     let output = run_wasmtime_for_output(
         &[
@@ -2282,7 +2281,6 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
-    
     // Test hexadecimal i32
     let output = run_wasmtime_for_output(
         &[
@@ -2296,7 +2294,6 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
-    
     // Test decimal i64
     let output = run_wasmtime_for_output(
         &[
@@ -2310,7 +2307,6 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
-    
     // Test hexadecimal i64
     let output = run_wasmtime_for_output(
         &[
@@ -2324,6 +2320,5 @@ fn numeric_args() -> Result<()> {
     )?;
     assert_eq!(output.status.success(), true);
     assert_eq!(output.stdout, b"42\n");
-    
     Ok(())
 }

--- a/tests/all/cli_tests/numeric_args.wat
+++ b/tests/all/cli_tests/numeric_args.wat
@@ -1,0 +1,13 @@
+(module
+  (func $i32_test (export "i32_test") (param i32) (result i32)
+    local.get 0)
+  
+  (func $i64_test (export "i64_test") (param i64) (result i64)
+    local.get 0)
+  
+  (func $f32_test (export "f32_test") (param f32) (result f32)
+    local.get 0)
+  
+  (func $f64_test (export "f64_test") (param f64) (result f64)
+    local.get 0)
+) 


### PR DESCRIPTION

Previously, the CLI interface would only accept base-10 (decimal) integers when 
passing arguments to WebAssembly functions. This change adds support for 
hexadecimal notation with the '0x' prefix.

Now users can pass hexadecimal values directly to functions that expect integer
arguments, making it more convenient to work with bit patterns, addresses, and
other values commonly represented in hexadecimal format.

Fixes the TODO comment in the run.rs file that requested this feature.