### PR TITLE
Fix an issue with DRC collector's barriers and `(extern.convert_any (ref.i31 ...))`

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -1388,8 +1388,14 @@ impl FuncEnvironment<'_> {
             | WasmHeapType::ConcreteStruct(_)
             | WasmHeapType::None => false,
 
-            // Wrong type hierarchy: cannot be an i31.
-            WasmHeapType::Extern | WasmHeapType::NoExtern => false,
+            // Despite being a different type hierarchy, this *could* be an
+            // `i31` if it is the result of
+            //
+            //     (extern.convert_any (ref.i31 ...))
+            WasmHeapType::Extern => true,
+
+            // Can only ever be `null`.
+            WasmHeapType::NoExtern => false,
 
             // Wrong type hierarchy, and also funcrefs are not GC-managed
             // types. Should have been caught by the assertion at the start of

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -23,53 +23,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v45 = iconst.i64 80
-;; @0034                               v4 = iadd v0, v45  ; v45 = 80
+;;                                     v49 = iconst.i64 80
+;; @0034                               v4 = iadd v0, v49  ; v49 = 80
 ;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v5, v46
-;;                                     v48 = iconst.i32 0
-;; @0034                               v6 = icmp eq v5, v48  ; v48 = 0
-;; @0034                               brif v6, block5, block2
+;;                                     v50 = stack_addr.i64 ss0
+;;                                     store notrap v5, v50
+;;                                     v52 = iconst.i32 1
+;; @0034                               v6 = band v5, v52  ; v52 = 1
+;;                                     v54 = iconst.i32 0
+;; @0034                               v7 = icmp eq v5, v54  ; v54 = 0
+;; @0034                               v8 = uextend.i32 v7
+;; @0034                               v9 = bor v6, v8
+;; @0034                               brif v9, block5, block2
 ;;
 ;;                                 block2:
-;; @0034                               v8 = load.i64 notrap aligned readonly v0+56
-;; @0034                               v9 = load.i64 notrap aligned v8
-;; @0034                               v10 = load.i64 notrap aligned v8+8
-;; @0034                               v11 = icmp eq v9, v10
-;; @0034                               brif v11, block3, block4
+;; @0034                               v11 = load.i64 notrap aligned readonly v0+56
+;; @0034                               v12 = load.i64 notrap aligned v11
+;; @0034                               v13 = load.i64 notrap aligned v11+8
+;; @0034                               v14 = icmp eq v12, v13
+;; @0034                               brif v14, block3, block4
 ;;
 ;;                                 block4:
-;; @0034                               v16 = uextend.i64 v5
-;; @0034                               v17 = iconst.i64 8
-;; @0034                               v18 = uadd_overflow_trap v16, v17, user1  ; v17 = 8
-;; @0034                               v20 = uadd_overflow_trap v18, v17, user1  ; v17 = 8
-;; @0034                               v15 = load.i64 notrap aligned readonly can_move v0+48
-;; @0034                               v21 = icmp ule v20, v15
-;; @0034                               trapz v21, user1
-;; @0034                               v13 = load.i64 notrap aligned readonly can_move v0+40
-;; @0034                               v22 = iadd v13, v18
-;; @0034                               v23 = load.i64 notrap aligned v22
-;;                                     v50 = iconst.i64 1
-;; @0034                               v24 = iadd v23, v50  ; v50 = 1
-;; @0034                               store notrap aligned v24, v22
-;;                                     v41 = load.i32 notrap v46
-;; @0034                               store notrap aligned v41, v9
-;;                                     v53 = iconst.i64 4
-;; @0034                               v36 = iadd.i64 v9, v53  ; v53 = 4
-;; @0034                               store notrap aligned v36, v8
+;; @0034                               v19 = uextend.i64 v5
+;; @0034                               v20 = iconst.i64 8
+;; @0034                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
+;; @0034                               v23 = uadd_overflow_trap v21, v20, user1  ; v20 = 8
+;; @0034                               v18 = load.i64 notrap aligned readonly can_move v0+48
+;; @0034                               v24 = icmp ule v23, v18
+;; @0034                               trapz v24, user1
+;; @0034                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0034                               v25 = iadd v16, v21
+;; @0034                               v26 = load.i64 notrap aligned v25
+;;                                     v56 = iconst.i64 1
+;; @0034                               v27 = iadd v26, v56  ; v56 = 1
+;; @0034                               store notrap aligned v27, v25
+;;                                     v44 = load.i32 notrap v50
+;; @0034                               store notrap aligned v44, v12
+;;                                     v59 = iconst.i64 4
+;; @0034                               v39 = iadd.i64 v12, v59  ; v59 = 4
+;; @0034                               store notrap aligned v39, v11
 ;; @0034                               jump block5
 ;;
 ;;                                 block3 cold:
-;; @0034                               v38 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]
+;; @0034                               v41 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]
 ;; @0034                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v39 = load.i32 notrap v46
+;;                                     v42 = load.i32 notrap v50
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v39
+;; @0036                               return v42
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
@@ -82,60 +86,68 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v58 = iconst.i64 80
-;; @003b                               v4 = iadd v0, v58  ; v58 = 80
+;;                                     v64 = iconst.i64 80
+;; @003b                               v4 = iadd v0, v64  ; v64 = 80
 ;; @003b                               v5 = load.i32 notrap aligned v4
-;;                                     v59 = iconst.i32 0
-;; @003b                               v6 = icmp eq v2, v59  ; v59 = 0
-;; @003b                               brif v6, block3, block2
+;;                                     v65 = iconst.i32 1
+;; @003b                               v6 = band v2, v65  ; v65 = 1
+;;                                     v66 = iconst.i32 0
+;; @003b                               v7 = icmp eq v2, v66  ; v66 = 0
+;; @003b                               v8 = uextend.i32 v7
+;; @003b                               v9 = bor v6, v8
+;; @003b                               brif v9, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v11 = uextend.i64 v2
-;; @003b                               v37 = iconst.i64 8
-;; @003b                               v13 = uadd_overflow_trap v11, v37, user1  ; v37 = 8
-;; @003b                               v15 = uadd_overflow_trap v13, v37, user1  ; v37 = 8
-;; @003b                               v35 = load.i64 notrap aligned readonly can_move v0+48
-;; @003b                               v16 = icmp ule v15, v35
-;; @003b                               trapz v16, user1
-;; @003b                               v33 = load.i64 notrap aligned readonly can_move v0+40
-;; @003b                               v17 = iadd v33, v13
-;; @003b                               v18 = load.i64 notrap aligned v17
-;;                                     v60 = iconst.i64 1
-;; @003b                               v19 = iadd v18, v60  ; v60 = 1
-;; @003b                               store notrap aligned v19, v17
+;; @003b                               v14 = uextend.i64 v2
+;; @003b                               v43 = iconst.i64 8
+;; @003b                               v16 = uadd_overflow_trap v14, v43, user1  ; v43 = 8
+;; @003b                               v18 = uadd_overflow_trap v16, v43, user1  ; v43 = 8
+;; @003b                               v41 = load.i64 notrap aligned readonly can_move v0+48
+;; @003b                               v19 = icmp ule v18, v41
+;; @003b                               trapz v19, user1
+;; @003b                               v39 = load.i64 notrap aligned readonly can_move v0+40
+;; @003b                               v20 = iadd v39, v16
+;; @003b                               v21 = load.i64 notrap aligned v20
+;;                                     v67 = iconst.i64 1
+;; @003b                               v22 = iadd v21, v67  ; v67 = 1
+;; @003b                               store notrap aligned v22, v20
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v64 = iadd.i64 v0, v58  ; v58 = 80
-;; @003b                               store.i32 notrap aligned v2, v64
-;;                                     v65 = iconst.i32 0
-;;                                     v66 = icmp.i32 eq v5, v65  ; v65 = 0
-;; @003b                               brif v66, block7, block4
+;;                                     v72 = iadd.i64 v0, v64  ; v64 = 80
+;; @003b                               store.i32 notrap aligned v2, v72
+;;                                     v73 = iconst.i32 1
+;;                                     v74 = band.i32 v5, v73  ; v73 = 1
+;;                                     v75 = iconst.i32 0
+;;                                     v76 = icmp.i32 eq v5, v75  ; v75 = 0
+;; @003b                               v36 = uextend.i32 v76
+;; @003b                               v37 = bor v74, v36
+;; @003b                               brif v37, block7, block4
 ;;
 ;;                                 block4:
-;; @003b                               v36 = uextend.i64 v5
-;;                                     v67 = iconst.i64 8
-;; @003b                               v38 = uadd_overflow_trap v36, v67, user1  ; v67 = 8
-;; @003b                               v40 = uadd_overflow_trap v38, v67, user1  ; v67 = 8
-;;                                     v68 = load.i64 notrap aligned readonly can_move v0+48
-;; @003b                               v41 = icmp ule v40, v68
-;; @003b                               trapz v41, user1
-;;                                     v69 = load.i64 notrap aligned readonly can_move v0+40
-;; @003b                               v42 = iadd v69, v38
-;; @003b                               v43 = load.i64 notrap aligned v42
-;;                                     v62 = iconst.i64 -1
-;; @003b                               v44 = iadd v43, v62  ; v62 = -1
-;;                                     v63 = iconst.i64 0
-;; @003b                               v45 = icmp eq v44, v63  ; v63 = 0
-;; @003b                               brif v45, block5, block6
+;; @003b                               v42 = uextend.i64 v5
+;;                                     v77 = iconst.i64 8
+;; @003b                               v44 = uadd_overflow_trap v42, v77, user1  ; v77 = 8
+;; @003b                               v46 = uadd_overflow_trap v44, v77, user1  ; v77 = 8
+;;                                     v78 = load.i64 notrap aligned readonly can_move v0+48
+;; @003b                               v47 = icmp ule v46, v78
+;; @003b                               trapz v47, user1
+;;                                     v79 = load.i64 notrap aligned readonly can_move v0+40
+;; @003b                               v48 = iadd v79, v44
+;; @003b                               v49 = load.i64 notrap aligned v48
+;;                                     v70 = iconst.i64 -1
+;; @003b                               v50 = iadd v49, v70  ; v70 = -1
+;;                                     v71 = iconst.i64 0
+;; @003b                               v51 = icmp eq v50, v71  ; v71 = 0
+;; @003b                               brif v51, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v5)
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;;                                     v70 = iadd.i64 v43, v62  ; v62 = -1
-;; @003b                               store notrap aligned v70, v42
+;;                                     v80 = iadd.i64 v49, v70  ; v70 = -1
+;; @003b                               store notrap aligned v80, v48
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -25,138 +25,150 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v94 = iconst.i64 96
-;; @008f                               v7 = iadd v0, v94  ; v94 = 96
+;;                                     v102 = iconst.i64 96
+;; @008f                               v7 = iadd v0, v102  ; v102 = 96
 ;; @008f                               v8 = load.i32 notrap aligned readonly can_move v7
