### PR TITLE
Introduce log2_min_function_alignment flag

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -398,6 +398,13 @@ pub(crate) fn define() -> SettingGroup {
         0,
     );
 
+    settings.add_num(
+        "log2_min_function_alignment",
+        "The log2 of the minimum alignment of functions",
+        "The bigger of this value and the default alignment will be used as actual alignment.",
+        0,
+    );
+
     // When adding new settings please check if they can also be added
     // in cranelift/fuzzgen/src/lib.rs for fuzzing.
     settings.build()

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -382,6 +382,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             block_order,
             constants,
             VCodeBuildDirection::Backward,
+            flags.log2_min_function_alignment(),
         );
 
         // We usually need two VRegs per instruction result, plus extras for

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -195,6 +195,8 @@ pub struct VCode<I: VCodeInst> {
 
     /// Facts on VRegs, for proof-carrying code verification.
     facts: Vec<Option<Fact>>,
+
+    log2_min_function_alignment: u8,
 }
 
 /// The result of `VCode::emit`. Contains all information computed
@@ -281,8 +283,16 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         block_order: BlockLoweringOrder,
         constants: VCodeConstants,
         direction: VCodeBuildDirection,
+        log2_min_function_alignment: u8,
     ) -> Self {
-        let vcode = VCode::new(sigs, abi, emit_info, block_order, constants);
+        let vcode = VCode::new(
+            sigs,
+            abi,
+            emit_info,
+            block_order,
+            constants,
+            log2_min_function_alignment,
+        );
 
         VCodeBuilder {
             vcode,
@@ -602,6 +612,7 @@ impl<I: VCodeInst> VCode<I> {
         emit_info: I::Info,
         block_order: BlockLoweringOrder,
         constants: VCodeConstants,
+        log2_min_function_alignment: u8,
     ) -> Self {
         let n_blocks = block_order.lowered_order().len();
         VCode {
@@ -630,6 +641,7 @@ impl<I: VCodeInst> VCode<I> {
             constants,
             debug_value_labels: vec![],
             facts: vec![],
+            log2_min_function_alignment,
         }
     }
 
@@ -714,6 +726,7 @@ impl<I: VCodeInst> VCode<I> {
 
         let _tt = timing::vcode_emit();
         let mut buffer = MachBuffer::new();
+        buffer.set_log2_min_function_alignment(self.log2_min_function_alignment);
         let mut bb_starts: Vec<Option<CodeOffset>> = vec![];
 
         // The first M MachLabels are reserved for block indices.

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -517,6 +517,7 @@ libcall_call_conv = "isa_default"
 probestack_size_log2 = 12
 probestack_strategy = "outline"
 bb_padding_log2_minus_one = 0
+log2_min_function_alignment = 0
 regalloc_checker = false
 regalloc_verbose_logs = false
 enable_alias_analysis = true

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -641,9 +641,7 @@ impl Module for JITModule {
         let compiled_code = ctx.compiled_code().unwrap();
 
         let size = compiled_code.code_info().total_size as usize;
-        let align = alignment
-            .max(self.isa.function_alignment().minimum as u64)
-            .max(self.isa.symbol_alignment());
+        let align = alignment.max(self.isa.symbol_alignment());
         let ptr = self
             .memory
             .code
@@ -702,9 +700,7 @@ impl Module for JITModule {
         }
 
         let size = bytes.len();
-        let align = alignment
-            .max(self.isa.function_alignment().minimum as u64)
-            .max(self.isa.symbol_alignment());
+        let align = alignment.max(self.isa.symbol_alignment());
         let ptr = self
             .memory
             .code

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -495,9 +495,7 @@ impl ObjectModule {
         }
         *defined = true;
 
-        let align = alignment
-            .max(self.isa.function_alignment().minimum.into())
-            .max(self.isa.symbol_alignment());
+        let align = alignment.max(self.isa.symbol_alignment());
         let section = if self.per_function_section {
             // FIXME pass empty symbol name once add_subsection produces `.text` as section name
             // instead of `.text.` when passed an empty symbol name. (object#748) Until then pass

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -392,6 +392,7 @@ impl Engine {
             | "regalloc_algorithm"
             | "is_pic"
             | "bb_padding_log2_minus_one"
+            | "log2_min_function_alignment"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
             | "stack_switch_model" // wasmtime doesn't use stack switching right now


### PR DESCRIPTION
This is required for cg_clif to implement `-Zmin-function-alignment`.

Required for https://github.com/rust-lang/rustc_codegen_cranelift/issues/1555