### PR TITLE
Perform `(ref null none)` loads that can trap

### DIFF
--- a/tests/misc_testsuite/gc/issue-10353.wast
+++ b/tests/misc_testsuite/gc/issue-10353.wast
@@ -1,0 +1,11 @@
+;;! gc = true
+
+(module
+  (table $t 10 (ref null none))
+  (func (export "f") (result (ref null none))
+    (i32.const 99)
+    (table.get $t)
+  )
+)
+
+(assert_trap (invoke "f") "out of bounds table access")


### PR DESCRIPTION
As an optimization, we were previously avoiding the load and instead simply materializing the null reference value, since that is the only value that inhabits `(ref null none)`. However, in certain situations, such as when loading from a table when Spectre mitigations are enabled, we rely on that load being attempted and resulting in a trap if the table index is out of bounds. This commit makes it so that we will always perform the load if our given `ir::MemFlags` can trap.

Fixes #10353

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