-;;                                     v95 = stack_addr.i64 ss0
-;;                                     store notrap v8, v95
-;;                                     v96 = stack_addr.i64 ss0
-;;                                     v93 = load.i32 notrap v96
-;;                                     v97 = iconst.i32 0
-;; @008f                               v9 = icmp eq v93, v97  ; v97 = 0
-;; @008f                               brif v9, block5, block2
+;;                                     v103 = stack_addr.i64 ss0
+;;                                     store notrap v8, v103
+;;                                     v104 = stack_addr.i64 ss0
+;;                                     v101 = load.i32 notrap v104
+;;                                     v105 = iconst.i32 1
+;; @008f                               v9 = band v101, v105  ; v105 = 1
+;;                                     v106 = stack_addr.i64 ss0
+;;                                     v100 = load.i32 notrap v106
+;;                                     v107 = iconst.i32 0
+;; @008f                               v10 = icmp eq v100, v107  ; v107 = 0
+;; @008f                               v11 = uextend.i32 v10
+;; @008f                               v12 = bor v9, v11
+;; @008f                               brif v12, block5, block2
 ;;
 ;;                                 block2:
-;; @008f                               v11 = load.i64 notrap aligned readonly v0+56
-;; @008f                               v12 = load.i64 notrap aligned v11
-;; @008f                               v13 = load.i64 notrap aligned v11+8
-;; @008f                               v14 = icmp eq v12, v13
-;; @008f                               brif v14, block3, block4
+;; @008f                               v14 = load.i64 notrap aligned readonly v0+56
+;; @008f                               v15 = load.i64 notrap aligned v14
+;; @008f                               v16 = load.i64 notrap aligned v14+8
+;; @008f                               v17 = icmp eq v15, v16
+;; @008f                               brif v17, block3, block4
 ;;
 ;;                                 block4:
-;; @008f                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @008f                               v18 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v98 = stack_addr.i64 ss0
-;;                                     v92 = load.i32 notrap v98
-;; @008f                               v19 = uextend.i64 v92
-;; @008f                               v20 = iconst.i64 8
-;; @008f                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
-;; @008f                               v22 = iconst.i64 8
-;; @008f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
-;; @008f                               v24 = icmp ule v23, v18
-;; @008f                               trapz v24, user1
-;; @008f                               v25 = iadd v16, v21
-;; @008f                               v26 = load.i64 notrap aligned v25
-;;                                     v99 = iconst.i64 1
-;; @008f                               v27 = iadd v26, v99  ; v99 = 1
-;; @008f                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @008f                               v31 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v100 = stack_addr.i64 ss0
-;;                                     v91 = load.i32 notrap v100
-;; @008f                               v32 = uextend.i64 v91
-;; @008f                               v33 = iconst.i64 8
-;; @008f                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @008f                               v35 = iconst.i64 8
-;; @008f                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
-;; @008f                               v37 = icmp ule v36, v31
-;; @008f                               trapz v37, user1
-;; @008f                               v38 = iadd v29, v34
-;; @008f                               store notrap aligned v27, v38
-;;                                     v101 = stack_addr.i64 ss0
-;;                                     v90 = load.i32 notrap v101
-;; @008f                               store notrap aligned v90, v12
-;;                                     v102 = iconst.i64 4
-;; @008f                               v39 = iadd.i64 v12, v102  ; v102 = 4
-;; @008f                               store notrap aligned v39, v11
+;; @008f                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @008f                               v21 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v108 = stack_addr.i64 ss0
+;;                                     v99 = load.i32 notrap v108
+;; @008f                               v22 = uextend.i64 v99
+;; @008f                               v23 = iconst.i64 8
+;; @008f                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
+;; @008f                               v25 = iconst.i64 8
+;; @008f                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
+;; @008f                               v27 = icmp ule v26, v21
+;; @008f                               trapz v27, user1
+;; @008f                               v28 = iadd v19, v24
+;; @008f                               v29 = load.i64 notrap aligned v28
+;;                                     v109 = iconst.i64 1
+;; @008f                               v30 = iadd v29, v109  ; v109 = 1
+;; @008f                               v32 = load.i64 notrap aligned readonly can_move v0+40
+;; @008f                               v34 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v110 = stack_addr.i64 ss0
+;;                                     v98 = load.i32 notrap v110
+;; @008f                               v35 = uextend.i64 v98
+;; @008f                               v36 = iconst.i64 8
+;; @008f                               v37 = uadd_overflow_trap v35, v36, user1  ; v36 = 8
+;; @008f                               v38 = iconst.i64 8
+;; @008f                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
+;; @008f                               v40 = icmp ule v39, v34
+;; @008f                               trapz v40, user1
+;; @008f                               v41 = iadd v32, v37
+;; @008f                               store notrap aligned v30, v41
+;;                                     v111 = stack_addr.i64 ss0
+;;                                     v97 = load.i32 notrap v111
+;; @008f                               store notrap aligned v97, v15
+;;                                     v112 = iconst.i64 4
+;; @008f                               v42 = iadd.i64 v15, v112  ; v112 = 4
+;; @008f                               store notrap aligned v42, v14
 ;; @008f                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v103 = stack_addr.i64 ss0
-;;                                     v89 = load.i32 notrap v103
-;; @008f                               v41 = call fn0(v0, v89), stack_map=[i32 @ ss0+0]
+;;                                     v113 = stack_addr.i64 ss0
+;;                                     v96 = load.i32 notrap v113
+;; @008f                               v44 = call fn0(v0, v96), stack_map=[i32 @ ss0+0]
 ;; @008f                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v104 = iconst.i64 112
-;; @0091                               v43 = iadd.i64 v0, v104  ; v104 = 112
-;; @0091                               v44 = load.i32 notrap aligned readonly can_move v43
-;;                                     v105 = stack_addr.i64 ss1
-;;                                     store notrap v44, v105
-;;                                     v106 = stack_addr.i64 ss1
-;;                                     v88 = load.i32 notrap v106
-;;                                     v107 = iconst.i32 0
-;; @0091                               v45 = icmp eq v88, v107  ; v107 = 0
-;; @0091                               brif v45, block9, block6
+;;                                     v114 = iconst.i64 112
+;; @0091                               v46 = iadd.i64 v0, v114  ; v114 = 112
+;; @0091                               v47 = load.i32 notrap aligned readonly can_move v46
+;;                                     v115 = stack_addr.i64 ss1
+;;                                     store notrap v47, v115
+;;                                     v116 = stack_addr.i64 ss1
+;;                                     v95 = load.i32 notrap v116
+;;                                     v117 = iconst.i32 1
+;; @0091                               v48 = band v95, v117  ; v117 = 1
+;;                                     v118 = stack_addr.i64 ss1
+;;                                     v94 = load.i32 notrap v118
+;;                                     v119 = iconst.i32 0
+;; @0091                               v49 = icmp eq v94, v119  ; v119 = 0
+;; @0091                               v50 = uextend.i32 v49
+;; @0091                               v51 = bor v48, v50
+;; @0091                               brif v51, block9, block6
 ;;
 ;;                                 block6:
-;; @0091                               v47 = load.i64 notrap aligned readonly v0+56
-;; @0091                               v48 = load.i64 notrap aligned v47
-;; @0091                               v49 = load.i64 notrap aligned v47+8
-;; @0091                               v50 = icmp eq v48, v49
-;; @0091                               brif v50, block7, block8
+;; @0091                               v53 = load.i64 notrap aligned readonly v0+56
+;; @0091                               v54 = load.i64 notrap aligned v53
+;; @0091                               v55 = load.i64 notrap aligned v53+8
+;; @0091                               v56 = icmp eq v54, v55
+;; @0091                               brif v56, block7, block8
 ;;
 ;;                                 block8:
