### PR TITLE
Cranelift: avoid integer-shift optimization with invalid reduces on vector types.

### DIFF
--- a/cranelift/codegen/src/egraph/cost.rs
+++ b/cranelift/codegen/src/egraph/cost.rs
@@ -150,7 +150,7 @@ fn pure_op_cost(op: Opcode) -> Cost {
 
         // Extends/reduces.
         Opcode::Uextend | Opcode::Sextend | Opcode::Ireduce | Opcode::Iconcat | Opcode::Isplit => {
-            Cost::new(2, 0)
+            Cost::new(1, 0)
         }
 
         // "Simple" arithmetic.

--- a/cranelift/codegen/src/opts/shifts.isle
+++ b/cranelift/codegen/src/opts/shifts.isle
@@ -81,11 +81,11 @@
 ;;
 ;; Note that the shift is required to be >0 to ensure this doesn't accidentally
 ;; try to `ireduce` a type to itself, which isn't a valid use of `ireduce`.
-(rule (simplify (sshr ty (ishl ty x (iconst _ shift)) (iconst _ shift)))
+(rule (simplify (sshr (ty_int ty) (ishl ty x (iconst _ shift)) (iconst _ shift)))
       (if-let (u64_from_imm64 (u64_nonzero shift_u64)) shift)
       (if-let ty_small (shift_amt_to_type (u64_sub (ty_bits ty) shift_u64)))
       (sextend ty (ireduce ty_small x)))
-(rule (simplify (ushr ty (ishl ty x (iconst _ shift)) (iconst _ shift)))
+(rule (simplify (ushr (ty_int ty) (ishl ty x (iconst _ shift)) (iconst _ shift)))
       (if-let (u64_from_imm64 (u64_nonzero shift_u64)) shift)
       (if-let ty_small (shift_amt_to_type (u64_sub (ty_bits ty) shift_u64)))
       (uextend ty (ireduce ty_small x)))

--- a/cranelift/filetests/filetests/egraph/issue-10409.clif
+++ b/cranelift/filetests/filetests/egraph/issue-10409.clif
@@ -1,0 +1,28 @@
+test optimize
+set opt_level=speed_and_size
+target x86_64
+
+function u0:0(i64x2) -> i64x2 system_v {
+    block0(v1: i64x2):
+        v2 = iconst.i8 96
+        v3 = ishl v1, v2
+        v4 = ushr v3, v2
+        return v4
+}
+
+; check: v5 = iconst.i8 32
+; next: v6 = ishl v1, v5
+; next: v8 = ushr v6, v5
+; next: return v8
+
+function u0:1(i64) -> i64 system_v {
+    block0(v1: i64):
+        v2 = iconst.i8 32
+        v3 = ishl v1, v2
+        v4 = ushr v3, v2
+        return v4
+}
+
+; check: v5 = ireduce.i32 v1
+; next: v6 = uextend.i64 v5
+; next: return v6

--- a/cranelift/filetests/filetests/egraph/shifts.clif
+++ b/cranelift/filetests/filetests/egraph/shifts.clif
@@ -86,8 +86,8 @@ block0(v0: i32):
     v3 = ishl v2, v1
     v4 = ushr v3, v1
     return v4
-    ; check: v7 = uextend.i64 v0
-    ; check: return v7
+    ; check: v6 = uextend.i64 v0
+    ; check: return v6
 }
 
 function %sextend_shift_32_64_signed(i32) -> i64 {
@@ -129,8 +129,8 @@ block0(v0: i8):
     v3 = ishl v2, v1
     v4 = ushr v3, v1
     return v4
-    ; check: v7 = uextend.i64 v0
-    ; check: return v7
+    ; check: v6 = uextend.i64 v0
+    ; check: return v6
 }
 
 function %sextend_shift_8_64_signed(i8) -> i64 {
@@ -271,9 +271,9 @@ block0(v0: i32):
     v1 = ishl_imm v0, 24
     v2 = ushr_imm v1, 24
     return v2
-    ; check: v7 = ireduce.i8 v0
-    ; check: v8 = uextend.i32 v7
-    ; check: return v8
+    ; check: v5 = ireduce.i8 v0
+    ; check: v6 = uextend.i32 v5
+    ; check: return v6
 }
 
 function %i32_shl_ushr_16_to_ireduce(i32) -> i32 {
@@ -281,9 +281,9 @@ block0(v0: i32):
     v1 = ishl_imm v0, 16
     v2 = ushr_imm v1, 16
     return v2
-    ; check: v7 = ireduce.i16 v0
-    ; check: v8 = uextend.i32 v7
-    ; check: return v8
+    ; check: v5 = ireduce.i16 v0
+    ; check: v6 = uextend.i32 v5
+    ; check: return v6
 }
 
 function %i64_shl_ushr_8_to_ireduce(i64) -> i64 {
@@ -291,9 +291,9 @@ block0(v0: i64):
     v1 = ishl_imm v0, 56
     v2 = ushr_imm v1, 56
     return v2
-    ; check: v7 = ireduce.i8 v0
-    ; check: v8 = uextend.i64 v7
-    ; check: return v8
+    ; check: v5 = ireduce.i8 v0
+    ; check: v6 = uextend.i64 v5
+    ; check: return v6
 }
 
 function %i64_shl_ushr_16_to_ireduce(i64) -> i64 {
@@ -301,9 +301,9 @@ block0(v0: i64):
     v1 = ishl_imm v0, 48
     v2 = ushr_imm v1, 48
     return v2
-    ; check: v7 = ireduce.i16 v0
-    ; check: v8 = uextend.i64 v7
-    ; check: return v8
+    ; check: v5 = ireduce.i16 v0
+    ; check: v6 = uextend.i64 v5
+    ; check: return v6
 }
 
 function %i64_shl_ushr_32_to_ireduce(i64) -> i64 {
@@ -311,9 +311,9 @@ block0(v0: i64):
     v1 = ishl_imm v0, 32
     v2 = ushr_imm v1, 32
     return v2
-    ; check: v7 = ireduce.i32 v0
-    ; check: v8 = uextend.i64 v7
-    ; check: return v8
+    ; check: v5 = ireduce.i32 v0
+    ; check: v6 = uextend.i64 v5
+    ; check: return v6
 }
 
 function %ishl_amt_type_ireduce(i8, i16) -> i8 {


### PR DESCRIPTION
An optimization rule in our mid-end implemented the following equivalence:

```
    (x << N) >> N == x as T1 as T2
```

where `T1` is a smaller integer type and `T2` is a larger integer type, and `N` is the difference in bitwidths between them. In other words, when a left-then-right-shift clears the upper bits (or sign-extends them), we can implement that by reducing to a smaller type then extending back to the original type.

Unfortunately, `ireduce` is not valid on vector-of-integer types. A fuzzbug reported in #10409 shows that this pattern results in invalid CLIF when optimizing this pattern with an `i64x2` as input.

This PR tightens the rule's LHS to only apply to integer types.

Note that there is another optimization rule that can also implement this behavior with a bitwise AND with a mask. Previously the two resulting expressions had the same cost in the egraph, and whatever perturbation occurred in the ISLE compilation of the rule (which is a multi-constructor because this is the mid-end, so is returning multiple results) caused that rule's result to be picked instead during extraction. I've also tweaked the costs to make reduces/extends cheaper than ordinary arithmetic as a result, to keep the same optimizer outputs after extraction. One x64 test in particular showed why this is correct: the mask-with-AND resulted in two instructions (move, AND-with-immediate) while a uextend can be done with one (zero-extending move, `movzbl`), and aarch64 has similar builtin extends in many cases.

Fixes #10409.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
