### PR TITLE
asm: fuzz `cranelift-codegen-x64` in the `misc` target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,7 @@ dependencies = [
  "arbitrary",
  "component-fuzz-util",
  "component-test-util",
+ "cranelift-assembler-x64",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-filetests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,6 +261,7 @@ test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter = { path = 'pulley', version = "=32.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.119.0" }
 cranelift-codegen = { path = "cranelift/codegen", version = "0.119.0", default-features = false, features = ["std", "unwind"] }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.119.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.119.0" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -24,7 +24,7 @@ features = ["all-arch"]
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-assembler-x64 = { path = "../assembler-x64", version = "0.119.0" }
+cranelift-assembler-x64 = { workspace = true }
 cranelift-codegen-shared = { path = "./shared", version = "0.119.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ cargo-fuzz = true
 [dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
+cranelift-assembler-x64 = { workspace = true, features = ["fuzz"] }
 cranelift-codegen = { workspace = true, features = ["incremental-cache", "x86", "arm64", "s390x", "riscv64"] }
 cranelift-reader = { workspace = true }
 cranelift-filetests = { workspace = true }

--- a/fuzz/fuzz_targets/misc.rs
+++ b/fuzz/fuzz_targets/misc.rs
@@ -62,6 +62,7 @@ macro_rules! run_fuzzers {
 
 run_fuzzers! {
     pulley_roundtrip
+    assembler_roundtrip
     memory_accesses
     table_ops
     stacks
@@ -71,6 +72,13 @@ run_fuzzers! {
 
 fn pulley_roundtrip(u: Unstructured<'_>) -> Result<()> {
     pulley_interpreter_fuzz::roundtrip(Arbitrary::arbitrary_take_rest(u)?);
+    Ok(())
+}
+
+fn assembler_roundtrip(u: Unstructured<'_>) -> Result<()> {
+    use cranelift_assembler_x64::{fuzz, Inst};
+    let inst: Inst<fuzz::FuzzRegs> = Arbitrary::arbitrary_take_rest(u)?;
+    fuzz::roundtrip(&inst);
     Ok(())
 }
 


### PR DESCRIPTION
As discussed previously, this change adds fuzzing for the x64 assembler to the melting pot target, `misc`, in order to get at least some fuzzing cycles on OSS-Fuzz.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