-;; @0091                               v52 = load.i64 notrap aligned readonly can_move v0+40
-;; @0091                               v54 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v108 = stack_addr.i64 ss1
-;;                                     v87 = load.i32 notrap v108
-;; @0091                               v55 = uextend.i64 v87
-;; @0091                               v56 = iconst.i64 8
-;; @0091                               v57 = uadd_overflow_trap v55, v56, user1  ; v56 = 8
-;; @0091                               v58 = iconst.i64 8
-;; @0091                               v59 = uadd_overflow_trap v57, v58, user1  ; v58 = 8
-;; @0091                               v60 = icmp ule v59, v54
-;; @0091                               trapz v60, user1
-;; @0091                               v61 = iadd v52, v57
-;; @0091                               v62 = load.i64 notrap aligned v61
-;;                                     v109 = iconst.i64 1
-;; @0091                               v63 = iadd v62, v109  ; v109 = 1
-;; @0091                               v65 = load.i64 notrap aligned readonly can_move v0+40
-;; @0091                               v67 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v110 = stack_addr.i64 ss1
-;;                                     v86 = load.i32 notrap v110
-;; @0091                               v68 = uextend.i64 v86
-;; @0091                               v69 = iconst.i64 8
-;; @0091                               v70 = uadd_overflow_trap v68, v69, user1  ; v69 = 8
-;; @0091                               v71 = iconst.i64 8
-;; @0091                               v72 = uadd_overflow_trap v70, v71, user1  ; v71 = 8
-;; @0091                               v73 = icmp ule v72, v67
-;; @0091                               trapz v73, user1
-;; @0091                               v74 = iadd v65, v70
-;; @0091                               store notrap aligned v63, v74
-;;                                     v111 = stack_addr.i64 ss1
-;;                                     v85 = load.i32 notrap v111
-;; @0091                               store notrap aligned v85, v48
-;;                                     v112 = iconst.i64 4
-;; @0091                               v75 = iadd.i64 v48, v112  ; v112 = 4
-;; @0091                               store notrap aligned v75, v47
+;; @0091                               v58 = load.i64 notrap aligned readonly can_move v0+40
+;; @0091                               v60 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v120 = stack_addr.i64 ss1
+;;                                     v93 = load.i32 notrap v120
+;; @0091                               v61 = uextend.i64 v93
+;; @0091                               v62 = iconst.i64 8
+;; @0091                               v63 = uadd_overflow_trap v61, v62, user1  ; v62 = 8
+;; @0091                               v64 = iconst.i64 8
+;; @0091                               v65 = uadd_overflow_trap v63, v64, user1  ; v64 = 8
+;; @0091                               v66 = icmp ule v65, v60
+;; @0091                               trapz v66, user1
+;; @0091                               v67 = iadd v58, v63
+;; @0091                               v68 = load.i64 notrap aligned v67
+;;                                     v121 = iconst.i64 1
+;; @0091                               v69 = iadd v68, v121  ; v121 = 1
+;; @0091                               v71 = load.i64 notrap aligned readonly can_move v0+40
+;; @0091                               v73 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v122 = stack_addr.i64 ss1
+;;                                     v92 = load.i32 notrap v122
+;; @0091                               v74 = uextend.i64 v92
+;; @0091                               v75 = iconst.i64 8
+;; @0091                               v76 = uadd_overflow_trap v74, v75, user1  ; v75 = 8
+;; @0091                               v77 = iconst.i64 8
+;; @0091                               v78 = uadd_overflow_trap v76, v77, user1  ; v77 = 8
+;; @0091                               v79 = icmp ule v78, v73
+;; @0091                               trapz v79, user1
+;; @0091                               v80 = iadd v71, v76
+;; @0091                               store notrap aligned v69, v80
+;;                                     v123 = stack_addr.i64 ss1
+;;                                     v91 = load.i32 notrap v123
+;; @0091                               store notrap aligned v91, v54
+;;                                     v124 = iconst.i64 4
+;; @0091                               v81 = iadd.i64 v54, v124  ; v124 = 4
+;; @0091                               store notrap aligned v81, v53
 ;; @0091                               jump block9
 ;;
 ;;                                 block7 cold:
-;;                                     v113 = stack_addr.i64 ss1
-;;                                     v84 = load.i32 notrap v113
-;; @0091                               v77 = call fn0(v0, v84), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;;                                     v125 = stack_addr.i64 ss1
+;;                                     v90 = load.i32 notrap v125
+;; @0091                               v83 = call fn0(v0, v90), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0091                               jump block9
 ;;
 ;;                                 block9:
-;; @0093                               v79 = load.i64 notrap aligned table v0+128
-;; @0095                               v81 = load.i64 notrap aligned table v0+144
-;;                                     v114 = stack_addr.i64 ss0
-;;                                     v82 = load.i32 notrap v114
-;;                                     v115 = stack_addr.i64 ss1
-;;                                     v83 = load.i32 notrap v115
+;; @0093                               v85 = load.i64 notrap aligned table v0+128
+;; @0095                               v87 = load.i64 notrap aligned table v0+144
+;;                                     v126 = stack_addr.i64 ss0
+;;                                     v88 = load.i32 notrap v126
+;;                                     v127 = stack_addr.i64 ss1
+;;                                     v89 = load.i32 notrap v127
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
-;; @0097                               return v82, v83, v79, v81
+;; @0097                               return v88, v89, v85, v87
 ;; }

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -32,77 +32,83 @@
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0054                               v7 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v53 = iconst.i64 2
-;; @0054                               v8 = ishl v6, v53  ; v53 = 2
+;;                                     v57 = iconst.i64 2
+;; @0054                               v8 = ishl v6, v57  ; v57 = 2
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.i32 user5 aligned table v11
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v12, v54
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v51 = load.i32 notrap v55
-;;                                     v56 = iconst.i32 0
-;; @0054                               v13 = icmp eq v51, v56  ; v56 = 0
-;; @0054                               brif v13, block5, block2
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     store notrap v12, v58
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v55 = load.i32 notrap v59
+;;                                     v60 = iconst.i32 1
+;; @0054                               v13 = band v55, v60  ; v60 = 1
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v54 = load.i32 notrap v61
+;;                                     v62 = iconst.i32 0
+;; @0054                               v14 = icmp eq v54, v62  ; v62 = 0
+;; @0054                               v15 = uextend.i32 v14
+;; @0054                               v16 = bor v13, v15
+;; @0054                               brif v16, block5, block2
 ;;
 ;;                                 block2:
-;; @0054                               v15 = load.i64 notrap aligned readonly v0+56
-;; @0054                               v16 = load.i64 notrap aligned v15
-;; @0054                               v17 = load.i64 notrap aligned v15+8
-;; @0054                               v18 = icmp eq v16, v17
-;; @0054                               brif v18, block3, block4
+;; @0054                               v18 = load.i64 notrap aligned readonly v0+56
+;; @0054                               v19 = load.i64 notrap aligned v18
+;; @0054                               v20 = load.i64 notrap aligned v18+8
+;; @0054                               v21 = icmp eq v19, v20
+;; @0054                               brif v21, block3, block4
 ;;
 ;;                                 block4:
-;; @0054                               v20 = load.i64 notrap aligned readonly can_move v0+40
-;; @0054                               v22 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v57
-;; @0054                               v23 = uextend.i64 v50
-;; @0054                               v24 = iconst.i64 8
-;; @0054                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @0054                               v26 = iconst.i64 8
-;; @0054                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
-;; @0054                               v28 = icmp ule v27, v22
-;; @0054                               trapz v28, user1
-;; @0054                               v29 = iadd v20, v25
-;; @0054                               v30 = load.i64 notrap aligned v29
-;;                                     v58 = iconst.i64 1
-;; @0054                               v31 = iadd v30, v58  ; v58 = 1
-;; @0054                               v33 = load.i64 notrap aligned readonly can_move v0+40
-;; @0054                               v35 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v59 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v59
-;; @0054                               v36 = uextend.i64 v49
-;; @0054                               v37 = iconst.i64 8
-;; @0054                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
-;; @0054                               v39 = iconst.i64 8
-;; @0054                               v40 = uadd_overflow_trap v38, v39, user1  ; v39 = 8
-;; @0054                               v41 = icmp ule v40, v35
-;; @0054                               trapz v41, user1
-;; @0054                               v42 = iadd v33, v38
-;; @0054                               store notrap aligned v31, v42
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v60
-;; @0054                               store notrap aligned v48, v16
-;;                                     v61 = iconst.i64 4
-;; @0054                               v43 = iadd.i64 v16, v61  ; v61 = 4
-;; @0054                               store notrap aligned v43, v15
+;; @0054                               v23 = load.i64 notrap aligned readonly can_move v0+40
+;; @0054                               v25 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v53 = load.i32 notrap v63
+;; @0054                               v26 = uextend.i64 v53
+;; @0054                               v27 = iconst.i64 8
+;; @0054                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
+;; @0054                               v29 = iconst.i64 8
+;; @0054                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
+;; @0054                               v31 = icmp ule v30, v25
+;; @0054                               trapz v31, user1
+;; @0054                               v32 = iadd v23, v28
+;; @0054                               v33 = load.i64 notrap aligned v32
+;;                                     v64 = iconst.i64 1
+;; @0054                               v34 = iadd v33, v64  ; v64 = 1
+;; @0054                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @0054                               v38 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v65
+;; @0054                               v39 = uextend.i64 v52
+;; @0054                               v40 = iconst.i64 8
+;; @0054                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
+;; @0054                               v42 = iconst.i64 8
+;; @0054                               v43 = uadd_overflow_trap v41, v42, user1  ; v42 = 8
+;; @0054                               v44 = icmp ule v43, v38
+;; @0054                               trapz v44, user1
+;; @0054                               v45 = iadd v36, v41
+;; @0054                               store notrap aligned v34, v45
+;;                                     v66 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v66
+;; @0054                               store notrap aligned v51, v19
+;;                                     v67 = iconst.i64 4
+;; @0054                               v46 = iadd.i64 v19, v67  ; v67 = 4
+;; @0054                               store notrap aligned v46, v18
 ;; @0054                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v62
-;; @0054                               v45 = call fn0(v0, v47), stack_map=[i32 @ ss0+0]
+;;                                     v68 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v68
+;; @0054                               v48 = call fn0(v0, v50), stack_map=[i32 @ ss0+0]
 ;; @0054                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v63
+;;                                     v69 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v69
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v46
+;; @0056                               return v49
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -121,75 +127,81 @@
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v7 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v53 = iconst.i64 2
-;; @005b                               v8 = ishl v6, v53  ; v53 = 2
+;;                                     v57 = iconst.i64 2
+;; @005b                               v8 = ishl v6, v57  ; v57 = 2
 ;; @005b                               v9 = iadd v7, v8
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.i32 user5 aligned table v11
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v12, v54
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v51 = load.i32 notrap v55
-;;                                     v56 = iconst.i32 0
-;; @005b                               v13 = icmp eq v51, v56  ; v56 = 0
-;; @005b                               brif v13, block5, block2
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     store notrap v12, v58
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v55 = load.i32 notrap v59
+;;                                     v60 = iconst.i32 1
+;; @005b                               v13 = band v55, v60  ; v60 = 1
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v54 = load.i32 notrap v61
+;;                                     v62 = iconst.i32 0
+;; @005b                               v14 = icmp eq v54, v62  ; v62 = 0
+;; @005b                               v15 = uextend.i32 v14
+;; @005b                               v16 = bor v13, v15
+;; @005b                               brif v16, block5, block2
 ;;
 ;;                                 block2:
