### PR TITLE
Enable async support in wast tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4783,6 +4783,7 @@ version = "32.0.0"
 dependencies = [
  "anyhow",
  "log",
+ "tokio",
  "wasmtime",
  "wast 227.0.0",
 ]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime', 'gc'] }
+wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime', 'gc', 'async'] }
 wast = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ['rt'] }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { workspace = true }
 wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime', 'gc'] }
 wast = { workspace = true }
 log = { workspace = true }
+tokio = { workspace = true, features = ['rt'] }
 
 [features]
 component-model = ['wasmtime/component-model', 'wasmtime/component-model-async']

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -9,7 +9,7 @@ mod spectest;
 mod wast;
 
 pub use crate::spectest::{link_spectest, SpectestConfig};
-pub use crate::wast::WastContext;
+pub use crate::wast::{Async, WastContext};
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/fuzz/fuzz_targets/wast_tests.rs
+++ b/fuzz/fuzz_targets/wast_tests.rs
@@ -1,9 +1,12 @@
 #![no_main]
 
+use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
-use wasmtime_fuzzing::generators::{Config, WastTest};
 
-fuzz_target!(|pair: (Config, WastTest)| {
-    let (config, test) = pair;
-    wasmtime_fuzzing::oracles::wast_test(config, test);
+fuzz_target!(|data: &[u8]| {
+    // Errors in `wast_test` have to do with not enough input in `data` or the
+    // test case being thrown out, which we ignore here since it doesn't affect
+    // how we'd like to fuzz.
+    let mut u = Unstructured::new(data);
+    let _ = wasmtime_fuzzing::oracles::wast_test(&mut u);
 });

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -4,7 +4,7 @@ use std::sync::{Condvar, LazyLock, Mutex};
 use wasmtime::{
     Config, Engine, InstanceAllocationStrategy, MpkEnabled, PoolingAllocationConfig, Store,
 };
-use wasmtime_wast::{SpectestConfig, WastContext};
+use wasmtime_wast::{Async, SpectestConfig, WastContext};
 use wasmtime_wast_util::{limits, Collector, Compiler, WastConfig, WastTest};
 
 fn main() {
@@ -123,6 +123,7 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
     };
 
     let mut cfg = Config::new();
+    cfg.async_support(true);
     component_test_util::apply_test_config(&mut cfg, &test_config);
     component_test_util::apply_wast_config(&mut cfg, &config);
 
@@ -229,7 +230,7 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
     for (engine, desc) in engines {
         let result = engine.and_then(|engine| {
             let store = Store::new(&engine, ());
-            let mut wast_context = WastContext::new(store);
+            let mut wast_context = WastContext::new(store, Async::Yes);
             wast_context.register_spectest(&SpectestConfig {
                 use_shared_memory: true,
                 suppress_prints: true,


### PR DESCRIPTION
This commit updates the `wasmtime-wast` crate to conditionally use the `Config::async_support` mode of Wasmtime, notably executing `instantiate_async` and `call_async`. At this time no actual concurrency is supported and everything is immediately await'd on via `block_on` and a local single-thread tokio runtime.

The motivation for this commit is that in the upcoming implementation of WASIp3 async will effectively be the only way to invoke components. Furthermore to test these components we're wanting to use async APIs as the root of invocations for writing `*.wast` tests for testing component-model async features.

In enabling this support this commit additionally updates the `wast_tests` fuzzer to execute all tests both with and without async. Effectively the async configuration is now a fuzz option, meaning that all tests are being executed with async now as well to ensure that they work (yay!).

The `--test wast` testing mode and `wasmtime wast` CLI command are both updated to unconditionally use async. There should be no loss in test coverage due to the fuzzer update, and right now knobs aren't provided to conditionally use sync in these two modes, again because it's currently expected that this won't be able to run component model async tests, so the defaults are changing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
