### PR TITLE
Don’t panic when http `handle` function returns before invoking `set`

### DIFF
--- a/crates/test-programs/src/bin/cli_serve_return_before_set.rs
+++ b/crates/test-programs/src/bin/cli_serve_return_before_set.rs
@@ -1,0 +1,12 @@
+use test_programs::proxy;
+use test_programs::wasi::http::types::{IncomingRequest, ResponseOutparam};
+
+struct T;
+
+proxy::export!(T);
+
+impl proxy::exports::wasi::http::incoming_handler::Guest for T {
+    fn handle(_request: IncomingRequest, _outparam: ResponseOutparam) {}
+}
+
+fn main() {}

--- a/crates/test-programs/src/bin/cli_serve_trap_before_set.rs
+++ b/crates/test-programs/src/bin/cli_serve_trap_before_set.rs
@@ -1,0 +1,15 @@
+use test_programs::proxy;
+use test_programs::wasi::http::types::{IncomingRequest, ResponseOutparam};
+
+struct T;
+
+proxy::export!(T);
+
+impl proxy::exports::wasi::http::incoming_handler::Guest for T {
+    #[cfg(target_arch = "wasm32")]
+    fn handle(_request: IncomingRequest, _outparam: ResponseOutparam) {
+        core::arch::wasm32::unreachable();
+    }
+}
+
+fn main() {}

--- a/crates/test-programs/src/bin/cli_serve_trap_before_set.rs
+++ b/crates/test-programs/src/bin/cli_serve_trap_before_set.rs
@@ -6,8 +6,8 @@ struct T;
 proxy::export!(T);
 
 impl proxy::exports::wasi::http::incoming_handler::Guest for T {
-    #[cfg(target_arch = "wasm32")]
     fn handle(_request: IncomingRequest, _outparam: ResponseOutparam) {
+        #[cfg(target_arch = "wasm32")]
         core::arch::wasm32::unreachable();
     }
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -179,10 +179,13 @@
 //!             // inspect the `task` result to see what happened
 //!             Err(_) => {
 //!                 let e = match task.await {
-//!                     Ok(r) => r.unwrap_err(),
+//!                     Ok(Ok(())) => {
+//!                         bail!("guest returned before invoking `response-outparam::set` method")
+//!                     }
+//!                     Ok(Err(e)) => e,
 //!                     Err(e) => e.into(),
 //!                 };
-//!                 bail!("guest never invoked `response-outparam::set` method: {e:?}")
+//!                 return Err(e.context("guest never invoked `response-outparam::set` method"));
 //!             }
 //!         }
 //!     }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -180,7 +180,7 @@
 //!             Err(_) => {
 //!                 let e = match task.await {
 //!                     Ok(Ok(())) => {
-//!                         bail!("guest returned before invoking `response-outparam::set` method")
+//!                         bail!("guest never invoked `response-outparam::set` method")
 //!                     }
 //!                     Ok(Err(e)) => e,
 //!                     Err(e) => e.into(),

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -534,7 +534,10 @@ async fn handle_request(
             // that we assume the task has already exited at this point so the
             // `await` should resolve immediately.
             let e = match task.await {
-                Ok(r) => r.expect_err("if the receiver has an error, the task must have failed"),
+                Ok(Ok(())) => {
+                    bail!("guest returned before invoking `response-outparam::set` method")
+                }
+                Ok(Err(e)) => e,
                 Err(e) => e.into(),
             };
             return Err(e.context("guest never invoked `response-outparam::set` method"));

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -535,7 +535,7 @@ async fn handle_request(
             // `await` should resolve immediately.
             let e = match task.await {
                 Ok(Ok(())) => {
-                    bail!("guest returned before invoking `response-outparam::set` method")
+                    bail!("guest never invoked `response-outparam::set` method")
                 }
                 Ok(Err(e)) => e,
                 Err(e) => e.into(),

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2083,33 +2083,8 @@ after empty
         Ok(())
     }
 
-    #[tokio::test]
-    async fn cli_serve_return_before_set() -> Result<()> {
-        let server = WasmtimeServe::new(CLI_SERVE_RETURN_BEFORE_SET_COMPONENT, |cmd| {
-            cmd.arg("-Scli");
-        })?;
-
-        for _ in 0..2 {
-            let res = server
-                .send_request(
-                    hyper::Request::builder()
-                        .uri("http://localhost/")
-                        .body(String::new())
-                        .context("failed to make request")?,
-                )
-                .await;
-            assert!(res.is_err());
-        }
-
-        let stderr = server.finish()?.1;
-        assert!(stderr.contains("guest returned before invoking `response-outparam::set` method"));
-        assert!(!stderr.contains("panicked"));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn cli_serve_trap_before_set() -> Result<()> {
-        let server = WasmtimeServe::new(CLI_SERVE_TRAP_BEFORE_SET_COMPONENT, |cmd| {
+    async fn cli_serve_guest_never_invoked_set(wasm: &str) -> Result<()> {
+        let server = WasmtimeServe::new(wasm, |cmd| {
             cmd.arg("-Scli");
         })?;
 
@@ -2129,6 +2104,16 @@ after empty
         assert!(stderr.contains("guest never invoked `response-outparam::set` method"));
         assert!(!stderr.contains("panicked"));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn cli_serve_return_before_set() -> Result<()> {
+        cli_serve_guest_never_invoked_set(CLI_SERVE_RETURN_BEFORE_SET_COMPONENT).await
+    }
+
+    #[tokio::test]
+    async fn cli_serve_trap_before_set() -> Result<()> {
+        cli_serve_guest_never_invoked_set(CLI_SERVE_TRAP_BEFORE_SET_COMPONENT).await
     }
 }
 


### PR DESCRIPTION
`wasmtime serve` currently presumes that a failure to call `response-outparam::set` inside `handle` means the component trapped. But it can also happen by returning before invoking `set`. This PR accommodates for that.

Redo of #10256