-;; @005b                               v15 = load.i64 notrap aligned readonly v0+56
-;; @005b                               v16 = load.i64 notrap aligned v15
-;; @005b                               v17 = load.i64 notrap aligned v15+8
-;; @005b                               v18 = icmp eq v16, v17
-;; @005b                               brif v18, block3, block4
+;; @005b                               v18 = load.i64 notrap aligned readonly v0+56
+;; @005b                               v19 = load.i64 notrap aligned v18
+;; @005b                               v20 = load.i64 notrap aligned v18+8
+;; @005b                               v21 = icmp eq v19, v20
+;; @005b                               brif v21, block3, block4
 ;;
 ;;                                 block4:
-;; @005b                               v20 = load.i64 notrap aligned readonly can_move v0+40
-;; @005b                               v22 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v57
-;; @005b                               v23 = uextend.i64 v50
-;; @005b                               v24 = iconst.i64 8
-;; @005b                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
-;; @005b                               v26 = iconst.i64 8
-;; @005b                               v27 = uadd_overflow_trap v25, v26, user1  ; v26 = 8
-;; @005b                               v28 = icmp ule v27, v22
-;; @005b                               trapz v28, user1
-;; @005b                               v29 = iadd v20, v25
-;; @005b                               v30 = load.i64 notrap aligned v29
-;;                                     v58 = iconst.i64 1
-;; @005b                               v31 = iadd v30, v58  ; v58 = 1
-;; @005b                               v33 = load.i64 notrap aligned readonly can_move v0+40
-;; @005b                               v35 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v59 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v59
-;; @005b                               v36 = uextend.i64 v49
-;; @005b                               v37 = iconst.i64 8
-;; @005b                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
-;; @005b                               v39 = iconst.i64 8
-;; @005b                               v40 = uadd_overflow_trap v38, v39, user1  ; v39 = 8
-;; @005b                               v41 = icmp ule v40, v35
-;; @005b                               trapz v41, user1
-;; @005b                               v42 = iadd v33, v38
-;; @005b                               store notrap aligned v31, v42
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v60
-;; @005b                               store notrap aligned v48, v16
-;;                                     v61 = iconst.i64 4
-;; @005b                               v43 = iadd.i64 v16, v61  ; v61 = 4
-;; @005b                               store notrap aligned v43, v15
+;; @005b                               v23 = load.i64 notrap aligned readonly can_move v0+40
+;; @005b                               v25 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v53 = load.i32 notrap v63
+;; @005b                               v26 = uextend.i64 v53
+;; @005b                               v27 = iconst.i64 8
+;; @005b                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
+;; @005b                               v29 = iconst.i64 8
+;; @005b                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
+;; @005b                               v31 = icmp ule v30, v25
+;; @005b                               trapz v31, user1
+;; @005b                               v32 = iadd v23, v28
+;; @005b                               v33 = load.i64 notrap aligned v32
+;;                                     v64 = iconst.i64 1
+;; @005b                               v34 = iadd v33, v64  ; v64 = 1
+;; @005b                               v36 = load.i64 notrap aligned readonly can_move v0+40
+;; @005b                               v38 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v65
+;; @005b                               v39 = uextend.i64 v52
+;; @005b                               v40 = iconst.i64 8
+;; @005b                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
+;; @005b                               v42 = iconst.i64 8
+;; @005b                               v43 = uadd_overflow_trap v41, v42, user1  ; v42 = 8
+;; @005b                               v44 = icmp ule v43, v38
+;; @005b                               trapz v44, user1
+;; @005b                               v45 = iadd v36, v41
+;; @005b                               store notrap aligned v34, v45
+;;                                     v66 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v66
+;; @005b                               store notrap aligned v51, v19
+;;                                     v67 = iconst.i64 4
+;; @005b                               v46 = iadd.i64 v19, v67  ; v67 = 4
+;; @005b                               store notrap aligned v46, v18
 ;; @005b                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v62
-;; @005b                               v45 = call fn0(v0, v47), stack_map=[i32 @ ss0+0]
+;;                                     v68 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v68
+;; @005b                               v48 = call fn0(v0, v50), stack_map=[i32 @ ss0+0]
 ;; @005b                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v46 = load.i32 notrap v63
+;;                                     v69 = stack_addr.i64 ss0
+;;                                     v49 = load.i32 notrap v69
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v46
+;; @005d                               return v49
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -33,77 +33,83 @@
 ;; @0053                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0053                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0053                               v8 = load.i64 notrap aligned v0+72
-;;                                     v55 = iconst.i64 2
-;; @0053                               v9 = ishl v7, v55  ; v55 = 2
+;;                                     v59 = iconst.i64 2
+;; @0053                               v9 = ishl v7, v59  ; v59 = 2
 ;; @0053                               v10 = iadd v8, v9
 ;; @0053                               v11 = iconst.i64 0
 ;; @0053                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0053                               v13 = load.i32 user5 aligned table v12
-;;                                     v56 = stack_addr.i64 ss0
-;;                                     store notrap v13, v56
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v52 = load.i32 notrap v57
-;;                                     v58 = iconst.i32 0
-;; @0053                               v14 = icmp eq v52, v58  ; v58 = 0
-;; @0053                               brif v14, block5, block2
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     store notrap v13, v60
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v56 = load.i32 notrap v61
+;;                                     v62 = iconst.i32 1
+;; @0053                               v14 = band v56, v62  ; v62 = 1
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v55 = load.i32 notrap v63
+;;                                     v64 = iconst.i32 0
+;; @0053                               v15 = icmp eq v55, v64  ; v64 = 0
+;; @0053                               v16 = uextend.i32 v15
+;; @0053                               v17 = bor v14, v16
+;; @0053                               brif v17, block5, block2
 ;;
 ;;                                 block2:
-;; @0053                               v16 = load.i64 notrap aligned readonly v0+56
-;; @0053                               v17 = load.i64 notrap aligned v16
-;; @0053                               v18 = load.i64 notrap aligned v16+8
-;; @0053                               v19 = icmp eq v17, v18
-;; @0053                               brif v19, block3, block4
+;; @0053                               v19 = load.i64 notrap aligned readonly v0+56
+;; @0053                               v20 = load.i64 notrap aligned v19
+;; @0053                               v21 = load.i64 notrap aligned v19+8
+;; @0053                               v22 = icmp eq v20, v21
+;; @0053                               brif v22, block3, block4
 ;;
 ;;                                 block4:
-;; @0053                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @0053                               v23 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v59 = stack_addr.i64 ss0
-;;                                     v51 = load.i32 notrap v59
-;; @0053                               v24 = uextend.i64 v51
-;; @0053                               v25 = iconst.i64 8
-;; @0053                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
-;; @0053                               v27 = iconst.i64 8
-;; @0053                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
-;; @0053                               v29 = icmp ule v28, v23
-;; @0053                               trapz v29, user1
-;; @0053                               v30 = iadd v21, v26
-;; @0053                               v31 = load.i64 notrap aligned v30
-;;                                     v60 = iconst.i64 1
-;; @0053                               v32 = iadd v31, v60  ; v60 = 1
-;; @0053                               v34 = load.i64 notrap aligned readonly can_move v0+40
-;; @0053                               v36 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v61
-;; @0053                               v37 = uextend.i64 v50
-;; @0053                               v38 = iconst.i64 8
-;; @0053                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
-;; @0053                               v40 = iconst.i64 8
-;; @0053                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
-;; @0053                               v42 = icmp ule v41, v36
-;; @0053                               trapz v42, user1
-;; @0053                               v43 = iadd v34, v39
-;; @0053                               store notrap aligned v32, v43
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v62
-;; @0053                               store notrap aligned v49, v17
-;;                                     v63 = iconst.i64 4
-;; @0053                               v44 = iadd.i64 v17, v63  ; v63 = 4
-;; @0053                               store notrap aligned v44, v16
+;; @0053                               v24 = load.i64 notrap aligned readonly can_move v0+40
+;; @0053                               v26 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v54 = load.i32 notrap v65
+;; @0053                               v27 = uextend.i64 v54
+;; @0053                               v28 = iconst.i64 8
+;; @0053                               v29 = uadd_overflow_trap v27, v28, user1  ; v28 = 8
+;; @0053                               v30 = iconst.i64 8
+;; @0053                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @0053                               v32 = icmp ule v31, v26
+;; @0053                               trapz v32, user1
+;; @0053                               v33 = iadd v24, v29
+;; @0053                               v34 = load.i64 notrap aligned v33
+;;                                     v66 = iconst.i64 1
+;; @0053                               v35 = iadd v34, v66  ; v66 = 1
+;; @0053                               v37 = load.i64 notrap aligned readonly can_move v0+40
+;; @0053                               v39 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v67 = stack_addr.i64 ss0
+;;                                     v53 = load.i32 notrap v67
+;; @0053                               v40 = uextend.i64 v53
+;; @0053                               v41 = iconst.i64 8
+;; @0053                               v42 = uadd_overflow_trap v40, v41, user1  ; v41 = 8
+;; @0053                               v43 = iconst.i64 8
+;; @0053                               v44 = uadd_overflow_trap v42, v43, user1  ; v43 = 8
+;; @0053                               v45 = icmp ule v44, v39
+;; @0053                               trapz v45, user1
+;; @0053                               v46 = iadd v37, v42
+;; @0053                               store notrap aligned v35, v46
+;;                                     v68 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v68
+;; @0053                               store notrap aligned v52, v20
+;;                                     v69 = iconst.i64 4
+;; @0053                               v47 = iadd.i64 v20, v69  ; v69 = 4
+;; @0053                               store notrap aligned v47, v19
 ;; @0053                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v64 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v64
