### PR TITLE
Remove some now-unnecessary `allow(clippy)` lints

### DIFF
--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -84,7 +84,6 @@ fn pretty_print_hexadecimal(hex: &[u8]) -> String {
 /// See `replace_signed_immediates`.
 macro_rules! hex_print_signed_imm {
     ($hex:expr, $from:ty => $to:ty) => {{
-        #[allow(clippy::cast_possible_wrap, reason = "bit conversion is intended here")]
         let imm = <$from>::from_str_radix($hex, 16).unwrap() as $to;
         let mut simm = String::new();
         if imm < 0 {

--- a/cranelift/assembler-x64/src/imm.rs
+++ b/cranelift/assembler-x64/src/imm.rs
@@ -1,7 +1,5 @@
 //! Immediate operands to instructions.
 
-#![allow(clippy::module_name_repetitions, reason = "'imm::Imm*' is fine")]
-
 use crate::api::CodeSink;
 use std::fmt;
 
@@ -67,7 +65,6 @@ impl Simm8 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put1(self.0 as u8);
     }
 
@@ -127,7 +124,6 @@ impl Simm16 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put2(self.0 as u16);
     }
 
@@ -195,7 +191,6 @@ impl Simm32 {
     }
 
     pub fn encode(&self, sink: &mut impl CodeSink) {
-        #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
         sink.put4(self.0 as u32);
     }
 

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -384,7 +384,6 @@ pub fn emit_modrm_sib_disp<R: AsReg>(
             // to the end of the u32 field. So, to compensate for
             // this, we emit a negative extra offset in the u32 field
             // initially, and the relocation will add to it.
-            #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
             sink.put4(-(i32::from(bytes_at_end)) as u32);
         }
     }

--- a/cranelift/assembler-x64/src/rex.rs
+++ b/cranelift/assembler-x64/src/rex.rs
@@ -1,7 +1,5 @@
 //! Encoding logic for REX instructions.
 
-// #![allow(clippy::bool_to_int_with_if)]
-
 use crate::api::CodeSink;
 
 pub(crate) fn low8_will_sign_extend_to_32(xs: i32) -> bool {
@@ -151,7 +149,6 @@ impl Imm {
                 if val % i32::from(scaling) == 0 {
                     let scaled = val / i32::from(scaling);
                     if low8_will_sign_extend_to_32(scaled) {
-                        #[allow(clippy::cast_possible_truncation, reason = "pre-existing code")]
                         return Imm::Imm8(scaled as i8);
                     }
                 }
@@ -183,7 +180,6 @@ impl Imm {
     }
 
     /// Emit the truncated immediate into the code sink.
-    #[allow(clippy::cast_sign_loss, reason = "bit conversion is intended here")]
     pub fn emit(self, sink: &mut impl CodeSink) {
         match self {
             Imm::None => {}


### PR DESCRIPTION
These were a holdover before the assembler crate inherited lint settings from the workspace.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
