### PR TITLE
Transitively dec-ref objects in the DRC collector

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -316,7 +316,7 @@ pub fn translate_struct_get(
     let struct_size = struct_layout.size;
     let struct_size_val = builder.ins().iconst(ir::types::I32, i64::from(struct_size));
 
-    let field_offset = struct_layout.fields[field_index];
+    let field_offset = struct_layout.fields[field_index].offset;
     let field_ty = &func_env.types.unwrap_struct(interned_type_index)?.fields[field_index];
     let field_size = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&field_ty.element_type);
     assert!(field_offset + field_size <= struct_size);
@@ -361,7 +361,7 @@ pub fn translate_struct_set(
     let struct_size = struct_layout.size;
     let struct_size_val = builder.ins().iconst(ir::types::I32, i64::from(struct_size));
 
-    let field_offset = struct_layout.fields[field_index];
+    let field_offset = struct_layout.fields[field_index].offset;
     let field_ty = &func_env.types.unwrap_struct(interned_type_index)?.fields[field_index];
     let field_size = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&field_ty.element_type);
     assert!(field_offset + field_size <= struct_size);
@@ -1194,7 +1194,7 @@ fn initialize_struct_fields(
 ) -> WasmResult<()> {
     let struct_layout = func_env.struct_layout(struct_ty);
     let struct_size = struct_layout.size;
-    let field_offsets: SmallVec<[_; 8]> = struct_layout.fields.iter().copied().collect();
+    let field_offsets: SmallVec<[_; 8]> = struct_layout.fields.iter().map(|f| f.offset).collect();
     assert_eq!(field_offsets.len(), field_values.len());
 
     assert!(!func_env.types[struct_ty].composite_type.shared);

--- a/crates/environ/src/gc/drc.rs
+++ b/crates/environ/src/gc/drc.rs
@@ -1,9 +1,10 @@
 //! Layout of Wasm GC objects in the deferred reference-counting collector.
 
 use super::*;
+use core::cmp;
 
 /// The size of the `VMDrcHeader` header for GC objects.
-pub const HEADER_SIZE: u32 = 16;
+pub const HEADER_SIZE: u32 = 24;
 
 /// The align of the `VMDrcHeader` header for GC objects.
 pub const HEADER_ALIGN: u32 = 8;
@@ -25,6 +26,54 @@ impl GcTypeLayouts for DrcTypeLayouts {
     }
 
     fn struct_layout(&self, ty: &WasmStructType) -> GcStructLayout {
-        common_struct_layout(ty, HEADER_SIZE, HEADER_ALIGN)
+        // Sort the struct fields into the order in which we will lay them out.
+        //
+        // NB: we put all GC refs first so that we can simply store the number
+        // of GC refs in any object in the `VMDrcHeader` and then uniformly
+        // trace all structs types.
+        let mut fields: Vec<_> = ty.fields.iter().enumerate().collect();
+        fields.sort_by_key(|(i, f)| {
+            let is_gc_ref = f.element_type.is_vmgcref_type_and_not_i31();
+            let size = byte_size_of_wasm_ty_in_gc_heap(&f.element_type);
+            (cmp::Reverse(is_gc_ref), cmp::Reverse(size), *i)
+        });
+
+        // Compute the offset of each field as well as the size and alignment of
+        // the whole struct.
+        let mut size = HEADER_SIZE;
+        let mut align = HEADER_ALIGN;
+        let mut fields: Vec<_> = fields
+            .into_iter()
+            .map(|(i, f)| {
+                let field_size = byte_size_of_wasm_ty_in_gc_heap(&f.element_type);
+                let offset = field(&mut size, &mut align, field_size);
+                let is_gc_ref = f.element_type.is_vmgcref_type_and_not_i31();
+                (i, GcStructLayoutField { offset, is_gc_ref })
+            })
+            .collect();
+        if let Some((_i, f)) = fields.get(0) {
+            if f.is_gc_ref {
+                debug_assert_eq!(
+                    f.offset, HEADER_SIZE,
+                    "GC refs should come directly after the header, without any padding",
+                );
+            }
+        }
+
+        // Re-sort the fields into their definition (rather than layout) order
+        // and throw away the definition index.
+        fields.sort_by_key(|(i, _f)| *i);
+        let fields: Vec<_> = fields.into_iter().map(|(_i, f)| f).collect();
+
+        // Ensure that the final size is a multiple of the alignment, for
+        // simplicity.
+        let align_size_to = align;
+        align_up(&mut size, &mut align, align_size_to);
+
+        GcStructLayout {
+            size,
+            align,
+            fields,
+        }
     }
 }

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -198,8 +198,8 @@ impl WasmValType {
     /// Is this a type that is represented as a `VMGcRef` and is additionally
     /// not an `i31`?
     ///
-    /// That is, is this a a type that actually refers to an object allocated in
-    /// a GC heap?
+    /// That is, is this a type that actually refers to an object allocated in a
+    /// GC heap?
     #[inline]
     pub fn is_vmgcref_type_and_not_i31(&self) -> bool {
         match self {
@@ -280,8 +280,8 @@ impl WasmRefType {
     /// Is this a type that is represented as a `VMGcRef` and is additionally
     /// not an `i31`?
     ///
-    /// That is, is this a a type that actually refers to an object allocated in
-    /// a GC heap?
+    /// That is, is this a type that actually refers to an object allocated in a
+    /// GC heap?
     #[inline]
     pub fn is_vmgcref_type_and_not_i31(&self) -> bool {
         self.heap_type.is_vmgcref_type_and_not_i31()
@@ -545,8 +545,8 @@ impl WasmHeapType {
     /// Is this a type that is represented as a `VMGcRef` and is additionally
     /// not an `i31`?
     ///
-    /// That is, is this a a type that actually refers to an object allocated in
-    /// a GC heap?
+    /// That is, is this a type that actually refers to an object allocated in a
+    /// GC heap?
     #[inline]
     pub fn is_vmgcref_type_and_not_i31(&self) -> bool {
         self.is_vmgcref_type() && *self != Self::I31
@@ -858,6 +858,20 @@ impl TypeTrace for WasmStorageType {
         match self {
             WasmStorageType::I8 | WasmStorageType::I16 => Ok(()),
             WasmStorageType::Val(v) => v.trace_mut(func),
+        }
+    }
+}
+
+impl WasmStorageType {
+    /// Is this a type that is represented as a `VMGcRef` and is additionally
+    /// not an `i31`?
+    ///
+    /// That is, is this a type that actually refers to an object allocated in a
+    /// GC heap?
+    pub fn is_vmgcref_type_and_not_i31(&self) -> bool {
+        match self {
+            WasmStorageType::I8 | WasmStorageType::I16 => false,
+            WasmStorageType::Val(v) => v.is_vmgcref_type_and_not_i31(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -437,8 +437,8 @@ impl RootSet {
         for root in lifo_roots.drain(scope..) {
             // Only drop the GC reference if we actually have a GC store. How
             // can we have a GC reference but not a GC store? If we've only
-            // create `i31refs`, we never force a GC store's allocation. This is
-            // fine because `i31ref`s never need drop barriers.
+            // created `i31refs`, we never force a GC store's allocation. This
+            // is fine because `i31ref`s never need drop barriers.
             if let Some(gc_store) = &mut gc_store {
                 gc_store.drop_gc_ref(root.gc_ref);
             }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -142,7 +142,6 @@ impl DrcHeap {
 
     fn dealloc(&mut self, gc_ref: VMGcRef) {
         let drc_ref = drc_ref(&gc_ref);
-        debug_assert_eq!(unsafe { *self.index(drc_ref).ref_count.get() }, 0);
         let size = self.index(drc_ref).object_size();
         let layout = FreeList::layout(size);
         self.free_list

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
@@ -139,7 +139,7 @@ impl VMStructRef {
         ty: &StorageType,
         field: usize,
     ) -> Val {
-        let offset = layout.fields[field];
+        let offset = layout.fields[field].offset;
         let data = store.unwrap_gc_store_mut().gc_object_data(self.as_gc_ref());
         match ty {
             StorageType::I8 => Val::I32(data.read_u8(offset).into()),
@@ -195,7 +195,7 @@ impl VMStructRef {
     ) -> Result<()> {
         debug_assert!(val._matches_ty(&store, &ty.unpack())?);
 
-        let offset = layout.fields[field];
+        let offset = layout.fields[field].offset;
         let mut data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
         match val {
             Val::I32(i) if ty.is_i8() => data.write_i8(offset, truncate_i32_to_i8(i)),
@@ -286,7 +286,7 @@ impl VMStructRef {
         val: Val,
     ) -> Result<()> {
         debug_assert!(val._matches_ty(&store, &ty.unpack())?);
-        let offset = layout.fields[field];
+        let offset = layout.fields[field].offset;
         match val {
             Val::I32(i) if ty.is_i8() => store
                 .gc_store_mut()?

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
 ;; @0027                               v10 = uextend.i64 v2
-;; @0027                               v11 = iconst.i64 16
-;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
+;; @0027                               v11 = iconst.i64 24
+;; @0027                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 24
 ;; @0027                               v13 = iconst.i64 4
 ;; @0027                               v14 = uadd_overflow_trap v12, v13, user1  ; v13 = 4
 ;; @0027                               v9 = load.i64 notrap aligned readonly can_move v0+48
@@ -40,10 +40,10 @@
 ;; @0027                               trapnz v23, user1
 ;;                                     v58 = iconst.i32 3
 ;;                                     v59 = ishl v17, v58  ; v58 = 3
-;; @0027                               v25 = iconst.i32 24
-;; @0027                               v26 = uadd_overflow_trap v59, v25, user1  ; v25 = 24
+;; @0027                               v25 = iconst.i32 32
+;; @0027                               v26 = uadd_overflow_trap v59, v25, user1  ; v25 = 32
 ;;                                     v66 = ishl v3, v58  ; v58 = 3
-;;                                     v68 = iadd v66, v25  ; v25 = 24
+;;                                     v68 = iadd v66, v25  ; v25 = 32
 ;; @0027                               v35 = uextend.i64 v68
 ;; @0027                               v36 = uadd_overflow_trap v10, v35, user1
 ;; @0027                               v37 = uextend.i64 v26

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = uextend.i64 v2
-;; @0022                               v10 = iconst.i64 16
-;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v10 = iconst.i64 24
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
 ;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
@@ -35,9 +35,9 @@
 ;;                                     v41 = iconst.i64 32
 ;; @0022                               v21 = ushr v19, v41  ; v41 = 32
 ;; @0022                               trapnz v21, user1
-;; @0022                               v23 = iconst.i32 20
-;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
-;; @0022                               v27 = iadd v3, v23  ; v23 = 20
+;; @0022                               v23 = iconst.i32 28
+;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 28
+;; @0022                               v27 = iadd v3, v23  ; v23 = 28
 ;; @0022                               v33 = uextend.i64 v27
 ;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
 ;; @0022                               v35 = uextend.i64 v24

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = uextend.i64 v2
-;; @0022                               v10 = iconst.i64 16
-;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v10 = iconst.i64 24
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
 ;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
@@ -35,9 +35,9 @@
 ;;                                     v41 = iconst.i64 32
 ;; @0022                               v21 = ushr v19, v41  ; v41 = 32
 ;; @0022                               trapnz v21, user1
-;; @0022                               v23 = iconst.i32 20
-;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
-;; @0022                               v27 = iadd v3, v23  ; v23 = 20
+;; @0022                               v23 = iconst.i32 28
+;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 28
+;; @0022                               v27 = iadd v3, v23  ; v23 = 28
 ;; @0022                               v33 = uextend.i64 v27
 ;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
 ;; @0022                               v35 = uextend.i64 v24

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = uextend.i64 v2
-;; @0022                               v10 = iconst.i64 16
-;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0022                               v10 = iconst.i64 24
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;; @0022                               v12 = iconst.i64 4
 ;; @0022                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
 ;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
@@ -39,10 +39,10 @@
 ;; @0022                               trapnz v21, user1
 ;;                                     v51 = iconst.i32 3
 ;;                                     v52 = ishl v16, v51  ; v51 = 3
-;; @0022                               v23 = iconst.i32 24
-;; @0022                               v24 = uadd_overflow_trap v52, v23, user1  ; v23 = 24
+;; @0022                               v23 = iconst.i32 32
+;; @0022                               v24 = uadd_overflow_trap v52, v23, user1  ; v23 = 32
 ;;                                     v59 = ishl v3, v51  ; v51 = 3
-;; @0022                               v27 = iadd v59, v23  ; v23 = 24
+;; @0022                               v27 = iadd v59, v23  ; v23 = 32
 ;; @0022                               v33 = uextend.i64 v27
 ;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
 ;; @0022                               v35 = uextend.i64 v24

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @001f                               trapz v2, user16
 ;; @001f                               v8 = uextend.i64 v2
-;; @001f                               v9 = iconst.i64 16
-;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 16
+;; @001f                               v9 = iconst.i64 24
+;; @001f                               v10 = uadd_overflow_trap v8, v9, user1  ; v9 = 24
 ;; @001f                               v11 = iconst.i64 4
 ;; @001f                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 4
 ;; @001f                               v7 = load.i64 notrap aligned readonly can_move v0+48

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -19,33 +19,34 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v43 = iconst.i64 0
-;; @0025                               trapnz v43, user18  ; v43 = 0
-;; @0025                               v6 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v6, v6, user18  ; v6 = 24, v6 = 24
-;; @0025                               v14 = iconst.i32 -1476395008
-;; @0025                               v15 = iconst.i32 0
-;; @0025                               v16 = iconst.i32 8
-;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
+;;                                     v45 = iconst.i64 0
+;; @0025                               trapnz v45, user18  ; v45 = 0
+;; @0025                               v6 = iconst.i32 32
+;;                                     v46 = iconst.i32 24
+;; @0025                               v12 = uadd_overflow_trap v6, v46, user18  ; v6 = 32, v46 = 24
+;; @0025                               v15 = iconst.i32 -1476395008
+;; @0025                               v13 = iconst.i32 0
+;; @0025                               v18 = iconst.i32 8
+;; @0025                               v19 = call fn0(v0, v15, v13, v12, v18)  ; v15 = -1476395008, v13 = 0, v18 = 8
 ;; @0025                               v7 = iconst.i32 3
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v18 = ireduce.i32 v17
-;; @0025                               v21 = uextend.i64 v18
-;; @0025                               v22 = iadd v20, v21
-;;                                     v33 = iconst.i64 16
-;; @0025                               v23 = iadd v22, v33  ; v33 = 16
-;; @0025                               store notrap aligned v7, v23  ; v7 = 3
-;;                                     v35 = iconst.i64 24
-;;                                     v50 = iadd v22, v35  ; v35 = 24
-;; @0025                               store notrap aligned little v2, v50
-;;                                     v32 = iconst.i64 32
-;;                                     v57 = iadd v22, v32  ; v32 = 32
-;; @0025                               store notrap aligned little v3, v57
-;;                                     v59 = iconst.i64 40
-;;                                     v65 = iadd v22, v59  ; v59 = 40
-;; @0025                               store notrap aligned little v4, v65
+;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v20 = ireduce.i32 v19
+;; @0025                               v23 = uextend.i64 v20
+;; @0025                               v24 = iadd v22, v23
+;;                                     v37 = iconst.i64 24
+;; @0025                               v25 = iadd v24, v37  ; v37 = 24
+;; @0025                               store notrap aligned v7, v25  ; v7 = 3
+;;                                     v34 = iconst.i64 32
+;;                                     v59 = iadd v24, v34  ; v34 = 32
+;; @0025                               store notrap aligned little v2, v59
+;;                                     v61 = iconst.i64 40
+;;                                     v67 = iadd v24, v61  ; v61 = 40
+;; @0025                               store notrap aligned little v3, v67
+;;                                     v69 = iconst.i64 48
+;;                                     v75 = iadd v24, v69  ; v69 = 48
+;; @0025                               store notrap aligned little v4, v75
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v18
+;; @0029                               return v20
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -20,46 +20,45 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v35 = iconst.i64 3
-;;                                     v36 = ishl v6, v35  ; v35 = 3
-;;                                     v33 = iconst.i64 32
-;; @0022                               v8 = ushr v36, v33  ; v33 = 32
+;;                                     v37 = iconst.i64 3
+;;                                     v38 = ishl v6, v37  ; v37 = 3
+;;                                     v35 = iconst.i64 32
+;; @0022                               v8 = ushr v38, v35  ; v35 = 32
 ;; @0022                               trapnz v8, user18
-;; @0022                               v5 = iconst.i32 24
-;;                                     v42 = iconst.i32 3
-;;                                     v43 = ishl v3, v42  ; v42 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v43, user18  ; v5 = 24
-;; @0022                               v12 = iconst.i32 -1476395008
-;; @0022                               v13 = iconst.i32 0
-;;                                     v40 = iconst.i32 8
-;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
-;; @0022                               v18 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v16 = ireduce.i32 v15
-;; @0022                               v19 = uextend.i64 v16
-;; @0022                               v20 = iadd v18, v19
-;;                                     v34 = iconst.i64 16
-;; @0022                               v21 = iadd v20, v34  ; v34 = 16
-;; @0022                               store notrap aligned v3, v21
-;;                                     v47 = iconst.i64 24
-;;                                     v53 = iadd v20, v47  ; v47 = 24
-;; @0022                               v27 = uextend.i64 v10
-;; @0022                               v28 = iadd v20, v27
-;;                                     v32 = iconst.i64 8
-;; @0022                               jump block2(v53)
+;; @0022                               v5 = iconst.i32 32
+;;                                     v44 = iconst.i32 3
+;;                                     v45 = ishl v3, v44  ; v44 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v45, user18  ; v5 = 32
+;; @0022                               v13 = iconst.i32 -1476395008
+;; @0022                               v11 = iconst.i32 0
+;;                                     v42 = iconst.i32 8
+;; @0022                               v17 = call fn0(v0, v13, v11, v10, v42)  ; v13 = -1476395008, v11 = 0, v42 = 8
+;; @0022                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v18 = ireduce.i32 v17
+;; @0022                               v21 = uextend.i64 v18
+;; @0022                               v22 = iadd v20, v21
+;;                                     v36 = iconst.i64 24
+;; @0022                               v23 = iadd v22, v36  ; v36 = 24
+;; @0022                               store notrap aligned v3, v23
+;;                                     v60 = iadd v22, v35  ; v35 = 32
+;; @0022                               v29 = uextend.i64 v10
+;; @0022                               v30 = iadd v22, v29
+;;                                     v34 = iconst.i64 8
+;; @0022                               jump block2(v60)
 ;;
-;;                                 block2(v29: i64):
-;; @0022                               v30 = icmp eq v29, v28
-;; @0022                               brif v30, block4, block3
+;;                                 block2(v31: i64):
+;; @0022                               v32 = icmp eq v31, v30
+;; @0022                               brif v32, block4, block3
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 notrap aligned little v2, v29
-;;                                     v65 = iconst.i64 8
-;;                                     v66 = iadd.i64 v29, v65  ; v65 = 8
-;; @0022                               jump block2(v66)
+;; @0022                               store.i64 notrap aligned little v2, v31
+;;                                     v72 = iconst.i64 8
+;;                                     v73 = iadd.i64 v31, v72  ; v72 = 8
+;; @0022                               jump block2(v73)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v16
+;; @0025                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -19,8 +19,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v9 = uextend.i64 v2
-;; @0024                               v10 = iconst.i64 16
-;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
+;; @0024                               v10 = iconst.i64 24
+;; @0024                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
 ;; @0024                               v12 = iconst.i64 4
 ;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 4
 ;; @0024                               v8 = load.i64 notrap aligned readonly can_move v0+48
@@ -39,10 +39,10 @@
 ;; @0024                               trapnz v21, user1
 ;;                                     v50 = iconst.i32 3
 ;;                                     v51 = ishl v16, v50  ; v50 = 3
-;; @0024                               v23 = iconst.i32 24
-;; @0024                               v24 = uadd_overflow_trap v51, v23, user1  ; v23 = 24
+;; @0024                               v23 = iconst.i32 32
+;; @0024                               v24 = uadd_overflow_trap v51, v23, user1  ; v23 = 32
 ;;                                     v58 = ishl v3, v50  ; v50 = 3
-;; @0024                               v27 = iadd v58, v23  ; v23 = 24
+;; @0024                               v27 = iadd v58, v23  ; v23 = 32
 ;; @0024                               v33 = uextend.i64 v27
 ;; @0024                               v34 = uadd_overflow_trap v9, v33, user1
 ;; @0024                               v35 = uextend.i64 v24

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -21,10 +21,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0020                               trapz v2, user16
 ;; @0020                               v9 = uextend.i64 v2
-;; @0020                               v10 = iconst.i64 16
-;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v20 = iconst.i64 24
-;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 24
+;; @0020                               v10 = iconst.i64 24
+;; @0020                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
+;;                                     v20 = iconst.i64 32
+;; @0020                               v13 = uadd_overflow_trap v9, v20, user1  ; v20 = 32
 ;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0020                               v14 = icmp ule v13, v8
 ;; @0020                               trapz v14, user1

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -22,25 +22,25 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;; @0020                               v6 = iconst.i32 -1342177280
-;; @0020                               v7 = iconst.i32 0
-;; @0020                               v4 = iconst.i32 24
-;; @0020                               v8 = iconst.i32 8
-;; @0020                               v9 = call fn0(v0, v6, v7, v4, v8)  ; v6 = -1342177280, v7 = 0, v4 = 24, v8 = 8
-;; @0020                               v10 = ireduce.i32 v9
-;;                                     v21 = stack_addr.i64 ss0
-;;                                     store notrap v10, v21
-;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v18 = ireduce.i32 v17
-;; @0020                               v12 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v13 = uextend.i64 v10
-;; @0020                               v14 = iadd v12, v13
-;;                                     v23 = iconst.i64 16
-;; @0020                               v15 = iadd v14, v23  ; v23 = 16
-;; @0020                               store notrap aligned little v18, v15
-;;                                     v19 = load.i32 notrap v21
+;; @0020                               v7 = iconst.i32 -1342177280
+;; @0020                               v5 = iconst.i32 0
+;; @0020                               v4 = iconst.i32 32
+;; @0020                               v10 = iconst.i32 8
+;; @0020                               v11 = call fn0(v0, v7, v5, v4, v10)  ; v7 = -1342177280, v5 = 0, v4 = 32, v10 = 8
+;; @0020                               v12 = ireduce.i32 v11
+;;                                     v23 = stack_addr.i64 ss0
+;;                                     store notrap v12, v23
+;; @0020                               v19 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v20 = ireduce.i32 v19
+;; @0020                               v14 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v15 = uextend.i64 v12
+;; @0020                               v16 = iadd v14, v15
+;;                                     v25 = iconst.i64 24
+;; @0020                               v17 = iadd v16, v25  ; v25 = 24
+;; @0020                               store notrap aligned little v20, v17
+;;                                     v21 = load.i32 notrap v23
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v19
+;; @0023                               return v21
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -21,10 +21,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
 ;; @0022                               trapz v2, user16
 ;; @0022                               v9 = uextend.i64 v2
-;; @0022                               v10 = iconst.i64 16
-;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v19 = iconst.i64 24
-;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 24
+;; @0022                               v10 = iconst.i64 24
+;; @0022                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
+;;                                     v19 = iconst.i64 32
+;; @0022                               v13 = uadd_overflow_trap v9, v19, user1  ; v19 = 32
 ;; @0022                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0022                               v14 = icmp ule v13, v8
 ;; @0022                               trapz v14, user1

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -20,8 +20,8 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
 ;; @0024                               v11 = uextend.i64 v2
-;; @0024                               v12 = iconst.i64 16
-;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 16
+;; @0024                               v12 = iconst.i64 24
+;; @0024                               v13 = uadd_overflow_trap v11, v12, user1  ; v12 = 24
 ;; @0024                               v14 = iconst.i64 4
 ;; @0024                               v15 = uadd_overflow_trap v13, v14, user1  ; v14 = 4
 ;; @0024                               v10 = load.i64 notrap aligned readonly can_move v0+48
@@ -40,10 +40,10 @@
 ;; @0024                               trapnz v23, user1
 ;;                                     v89 = iconst.i32 3
 ;;                                     v90 = ishl v18, v89  ; v89 = 3
-;; @0024                               v25 = iconst.i32 24
-;; @0024                               v26 = uadd_overflow_trap v90, v25, user1  ; v25 = 24
+;; @0024                               v25 = iconst.i32 32
+;; @0024                               v26 = uadd_overflow_trap v90, v25, user1  ; v25 = 32
 ;;                                     v97 = ishl v3, v89  ; v89 = 3
-;; @0024                               v29 = iadd v97, v25  ; v25 = 24
+;; @0024                               v29 = iadd v97, v25  ; v25 = 32
 ;; @0024                               v35 = uextend.i64 v29
 ;; @0024                               v36 = uadd_overflow_trap v11, v35, user1
 ;; @0024                               v37 = uextend.i64 v26
@@ -55,7 +55,7 @@
 ;; @002b                               v54 = icmp ult v4, v18
 ;; @002b                               trapz v54, user17
 ;;                                     v99 = ishl v4, v89  ; v89 = 3
-;; @002b                               v64 = iadd v99, v25  ; v25 = 24
+;; @002b                               v64 = iadd v99, v25  ; v25 = 32
 ;; @002b                               v70 = uextend.i64 v64
 ;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
 ;; @002b                               v75 = iadd v8, v71

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -21,18 +21,18 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
 ;; @0023                               v10 = uextend.i64 v2
-;; @0023                               v11 = iconst.i64 16
-;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 16
-;;                                     v32 = iconst.i64 24
-;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 24
+;; @0023                               v11 = iconst.i64 24
+;; @0023                               v12 = uadd_overflow_trap v10, v11, user1  ; v11 = 24
+;;                                     v32 = iconst.i64 32
+;; @0023                               v14 = uadd_overflow_trap v10, v32, user1  ; v32 = 32
 ;; @0023                               v9 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0023                               v15 = icmp ule v14, v9
 ;; @0023                               trapz v15, user1
 ;; @0023                               v7 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0023                               v16 = iadd v7, v12
 ;; @0023                               v17 = load.f32 notrap aligned little v16
-;; @0029                               v24 = iconst.i64 20
-;; @0029                               v25 = uadd_overflow_trap v10, v24, user1  ; v24 = 20
+;; @0029                               v24 = iconst.i64 28
+;; @0029                               v25 = uadd_overflow_trap v10, v24, user1  ; v24 = 28
 ;; @0029                               v29 = iadd v7, v25
 ;; @0029                               v30 = load.i8 notrap aligned little v29
 ;; @002d                               jump block1

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -33,10 +33,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0033                               trapz v2, user16
 ;; @0033                               v9 = uextend.i64 v2
-;; @0033                               v10 = iconst.i64 16
-;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v17 = iconst.i64 32
-;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 32
+;; @0033                               v10 = iconst.i64 28
+;; @0033                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 28
+;;                                     v17 = iconst.i64 40
+;; @0033                               v13 = uadd_overflow_trap v9, v17, user1  ; v17 = 40
 ;; @0033                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0033                               v14 = icmp ule v13, v8
 ;; @0033                               trapz v14, user1
@@ -59,10 +59,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @003c                               trapz v2, user16
 ;; @003c                               v9 = uextend.i64 v2
-;; @003c                               v10 = iconst.i64 20
-;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
-;;                                     v18 = iconst.i64 32
-;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
+;; @003c                               v10 = iconst.i64 32
+;; @003c                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 32
+;;                                     v18 = iconst.i64 40
+;; @003c                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 40
 ;; @003c                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003c                               v14 = icmp ule v13, v8
 ;; @003c                               trapz v14, user1
@@ -86,10 +86,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0045                               trapz v2, user16
 ;; @0045                               v9 = uextend.i64 v2
-;; @0045                               v10 = iconst.i64 20
-;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
-;;                                     v18 = iconst.i64 32
-;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 32
+;; @0045                               v10 = iconst.i64 32
+;; @0045                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 32
+;;                                     v18 = iconst.i64 40
+;; @0045                               v13 = uadd_overflow_trap v9, v18, user1  ; v18 = 40
 ;; @0045                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0045                               v14 = icmp ule v13, v8
 ;; @0045                               trapz v14, user1
@@ -118,8 +118,8 @@
 ;; @004e                               v9 = uextend.i64 v2
 ;; @004e                               v10 = iconst.i64 24
 ;; @004e                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
-;;                                     v72 = iconst.i64 32
-;; @004e                               v13 = uadd_overflow_trap v9, v72, user1  ; v72 = 32
+;;                                     v72 = iconst.i64 40
+;; @004e                               v13 = uadd_overflow_trap v9, v72, user1  ; v72 = 40
 ;; @004e                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004e                               v14 = icmp ule v13, v8
 ;; @004e                               trapz v14, user1

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -21,47 +21,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v8 = iconst.i32 -1342177280
+;;                                     v56 = iconst.i32 -1342177279
 ;; @0021                               v4 = iconst.i32 0
-;; @0021                               v6 = iconst.i32 32
-;; @0021                               v10 = iconst.i32 8
-;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
+;; @0021                               v6 = iconst.i32 40
+;; @0021                               v12 = iconst.i32 8
+;; @0021                               v13 = call fn0(v0, v56, v4, v6, v12)  ; v56 = -1342177279, v4 = 0, v6 = 40, v12 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @0021                               v12 = ireduce.i32 v11
-;; @0021                               v15 = uextend.i64 v12
-;; @0021                               v16 = iadd v14, v15
-;;                                     v48 = iconst.i64 16
-;; @0021                               v17 = iadd v16, v48  ; v48 = 16
-;; @0021                               store notrap aligned little v3, v17  ; v3 = 0.0
-;;                                     v49 = iconst.i64 20
-;; @0021                               v18 = iadd v16, v49  ; v49 = 20
-;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
-;;                                     v51 = iconst.i32 1
-;; @0021                               brif v51, block3, block2  ; v51 = 1
+;; @0021                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v14 = ireduce.i32 v13
+;; @0021                               v17 = uextend.i64 v14
+;; @0021                               v18 = iadd v16, v17
+;;                                     v50 = iconst.i64 28
+;; @0021                               v19 = iadd v18, v50  ; v50 = 28
+;; @0021                               store notrap aligned little v3, v19  ; v3 = 0.0
+;;                                     v51 = iconst.i64 32
+;; @0021                               v20 = iadd v18, v51  ; v51 = 32
+;; @0021                               istore8 notrap aligned little v4, v20  ; v4 = 0
+;; @0021                               v7 = iconst.i32 1
+;; @0021                               brif v7, block3, block2  ; v7 = 1
 ;;
 ;;                                 block2:
-;;                                     v73 = iconst.i64 0
-;; @0021                               v29 = iconst.i64 8
-;; @0021                               v30 = uadd_overflow_trap v73, v29, user1  ; v73 = 0, v29 = 8
-;; @0021                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @0021                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0021                               v33 = icmp ule v32, v27
-;; @0021                               trapz v33, user1
-;; @0021                               v34 = iadd.i64 v14, v30
-;; @0021                               v35 = load.i64 notrap aligned v34
-;;                                     v53 = iconst.i64 1
-;; @0021                               v36 = iadd v35, v53  ; v53 = 1
-;; @0021                               store notrap aligned v36, v34
+;;                                     v82 = iconst.i64 0
+;; @0021                               v31 = iconst.i64 8
+;; @0021                               v32 = uadd_overflow_trap v82, v31, user1  ; v82 = 0, v31 = 8
+;; @0021                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
+;; @0021                               v29 = load.i64 notrap aligned readonly can_move v0+48
+;; @0021                               v35 = icmp ule v34, v29
+;; @0021                               trapz v35, user1
+;; @0021                               v36 = iadd.i64 v16, v32
+;; @0021                               v37 = load.i64 notrap aligned v36
+;;                                     v55 = iconst.i64 1
+;; @0021                               v38 = iadd v37, v55  ; v55 = 1
+;; @0021                               store notrap aligned v38, v36
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v74 = iconst.i32 0
-;;                                     v50 = iconst.i64 24
-;; @0021                               v19 = iadd.i64 v16, v50  ; v50 = 24
-;; @0021                               store notrap aligned little v74, v19  ; v74 = 0
+;;                                     v83 = iconst.i32 0
+;;                                     v52 = iconst.i64 24
+;; @0021                               v21 = iadd.i64 v18, v52  ; v52 = 24
+;; @0021                               store notrap aligned little v83, v21  ; v83 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v12
+;; @0024                               return v14
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -22,53 +22,53 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     store notrap v4, v53
-;; @002a                               v8 = iconst.i32 -1342177280
-;; @002a                               v9 = iconst.i32 0
-;; @002a                               v6 = iconst.i32 32
-;; @002a                               v10 = iconst.i32 8
-;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v12 = ireduce.i32 v11
-;; @002a                               v15 = uextend.i64 v12
-;; @002a                               v16 = iadd v14, v15
-;;                                     v54 = iconst.i64 16
-;; @002a                               v17 = iadd v16, v54  ; v54 = 16
-;; @002a                               store notrap aligned little v2, v17
-;;                                     v55 = iconst.i64 20
-;; @002a                               v18 = iadd v16, v55  ; v55 = 20
-;; @002a                               istore8 notrap aligned little v3, v18
-;;                                     v52 = load.i32 notrap v53
-;;                                     v58 = iconst.i32 1
-;; @002a                               v20 = band v52, v58  ; v58 = 1
-;; @002a                               v21 = icmp eq v52, v9  ; v9 = 0
-;; @002a                               v22 = uextend.i32 v21
-;; @002a                               v23 = bor v20, v22
-;; @002a                               brif v23, block3, block2
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     store notrap v4, v55
+;;                                     v67 = iconst.i32 -1342177279
+;; @002a                               v11 = iconst.i32 0
+;; @002a                               v6 = iconst.i32 40
+;; @002a                               v12 = iconst.i32 8
+;; @002a                               v13 = call fn0(v0, v67, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v67 = -1342177279, v11 = 0, v6 = 40, v12 = 8
+;; @002a                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v14 = ireduce.i32 v13
+;; @002a                               v17 = uextend.i64 v14
+;; @002a                               v18 = iadd v16, v17
+;;                                     v56 = iconst.i64 28
+;; @002a                               v19 = iadd v18, v56  ; v56 = 28
+;; @002a                               store notrap aligned little v2, v19
+;;                                     v57 = iconst.i64 32
+;; @002a                               v20 = iadd v18, v57  ; v57 = 32
+;; @002a                               istore8 notrap aligned little v3, v20
+;;                                     v54 = load.i32 notrap v55
+;; @002a                               v7 = iconst.i32 1
+;; @002a                               v22 = band v54, v7  ; v7 = 1
+;; @002a                               v23 = icmp eq v54, v11  ; v11 = 0
+;; @002a                               v24 = uextend.i32 v23
+;; @002a                               v25 = bor v22, v24
+;; @002a                               brif v25, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v28 = uextend.i64 v52
-;; @002a                               v29 = iconst.i64 8
-;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
-;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @002a                               v33 = icmp ule v32, v27
-;; @002a                               trapz v33, user1
-;; @002a                               v34 = iadd.i64 v14, v30
-;; @002a                               v35 = load.i64 notrap aligned v34
-;;                                     v62 = iconst.i64 1
-;; @002a                               v36 = iadd v35, v62  ; v62 = 1
-;; @002a                               store notrap aligned v36, v34
+;; @002a                               v30 = uextend.i64 v54
+;; @002a                               v31 = iconst.i64 8
+;; @002a                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
+;; @002a                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
+;; @002a                               v29 = load.i64 notrap aligned readonly can_move v0+48
+;; @002a                               v35 = icmp ule v34, v29
+;; @002a                               trapz v35, user1
+;; @002a                               v36 = iadd.i64 v16, v32
+;; @002a                               v37 = load.i64 notrap aligned v36
+;;                                     v64 = iconst.i64 1
+;; @002a                               v38 = iadd v37, v64  ; v64 = 1
+;; @002a                               store notrap aligned v38, v36
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v48 = load.i32 notrap v53
-;;                                     v56 = iconst.i64 24
-;; @002a                               v19 = iadd.i64 v16, v56  ; v56 = 24
-;; @002a                               store notrap aligned little v48, v19
+;;                                     v50 = load.i32 notrap v55
+;;                                     v58 = iconst.i64 24
+;; @002a                               v21 = iadd.i64 v18, v58  ; v58 = 24
+;; @002a                               store notrap aligned little v50, v21
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v12
+;; @002d                               return v14
 ;; }

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -29,10 +29,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
 ;; @0034                               trapz v2, user16
 ;; @0034                               v9 = uextend.i64 v2
-;; @0034                               v10 = iconst.i64 16
-;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 16
-;;                                     v16 = iconst.i64 32
-;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
+;; @0034                               v10 = iconst.i64 28
+;; @0034                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 28
+;;                                     v16 = iconst.i64 40
+;; @0034                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 40
 ;; @0034                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0034                               v14 = icmp ule v13, v8
 ;; @0034                               trapz v14, user1
@@ -55,10 +55,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @003f                               trapz v2, user16
 ;; @003f                               v9 = uextend.i64 v2
-;; @003f                               v10 = iconst.i64 20
-;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 20
-;;                                     v16 = iconst.i64 32
-;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 32
+;; @003f                               v10 = iconst.i64 32
+;; @003f                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 32
+;;                                     v16 = iconst.i64 40
+;; @003f                               v13 = uadd_overflow_trap v9, v16, user1  ; v16 = 40
 ;; @003f                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @003f                               v14 = icmp ule v13, v8
 ;; @003f                               trapz v14, user1
@@ -85,8 +85,8 @@
 ;; @004a                               v9 = uextend.i64 v2
 ;; @004a                               v10 = iconst.i64 24
 ;; @004a                               v11 = uadd_overflow_trap v9, v10, user1  ; v10 = 24
-;;                                     v82 = iconst.i64 32
-;; @004a                               v13 = uadd_overflow_trap v9, v82, user1  ; v82 = 32
+;;                                     v82 = iconst.i64 40
+;; @004a                               v13 = uadd_overflow_trap v9, v82, user1  ; v82 = 40
 ;; @004a                               v8 = load.i64 notrap aligned readonly can_move v0+48
 ;; @004a                               v14 = icmp ule v13, v8
 ;; @004a                               trapz v14, user1

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -23,51 +23,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0023                               v9 = iconst.i32 -1342177280
+;;                                     v59 = iconst.i32 -1342177279
 ;; @0023                               v4 = iconst.i32 0
-;; @0023                               v7 = iconst.i32 48
-;; @0023                               v11 = iconst.i32 16
-;; @0023                               v12 = call fn0(v0, v9, v4, v7, v11)  ; v9 = -1342177280, v4 = 0, v7 = 48, v11 = 16
+;; @0023                               v7 = iconst.i32 64
+;; @0023                               v13 = iconst.i32 16
+;; @0023                               v14 = call fn0(v0, v59, v4, v7, v13)  ; v59 = -1342177279, v4 = 0, v7 = 64, v13 = 16
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v15 = load.i64 notrap aligned readonly can_move v0+40
-;; @0023                               v13 = ireduce.i32 v12
-;; @0023                               v16 = uextend.i64 v13
-;; @0023                               v17 = iadd v15, v16
-;;                                     v50 = iconst.i64 16
-;; @0023                               v18 = iadd v17, v50  ; v50 = 16
-;; @0023                               store notrap aligned little v3, v18  ; v3 = 0.0
-;;                                     v51 = iconst.i64 20
-;; @0023                               v19 = iadd v17, v51  ; v51 = 20
-;; @0023                               istore8 notrap aligned little v4, v19  ; v4 = 0
-;;                                     v53 = iconst.i32 1
-;; @0023                               brif v53, block3, block2  ; v53 = 1
+;; @0023                               v17 = load.i64 notrap aligned readonly can_move v0+40
+;; @0023                               v15 = ireduce.i32 v14
+;; @0023                               v18 = uextend.i64 v15
+;; @0023                               v19 = iadd v17, v18
+;;                                     v52 = iconst.i64 48
+;; @0023                               v20 = iadd v19, v52  ; v52 = 48
+;; @0023                               store notrap aligned little v3, v20  ; v3 = 0.0
+;;                                     v53 = iconst.i64 52
+;; @0023                               v21 = iadd v19, v53  ; v53 = 52
+;; @0023                               istore8 notrap aligned little v4, v21  ; v4 = 0
+;; @0023                               v8 = iconst.i32 1
+;; @0023                               brif v8, block3, block2  ; v8 = 1
 ;;
 ;;                                 block2:
-;;                                     v76 = iconst.i64 0
-;; @0023                               v30 = iconst.i64 8
-;; @0023                               v31 = uadd_overflow_trap v76, v30, user1  ; v76 = 0, v30 = 8
-;; @0023                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
-;; @0023                               v28 = load.i64 notrap aligned readonly can_move v0+48
-;; @0023                               v34 = icmp ule v33, v28
-;; @0023                               trapz v34, user1
-;; @0023                               v35 = iadd.i64 v15, v31
-;; @0023                               v36 = load.i64 notrap aligned v35
-;;                                     v55 = iconst.i64 1
-;; @0023                               v37 = iadd v36, v55  ; v55 = 1
-;; @0023                               store notrap aligned v37, v35
+;;                                     v85 = iconst.i64 0
+;; @0023                               v32 = iconst.i64 8
+;; @0023                               v33 = uadd_overflow_trap v85, v32, user1  ; v85 = 0, v32 = 8
+;; @0023                               v35 = uadd_overflow_trap v33, v32, user1  ; v32 = 8
+;; @0023                               v30 = load.i64 notrap aligned readonly can_move v0+48
+;; @0023                               v36 = icmp ule v35, v30
+;; @0023                               trapz v36, user1
+;; @0023                               v37 = iadd.i64 v17, v33
+;; @0023                               v38 = load.i64 notrap aligned v37
+;;                                     v57 = iconst.i64 1
+;; @0023                               v39 = iadd v38, v57  ; v57 = 1
+;; @0023                               store notrap aligned v39, v37
 ;; @0023                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v77 = iconst.i32 0
-;;                                     v52 = iconst.i64 24
-;; @0023                               v20 = iadd.i64 v17, v52  ; v52 = 24
-;; @0023                               store notrap aligned little v77, v20  ; v77 = 0
+;;                                     v86 = iconst.i32 0
+;;                                     v54 = iconst.i64 24
+;; @0023                               v22 = iadd.i64 v19, v54  ; v54 = 24
+;; @0023                               store notrap aligned little v86, v22  ; v86 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
-;;                                     v56 = iconst.i64 32
-;; @0023                               v49 = iadd.i64 v17, v56  ; v56 = 32
-;; @0023                               store notrap aligned little v6, v49  ; v6 = const0
+;;                                     v58 = iconst.i64 32
+;; @0023                               v51 = iadd.i64 v19, v58  ; v58 = 32
+;; @0023                               store notrap aligned little v6, v51  ; v6 = const0
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:
-;; @0026                               return v13
+;; @0026                               return v15
 ;; }

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -22,53 +22,53 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     store notrap v4, v53
-;; @002a                               v8 = iconst.i32 -1342177280
-;; @002a                               v9 = iconst.i32 0
-;; @002a                               v6 = iconst.i32 32
-;; @002a                               v10 = iconst.i32 8
-;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v12 = ireduce.i32 v11
-;; @002a                               v15 = uextend.i64 v12
-;; @002a                               v16 = iadd v14, v15
-;;                                     v54 = iconst.i64 16
-;; @002a                               v17 = iadd v16, v54  ; v54 = 16
-;; @002a                               store notrap aligned little v2, v17
-;;                                     v55 = iconst.i64 20
-;; @002a                               v18 = iadd v16, v55  ; v55 = 20
-;; @002a                               istore8 notrap aligned little v3, v18
-;;                                     v52 = load.i32 notrap v53
-;;                                     v58 = iconst.i32 1
-;; @002a                               v20 = band v52, v58  ; v58 = 1
-;; @002a                               v21 = icmp eq v52, v9  ; v9 = 0
-;; @002a                               v22 = uextend.i32 v21
-;; @002a                               v23 = bor v20, v22
-;; @002a                               brif v23, block3, block2
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     store notrap v4, v55
+;;                                     v67 = iconst.i32 -1342177279
+;; @002a                               v11 = iconst.i32 0
+;; @002a                               v6 = iconst.i32 40
+;; @002a                               v12 = iconst.i32 8
+;; @002a                               v13 = call fn0(v0, v67, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v67 = -1342177279, v11 = 0, v6 = 40, v12 = 8
+;; @002a                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v14 = ireduce.i32 v13
+;; @002a                               v17 = uextend.i64 v14
+;; @002a                               v18 = iadd v16, v17
+;;                                     v56 = iconst.i64 28
+;; @002a                               v19 = iadd v18, v56  ; v56 = 28
+;; @002a                               store notrap aligned little v2, v19
+;;                                     v57 = iconst.i64 32
+;; @002a                               v20 = iadd v18, v57  ; v57 = 32
+;; @002a                               istore8 notrap aligned little v3, v20
+;;                                     v54 = load.i32 notrap v55
+;; @002a                               v7 = iconst.i32 1
+;; @002a                               v22 = band v54, v7  ; v7 = 1
+;; @002a                               v23 = icmp eq v54, v11  ; v11 = 0
+;; @002a                               v24 = uextend.i32 v23
+;; @002a                               v25 = bor v22, v24
+;; @002a                               brif v25, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v28 = uextend.i64 v52
-;; @002a                               v29 = iconst.i64 8
-;; @002a                               v30 = uadd_overflow_trap v28, v29, user1  ; v29 = 8
-;; @002a                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
-;; @002a                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @002a                               v33 = icmp ule v32, v27
-;; @002a                               trapz v33, user1
-;; @002a                               v34 = iadd.i64 v14, v30
-;; @002a                               v35 = load.i64 notrap aligned v34
-;;                                     v62 = iconst.i64 1
-;; @002a                               v36 = iadd v35, v62  ; v62 = 1
-;; @002a                               store notrap aligned v36, v34
+;; @002a                               v30 = uextend.i64 v54
+;; @002a                               v31 = iconst.i64 8
+;; @002a                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
+;; @002a                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
+;; @002a                               v29 = load.i64 notrap aligned readonly can_move v0+48
+;; @002a                               v35 = icmp ule v34, v29
+;; @002a                               trapz v35, user1
+;; @002a                               v36 = iadd.i64 v16, v32
+;; @002a                               v37 = load.i64 notrap aligned v36
+;;                                     v64 = iconst.i64 1
+;; @002a                               v38 = iadd v37, v64  ; v64 = 1
+;; @002a                               store notrap aligned v38, v36
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v48 = load.i32 notrap v53
-;;                                     v56 = iconst.i64 24
-;; @002a                               v19 = iadd.i64 v16, v56  ; v56 = 24
-;; @002a                               store notrap aligned little v48, v19
+;;                                     v50 = load.i32 notrap v55
+;;                                     v58 = iconst.i64 24
+;; @002a                               v21 = iadd.i64 v18, v58  ; v58 = 24
+;; @002a                               store notrap aligned little v50, v21
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v12
+;; @002d                               return v14
 ;; }


### PR DESCRIPTION
Previously, the DRC collector only performed shallow reference counting where if an object's ref count was decremented and reached zero, then we would deallocate that object, but we would not decrement the reference counts of any other object that was referenced by it. This commit changes that, so that now we will decrement the reference counts of other objects referenced by an object that is being deallocated.

This requires some method of tracing an object's outgoing edges. To avoid needing to keep around and dispatch upon type-specific information about which struct fields are GC references, for example, we instead pack all GC references at the start of the object, just after its header. We additionally keep a count of how many GC references an object has in its header. This allows us to create a slice of any object's GC references, and we can uniformly trace any GC object's outgoing edges. We don't need to reflect on the GC object's actual type.

A final detail: the DRC collector was previously storing the object size in the common GC header's reserved bits. It now stores the number of GC refs there instead, and the object size is stored in its own field in the DRC-specific header, next to the ref count. This is nice because, since we are making the DRC header larger anyways, it raises the DRC collector's implementation limit on object size from `u27::MAX` to `u32::MAX`.

Fixes #9701

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
