### PR TITLE
[DWARF] Fix the loclist to exprloc optimization

### DIFF
--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -229,6 +229,7 @@ fn generate_vars(
             let loc_list_id = {
                 let locs = CompiledExpression::from_label(*label)
                     .build_with_locals(scope_ranges, addr_tr, Some(frame_info), isa)
+                    .expressions
                     .map(|i| {
                         i.map(|(begin, length, data)| write::Location::StartLength {
                             begin,

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -20,6 +20,7 @@ pub(crate) fn append_vmctx_info(
         let expr = CompiledExpression::vmctx();
         let locs = expr
             .build_with_locals(scope_ranges, addr_tr, frame_info, isa)
+            .expressions
             .map(|i| {
                 i.map(|(begin, length, data)| write::Location::StartLength {
                     begin,

--- a/crates/test-programs/artifacts/build.rs
+++ b/crates/test-programs/artifacts/build.rs
@@ -210,17 +210,31 @@ fn build_debug_info_assets(paths_code: &mut String) {
     }
 
     // Compile the C/C++ assets.
-    let compile_commands = [(
-        "clang",
-        "generic.wasm",
-        [
-            "-target",
-            "wasm32-unknown-wasip1",
-            "-g",
-            "generic.cpp",
-            "generic-satellite.cpp",
-        ],
-    )];
+    let compile_commands = [
+        (
+            "clang",
+            "generic.wasm",
+            [
+                "-target",
+                "wasm32-unknown-wasip1",
+                "-g",
+                "generic.cpp",
+                "generic-satellite.cpp",
+            ]
+            .as_slice(),
+        ),
+        (
+            "clang",
+            "codegen-optimized.wasm",
+            [
+                "-target",
+                "wasm32-unknown-wasip1",
+                "-g",
+                "codegen-optimized.cpp",
+            ]
+            .as_slice(),
+        ),
+    ];
 
     // The debug tests relying on these assets are ignored by default,
     // so we cannot force the requirement of having a working WASI SDK

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -228,6 +228,41 @@ check: exited with status = 0
 
 #[test]
 #[ignore]
+pub fn test_debug_codegen_optimized_lldb() -> Result<()> {
+    let output = lldb_with_script(
+        &[
+            "-Ccache=n",
+            "-Ddebug-info",
+            "-Oopt-level=2",
+            assets::CODEGEN_OPTIMIZED_WASM_PATH,
+        ],
+        r#"b InitializeTest
+r
+b codegen-optimized.cpp:25
+b codegen-optimized.cpp:26
+c
+v x
+c
+v x
+c"#,
+    )?;
+
+    check_lldb_output(
+        &output,
+        r#"
+check: stop reason = breakpoint 1.1
+check: stop reason = breakpoint 2.1
+check: x = 42
+check: stop reason = breakpoint 3.1
+check: x = <variable not available>
+check: exited with status = 0
+"#,
+    )?;
+    Ok(())
+}
+
+#[test]
+#[ignore]
 pub fn test_debug_dwarf_ref() -> Result<()> {
     let output = lldb_with_script(
         &[

--- a/tests/all/debug/testsuite/codegen-optimized.cpp
+++ b/tests/all/debug/testsuite/codegen-optimized.cpp
@@ -1,0 +1,35 @@
+// clang-format off
+// clang -o codegen-optimized.wasm -target wasm32-unknown-wasip1 -g codegen-optimized.cpp
+// clang-format on
+
+// Make sure to adjust the break locations in lldb.rs when modifying the test.
+#define BREAKPOINT
+
+int InvalidateRegisters() {
+  int r1 = -1;
+  int r2 = -2;
+  int r3 = -3;
+  int r4 = -4;
+  int r5 = -5;
+  int r6 = -6;
+  int r7 = -7;
+  int r8 = -8;
+  return r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8;
+}
+
+void VariableWithSimpleLifetime() {
+  // Here we are testing that the value range of "x" is correctly recorded
+  // as being bound by a loclist that is shorted than the entire method body,
+  // even as the location can be represented with a single DWARF expression.
+  int x = 42;
+  InvalidateRegisters();
+  BREAKPOINT;
+}
+
+void InitializeTest() {}
+
+int main(int argc, char *argv[]) {
+  InitializeTest();
+  VariableWithSimpleLifetime();
+  return 0;
+}


### PR DESCRIPTION
When using an exprloc to describe a location, we must ensure the underlying expression computes the correct value over the whole parent scope.

```
; DWARF5

Single location descriptions

They are sufficient for describing the location of any object
as long as its lifetime is either static or the same as the lexical
block that owns it, and it does not move during its lifetime.
```
Fixes #9900.