### PR TITLE
Move `assembler.isle` to "untracked inputs"

### DIFF
--- a/cranelift/codegen/meta/src/isle.rs
+++ b/cranelift/codegen/meta/src/isle.rs
@@ -126,9 +126,8 @@ pub fn get_isle_compilations(
                     prelude_lower_isle.clone(),
                     src_isa_x64.join("inst.isle"),
                     src_isa_x64.join("lower.isle"),
-                    gen_dir.join("assembler.isle"),
                 ],
-                untracked_inputs: vec![clif_lower_isle.clone()],
+                untracked_inputs: vec![clif_lower_isle.clone(), gen_dir.join("assembler.isle")],
             },
             // The aarch64 instruction selector.
             IsleCompilation {


### PR DESCRIPTION
This fixes a minor issue from #10352 where because `assembler.isle` was written by the build script itself by including it in the "tracked inputs" it meant that the build script always re-ran, never caching the output. This commit moves the file to the "untracked inputs" which means that while it's used by ISLE it won't be passed to Cargo as input since it's generated in-process. This re-enables `cargo build` not doing anything after a successful build.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