-;; @0053                               v46 = call fn0(v0, v48), stack_map=[i32 @ ss0+0]
+;;                                     v70 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v70
+;; @0053                               v49 = call fn0(v0, v51), stack_map=[i32 @ ss0+0]
 ;; @0053                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v65 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v65
+;;                                     v71 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v71
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v47
+;; @0055                               return v50
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
@@ -124,75 +130,81 @@
 ;; @005a                               v6 = icmp uge v2, v5
 ;; @005a                               v7 = uextend.i64 v2
 ;; @005a                               v8 = load.i64 notrap aligned v0+72
-;;                                     v55 = iconst.i64 2
-;; @005a                               v9 = ishl v7, v55  ; v55 = 2
+;;                                     v59 = iconst.i64 2
+;; @005a                               v9 = ishl v7, v59  ; v59 = 2
 ;; @005a                               v10 = iadd v8, v9
 ;; @005a                               v11 = iconst.i64 0
 ;; @005a                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005a                               v13 = load.i32 user5 aligned table v12
-;;                                     v56 = stack_addr.i64 ss0
-;;                                     store notrap v13, v56
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v52 = load.i32 notrap v57
-;;                                     v58 = iconst.i32 0
-;; @005a                               v14 = icmp eq v52, v58  ; v58 = 0
-;; @005a                               brif v14, block5, block2
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     store notrap v13, v60
+;;                                     v61 = stack_addr.i64 ss0
+;;                                     v56 = load.i32 notrap v61
+;;                                     v62 = iconst.i32 1
+;; @005a                               v14 = band v56, v62  ; v62 = 1
+;;                                     v63 = stack_addr.i64 ss0
+;;                                     v55 = load.i32 notrap v63
+;;                                     v64 = iconst.i32 0
+;; @005a                               v15 = icmp eq v55, v64  ; v64 = 0
+;; @005a                               v16 = uextend.i32 v15
+;; @005a                               v17 = bor v14, v16
+;; @005a                               brif v17, block5, block2
 ;;
 ;;                                 block2:
-;; @005a                               v16 = load.i64 notrap aligned readonly v0+56
-;; @005a                               v17 = load.i64 notrap aligned v16
-;; @005a                               v18 = load.i64 notrap aligned v16+8
-;; @005a                               v19 = icmp eq v17, v18
-;; @005a                               brif v19, block3, block4
+;; @005a                               v19 = load.i64 notrap aligned readonly v0+56
+;; @005a                               v20 = load.i64 notrap aligned v19
+;; @005a                               v21 = load.i64 notrap aligned v19+8
+;; @005a                               v22 = icmp eq v20, v21
+;; @005a                               brif v22, block3, block4
 ;;
 ;;                                 block4:
-;; @005a                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @005a                               v23 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v59 = stack_addr.i64 ss0
-;;                                     v51 = load.i32 notrap v59
-;; @005a                               v24 = uextend.i64 v51
-;; @005a                               v25 = iconst.i64 8
-;; @005a                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
-;; @005a                               v27 = iconst.i64 8
-;; @005a                               v28 = uadd_overflow_trap v26, v27, user1  ; v27 = 8
-;; @005a                               v29 = icmp ule v28, v23
-;; @005a                               trapz v29, user1
-;; @005a                               v30 = iadd v21, v26
-;; @005a                               v31 = load.i64 notrap aligned v30
-;;                                     v60 = iconst.i64 1
-;; @005a                               v32 = iadd v31, v60  ; v60 = 1
-;; @005a                               v34 = load.i64 notrap aligned readonly can_move v0+40
-;; @005a                               v36 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v50 = load.i32 notrap v61
-;; @005a                               v37 = uextend.i64 v50
-;; @005a                               v38 = iconst.i64 8
-;; @005a                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
-;; @005a                               v40 = iconst.i64 8
-;; @005a                               v41 = uadd_overflow_trap v39, v40, user1  ; v40 = 8
-;; @005a                               v42 = icmp ule v41, v36
-;; @005a                               trapz v42, user1
-;; @005a                               v43 = iadd v34, v39
-;; @005a                               store notrap aligned v32, v43
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v49 = load.i32 notrap v62
-;; @005a                               store notrap aligned v49, v17
-;;                                     v63 = iconst.i64 4
-;; @005a                               v44 = iadd.i64 v17, v63  ; v63 = 4
-;; @005a                               store notrap aligned v44, v16
+;; @005a                               v24 = load.i64 notrap aligned readonly can_move v0+40
+;; @005a                               v26 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v65 = stack_addr.i64 ss0
+;;                                     v54 = load.i32 notrap v65
+;; @005a                               v27 = uextend.i64 v54
+;; @005a                               v28 = iconst.i64 8
+;; @005a                               v29 = uadd_overflow_trap v27, v28, user1  ; v28 = 8
+;; @005a                               v30 = iconst.i64 8
+;; @005a                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @005a                               v32 = icmp ule v31, v26
+;; @005a                               trapz v32, user1
+;; @005a                               v33 = iadd v24, v29
+;; @005a                               v34 = load.i64 notrap aligned v33
+;;                                     v66 = iconst.i64 1
+;; @005a                               v35 = iadd v34, v66  ; v66 = 1
+;; @005a                               v37 = load.i64 notrap aligned readonly can_move v0+40
+;; @005a                               v39 = load.i64 notrap aligned readonly can_move v0+48
+;;                                     v67 = stack_addr.i64 ss0
+;;                                     v53 = load.i32 notrap v67
+;; @005a                               v40 = uextend.i64 v53
+;; @005a                               v41 = iconst.i64 8
+;; @005a                               v42 = uadd_overflow_trap v40, v41, user1  ; v41 = 8
+;; @005a                               v43 = iconst.i64 8
+;; @005a                               v44 = uadd_overflow_trap v42, v43, user1  ; v43 = 8
+;; @005a                               v45 = icmp ule v44, v39
+;; @005a                               trapz v45, user1
+;; @005a                               v46 = iadd v37, v42
+;; @005a                               store notrap aligned v35, v46
+;;                                     v68 = stack_addr.i64 ss0
+;;                                     v52 = load.i32 notrap v68
+;; @005a                               store notrap aligned v52, v20
+;;                                     v69 = iconst.i64 4
+;; @005a                               v47 = iadd.i64 v20, v69  ; v69 = 4
+;; @005a                               store notrap aligned v47, v19
 ;; @005a                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v64 = stack_addr.i64 ss0
-;;                                     v48 = load.i32 notrap v64
-;; @005a                               v46 = call fn0(v0, v48), stack_map=[i32 @ ss0+0]
+;;                                     v70 = stack_addr.i64 ss0
+;;                                     v51 = load.i32 notrap v70
+;; @005a                               v49 = call fn0(v0, v51), stack_map=[i32 @ ss0+0]
 ;; @005a                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v65 = stack_addr.i64 ss0
-;;                                     v47 = load.i32 notrap v65
+;;                                     v71 = stack_addr.i64 ss0
+;;                                     v50 = load.i32 notrap v71
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v47
+;; @005c                               return v50
 ;; }

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -32,83 +32,91 @@
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v7 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v66 = iconst.i64 2
-;; @0056                               v8 = ishl v6, v66  ; v66 = 2
+;;                                     v72 = iconst.i64 2
+;; @0056                               v8 = ishl v6, v72  ; v72 = 2
 ;; @0056                               v9 = iadd v7, v8
 ;; @0056                               v10 = iconst.i64 0
 ;; @0056                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0056                               v12 = load.i32 user5 aligned table v11
-;;                                     v67 = iconst.i32 0
-;; @0056                               v13 = icmp eq v2, v67  ; v67 = 0
-;; @0056                               brif v13, block3, block2
+;;                                     v73 = iconst.i32 1
+;; @0056                               v13 = band v2, v73  ; v73 = 1
+;;                                     v74 = iconst.i32 0
+;; @0056                               v14 = icmp eq v2, v74  ; v74 = 0
+;; @0056                               v15 = uextend.i32 v14
+;; @0056                               v16 = bor v13, v15
+;; @0056                               brif v16, block3, block2
 ;;
 ;;                                 block2:
-;; @0056                               v15 = load.i64 notrap aligned readonly can_move v0+40
-;; @0056                               v17 = load.i64 notrap aligned readonly can_move v0+48
-;; @0056                               v18 = uextend.i64 v2
-;; @0056                               v19 = iconst.i64 8
-;; @0056                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
-;; @0056                               v21 = iconst.i64 8
-;; @0056                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
-;; @0056                               v23 = icmp ule v22, v17
-;; @0056                               trapz v23, user1
-;; @0056                               v24 = iadd v15, v20
-;; @0056                               v25 = load.i64 notrap aligned v24
-;;                                     v68 = iconst.i64 1
-;; @0056                               v26 = iadd v25, v68  ; v68 = 1
-;; @0056                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @0056                               v30 = load.i64 notrap aligned readonly can_move v0+48
-;; @0056                               v31 = uextend.i64 v2
-;; @0056                               v32 = iconst.i64 8
-;; @0056                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
-;; @0056                               v34 = iconst.i64 8
-;; @0056                               v35 = uadd_overflow_trap v33, v34, user1  ; v34 = 8
-;; @0056                               v36 = icmp ule v35, v30
-;; @0056                               trapz v36, user1
-;; @0056                               v37 = iadd v28, v33
-;; @0056                               store notrap aligned v26, v37
+;; @0056                               v18 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v20 = load.i64 notrap aligned readonly can_move v0+48
+;; @0056                               v21 = uextend.i64 v2
+;; @0056                               v22 = iconst.i64 8
+;; @0056                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
+;; @0056                               v24 = iconst.i64 8
+;; @0056                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @0056                               v26 = icmp ule v25, v20
+;; @0056                               trapz v26, user1
+;; @0056                               v27 = iadd v18, v23
+;; @0056                               v28 = load.i64 notrap aligned v27
+;;                                     v75 = iconst.i64 1
+;; @0056                               v29 = iadd v28, v75  ; v75 = 1
+;; @0056                               v31 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v33 = load.i64 notrap aligned readonly can_move v0+48
+;; @0056                               v34 = uextend.i64 v2
+;; @0056                               v35 = iconst.i64 8
+;; @0056                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;; @0056                               v37 = iconst.i64 8
+;; @0056                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
+;; @0056                               v39 = icmp ule v38, v33
+;; @0056                               trapz v39, user1
+;; @0056                               v40 = iadd v31, v36
+;; @0056                               store notrap aligned v29, v40
 ;; @0056                               jump block3
 ;;
 ;;                                 block3:
 ;; @0056                               store.i32 user5 aligned table v2, v11
