### PR TITLE
wasi-tls: Add a second endpoint to make the test less flakey

### DIFF
--- a/crates/test-programs/src/bin/tls_sample_application.rs
+++ b/crates/test-programs/src/bin/tls_sample_application.rs
@@ -1,25 +1,24 @@
+use anyhow::{Context, Result};
 use core::str;
-
 use test_programs::wasi::sockets::network::{IpSocketAddress, Network};
 use test_programs::wasi::sockets::tcp::{ShutdownType, TcpSocket};
 use test_programs::wasi::tls::types::ClientHandshake;
 
-fn test_tls_sample_application() {
+fn make_tls_request(domain: &str) -> Result<String> {
     const PORT: u16 = 443;
-    const DOMAIN: &'static str = "example.com";
 
-    let request = format!("GET / HTTP/1.1\r\nHost: {DOMAIN}\r\n\r\n");
+    let request =
+        format!("GET / HTTP/1.1\r\nHost: {domain}\r\nUser-Agent: wasmtime-wasi-rust\r\n\r\n");
 
     let net = Network::default();
 
     let Some(ip) = net
-        .permissive_blocking_resolve_addresses(DOMAIN)
+        .permissive_blocking_resolve_addresses(domain)
         .unwrap()
         .first()
         .map(|a| a.to_owned())
     else {
-        eprintln!("DNS lookup failed.");
-        return;
+        return Err(anyhow::anyhow!("DNS lookup failed."));
     };
 
     let socket = TcpSocket::new(ip.family()).unwrap();
@@ -28,7 +27,7 @@ fn test_tls_sample_application() {
         .unwrap();
 
     let (client_connection, tls_input, tls_output) =
-        ClientHandshake::new(DOMAIN, tcp_input, tcp_output)
+        ClientHandshake::new(domain, tcp_input, tcp_output)
             .blocking_finish()
             .unwrap();
 
@@ -36,11 +35,24 @@ fn test_tls_sample_application() {
     client_connection
         .blocking_close_output(&tls_output)
         .unwrap();
-    socket.shutdown(ShutdownType::Send).unwrap();
+    socket.shutdown(ShutdownType::Send)?;
     let response = tls_input.blocking_read_to_end().unwrap();
-    let response = String::from_utf8(response).unwrap();
+    String::from_utf8(response).context("error converting response")
+}
 
-    assert!(response.contains("HTTP/1.1 200 OK"));
+fn test_tls_sample_application() {
+    // since this is testing remote endpoint to ensure system cert store works
+    // the test uses a couple different endpoints to reduce the number of flakes
+    const DOMAIN1: &'static str = "example.com";
+    const DOMAIN2: &'static str = "api.github.com";
+
+    let response1 = make_tls_request(DOMAIN1).unwrap();
+    let response2 = make_tls_request(DOMAIN2).unwrap();
+
+    assert!(
+        response1.contains("HTTP/1.1 200 OK") || response2.contains("HTTP/1.1 200 OK"),
+        "Neither response contains 200 OK"
+    );
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/tls_sample_application.rs
+++ b/crates/test-programs/src/bin/tls_sample_application.rs
@@ -54,7 +54,7 @@ fn test_tls_sample_application() {
                 return;
             }
             Err(e) => {
-                eprintln!("Failed to make TLS request to {}: {}", domain, e);
+                eprintln!("Failed to make TLS request to {domain}: {e}");
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Helps address https://github.com/bytecodealliance/wasmtime/issues/10369 by adding a second endpoint.  One reason for testing the external endpoint is to make sure the set up of the system cert store works when calling external sites, so this preserves the external call but should also help the tests be less flakey.

