### PR TITLE
Add graceful shutdown to `wasmtime serve`, fix flaky CI

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -629,7 +629,7 @@ async fn handle_request(
             // which should more clearly tell the user what went wrong. Note
             // that we assume the task has already exited at this point so the
             // `await` should resolve immediately.
-            let e = match dbg!(task.await) {
+            let e = match task.await {
                 Ok(Ok(())) => {
                     bail!("guest never invoked `response-outparam::set` method")
                 }


### PR DESCRIPTION
This commit fixes the spurious CI failure found [here][fail]. The problem here is that the infrastructure for testing `wasmtime serve` was not properly waiting for all output in `finish`. There's some infrastructure in the tests for spawning a subprocess and managing it, but prior to this commit there was no way to shut down the server gracefully and thus read all pending output from the child tasks.

The specific problem is that a specific error message was expected in the logs after a request had been processed, but the `finish` method wasn't reading the message. The reason for this is that `finish` had to resort to `kill -9` on the child process as there was no other means of shutting it down. This meant that the print, which happened after request completion, might be killed and never happen.

The solution ended up in this commit is to (a) add a `--shutdown-addr` CLI flag to `wasmtime serve` and (b) beef up handling of graceful shutdown. Previously ctrl-c was used to exit the server but it didn't do anything but drop all in-progress work. Instead graceful shutdown is now handled by breaking out of the `accept` loop and then waiting for all child tasks to complete, meaning that no http requests once received are cancelled. In addition to ctrl-c the `--shutdown-addr` is used to listen for a TCP connection which is a second means of cancellation. The reason for this is that sending ctrl-c to a process is not nearly as trivial on Windows as it is on Unix, so I didn't want to deal with all the console bits necessary to get that aligned.

[fail]: https://github.com/bytecodealliance/wasmtime/actions/runs/13833291117/job/38702374924?pr=10390

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
