### PR TITLE
Disable wide-arithmetic fuzzing in wasmi

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -20,6 +20,10 @@ impl WasmiEngine {
         config.exceptions_enabled = false;
         config.gc_enabled = false;
 
+        // FIXME: currently wasmi has a bug in wide-arithmetic (see #10418), so
+        // disable it temporarily.
+        config.wide_arithmetic_enabled = false;
+
         let mut wasmi_config = wasmi::Config::default();
         wasmi_config
             .consume_fuel(false)


### PR DESCRIPTION
Due to #10418 I believe there's a bug in wasmi for now, so disable temporarily until it's updated with a fix.

Closes #10418

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