-;;                                     v69 = iconst.i32 0
-;; @0056                               v38 = icmp.i32 eq v12, v69  ; v69 = 0
-;; @0056                               brif v38, block7, block4
+;;                                     v76 = iconst.i32 1
+;; @0056                               v41 = band.i32 v12, v76  ; v76 = 1
+;;                                     v77 = iconst.i32 0
+;; @0056                               v42 = icmp.i32 eq v12, v77  ; v77 = 0
+;; @0056                               v43 = uextend.i32 v42
+;; @0056                               v44 = bor v41, v43
+;; @0056                               brif v44, block7, block4
 ;;
 ;;                                 block4:
-;; @0056                               v40 = load.i64 notrap aligned readonly can_move v0+40
-;; @0056                               v42 = load.i64 notrap aligned readonly can_move v0+48
-;; @0056                               v43 = uextend.i64 v12
-;; @0056                               v44 = iconst.i64 8
-;; @0056                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
-;; @0056                               v46 = iconst.i64 8
-;; @0056                               v47 = uadd_overflow_trap v45, v46, user1  ; v46 = 8
-;; @0056                               v48 = icmp ule v47, v42
-;; @0056                               trapz v48, user1
-;; @0056                               v49 = iadd v40, v45
-;; @0056                               v50 = load.i64 notrap aligned v49
-;;                                     v70 = iconst.i64 -1
-;; @0056                               v51 = iadd v50, v70  ; v70 = -1
-;;                                     v71 = iconst.i64 0
-;; @0056                               v52 = icmp eq v51, v71  ; v71 = 0
-;; @0056                               brif v52, block5, block6
+;; @0056                               v46 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v48 = load.i64 notrap aligned readonly can_move v0+48
+;; @0056                               v49 = uextend.i64 v12
+;; @0056                               v50 = iconst.i64 8
+;; @0056                               v51 = uadd_overflow_trap v49, v50, user1  ; v50 = 8
+;; @0056                               v52 = iconst.i64 8
+;; @0056                               v53 = uadd_overflow_trap v51, v52, user1  ; v52 = 8
+;; @0056                               v54 = icmp ule v53, v48
+;; @0056                               trapz v54, user1
+;; @0056                               v55 = iadd v46, v51
+;; @0056                               v56 = load.i64 notrap aligned v55
+;;                                     v78 = iconst.i64 -1
+;; @0056                               v57 = iadd v56, v78  ; v78 = -1
+;;                                     v79 = iconst.i64 0
+;; @0056                               v58 = icmp eq v57, v79  ; v79 = 0
+;; @0056                               brif v58, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @0056                               call fn0(v0, v12)
 ;; @0056                               jump block7
 ;;
 ;;                                 block6:
-;; @0056                               v55 = load.i64 notrap aligned readonly can_move v0+40
-;; @0056                               v57 = load.i64 notrap aligned readonly can_move v0+48
-;; @0056                               v58 = uextend.i64 v12
-;; @0056                               v59 = iconst.i64 8
-;; @0056                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
-;; @0056                               v61 = iconst.i64 8
-;; @0056                               v62 = uadd_overflow_trap v60, v61, user1  ; v61 = 8
-;; @0056                               v63 = icmp ule v62, v57
-;; @0056                               trapz v63, user1
-;; @0056                               v64 = iadd v55, v60
-;; @0056                               store.i64 notrap aligned v51, v64
+;; @0056                               v61 = load.i64 notrap aligned readonly can_move v0+40
+;; @0056                               v63 = load.i64 notrap aligned readonly can_move v0+48
+;; @0056                               v64 = uextend.i64 v12
+;; @0056                               v65 = iconst.i64 8
+;; @0056                               v66 = uadd_overflow_trap v64, v65, user1  ; v65 = 8
+;; @0056                               v67 = iconst.i64 8
+;; @0056                               v68 = uadd_overflow_trap v66, v67, user1  ; v67 = 8
+;; @0056                               v69 = icmp ule v68, v63
+;; @0056                               trapz v69, user1
+;; @0056                               v70 = iadd v61, v66
+;; @0056                               store.i64 notrap aligned v57, v70
 ;; @0056                               jump block7
 ;;
 ;;                                 block7:
@@ -133,83 +141,91 @@
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
 ;; @005f                               v7 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v66 = iconst.i64 2
-;; @005f                               v8 = ishl v6, v66  ; v66 = 2
+;;                                     v72 = iconst.i64 2
+;; @005f                               v8 = ishl v6, v72  ; v72 = 2
 ;; @005f                               v9 = iadd v7, v8
 ;; @005f                               v10 = iconst.i64 0
 ;; @005f                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005f                               v12 = load.i32 user5 aligned table v11
-;;                                     v67 = iconst.i32 0
-;; @005f                               v13 = icmp eq v3, v67  ; v67 = 0
-;; @005f                               brif v13, block3, block2
+;;                                     v73 = iconst.i32 1
+;; @005f                               v13 = band v3, v73  ; v73 = 1
+;;                                     v74 = iconst.i32 0
+;; @005f                               v14 = icmp eq v3, v74  ; v74 = 0
+;; @005f                               v15 = uextend.i32 v14
+;; @005f                               v16 = bor v13, v15
+;; @005f                               brif v16, block3, block2
 ;;
 ;;                                 block2:
-;; @005f                               v15 = load.i64 notrap aligned readonly can_move v0+40
-;; @005f                               v17 = load.i64 notrap aligned readonly can_move v0+48
-;; @005f                               v18 = uextend.i64 v3
-;; @005f                               v19 = iconst.i64 8
-;; @005f                               v20 = uadd_overflow_trap v18, v19, user1  ; v19 = 8
-;; @005f                               v21 = iconst.i64 8
-;; @005f                               v22 = uadd_overflow_trap v20, v21, user1  ; v21 = 8
-;; @005f                               v23 = icmp ule v22, v17
-;; @005f                               trapz v23, user1
-;; @005f                               v24 = iadd v15, v20
-;; @005f                               v25 = load.i64 notrap aligned v24
-;;                                     v68 = iconst.i64 1
-;; @005f                               v26 = iadd v25, v68  ; v68 = 1
-;; @005f                               v28 = load.i64 notrap aligned readonly can_move v0+40
-;; @005f                               v30 = load.i64 notrap aligned readonly can_move v0+48
-;; @005f                               v31 = uextend.i64 v3
-;; @005f                               v32 = iconst.i64 8
-;; @005f                               v33 = uadd_overflow_trap v31, v32, user1  ; v32 = 8
-;; @005f                               v34 = iconst.i64 8
-;; @005f                               v35 = uadd_overflow_trap v33, v34, user1  ; v34 = 8
-;; @005f                               v36 = icmp ule v35, v30
-;; @005f                               trapz v36, user1
-;; @005f                               v37 = iadd v28, v33
-;; @005f                               store notrap aligned v26, v37
+;; @005f                               v18 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v20 = load.i64 notrap aligned readonly can_move v0+48
+;; @005f                               v21 = uextend.i64 v3
+;; @005f                               v22 = iconst.i64 8
+;; @005f                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
+;; @005f                               v24 = iconst.i64 8
+;; @005f                               v25 = uadd_overflow_trap v23, v24, user1  ; v24 = 8
+;; @005f                               v26 = icmp ule v25, v20
+;; @005f                               trapz v26, user1
+;; @005f                               v27 = iadd v18, v23
+;; @005f                               v28 = load.i64 notrap aligned v27
+;;                                     v75 = iconst.i64 1
+;; @005f                               v29 = iadd v28, v75  ; v75 = 1
+;; @005f                               v31 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v33 = load.i64 notrap aligned readonly can_move v0+48
+;; @005f                               v34 = uextend.i64 v3
+;; @005f                               v35 = iconst.i64 8
+;; @005f                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
+;; @005f                               v37 = iconst.i64 8
+;; @005f                               v38 = uadd_overflow_trap v36, v37, user1  ; v37 = 8
+;; @005f                               v39 = icmp ule v38, v33
+;; @005f                               trapz v39, user1
+;; @005f                               v40 = iadd v31, v36
+;; @005f                               store notrap aligned v29, v40
 ;; @005f                               jump block3
 ;;
 ;;                                 block3:
 ;; @005f                               store.i32 user5 aligned table v3, v11
-;;                                     v69 = iconst.i32 0
-;; @005f                               v38 = icmp.i32 eq v12, v69  ; v69 = 0
-;; @005f                               brif v38, block7, block4
+;;                                     v76 = iconst.i32 1
+;; @005f                               v41 = band.i32 v12, v76  ; v76 = 1
+;;                                     v77 = iconst.i32 0
+;; @005f                               v42 = icmp.i32 eq v12, v77  ; v77 = 0
+;; @005f                               v43 = uextend.i32 v42
+;; @005f                               v44 = bor v41, v43
+;; @005f                               brif v44, block7, block4
 ;;
 ;;                                 block4:
