### PR TITLE
aarch64: Fix an overflowing shift panic

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3884,10 +3884,10 @@
 ;; extension must happen before the shift. This will pattern-match the shift
 ;; first and then if that succeeds afterwards try to find an extend.
 (rule 6 (amode_no_more_iconst ty (iadd x (ishl y (iconst (u64_from_imm64 n)))) offset)
-        (if-let true (u64_eq (ty_bytes ty) (u64_shl 1 n)))
+        (if-let true (u64_eq (ty_bytes ty) (u64_shl 1 (shift_masked_imm ty n))))
         (amode_reg_scaled (amode_add x offset) y))
 (rule 7 (amode_no_more_iconst ty (iadd (ishl y (iconst (u64_from_imm64 n))) x) offset)
-        (if-let true (u64_eq (ty_bytes ty) (u64_shl 1 n)))
+        (if-let true (u64_eq (ty_bytes ty) (u64_shl 1 (shift_masked_imm ty n))))
         (amode_reg_scaled (amode_add x offset) y))
 
 (decl amode_reg_scaled (Reg Value) AMode)

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -784,3 +784,33 @@ block0(v0: i64, v1: i32):
 ;   ldr x0, [x0, w1, sxtw #3] ; trap: heap_oob
 ;   ret
 
+function %no_panic(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v8 = ishl_imm v1, 100
+  v9 = iadd v0, v8
+  v10 = load.i64 v9
+
+  v5 = ishl_imm v1, 100
+  v6 = iadd v5, v0
+  v7 = load.i64 v6
+  return v10
+}
+
+; VCode:
+; block0:
+;   lsl x6, x1, #36
+;   ldr x6, [x0, x6]
+;   lsl x7, x1, #36
+;   ldr x7, [x7, x0]
+;   mov x0, x6
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lsl x6, x1, #0x24
+;   ldr x6, [x0, x6] ; trap: heap_oob
+;   lsl x7, x1, #0x24
+;   ldr x7, [x7, x0] ; trap: heap_oob
+;   mov x0, x6
+;   ret
+


### PR DESCRIPTION
Ensure that a compile-time-shift-amount is masked to avoid a debug assertion about an overflowing shift.

Closes #10373

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
