### PR TITLE
Change `allow(missing_docs)` to `expect(..)`

### DIFF
--- a/cranelift/assembler-x64/src/rex.rs
+++ b/cranelift/assembler-x64/src/rex.rs
@@ -121,7 +121,6 @@ impl RexFlags {
 }
 
 #[derive(Copy, Clone)]
-#[allow(missing_docs, reason = "variants are self-explanatory")]
 pub enum Imm {
     None,
     Imm8(i8),

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -220,7 +220,7 @@ impl From<FuncOrDataId> for ModuleRelocTarget {
     feature = "enable-serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
 )]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct FunctionDeclaration {
     pub name: Option<String>,
     pub linkage: Linkage,
@@ -377,7 +377,7 @@ pub type ModuleResult<T> = Result<T, ModuleError>;
     feature = "enable-serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
 )]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct DataDeclaration {
     pub name: Option<String>,
     pub linkage: Linkage,

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -29,7 +29,7 @@ use std::str::FromStr;
 use target_lexicon::Triple;
 
 /// Like `FlagsOrIsa`, but holds ownership.
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum OwnedFlagsOrIsa {
     Flags(settings::Flags),
     Isa(OwnedTargetIsa),

--- a/cranelift/reader/src/run_command.rs
+++ b/cranelift/reader/src/run_command.rs
@@ -105,7 +105,7 @@ impl Display for Invocation {
 }
 
 /// A CLIF comparison operation; e.g. `==`.
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Debug, PartialEq)]
 pub enum Comparison {
     Equals,

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -285,7 +285,7 @@ macro_rules! declare_builtin_index_constructors {
              $rest_name:ident;
          )*
     ) => {
-        #[allow(missing_docs, reason = "macro-generated")]
+        #[expect(missing_docs, reason = "macro-generated")]
         pub const fn $this_name() -> Self {
             Self($index)
         }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -118,7 +118,7 @@ pub struct FunctionBodyData<'a> {
 }
 
 #[derive(Debug, Default)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct DebugInfoData<'a> {
     pub dwarf: Dwarf<'a>,
     pub name_section: NameSection<'a>,
@@ -131,13 +131,13 @@ pub struct DebugInfoData<'a> {
     pub debug_tu_index: gimli::DebugTuIndex<Reader<'a>>,
 }
 
-#[allow(missing_docs, reason = "self-describing")]
+#[expect(missing_docs, reason = "self-describing")]
 pub type Dwarf<'input> = gimli::Dwarf<Reader<'input>>;
 
 type Reader<'input> = gimli::EndianSlice<'input, gimli::LittleEndian>;
 
 #[derive(Debug, Default)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct NameSection<'a> {
     pub module_name: Option<&'a str>,
     pub func_names: HashMap<FuncIndex, &'a str>,
@@ -145,7 +145,7 @@ pub struct NameSection<'a> {
 }
 
 #[derive(Debug, Default)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct WasmFileInfo {
     pub path: Option<PathBuf>,
     pub code_section_offset: u64,
