### PR TITLE
`AnyRef::from_raw` needs to clone its GC ref

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -278,6 +278,7 @@ impl AnyRef {
     // (Not actually memory unsafe since we have indexed GC heaps.)
     pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<Self>> {
         let gc_ref = VMGcRef::from_raw_u32(raw)?;
+        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
         Some(Self::from_cloned_gc_ref(store, gc_ref))
     }
 

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -167,6 +167,7 @@ impl ConstExprEvaluator {
         let mut store = AutoAssertNoGc::new(&mut store);
 
         for op in expr.ops() {
+            log::trace!("const-evaluating op: {op:?}");
             match op {
                 ConstOp::I32Const(i) => self.stack.push(ValRaw::i32(*i)),
                 ConstOp::I64Const(i) => self.stack.push(ValRaw::i64(*i)),

--- a/tests/misc_testsuite/gc/issue-10182.wast
+++ b/tests/misc_testsuite/gc/issue-10182.wast
@@ -1,0 +1,23 @@
+;;! gc = true
+
+(module
+  (type (array (mut anyref)))
+
+  (global (ref 0) (array.new_fixed 0 1 (array.new_fixed 0 0)))
+
+  (func (export "")
+    (local $l (ref 0))
+
+    global.get 0
+    local.set $l
+
+    local.get 0
+    i32.const 0
+    local.get 0
+    i32.const 0
+    i32.const 1
+    array.copy 0 0
+  )
+)
+
+(assert_return (invoke ""))


### PR DESCRIPTION
Like `ExternRef::from_raw` does.

This is because while `to_raw` clones the GC ref, it also exposes it to Wasm, inserting it into the DRC collector's table, which effectively gives ownership of that clone to Wasm. Then, if we don't clone in `from_raw`, when a GC is triggered, the DRC collector will see that Wasm isn't holding the ref alive anymore and will decref (and perhaps even deallocate) it, which leaves the `AnyRef` we constructed via `from_raw` dangling.

Fixes #10182

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
