### PR TITLE
Correctly document `cranelift_opt_level`'s default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1192,7 +1192,7 @@ impl Config {
     /// optimization level used for generated code in a few various ways. For
     /// more information see the documentation of [`OptLevel`].
     ///
-    /// The default value for this is `OptLevel::None`.
+    /// The default value for this is `OptLevel::Speed`.
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn cranelift_opt_level(&mut self, level: OptLevel) -> &mut Self {
         let val = match level {


### PR DESCRIPTION
The default has been "speed" for quite some time now, I'm not sure I remember a time when it was `None`...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