-;; @005f                               v40 = load.i64 notrap aligned readonly can_move v0+40
-;; @005f                               v42 = load.i64 notrap aligned readonly can_move v0+48
-;; @005f                               v43 = uextend.i64 v12
-;; @005f                               v44 = iconst.i64 8
-;; @005f                               v45 = uadd_overflow_trap v43, v44, user1  ; v44 = 8
-;; @005f                               v46 = iconst.i64 8
-;; @005f                               v47 = uadd_overflow_trap v45, v46, user1  ; v46 = 8
-;; @005f                               v48 = icmp ule v47, v42
-;; @005f                               trapz v48, user1
-;; @005f                               v49 = iadd v40, v45
-;; @005f                               v50 = load.i64 notrap aligned v49
-;;                                     v70 = iconst.i64 -1
-;; @005f                               v51 = iadd v50, v70  ; v70 = -1
-;;                                     v71 = iconst.i64 0
-;; @005f                               v52 = icmp eq v51, v71  ; v71 = 0
-;; @005f                               brif v52, block5, block6
+;; @005f                               v46 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v48 = load.i64 notrap aligned readonly can_move v0+48
+;; @005f                               v49 = uextend.i64 v12
+;; @005f                               v50 = iconst.i64 8
+;; @005f                               v51 = uadd_overflow_trap v49, v50, user1  ; v50 = 8
+;; @005f                               v52 = iconst.i64 8
+;; @005f                               v53 = uadd_overflow_trap v51, v52, user1  ; v52 = 8
+;; @005f                               v54 = icmp ule v53, v48
+;; @005f                               trapz v54, user1
+;; @005f                               v55 = iadd v46, v51
+;; @005f                               v56 = load.i64 notrap aligned v55
+;;                                     v78 = iconst.i64 -1
+;; @005f                               v57 = iadd v56, v78  ; v78 = -1
+;;                                     v79 = iconst.i64 0
+;; @005f                               v58 = icmp eq v57, v79  ; v79 = 0
+;; @005f                               brif v58, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @005f                               call fn0(v0, v12)
 ;; @005f                               jump block7
 ;;
 ;;                                 block6:
-;; @005f                               v55 = load.i64 notrap aligned readonly can_move v0+40
-;; @005f                               v57 = load.i64 notrap aligned readonly can_move v0+48
-;; @005f                               v58 = uextend.i64 v12
-;; @005f                               v59 = iconst.i64 8
-;; @005f                               v60 = uadd_overflow_trap v58, v59, user1  ; v59 = 8
-;; @005f                               v61 = iconst.i64 8
-;; @005f                               v62 = uadd_overflow_trap v60, v61, user1  ; v61 = 8
-;; @005f                               v63 = icmp ule v62, v57
-;; @005f                               trapz v63, user1
-;; @005f                               v64 = iadd v55, v60
-;; @005f                               store.i64 notrap aligned v51, v64
+;; @005f                               v61 = load.i64 notrap aligned readonly can_move v0+40
+;; @005f                               v63 = load.i64 notrap aligned readonly can_move v0+48
+;; @005f                               v64 = uextend.i64 v12
+;; @005f                               v65 = iconst.i64 8
+;; @005f                               v66 = uadd_overflow_trap v64, v65, user1  ; v65 = 8
+;; @005f                               v67 = iconst.i64 8
+;; @005f                               v68 = uadd_overflow_trap v66, v67, user1  ; v67 = 8
+;; @005f                               v69 = icmp ule v68, v63
+;; @005f                               trapz v69, user1
+;; @005f                               v70 = iadd v61, v66
+;; @005f                               store.i64 notrap aligned v57, v70
 ;; @005f                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -34,83 +34,91 @@
 ;; @0055                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0055                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0055                               v8 = load.i64 notrap aligned v0+72
-;;                                     v68 = iconst.i64 2
-;; @0055                               v9 = ishl v7, v68  ; v68 = 2
+;;                                     v74 = iconst.i64 2
+;; @0055                               v9 = ishl v7, v74  ; v74 = 2
 ;; @0055                               v10 = iadd v8, v9
 ;; @0055                               v11 = iconst.i64 0
 ;; @0055                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0055                               v13 = load.i32 user5 aligned table v12
-;;                                     v69 = iconst.i32 0
-;; @0055                               v14 = icmp eq v2, v69  ; v69 = 0
-;; @0055                               brif v14, block3, block2
+;;                                     v75 = iconst.i32 1
+;; @0055                               v14 = band v2, v75  ; v75 = 1
+;;                                     v76 = iconst.i32 0
+;; @0055                               v15 = icmp eq v2, v76  ; v76 = 0
+;; @0055                               v16 = uextend.i32 v15
+;; @0055                               v17 = bor v14, v16
+;; @0055                               brif v17, block3, block2
 ;;
 ;;                                 block2:
-;; @0055                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @0055                               v18 = load.i64 notrap aligned readonly can_move v0+48
-;; @0055                               v19 = uextend.i64 v2
-;; @0055                               v20 = iconst.i64 8
-;; @0055                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
-;; @0055                               v22 = iconst.i64 8
-;; @0055                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
-;; @0055                               v24 = icmp ule v23, v18
-;; @0055                               trapz v24, user1
-;; @0055                               v25 = iadd v16, v21
-;; @0055                               v26 = load.i64 notrap aligned v25
-;;                                     v70 = iconst.i64 1
-;; @0055                               v27 = iadd v26, v70  ; v70 = 1
-;; @0055                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0055                               v31 = load.i64 notrap aligned readonly can_move v0+48
-;; @0055                               v32 = uextend.i64 v2
-;; @0055                               v33 = iconst.i64 8
-;; @0055                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @0055                               v35 = iconst.i64 8
-;; @0055                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
-;; @0055                               v37 = icmp ule v36, v31
-;; @0055                               trapz v37, user1
-;; @0055                               v38 = iadd v29, v34
-;; @0055                               store notrap aligned v27, v38
+;; @0055                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v21 = load.i64 notrap aligned readonly can_move v0+48
+;; @0055                               v22 = uextend.i64 v2
+;; @0055                               v23 = iconst.i64 8
+;; @0055                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
+;; @0055                               v25 = iconst.i64 8
+;; @0055                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
+;; @0055                               v27 = icmp ule v26, v21
+;; @0055                               trapz v27, user1
+;; @0055                               v28 = iadd v19, v24
+;; @0055                               v29 = load.i64 notrap aligned v28
+;;                                     v77 = iconst.i64 1
+;; @0055                               v30 = iadd v29, v77  ; v77 = 1
+;; @0055                               v32 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v34 = load.i64 notrap aligned readonly can_move v0+48
+;; @0055                               v35 = uextend.i64 v2
+;; @0055                               v36 = iconst.i64 8
+;; @0055                               v37 = uadd_overflow_trap v35, v36, user1  ; v36 = 8
+;; @0055                               v38 = iconst.i64 8
+;; @0055                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
+;; @0055                               v40 = icmp ule v39, v34
+;; @0055                               trapz v40, user1
+;; @0055                               v41 = iadd v32, v37
+;; @0055                               store notrap aligned v30, v41
 ;; @0055                               jump block3
 ;;
 ;;                                 block3:
 ;; @0055                               store.i32 user5 aligned table v2, v12
-;;                                     v71 = iconst.i32 0
-;; @0055                               v39 = icmp.i32 eq v13, v71  ; v71 = 0
-;; @0055                               brif v39, block7, block4
+;;                                     v78 = iconst.i32 1
+;; @0055                               v42 = band.i32 v13, v78  ; v78 = 1
+;;                                     v79 = iconst.i32 0
+;; @0055                               v43 = icmp.i32 eq v13, v79  ; v79 = 0
+;; @0055                               v44 = uextend.i32 v43
+;; @0055                               v45 = bor v42, v44
+;; @0055                               brif v45, block7, block4
 ;;
 ;;                                 block4:
-;; @0055                               v41 = load.i64 notrap aligned readonly can_move v0+40
-;; @0055                               v43 = load.i64 notrap aligned readonly can_move v0+48
-;; @0055                               v44 = uextend.i64 v13
-;; @0055                               v45 = iconst.i64 8
-;; @0055                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
-;; @0055                               v47 = iconst.i64 8
-;; @0055                               v48 = uadd_overflow_trap v46, v47, user1  ; v47 = 8
-;; @0055                               v49 = icmp ule v48, v43
-;; @0055                               trapz v49, user1
-;; @0055                               v50 = iadd v41, v46
-;; @0055                               v51 = load.i64 notrap aligned v50
-;;                                     v72 = iconst.i64 -1
-;; @0055                               v52 = iadd v51, v72  ; v72 = -1
-;;                                     v73 = iconst.i64 0
-;; @0055                               v53 = icmp eq v52, v73  ; v73 = 0
-;; @0055                               brif v53, block5, block6
+;; @0055                               v47 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v49 = load.i64 notrap aligned readonly can_move v0+48
+;; @0055                               v50 = uextend.i64 v13
+;; @0055                               v51 = iconst.i64 8
+;; @0055                               v52 = uadd_overflow_trap v50, v51, user1  ; v51 = 8
+;; @0055                               v53 = iconst.i64 8
+;; @0055                               v54 = uadd_overflow_trap v52, v53, user1  ; v53 = 8
+;; @0055                               v55 = icmp ule v54, v49
+;; @0055                               trapz v55, user1
+;; @0055                               v56 = iadd v47, v52
+;; @0055                               v57 = load.i64 notrap aligned v56
+;;                                     v80 = iconst.i64 -1
+;; @0055                               v58 = iadd v57, v80  ; v80 = -1
+;;                                     v81 = iconst.i64 0
+;; @0055                               v59 = icmp eq v58, v81  ; v81 = 0
+;; @0055                               brif v59, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @0055                               call fn0(v0, v13)
 ;; @0055                               jump block7
 ;;
 ;;                                 block6:
