### PR TITLE
Make `GcStore::expose_gc_ref_to_wasm` return the raw GC ref

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -330,8 +330,7 @@ impl AnyRef {
 
     pub(crate) unsafe fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = gc_ref.as_raw_u32();
-        store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
         Ok(raw)
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -503,8 +503,7 @@ impl ExternRef {
 
     pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = gc_ref.as_raw_u32();
-        store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
         Ok(raw)
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -968,9 +968,7 @@ impl<T: GcRef> Rooted<T> {
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = gc_ref.as_raw_u32();
-        debug_assert_ne!(raw, 0);
-        store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
         ptr.write(val_raw(raw));
         Ok(())
     }
@@ -1758,9 +1756,7 @@ where
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
         let gc_ref = self.try_clone_gc_ref(store)?;
-        let raw = gc_ref.as_raw_u32();
-        debug_assert_ne!(raw, 0);
-        store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
         ptr.write(val_raw(raw));
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -134,11 +134,18 @@ impl GcStore {
     }
 
     /// Hook to call whenever a GC reference is about to be exposed to Wasm.
-    pub fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) {
+    ///
+    /// Returns the raw representation of this GC ref, ready to be passed to
+    /// Wasm.
+    #[must_use]
+    pub fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) -> u32 {
+        let raw = gc_ref.as_raw_u32();
+        debug_assert_ne!(raw, 0);
         if !gc_ref.is_i31() {
             log::trace!("exposing GC ref to Wasm: {gc_ref:p}");
             self.gc_heap.expose_gc_ref_to_wasm(gc_ref);
         }
+        raw
     }
 
     /// Allocate a new `externref`.

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -460,14 +460,13 @@ unsafe fn gc(store: &mut dyn VMStore, _instance: &mut Instance, gc_ref: u32) -> 
         // GC.
         let gc_store = store.store_opaque_mut().unwrap_gc_store_mut();
         let gc_ref = gc_store.clone_gc_ref(gc_ref);
-        gc_store.expose_gc_ref_to_wasm(gc_ref);
+        let _ = gc_store.expose_gc_ref_to_wasm(gc_ref);
     }
 
     match store.maybe_async_gc(gc_ref)? {
         None => Ok(0),
         Some(r) => {
-            let raw = r.as_raw_u32();
-            store
+            let raw = store
                 .store_opaque_mut()
                 .unwrap_gc_store_mut()
                 .expose_gc_ref_to_wasm(r);
@@ -529,9 +528,7 @@ unsafe fn gc_alloc_raw(
         }
     };
 
-    let raw = gc_ref.as_raw_u32();
-
-    store
+    let raw = store
         .store_opaque_mut()
         .unwrap_gc_store_mut()
         .expose_gc_ref_to_wasm(gc_ref);
@@ -669,8 +666,7 @@ unsafe fn array_new_data(
         .copy_from_slice(array_layout.base_size, data);
 
     // Return the array to Wasm!
-    let raw = array_ref.as_gc_ref().as_raw_u32();
-    store
+    let raw = store
         .store_opaque_mut()
         .unwrap_gc_store_mut()
         .expose_gc_ref_to_wasm(array_ref.into());
@@ -839,8 +835,7 @@ unsafe fn array_new_elem(
 
         let mut store = AutoAssertNoGc::new(store);
         let gc_ref = array.try_clone_gc_ref(&mut store)?;
-        let raw = gc_ref.as_raw_u32();
-        store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
         Ok(raw)
     })
 }


### PR DESCRIPTION
Every caller of `expose_gc_ref_to_wasm` except for one does this weird dance where they get the raw representation of the GC ref before giving up ownership of it to the `expose_gc_ref_to_wasm` call, and then do something with the raw GC ref (like return it to Wasm or whatever).

This small refactoring boxes up that dance inside `expose_gc_ref_to_wasm` so that callers don't have to do it themselves anymore. Makes things that much more concise and harder to mess up.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
