### PR TITLE
Winch: Fix issue with floats and replace_lane

### DIFF
--- a/crates/wast-util/src/lib.rs
+++ b/crates/wast-util/src/lib.rs
@@ -439,6 +439,7 @@ impl WastTest {
                     "misc_testsuite/simd/replace-lane-preserve.wast",
                     "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
                     "misc_testsuite/winch/issue-10331.wast",
+                    "misc_testsuite/winch/replace_lane.wast",
                     "spec_testsuite/simd_align.wast",
                     "spec_testsuite/simd_boolean.wast",
                     "spec_testsuite/simd_conversions.wast",

--- a/tests/disas/winch/x64/f64x2_replace_lane/const_lane0_avx.wat
+++ b/tests/disas/winch/x64/f64x2_replace_lane/const_lane0_avx.wat
@@ -14,32 +14,30 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x42
+;;       ja      0x47
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movdqu  0x1c(%rip), %xmm0
-;;       vmovsd  0x24(%rip), %xmm0
+;;       vmovsd  0x24(%rip), %xmm15
+;;       vmovsd  %xmm15, %xmm0, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   42: ud2
-;;   44: addb    %al, (%rax)
-;;   46: addb    %al, (%rax)
-;;   48: addb    %al, (%rax)
-;;   4a: addb    %al, (%rax)
-;;   4c: addb    %al, (%rax)
-;;   4e: addb    %al, (%rax)
-;;   50: addl    %eax, (%rax)
-;;   52: addb    %al, (%rax)
-;;   54: addb    %al, (%rax)
-;;   56: addb    %al, (%rax)
-;;   58: addb    (%rax), %al
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addb    %al, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
+;;   47: ud2
+;;   49: addb    %al, (%rax)
+;;   4b: addb    %al, (%rax)
+;;   4d: addb    %al, (%rax)
+;;   4f: addb    %al, (%rcx)
+;;   51: addb    %al, (%rax)
+;;   53: addb    %al, (%rax)
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rdx)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rax)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)

--- a/tests/misc_testsuite/winch/replace_lane.wast
+++ b/tests/misc_testsuite/winch/replace_lane.wast
@@ -1,0 +1,32 @@
+;;! simd = true
+
+(module
+    (func (export "f32x4_lane0") (result v128)
+        v128.const f32x4 2 3 4 5
+        f32.const 1
+        f32x4.replace_lane 0
+    )
+
+    (func (export "f32x4_lane1") (result v128)
+        v128.const f32x4 2 3 4 5
+        f32.const 1
+        f32x4.replace_lane 1
+    )
+
+    (func (export "f64x2_lane0") (result v128)
+        v128.const f64x2 2 3
+        f64.const 1
+        f64x2.replace_lane 0
+    )
+
+    (func (export "f64x2_lane1") (result v128)
+        v128.const f64x2 2 3
+        f64.const 1
+        f64x2.replace_lane 1
+    )
+)
+
+(assert_return (invoke "f32x4_lane0") (v128.const f32x4 1 3 4 5))
+(assert_return (invoke "f32x4_lane1") (v128.const f32x4 2 1 4 5))
+(assert_return (invoke "f64x2_lane0") (v128.const f64x2 1 3))
+(assert_return (invoke "f64x2_lane1") (v128.const f64x2 2 1))

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1963,6 +1963,7 @@ impl Assembler {
     }
 
     /// Moves 64-bit float from `src` into lower 64-bits of `dst`.
+    /// Zeroes out the upper 64 bits of `dst`.
     pub fn xmm_vmovsd_rm(&mut self, dst: WritableReg, src: &Address) {
         let src = Self::to_synthetic_amode(
             src,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fixes an issue with `f64x2.replace_lane` where it always zeroes out the second lane if the operand containing the replacement value is a `f64.const`.