-;; @0055                               v56 = load.i64 notrap aligned readonly can_move v0+40
-;; @0055                               v58 = load.i64 notrap aligned readonly can_move v0+48
-;; @0055                               v59 = uextend.i64 v13
-;; @0055                               v60 = iconst.i64 8
-;; @0055                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
-;; @0055                               v62 = iconst.i64 8
-;; @0055                               v63 = uadd_overflow_trap v61, v62, user1  ; v62 = 8
-;; @0055                               v64 = icmp ule v63, v58
-;; @0055                               trapz v64, user1
-;; @0055                               v65 = iadd v56, v61
-;; @0055                               store.i64 notrap aligned v52, v65
+;; @0055                               v62 = load.i64 notrap aligned readonly can_move v0+40
+;; @0055                               v64 = load.i64 notrap aligned readonly can_move v0+48
+;; @0055                               v65 = uextend.i64 v13
+;; @0055                               v66 = iconst.i64 8
+;; @0055                               v67 = uadd_overflow_trap v65, v66, user1  ; v66 = 8
+;; @0055                               v68 = iconst.i64 8
+;; @0055                               v69 = uadd_overflow_trap v67, v68, user1  ; v68 = 8
+;; @0055                               v70 = icmp ule v69, v64
+;; @0055                               trapz v70, user1
+;; @0055                               v71 = iadd v62, v67
+;; @0055                               store.i64 notrap aligned v58, v71
 ;; @0055                               jump block7
 ;;
 ;;                                 block7:
@@ -137,83 +145,91 @@
 ;; @005e                               v6 = icmp uge v2, v5
 ;; @005e                               v7 = uextend.i64 v2
 ;; @005e                               v8 = load.i64 notrap aligned v0+72
-;;                                     v68 = iconst.i64 2
-;; @005e                               v9 = ishl v7, v68  ; v68 = 2
+;;                                     v74 = iconst.i64 2
+;; @005e                               v9 = ishl v7, v74  ; v74 = 2
 ;; @005e                               v10 = iadd v8, v9
 ;; @005e                               v11 = iconst.i64 0
 ;; @005e                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005e                               v13 = load.i32 user5 aligned table v12
-;;                                     v69 = iconst.i32 0
-;; @005e                               v14 = icmp eq v3, v69  ; v69 = 0
-;; @005e                               brif v14, block3, block2
+;;                                     v75 = iconst.i32 1
+;; @005e                               v14 = band v3, v75  ; v75 = 1
+;;                                     v76 = iconst.i32 0
+;; @005e                               v15 = icmp eq v3, v76  ; v76 = 0
+;; @005e                               v16 = uextend.i32 v15
+;; @005e                               v17 = bor v14, v16
+;; @005e                               brif v17, block3, block2
 ;;
 ;;                                 block2:
-;; @005e                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @005e                               v18 = load.i64 notrap aligned readonly can_move v0+48
-;; @005e                               v19 = uextend.i64 v3
-;; @005e                               v20 = iconst.i64 8
-;; @005e                               v21 = uadd_overflow_trap v19, v20, user1  ; v20 = 8
-;; @005e                               v22 = iconst.i64 8
-;; @005e                               v23 = uadd_overflow_trap v21, v22, user1  ; v22 = 8
-;; @005e                               v24 = icmp ule v23, v18
-;; @005e                               trapz v24, user1
-;; @005e                               v25 = iadd v16, v21
-;; @005e                               v26 = load.i64 notrap aligned v25
-;;                                     v70 = iconst.i64 1
-;; @005e                               v27 = iadd v26, v70  ; v70 = 1
-;; @005e                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @005e                               v31 = load.i64 notrap aligned readonly can_move v0+48
-;; @005e                               v32 = uextend.i64 v3
-;; @005e                               v33 = iconst.i64 8
-;; @005e                               v34 = uadd_overflow_trap v32, v33, user1  ; v33 = 8
-;; @005e                               v35 = iconst.i64 8
-;; @005e                               v36 = uadd_overflow_trap v34, v35, user1  ; v35 = 8
-;; @005e                               v37 = icmp ule v36, v31
-;; @005e                               trapz v37, user1
-;; @005e                               v38 = iadd v29, v34
-;; @005e                               store notrap aligned v27, v38
+;; @005e                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v21 = load.i64 notrap aligned readonly can_move v0+48
+;; @005e                               v22 = uextend.i64 v3
+;; @005e                               v23 = iconst.i64 8
+;; @005e                               v24 = uadd_overflow_trap v22, v23, user1  ; v23 = 8
+;; @005e                               v25 = iconst.i64 8
+;; @005e                               v26 = uadd_overflow_trap v24, v25, user1  ; v25 = 8
+;; @005e                               v27 = icmp ule v26, v21
+;; @005e                               trapz v27, user1
+;; @005e                               v28 = iadd v19, v24
+;; @005e                               v29 = load.i64 notrap aligned v28
+;;                                     v77 = iconst.i64 1
+;; @005e                               v30 = iadd v29, v77  ; v77 = 1
+;; @005e                               v32 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v34 = load.i64 notrap aligned readonly can_move v0+48
+;; @005e                               v35 = uextend.i64 v3
+;; @005e                               v36 = iconst.i64 8
+;; @005e                               v37 = uadd_overflow_trap v35, v36, user1  ; v36 = 8
+;; @005e                               v38 = iconst.i64 8
+;; @005e                               v39 = uadd_overflow_trap v37, v38, user1  ; v38 = 8
+;; @005e                               v40 = icmp ule v39, v34
+;; @005e                               trapz v40, user1
+;; @005e                               v41 = iadd v32, v37
+;; @005e                               store notrap aligned v30, v41
 ;; @005e                               jump block3
 ;;
 ;;                                 block3:
 ;; @005e                               store.i32 user5 aligned table v3, v12
-;;                                     v71 = iconst.i32 0
-;; @005e                               v39 = icmp.i32 eq v13, v71  ; v71 = 0
-;; @005e                               brif v39, block7, block4
+;;                                     v78 = iconst.i32 1
+;; @005e                               v42 = band.i32 v13, v78  ; v78 = 1
+;;                                     v79 = iconst.i32 0
+;; @005e                               v43 = icmp.i32 eq v13, v79  ; v79 = 0
+;; @005e                               v44 = uextend.i32 v43
+;; @005e                               v45 = bor v42, v44
+;; @005e                               brif v45, block7, block4
 ;;
 ;;                                 block4:
-;; @005e                               v41 = load.i64 notrap aligned readonly can_move v0+40
-;; @005e                               v43 = load.i64 notrap aligned readonly can_move v0+48
-;; @005e                               v44 = uextend.i64 v13
-;; @005e                               v45 = iconst.i64 8
-;; @005e                               v46 = uadd_overflow_trap v44, v45, user1  ; v45 = 8
-;; @005e                               v47 = iconst.i64 8
-;; @005e                               v48 = uadd_overflow_trap v46, v47, user1  ; v47 = 8
-;; @005e                               v49 = icmp ule v48, v43
-;; @005e                               trapz v49, user1
-;; @005e                               v50 = iadd v41, v46
-;; @005e                               v51 = load.i64 notrap aligned v50
-;;                                     v72 = iconst.i64 -1
-;; @005e                               v52 = iadd v51, v72  ; v72 = -1
-;;                                     v73 = iconst.i64 0
-;; @005e                               v53 = icmp eq v52, v73  ; v73 = 0
-;; @005e                               brif v53, block5, block6
+;; @005e                               v47 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v49 = load.i64 notrap aligned readonly can_move v0+48
+;; @005e                               v50 = uextend.i64 v13
+;; @005e                               v51 = iconst.i64 8
+;; @005e                               v52 = uadd_overflow_trap v50, v51, user1  ; v51 = 8
+;; @005e                               v53 = iconst.i64 8
+;; @005e                               v54 = uadd_overflow_trap v52, v53, user1  ; v53 = 8
+;; @005e                               v55 = icmp ule v54, v49
+;; @005e                               trapz v55, user1
+;; @005e                               v56 = iadd v47, v52
+;; @005e                               v57 = load.i64 notrap aligned v56
+;;                                     v80 = iconst.i64 -1
+;; @005e                               v58 = iadd v57, v80  ; v80 = -1
+;;                                     v81 = iconst.i64 0
+;; @005e                               v59 = icmp eq v58, v81  ; v81 = 0
+;; @005e                               brif v59, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @005e                               call fn0(v0, v13)
 ;; @005e                               jump block7
 ;;
 ;;                                 block6:
-;; @005e                               v56 = load.i64 notrap aligned readonly can_move v0+40
-;; @005e                               v58 = load.i64 notrap aligned readonly can_move v0+48
-;; @005e                               v59 = uextend.i64 v13
-;; @005e                               v60 = iconst.i64 8
-;; @005e                               v61 = uadd_overflow_trap v59, v60, user1  ; v60 = 8
-;; @005e                               v62 = iconst.i64 8
-;; @005e                               v63 = uadd_overflow_trap v61, v62, user1  ; v62 = 8
-;; @005e                               v64 = icmp ule v63, v58
-;; @005e                               trapz v64, user1
-;; @005e                               v65 = iadd v56, v61
-;; @005e                               store.i64 notrap aligned v52, v65
+;; @005e                               v62 = load.i64 notrap aligned readonly can_move v0+40
+;; @005e                               v64 = load.i64 notrap aligned readonly can_move v0+48
+;; @005e                               v65 = uextend.i64 v13
+;; @005e                               v66 = iconst.i64 8
+;; @005e                               v67 = uadd_overflow_trap v65, v66, user1  ; v66 = 8
+;; @005e                               v68 = iconst.i64 8
+;; @005e                               v69 = uadd_overflow_trap v67, v68, user1  ; v68 = 8
+;; @005e                               v70 = icmp ule v69, v64
+;; @005e                               trapz v70, user1
+;; @005e                               v71 = iadd v62, v67
+;; @005e                               store.i64 notrap aligned v58, v71
 ;; @005e                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/misc_testsuite/gc/externrefs-can-be-i31refs.wast
+++ b/tests/misc_testsuite/gc/externrefs-can-be-i31refs.wast
@@ -1,0 +1,14 @@
+;;! gc = true
+
+(module
+  (type (struct (field externref)))
+  (func (export "")
+    i32.const 0x7fffffff
+    ref.i31
+    extern.convert_any
+    struct.new 0
+    drop
+  )
+)
+
+(assert_return (invoke ""))


### PR DESCRIPTION
Found during local fuzzing. This might be a fix for issue https://github.com/bytecodealliance/wasmtime/issues/10181 as well, but I want to get confirmation before marking it fixed, and IIUC there isn't a minimal test case in there at the moment.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