@@ -154,7 +154,7 @@ pub struct WasmFileInfo {
 }
 
 #[derive(Debug)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct FunctionMetadata {
     pub params: Box<[WasmValType]>,
     pub locals: Box<[(u32, WasmValType)]>,

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -166,7 +166,7 @@ pub enum SideEffect {
 macro_rules! id {
     ($(pub struct $name:ident(u32);)*) => ($(
         #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-        #[allow(missing_docs, reason = "tedious to document")]
+        #[expect(missing_docs, reason = "tedious to document")]
         pub struct $name(u32);
         cranelift_entity::entity_impl!($name);
     )*)
@@ -183,7 +183,7 @@ id! {
 }
 
 /// Same as `info::InstantiateModule`
-#[allow(missing_docs, reason = "tedious to document variants")]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum Instance {
     Static(StaticModuleIndex, Box<[CoreDef]>),
     Import(
@@ -193,7 +193,7 @@ pub enum Instance {
 }
 
 /// Same as `info::Export`
-#[allow(missing_docs, reason = "tedious to document variants")]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum Export {
     LiftedFunction {
         ty: TypeFuncIndex,
@@ -217,7 +217,7 @@ pub enum Export {
 
 /// Same as `info::CoreDef`, except has an extra `Adapter` variant.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs, reason = "tedious to document variants")]
+#[expect(missing_docs, reason = "tedious to document variants")]
 pub enum CoreDef {
     Export(CoreExport<EntityIndex>),
     InstanceFlags(RuntimeComponentInstanceIndex),
@@ -244,14 +244,14 @@ where
 
 /// Same as `info::CoreExport`
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct CoreExport<T> {
     pub instance: InstanceId,
     pub item: ExportItem<T>,
 }
 
 impl<T> CoreExport<T> {
-    #[allow(missing_docs, reason = "self-describing function")]
+    #[expect(missing_docs, reason = "self-describing function")]
     pub fn map_index<U>(self, f: impl FnOnce(T) -> U) -> CoreExport<U> {
         CoreExport {
             instance: self.instance,
@@ -265,7 +265,7 @@ impl<T> CoreExport<T> {
 
 /// Same as `info::Trampoline`
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub enum Trampoline {
     LowerImport {
         import: RuntimeImportIndex,
@@ -399,14 +399,14 @@ pub enum Trampoline {
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct FutureInfo {
     pub instance: RuntimeComponentInstanceIndex,
     pub payload_type: Option<InterfaceType>,
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct StreamInfo {
     pub instance: RuntimeComponentInstanceIndex,
     pub payload_type: InterfaceType,
@@ -414,7 +414,7 @@ pub struct StreamInfo {
 
 /// Same as `info::CanonicalOptions`
 #[derive(Clone, Hash, Eq, PartialEq)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct CanonicalOptions {
     pub instance: RuntimeComponentInstanceIndex,
     pub string_encoding: StringEncoding,
@@ -426,7 +426,7 @@ pub struct CanonicalOptions {
 }
 
 /// Same as `info::Resource`
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct Resource {
     pub rep: WasmValType,
     pub dtor: Option<CoreDef>,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -488,7 +488,7 @@ pub struct CanonicalOptions {
 
 /// Possible encodings of strings within the component model.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum StringEncoding {
     Utf8,
     Utf16,
@@ -515,7 +515,7 @@ impl StringEncoding {
 ///
 /// Note that each transcoding operation may have a unique signature depending
 /// on the precise operation.
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum Transcode {
     Copy(FixedEncoding),
@@ -571,7 +571,7 @@ impl Transcode {
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum FixedEncoding {
     Utf8,
     Utf16,

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -241,7 +241,7 @@ pub use crate::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex};
 /// Equivalent of `EntityIndex` but for the component model instead of core
 /// wasm.
 #[derive(Debug, Clone, Copy)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum ComponentItem {
     Func(ComponentFuncIndex),
     Module(ModuleIndex),
@@ -546,7 +546,7 @@ pub struct TypeFunc {
 /// forms where for non-primitive types a `ComponentTypes` structure is used to
 /// lookup further information based on the index found here.
 #[derive(Serialize, Deserialize, Copy, Clone, Hash, Eq, PartialEq, Debug)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum InterfaceType {
     Bool,
     S8,
@@ -1179,7 +1179,7 @@ impl FlatTypes<'_> {
 // regardless to changes in the core wasm type system since this will only
 // ever use integers/floats for the foreseeable future.
 #[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, Copy, Clone)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum FlatType {
     I32,
     I64,

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -325,7 +325,7 @@ impl GcStructLayout {
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[rustfmt::skip]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum VMGcKind {
     ExternRef      = 0b01000 << 27,
     AnyRef         = 0b10000 << 27,

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -25,7 +25,7 @@ pub struct CompiledFunctionInfo {
 /// Information about a function, such as trap information, address map,
 /// and stack maps.
 #[derive(Serialize, Deserialize, Default)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct WasmFunctionInfo {
     pub start_srcloc: FilePos,
     pub stack_maps: Box<[StackMapInformation]>,

--- a/crates/environ/src/obj.rs
+++ b/crates/environ/src/obj.rs
@@ -140,7 +140,7 @@ pub const ELF_WASMTIME_DWARF: &str = ".wasmtime.dwarf";
 macro_rules! libcalls {
     ($($rust:ident = $sym:tt)*) => (
         #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
-        #[allow(missing_docs, reason = "self-describing variants")]
+        #[expect(missing_docs, reason = "self-describing variants")]
         pub enum LibCall {
             $($rust,)*
         }

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -22,7 +22,7 @@ pub struct TrapInformation {
 // These need to be kept in sync.
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum Trap {
     /// The current stack space was exhausted.
     StackOverflow,

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -28,7 +28,7 @@ macro_rules! define_tunables {
 
         /// Optional tunable configuration options used in `wasmtime::Config`
         #[derive(Default, Clone)]
-        #[allow(missing_docs, reason = "macro-generated fields")]
+        #[expect(missing_docs, reason = "macro-generated fields")]
         pub struct $config_tunables {
             $(pub $field: Option<$field_ty>,)*
         }

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -425,7 +425,7 @@ impl EngineOrModuleTypeIndex {
 
 /// WebAssembly heap type -- equivalent of `wasmparser`'s HeapType
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum WasmHeapType {
     // External types.
     Extern,
@@ -964,7 +964,7 @@ impl TypeTrace for WasmStructType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing type")]
+#[expect(missing_docs, reason = "self-describing type")]
 pub struct WasmCompositeType {
     /// The type defined inside the composite type.
     pub inner: WasmCompositeInnerType,
@@ -988,7 +988,7 @@ impl fmt::Display for WasmCompositeType {
 
 /// A function, array, or struct type.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum WasmCompositeInnerType {
     Array(WasmArrayType),
     Func(WasmFuncType),
@@ -1007,7 +1007,7 @@ impl fmt::Display for WasmCompositeInnerType {
     }
 }
 
-#[allow(missing_docs, reason = "self-describing functions")]
+#[expect(missing_docs, reason = "self-describing functions")]
 impl WasmCompositeInnerType {
     #[inline]
     pub fn is_array(&self) -> bool {
@@ -1142,7 +1142,7 @@ impl fmt::Display for WasmSubType {
 /// Implicitly define all of these helper functions to handle only unshared
 /// types; essentially, these act like `is_unshared_*` functions until shared
 /// support is implemented.
-#[allow(missing_docs, reason = "self-describing functions")]
+#[expect(missing_docs, reason = "self-describing functions")]
 impl WasmSubType {
     #[inline]
     pub fn is_func(&self) -> bool {
@@ -1694,7 +1694,7 @@ impl ConstExpr {
 }
 
 /// The subset of Wasm opcodes that are constant.
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConstOp {
     I32Const(i32),
@@ -1780,7 +1780,7 @@ impl ConstOp {
 
 /// The type that can be used to index into [Memory] and [Table].
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum IndexType {
     I32,
     I64,
@@ -1788,7 +1788,7 @@ pub enum IndexType {
 
 /// The size range of resizeable storage associated with [Memory] types and [Table] types.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(missing_docs, reason = "self-describing fields")]
+#[expect(missing_docs, reason = "self-describing fields")]
 pub struct Limits {
     pub min: u64,
     pub max: Option<u64>,
@@ -2013,7 +2013,7 @@ impl Memory {
 }
 
 #[derive(Copy, Clone, Debug)]
-#[allow(missing_docs, reason = "self-describing error struct")]
+#[expect(missing_docs, reason = "self-describing error struct")]
 pub struct SizeOverflow;
 
 impl fmt::Display for SizeOverflow {
@@ -2072,7 +2072,7 @@ impl TypeTrace for Tag {
 }
 
 /// Helpers used to convert a `wasmparser` type to a type in this crate.
-#[allow(missing_docs, reason = "self-describing functions")]
+#[expect(missing_docs, reason = "self-describing functions")]
 pub trait TypeConvert {
     /// Converts a wasmparser table type into a wasmtime type
     fn convert_global_type(&self, ty: &wasmparser::GlobalType) -> Global {

--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -93,7 +93,7 @@ impl<T, const L: u32, const H: u32> Deref for VecInRange<T, L, H> {
 }
 
 /// Represents a component model interface type
-#[allow(missing_docs, reason = "self-describing")]
+#[expect(missing_docs, reason = "self-describing")]
 #[derive(Debug, Clone)]
 pub enum Type {
     Bool,

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -771,7 +771,7 @@ pub mod operands {
         ) => {
             $(
                 #[allow(unused_variables, reason = "macro-generated")]
-                #[allow(missing_docs, reason = "macro-generated")]
+                #[expect(missing_docs, reason = "macro-generated")]
                 pub fn $snake_name<T: BytecodeStream>(pc: &mut T) -> Result<($($($field_ty,)*)?), T::Error> {
                     Ok((($($((<$field_ty>::decode(pc))?,)*)?)))
                 }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -418,7 +418,7 @@ impl Default for XRegVal {
     }
 }
 
-#[allow(missing_docs, reason = "self-describing methods")]
+#[expect(missing_docs, reason = "self-describing methods")]
 impl XRegVal {
     pub fn new_i32(x: i32) -> Self {
         let mut val = XRegVal::default();
@@ -537,7 +537,7 @@ impl Default for FRegVal {
     }
 }
 
-#[allow(missing_docs, reason = "self-describing methods")]
+#[expect(missing_docs, reason = "self-describing methods")]
 impl FRegVal {
     pub fn new_f32(f: f32) -> Self {
         let mut val = Self::default();
@@ -620,7 +620,7 @@ impl Default for VRegVal {
     }
 }
 
-#[allow(missing_docs, reason = "self-describing methods")]
+#[expect(missing_docs, reason = "self-describing methods")]
 impl VRegVal {
     pub fn new_u128(i: u128) -> Self {
         let mut val = Self::default();
@@ -934,7 +934,7 @@ mod done {
     }
 
     /// Stored within `DoneReason::Trap`.
-    #[allow(missing_docs, reason = "self-describing variants")]
+    #[expect(missing_docs, reason = "self-describing variants")]
     pub enum TrapKind {
         DivideByZero,
         IntegerOverflow,

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -36,7 +36,7 @@ macro_rules! define_op {
                 $(
                     // TODO: add doc comments to all fields and update all
                     // the macros to match them.
-                    #[allow(missing_docs, reason = "macro-generated code")]
+                    #[expect(missing_docs, reason = "macro-generated code")]
                     pub $field : $field_ty,
                 )*
             )? }
@@ -86,7 +86,7 @@ macro_rules! define_extended_op {
                 $(
                     // TODO: add doc comments to all fields and update all
                     // the macros to match them.
-                    #[allow(missing_docs, reason = "macro-generated code")]
+                    #[expect(missing_docs, reason = "macro-generated code")]
                     pub $field : $field_ty,
                 )*
             )? }

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -65,7 +65,7 @@ macro_rules! impl_reg {
 #[repr(u8)]
 #[derive(Debug,Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum XReg {
@@ -108,7 +108,7 @@ fn assert_special_start_is_right() {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum FReg {
@@ -122,7 +122,7 @@ pub enum FReg {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[expect(non_camel_case_types, reason = "matching in-asm register names")]
 #[rustfmt::skip]
 pub enum VReg {
@@ -140,7 +140,7 @@ impl_reg!(VReg, V, 0..32);
 ///
 /// Never appears inside an instruction -- instructions always name a particular
 /// class of register -- but this is useful for testing and things like that.
-#[allow(missing_docs, reason = "self-describing variants")]
+#[expect(missing_docs, reason = "self-describing variants")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AnyReg {

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -32,7 +32,7 @@ const AFTER_HELP: &str =
 )]
 pub struct CompileCommand {
     #[command(flatten)]
-    #[allow(missing_docs, reason = "don't want to mess with clap doc-strings")]
+    #[expect(missing_docs, reason = "don't want to mess with clap doc-strings")]
     pub common: CommonOptions,
 
     /// The path of the output compiled module; defaults to `<MODULE>.cwasm`

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -47,7 +47,7 @@ fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
 #[derive(Parser)]
 pub struct RunCommand {
     #[command(flatten)]
-    #[allow(missing_docs, reason = "don't want to mess with clap doc-strings")]
+    #[expect(missing_docs, reason = "don't want to mess with clap doc-strings")]
     pub run: RunCommon,
 
     /// The name of the function to run


### PR DESCRIPTION
This wasn't possible when `expect` was first introduced due to a change being required in upstream rust-lang/rust. That change rust-lang/rust#130025) has now rode enough trains to be in our MSRV, so we can expect missing docs now instead of just allowing it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
