### PR TITLE
Rename `wasi` crate to `wasip1` in test-programs

### DIFF
--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ['std'] }
-wasi = "0.11.0"
 wasi-nn = "0.6.0"
 wit-bindgen = { workspace = true, features = ['default'] }
 libc = { workspace = true }
@@ -21,4 +20,5 @@ futures = { workspace = true, default-features = false, features = ['alloc'] }
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = "0.21.0"
+wasip1 = { version = "0.11.0", package = 'wasi' }
 wasip2 = { version = "0.14.0", package = 'wasi' }

--- a/crates/test-programs/src/bin/cli_multiple_preopens.rs
+++ b/crates/test-programs/src/bin/cli_multiple_preopens.rs
@@ -3,10 +3,10 @@ use std::str;
 fn main() {
     dbg!(wasip2::filesystem::preopens::get_directories());
     unsafe {
-        let p3 = wasi::fd_prestat_get(3).unwrap();
-        let p4 = wasi::fd_prestat_get(4).unwrap();
-        let p5 = wasi::fd_prestat_get(5).unwrap();
-        assert_eq!(wasi::fd_prestat_get(6).err().unwrap(), wasi::ERRNO_BADF);
+        let p3 = wasip1::fd_prestat_get(3).unwrap();
+        let p4 = wasip1::fd_prestat_get(4).unwrap();
+        let p5 = wasip1::fd_prestat_get(5).unwrap();
+        assert_eq!(wasip1::fd_prestat_get(6).err().unwrap(), wasip1::ERRNO_BADF);
 
         assert_eq!(p3.u.dir.pr_name_len, 2);
         assert_eq!(p4.u.dir.pr_name_len, 2);
@@ -14,15 +14,15 @@ fn main() {
 
         let mut buf = [0; 100];
 
-        wasi::fd_prestat_dir_name(3, buf.as_mut_ptr(), buf.len()).unwrap();
+        wasip1::fd_prestat_dir_name(3, buf.as_mut_ptr(), buf.len()).unwrap();
         assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/a");
-        wasi::fd_prestat_dir_name(4, buf.as_mut_ptr(), buf.len()).unwrap();
+        wasip1::fd_prestat_dir_name(4, buf.as_mut_ptr(), buf.len()).unwrap();
         assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/b");
-        wasi::fd_prestat_dir_name(5, buf.as_mut_ptr(), buf.len()).unwrap();
+        wasip1::fd_prestat_dir_name(5, buf.as_mut_ptr(), buf.len()).unwrap();
         assert_eq!(str::from_utf8(&buf[..2]).unwrap(), "/c");
         assert_eq!(
-            wasi::fd_prestat_dir_name(6, buf.as_mut_ptr(), buf.len()),
-            Err(wasi::ERRNO_BADF),
+            wasip1::fd_prestat_dir_name(6, buf.as_mut_ptr(), buf.len()),
+            Err(wasip1::ERRNO_BADF),
         );
     }
     // ..

--- a/crates/test-programs/src/bin/cli_stdin_empty.rs
+++ b/crates/test-programs/src/bin/cli_stdin_empty.rs
@@ -4,9 +4,9 @@ fn main() {
     let mut buffer = [0_u8; 0];
 
     unsafe {
-        wasi::fd_read(
+        wasip1::fd_read(
             STDIN_FD,
-            &[wasi::Iovec {
+            &[wasip1::Iovec {
                 buf: buffer.as_mut_ptr(),
                 buf_len: 0,
             }],

--- a/crates/test-programs/src/bin/preview1_big_random_buf.rs
+++ b/crates/test-programs/src/bin/preview1_big_random_buf.rs
@@ -2,7 +2,7 @@ fn test_big_random_buf() {
     let mut buf = Vec::new();
     buf.resize(1024, 0);
     unsafe {
-        wasi::random_get(buf.as_mut_ptr(), 1024).expect("failed to call random_get");
+        wasip1::random_get(buf.as_mut_ptr(), 1024).expect("failed to call random_get");
     }
     // Chances are pretty good that at least *one* byte will be non-zero in
     // any meaningful random function producing 1024 u8 values.

--- a/crates/test-programs/src/bin/preview1_clock_time_get.rs
+++ b/crates/test-programs/src/bin/preview1_clock_time_get.rs
@@ -2,12 +2,13 @@ unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.
     // clock_res_get is where information about precision can be provided.
-    wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 1).expect("precision 1 should work");
+    wasip1::clock_time_get(wasip1::CLOCKID_MONOTONIC, 1).expect("precision 1 should work");
 
     let first_time =
-        wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("precision 0 should work");
+        wasip1::clock_time_get(wasip1::CLOCKID_MONOTONIC, 0).expect("precision 0 should work");
 
-    let time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("re-fetch time should work");
+    let time =
+        wasip1::clock_time_get(wasip1::CLOCKID_MONOTONIC, 0).expect("re-fetch time should work");
     assert!(first_time <= time, "CLOCK_MONOTONIC should be monotonic");
 }
 

--- a/crates/test-programs/src/bin/preview1_close_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_close_preopen.rs
@@ -1,26 +1,26 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
-    let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
+unsafe fn test_close_preopen(dir_fd: wasip1::Fd) {
+    let pre_fd: wasip1::Fd = (libc::STDERR_FILENO + 1) as wasip1::Fd;
 
     assert!(dir_fd > pre_fd, "dir_fd number");
 
     // Try to close a preopened directory handle.
-    wasi::fd_close(pre_fd).expect("closing a preopened file descriptor");
+    wasip1::fd_close(pre_fd).expect("closing a preopened file descriptor");
 
     // Ensure that dir_fd is still open.
-    let dir_fdstat = wasi::fd_fdstat_get(dir_fd).expect("failed fd_fdstat_get");
+    let dir_fdstat = wasip1::fd_fdstat_get(dir_fd).expect("failed fd_fdstat_get");
     assert_eq!(
         dir_fdstat.fs_filetype,
-        wasi::FILETYPE_DIRECTORY,
+        wasip1::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
 
     // Ensure that pre_fd is closed.
     assert_errno!(
-        wasi::fd_fdstat_get(pre_fd).expect_err("failed fd_fdstat_get"),
-        wasi::ERRNO_BADF
+        wasip1::fd_fdstat_get(pre_fd).expect_err("failed fd_fdstat_get"),
+        wasip1::ERRNO_BADF
     );
 }
 

--- a/crates/test-programs/src/bin/preview1_dangling_fd.rs
+++ b/crates/test-programs/src/bin/preview1_dangling_fd.rs
@@ -1,31 +1,31 @@
 use std::{env, process};
 use test_programs::preview1::{config, open_scratch_directory};
 
-unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
+unsafe fn test_dangling_fd(dir_fd: wasip1::Fd) {
     if config().support_dangling_filesystem() {
         // Create a file, open it, delete it without closing the handle,
         // and then try creating it again
-        let fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).unwrap();
-        wasi::fd_close(fd).unwrap();
-        let file_fd = wasi::path_open(dir_fd, 0, "file", 0, 0, 0, 0).expect("failed to open");
+        let fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0).unwrap();
+        wasip1::fd_close(fd).unwrap();
+        let file_fd = wasip1::path_open(dir_fd, 0, "file", 0, 0, 0, 0).expect("failed to open");
         assert!(
-            file_fd > libc::STDERR_FILENO as wasi::Fd,
+            file_fd > libc::STDERR_FILENO as wasip1::Fd,
             "file descriptor range check",
         );
-        wasi::path_unlink_file(dir_fd, "file").expect("failed to unlink");
-        let fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).unwrap();
-        wasi::fd_close(fd).unwrap();
+        wasip1::path_unlink_file(dir_fd, "file").expect("failed to unlink");
+        let fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0).unwrap();
+        wasip1::fd_close(fd).unwrap();
 
         // Now, repeat the same process but for a directory
-        wasi::path_create_directory(dir_fd, "subdir").expect("failed to create dir");
-        let subdir_fd = wasi::path_open(dir_fd, 0, "subdir", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        wasip1::path_create_directory(dir_fd, "subdir").expect("failed to create dir");
+        let subdir_fd = wasip1::path_open(dir_fd, 0, "subdir", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect("failed to open dir");
         assert!(
-            subdir_fd > libc::STDERR_FILENO as wasi::Fd,
+            subdir_fd > libc::STDERR_FILENO as wasip1::Fd,
             "file descriptor range check",
         );
-        wasi::path_remove_directory(dir_fd, "subdir").expect("failed to remove dir 2");
-        wasi::path_create_directory(dir_fd, "subdir").expect("failed to create dir 2");
+        wasip1::path_remove_directory(dir_fd, "subdir").expect("failed to remove dir 2");
+        wasip1::path_create_directory(dir_fd, "subdir").expect("failed to create dir 2");
     }
 }
 

--- a/crates/test-programs/src/bin/preview1_dangling_symlink.rs
+++ b/crates/test-programs/src/bin/preview1_dangling_symlink.rs
@@ -1,30 +1,30 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, open_scratch_directory};
 
-unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
+unsafe fn test_dangling_symlink(dir_fd: wasip1::Fd) {
     if config().support_dangling_filesystem() {
         // First create a dangling symlink.
-        wasi::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
+        wasip1::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
 
         // Try to open it as a directory with O_NOFOLLOW.
         assert_errno!(
-            wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+            wasip1::path_open(dir_fd, 0, "symlink", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
                 .expect_err("opening a dangling symlink as a directory"),
-            wasi::ERRNO_NOTDIR,
-            wasi::ERRNO_LOOP,
-            wasi::ERRNO_NOENT
+            wasip1::ERRNO_NOTDIR,
+            wasip1::ERRNO_LOOP,
+            wasip1::ERRNO_NOENT
         );
 
         // Try to open it as a file with O_NOFOLLOW.
         assert_errno!(
-            wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
+            wasip1::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
                 .expect_err("opening a dangling symlink as a file"),
-            wasi::ERRNO_LOOP,
-            wasi::ERRNO_NOENT
+            wasip1::ERRNO_LOOP,
+            wasip1::ERRNO_NOENT
         );
 
         // Clean up.
-        wasi::path_unlink_file(dir_fd, "symlink").expect("failed to remove file");
+        wasip1::path_unlink_file(dir_fd, "symlink").expect("failed to remove file");
     }
 }
 

--- a/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
+++ b/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
@@ -1,93 +1,93 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_fd_dir_ops(dir_fd: wasi::Fd) {
-    let stat = wasi::fd_filestat_get(dir_fd).expect("failed to fdstat");
-    assert_eq!(stat.filetype, wasi::FILETYPE_DIRECTORY);
+unsafe fn test_fd_dir_ops(dir_fd: wasip1::Fd) {
+    let stat = wasip1::fd_filestat_get(dir_fd).expect("failed to fdstat");
+    assert_eq!(stat.filetype, wasip1::FILETYPE_DIRECTORY);
 
     let (pr_fd, pr_name_len) = (3..)
-        .map_while(|fd| wasi::fd_prestat_get(fd).ok().map(|stat| (fd, stat)))
-        .find_map(|(fd, wasi::Prestat { tag, u })| {
-            (tag == wasi::PREOPENTYPE_DIR.raw()).then_some((fd, u.dir.pr_name_len))
+        .map_while(|fd| wasip1::fd_prestat_get(fd).ok().map(|stat| (fd, stat)))
+        .find_map(|(fd, wasip1::Prestat { tag, u })| {
+            (tag == wasip1::PREOPENTYPE_DIR.raw()).then_some((fd, u.dir.pr_name_len))
         })
         .expect("failed to find preopen directory");
 
     let mut pr_name = vec![];
-    let r = wasi::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), 0);
-    assert_eq!(r, Err(wasi::ERRNO_NAMETOOLONG));
+    let r = wasip1::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), 0);
+    assert_eq!(r, Err(wasip1::ERRNO_NAMETOOLONG));
 
     // Test that passing a larger than necessary buffer works correctly
     let mut pr_name = vec![0; pr_name_len + 1];
-    let r = wasi::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), pr_name_len + 1);
+    let r = wasip1::fd_prestat_dir_name(pr_fd, pr_name.as_mut_ptr(), pr_name_len + 1);
     assert_eq!(r, Ok(()));
 
     let mut read_buf = vec![0; 128].into_boxed_slice();
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: read_buf.as_mut_ptr(),
         buf_len: read_buf.len(),
     };
-    let r = wasi::fd_read(dir_fd, &[iovec]);
+    let r = wasip1::fd_read(dir_fd, &[iovec]);
     // On posix, this fails with ERRNO_ISDIR:
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_read error");
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_read error");
 
-    let r = wasi::fd_pread(dir_fd, &[iovec], 0);
+    let r = wasip1::fd_pread(dir_fd, &[iovec], 0);
     // On posix, this fails with ERRNO_ISDIR
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_pread error");
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_pread error");
 
     let write_buf = vec![0; 128].into_boxed_slice();
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: write_buf.as_ptr(),
         buf_len: write_buf.len(),
     };
-    let r = wasi::fd_write(dir_fd, &[ciovec]);
+    let r = wasip1::fd_write(dir_fd, &[ciovec]);
     // Same behavior as specified by POSIX:
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_write error");
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_write error");
 
-    let r = wasi::fd_pwrite(dir_fd, &[ciovec], 0);
+    let r = wasip1::fd_pwrite(dir_fd, &[ciovec], 0);
     // Same behavior as specified by POSIX:
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_pwrite error");
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_pwrite error");
 
     // Divergence from posix: lseek(dirfd) will return 0
-    let r = wasi::fd_seek(dir_fd, 0, wasi::WHENCE_CUR);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_seek WHENCE_CUR error");
-    let r = wasi::fd_seek(dir_fd, 0, wasi::WHENCE_SET);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_seek WHENCE_SET error");
-    let r = wasi::fd_seek(dir_fd, 0, wasi::WHENCE_END);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_seek WHENCE_END error");
+    let r = wasip1::fd_seek(dir_fd, 0, wasip1::WHENCE_CUR);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_seek WHENCE_CUR error");
+    let r = wasip1::fd_seek(dir_fd, 0, wasip1::WHENCE_SET);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_seek WHENCE_SET error");
+    let r = wasip1::fd_seek(dir_fd, 0, wasip1::WHENCE_END);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_seek WHENCE_END error");
 
     // Tell isn't in posix, its basically lseek with WHENCE_CUR above
-    let r = wasi::fd_tell(dir_fd);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_tell error");
+    let r = wasip1::fd_tell(dir_fd);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_tell error");
 
     // posix_fadvise(dirfd, 0, 0, POSIX_FADV_DONTNEED) will return 0 on linux.
     // not available on mac os.
-    let r = wasi::fd_advise(dir_fd, 0, 0, wasi::ADVICE_DONTNEED);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_advise error");
+    let r = wasip1::fd_advise(dir_fd, 0, 0, wasip1::ADVICE_DONTNEED);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_advise error");
 
     // fallocate(dirfd, FALLOC_FL_ZERO_RANGE, 0, 1) will fail with errno EBADF on linux.
     // not available on mac os.
-    let r = wasi::fd_allocate(dir_fd, 0, 0);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_allocate error");
+    let r = wasip1::fd_allocate(dir_fd, 0, 0);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_allocate error");
 
     // fdatasync(dirfd) will return 0 on linux.
     // not available on mac os.
-    let r = wasi::fd_datasync(dir_fd);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_datasync error");
+    let r = wasip1::fd_datasync(dir_fd);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_datasync error");
 
     // fsync(dirfd) will return 0 on linux.
     // not available on mac os.
-    let r = wasi::fd_sync(dir_fd);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_sync error");
+    let r = wasip1::fd_sync(dir_fd);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_sync error");
 
     // fcntl(dirfd,  F_SETFL, O_NONBLOCK) will return 0 on linux.
     // not available on mac os.
-    let r = wasi::fd_fdstat_set_flags(dir_fd, wasi::FDFLAGS_NONBLOCK);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_fdstat_set_flags error");
+    let r = wasip1::fd_fdstat_set_flags(dir_fd, wasip1::FDFLAGS_NONBLOCK);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_fdstat_set_flags error");
 
     // ftruncate(dirfd, 1) will fail with errno EINVAL on posix.
     // here, we fail with EBADF instead:
-    let r = wasi::fd_filestat_set_size(dir_fd, 0);
-    assert_eq!(r, Err(wasi::ERRNO_BADF), "fd_filestat_set_size error");
+    let r = wasip1::fd_filestat_set_size(dir_fd, 0);
+    assert_eq!(r, Err(wasip1::ERRNO_BADF), "fd_filestat_set_size error");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_directory_seek.rs
+++ b/crates/test-programs/src/bin/preview1_directory_seek.rs
@@ -1,27 +1,27 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
+unsafe fn test_directory_seek(dir_fd: wasip1::Fd) {
     // Create a directory in the scratch directory.
-    wasi::path_create_directory(dir_fd, "dir").expect("failed to make directory");
+    wasip1::path_create_directory(dir_fd, "dir").expect("failed to make directory");
 
     // Open the directory and attempt to request rights for seeking.
-    let fd = wasi::path_open(dir_fd, 0, "dir", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+    let fd = wasip1::path_open(dir_fd, 0, "dir", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
         .expect("failed to open file");
     assert!(
-        fd > libc::STDERR_FILENO as wasi::Fd,
+        fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Attempt to seek.
     assert_errno!(
-        wasi::fd_seek(fd, 0, wasi::WHENCE_CUR).expect_err("seek on a directory"),
-        wasi::ERRNO_BADF
+        wasip1::fd_seek(fd, 0, wasip1::WHENCE_CUR).expect_err("seek on a directory"),
+        wasip1::ERRNO_BADF
     );
 
     // Clean up.
-    wasi::fd_close(fd).expect("failed to close fd");
-    wasi::path_remove_directory(dir_fd, "dir").expect("failed to remove dir");
+    wasip1::fd_close(fd).expect("failed to close fd");
+    wasip1::path_remove_directory(dir_fd, "dir").expect("failed to remove dir");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_fd_advise.rs
+++ b/crates/test-programs/src/bin/preview1_fd_advise.rs
@@ -1,42 +1,42 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
+unsafe fn test_fd_advise(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("failed to open file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Check file size
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed to fdstat");
     assert_eq!(stat.size, 0, "file size should be 0");
 
     // set_size it bigger
-    wasi::fd_filestat_set_size(file_fd, 100).expect("setting size");
+    wasip1::fd_filestat_set_size(file_fd, 100).expect("setting size");
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat 2");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed to fdstat 2");
     assert_eq!(stat.size, 100, "file size should be 100");
 
     // Advise the kernel
-    wasi::fd_advise(file_fd, 10, 50, wasi::ADVICE_NORMAL).expect("failed advise");
+    wasip1::fd_advise(file_fd, 10, 50, wasip1::ADVICE_NORMAL).expect("failed advise");
 
     // Advise shouldn't change size
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat 3");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed to fdstat 3");
     assert_eq!(stat.size, 100, "file size should be 100");
 
-    wasi::fd_close(file_fd).expect("failed to close");
-    wasi::path_unlink_file(dir_fd, "file").expect("failed to unlink");
+    wasip1::fd_close(file_fd).expect("failed to close");
+    wasip1::path_unlink_file(dir_fd, "file").expect("failed to unlink");
 }
 fn main() {
     let mut args = env::args();

--- a/crates/test-programs/src/bin/preview1_fd_filestat_get.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_get.rs
@@ -1,17 +1,17 @@
 unsafe fn test_fd_filestat_get() {
-    let stat = wasi::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
+    let stat = wasip1::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
     assert_eq!(stat.size, 0, "stdio size should be 0");
     assert_eq!(stat.atim, 0, "stdio atim should be 0");
     assert_eq!(stat.mtim, 0, "stdio mtim should be 0");
     assert_eq!(stat.ctim, 0, "stdio ctim should be 0");
 
-    let stat = wasi::fd_filestat_get(libc::STDOUT_FILENO as u32).expect("failed filestat 1");
+    let stat = wasip1::fd_filestat_get(libc::STDOUT_FILENO as u32).expect("failed filestat 1");
     assert_eq!(stat.size, 0, "stdio size should be 0");
     assert_eq!(stat.atim, 0, "stdio atim should be 0");
     assert_eq!(stat.mtim, 0, "stdio mtim should be 0");
     assert_eq!(stat.ctim, 0, "stdio ctim should be 0");
 
-    let stat = wasi::fd_filestat_get(libc::STDERR_FILENO as u32).expect("failed filestat 2");
+    let stat = wasip1::fd_filestat_get(libc::STDERR_FILENO as u32).expect("failed filestat 2");
     assert_eq!(stat.size, 0, "stdio size should be 0");
     assert_eq!(stat.atim, 0, "stdio atim should be 0");
     assert_eq!(stat.mtim, 0, "stdio mtim should be 0");

--- a/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
@@ -3,95 +3,95 @@ use test_programs::preview1::{
     assert_errno, assert_fs_time_eq, open_scratch_directory, TestConfig,
 };
 
-unsafe fn test_fd_filestat_set_size_rw(dir_fd: wasi::Fd) {
+unsafe fn test_fd_filestat_set_size_rw(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory, opened read/write
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("failed to create file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Check file size
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat");
     assert_eq!(stat.size, 0, "file size should be 0");
 
     // Check fd_filestat_set_size
-    wasi::fd_filestat_set_size(file_fd, 100).expect("fd_filestat_set_size");
+    wasip1::fd_filestat_set_size(file_fd, 100).expect("fd_filestat_set_size");
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat 2");
     assert_eq!(stat.size, 100, "file size should be 100");
 
-    wasi::fd_close(file_fd).expect("failed to close fd");
-    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
+    wasip1::fd_close(file_fd).expect("failed to close fd");
+    wasip1::path_unlink_file(dir_fd, "file").expect("failed to remove file");
 }
 
-unsafe fn test_fd_filestat_set_size_ro(dir_fd: wasi::Fd) {
+unsafe fn test_fd_filestat_set_size_ro(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory. Creating a file implies opening it for writing, so
     // we have to close and re-open read-only to observe read-only behavior.
-    let file_fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0)
+    let file_fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0)
         .expect("failed to create file");
-    wasi::fd_close(file_fd).expect("failed to close fd");
+    wasip1::fd_close(file_fd).expect("failed to close fd");
 
     // Open the created file read-only
-    let file_fd = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_READ, 0, 0)
+    let file_fd = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_READ, 0, 0)
         .expect("failed to create file");
 
     // Check file size
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat");
     assert_eq!(stat.size, 0, "file size should be 0");
 
     // Check fd_filestat_set_size on a file opened read-only fails with EINVAL, like ftruncate is defined to do on posix
     assert_errno!(
-        wasi::fd_filestat_set_size(file_fd, 100)
+        wasip1::fd_filestat_set_size(file_fd, 100)
             .expect_err("fd_filestat_set_size should error when file is opened read-only"),
-        windows => wasi::ERRNO_ACCES,
-        wasi::ERRNO_INVAL
+        windows => wasip1::ERRNO_ACCES,
+        wasip1::ERRNO_INVAL
     );
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat 2");
     assert_eq!(stat.size, 0, "file size should remain 0");
 
-    wasi::fd_close(file_fd).expect("failed to close fd");
-    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
+    wasip1::fd_close(file_fd).expect("failed to close fd");
+    wasip1::path_unlink_file(dir_fd, "file").expect("failed to remove file");
 }
 
-unsafe fn test_fd_filestat_set_times(dir_fd: wasi::Fd, rights: wasi::Rights) {
+unsafe fn test_fd_filestat_set_times(dir_fd: wasip1::Fd, rights: wasip1::Rights) {
     let cfg = TestConfig::from_env();
 
     // Create a file in the scratch directory. OFLAGS_CREAT implies opening for writing, so we will
     // close it and re-open with the desired rights (FD_READ for read only, FD_READ | FD_WRITE for
     // readwrite)
-    let file_fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0)
+    let file_fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0)
         .expect("failed to create file");
-    wasi::fd_close(file_fd).expect("failed to close fd");
+    wasip1::fd_close(file_fd).expect("failed to close fd");
 
     // Open the file with the rights given.
     let file_fd =
-        wasi::path_open(dir_fd, 0, "file", 0, rights, 0, 0).expect("failed to create file");
+        wasip1::path_open(dir_fd, 0, "file", 0, rights, 0, 0).expect("failed to create file");
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat 2");
 
     // Check fd_filestat_set_times
     let old_atim = Duration::from_nanos(stat.atim);
     let new_mtim = Duration::from_nanos(stat.mtim) - cfg.fs_time_precision() * 2;
-    wasi::fd_filestat_set_times(
+    wasip1::fd_filestat_set_times(
         file_fd,
         new_mtim.as_nanos() as u64,
         new_mtim.as_nanos() as u64,
-        wasi::FSTFLAGS_MTIM,
+        wasip1::FSTFLAGS_MTIM,
     )
     .expect("fd_filestat_set_times");
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 3");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("failed filestat 3");
     assert_eq!(stat.size, 0, "file size should remain unchanged at 0");
 
     // Support accuracy up to at least 1ms
@@ -106,11 +106,11 @@ unsafe fn test_fd_filestat_set_times(dir_fd: wasi::Fd, rights: wasi::Rights) {
         "atim should not change"
     );
 
-    // let status = wasi_fd_filestat_set_times(file_fd, new_mtim, new_mtim, wasi::FILESTAT_SET_MTIM | wasi::FILESTAT_SET_MTIM_NOW);
-    // assert_eq!(status, wasi::EINVAL, "ATIM & ATIM_NOW can't both be set");
+    // let status = wasi_fd_filestat_set_times(file_fd, new_mtim, new_mtim, wasip1::FILESTAT_SET_MTIM | wasip1::FILESTAT_SET_MTIM_NOW);
+    // assert_eq!(status, wasip1::EINVAL, "ATIM & ATIM_NOW can't both be set");
 
-    wasi::fd_close(file_fd).expect("failed to close fd");
-    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
+    wasip1::fd_close(file_fd).expect("failed to close fd");
+    wasip1::path_unlink_file(dir_fd, "file").expect("failed to remove file");
 }
 fn main() {
     let mut args = env::args();
@@ -143,7 +143,7 @@ fn main() {
     if test_programs::preview1::config().support_dangling_filesystem() {
         // Guarding to run on non-windows filesystems. Windows rejects set-times on read-only
         // files.
-        unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ) }
+        unsafe { test_fd_filestat_set_times(dir_fd, wasip1::RIGHTS_FD_READ) }
     }
-    unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE) }
+    unsafe { test_fd_filestat_set_times(dir_fd, wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE) }
 }

--- a/crates/test-programs/src/bin/preview1_fd_flags_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_flags_set.rs
@@ -1,26 +1,26 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
+unsafe fn test_fd_fdstat_set_flags(dir_fd: wasip1::Fd) {
     const FILE_NAME: &str = "file";
     let data = &[0u8; 100];
 
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         FILE_NAME,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
-        wasi::FDFLAGS_APPEND,
+        wasip1::FDFLAGS_APPEND,
     )
     .expect("opening a file");
 
     // Write some data and then verify the written data
     assert_eq!(
-        wasi::fd_write(
+        wasip1::fd_write(
             file_fd,
-            &[wasi::Ciovec {
+            &[wasip1::Ciovec {
                 buf: data.as_ptr(),
                 buf_len: data.len(),
             }],
@@ -31,14 +31,14 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
         data.len(),
     );
 
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking file");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking file");
 
     let buffer = &mut [0u8; 100];
 
     assert_eq!(
-        wasi::fd_read(
+        wasip1::fd_read(
             file_fd,
-            &[wasi::Iovec {
+            &[wasip1::Iovec {
                 buf: buffer.as_mut_ptr(),
                 buf_len: buffer.len(),
             }]
@@ -54,12 +54,12 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
     let data = &[1u8; 100];
 
     // Seek back to the start to ensure we're in append-only mode
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking file");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking file");
 
     assert_eq!(
-        wasi::fd_write(
+        wasip1::fd_write(
             file_fd,
-            &[wasi::Ciovec {
+            &[wasip1::Ciovec {
                 buf: data.as_ptr(),
                 buf_len: data.len(),
             }],
@@ -70,12 +70,12 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
         data.len(),
     );
 
-    wasi::fd_seek(file_fd, 100, wasi::WHENCE_SET).expect("seeking file");
+    wasip1::fd_seek(file_fd, 100, wasip1::WHENCE_SET).expect("seeking file");
 
     assert_eq!(
-        wasi::fd_read(
+        wasip1::fd_read(
             file_fd,
-            &[wasi::Iovec {
+            &[wasip1::Iovec {
                 buf: buffer.as_mut_ptr(),
                 buf_len: buffer.len(),
             }]
@@ -88,17 +88,17 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
 
     assert_eq!(&data[..], &buffer[..]);
 
-    wasi::fd_fdstat_set_flags(file_fd, 0).expect("disabling flags");
+    wasip1::fd_fdstat_set_flags(file_fd, 0).expect("disabling flags");
 
     // Overwrite some existing data to ensure the append mode is now off
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking file");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking file");
 
     let data = &[2u8; 100];
 
     assert_eq!(
-        wasi::fd_write(
+        wasip1::fd_write(
             file_fd,
-            &[wasi::Ciovec {
+            &[wasip1::Ciovec {
                 buf: data.as_ptr(),
                 buf_len: data.len(),
             }],
@@ -109,12 +109,12 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
         data.len(),
     );
 
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking file");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking file");
 
     assert_eq!(
-        wasi::fd_read(
+        wasip1::fd_read(
             file_fd,
-            &[wasi::Iovec {
+            &[wasip1::Iovec {
                 buf: buffer.as_mut_ptr(),
                 buf_len: buffer.len(),
             }]
@@ -127,13 +127,13 @@ unsafe fn test_fd_fdstat_set_flags(dir_fd: wasi::Fd) {
 
     assert_eq!(&data[..], &buffer[..]);
 
-    wasi::fd_close(file_fd).expect("close file");
+    wasip1::fd_close(file_fd).expect("close file");
 
-    let stat = wasi::path_filestat_get(dir_fd, 0, FILE_NAME).expect("stat path");
+    let stat = wasip1::path_filestat_get(dir_fd, 0, FILE_NAME).expect("stat path");
 
     assert_eq!(stat.size, 200, "expected a file size of 200");
 
-    wasi::path_unlink_file(dir_fd, FILE_NAME).expect("unlinking file");
+    wasip1::path_unlink_file(dir_fd, FILE_NAME).expect("unlinking file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_allocate.rs
+++ b/crates/test-programs/src/bin/preview1_file_allocate.rs
@@ -1,41 +1,41 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
+unsafe fn test_file_allocate(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Check file size
-    let mut stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+    let mut stat = wasip1::fd_filestat_get(file_fd).expect("reading file stats");
     assert_eq!(stat.size, 0, "file size should be 0");
 
-    let err = wasi::fd_allocate(file_fd, 0, 100)
+    let err = wasip1::fd_allocate(file_fd, 0, 100)
         .err()
         .expect("fd_allocate must fail");
     assert_eq!(
         err,
-        wasi::ERRNO_NOTSUP,
+        wasip1::ERRNO_NOTSUP,
         "fd_allocate should fail with NOTSUP"
     );
 
-    stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+    stat = wasip1::fd_filestat_get(file_fd).expect("reading file stats");
     assert_eq!(stat.size, 0, "file size should still be 0");
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
+++ b/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
@@ -1,37 +1,37 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
+unsafe fn test_file_pread_pwrite(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     let contents = &[0u8, 1, 2, 3];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    let mut nwritten = wasi::fd_pwrite(file_fd, &[ciovec], 0).expect("writing bytes at offset 0");
+    let mut nwritten = wasip1::fd_pwrite(file_fd, &[ciovec], 0).expect("writing bytes at offset 0");
     assert_eq!(nwritten, 4, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    let mut nread = wasi::fd_pread(file_fd, &[iovec], 0).expect("reading bytes at offset 0");
+    let mut nread = wasip1::fd_pread(file_fd, &[iovec], 0).expect("reading bytes at offset 0");
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 2, 3], "written bytes equal read bytes");
 
@@ -43,21 +43,21 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
     let contents = &[0u8, 1, 2, 3];
     let mut offset = 0usize;
     loop {
-        let mut ciovecs: Vec<wasi::Ciovec> = Vec::new();
+        let mut ciovecs: Vec<wasip1::Ciovec> = Vec::new();
         let mut remaining = contents.len() - offset;
         if remaining > 2 {
-            ciovecs.push(wasi::Ciovec {
+            ciovecs.push(wasip1::Ciovec {
                 buf: contents[offset..].as_ptr() as *const _,
                 buf_len: 2,
             });
             remaining -= 2;
         }
-        ciovecs.push(wasi::Ciovec {
+        ciovecs.push(wasip1::Ciovec {
             buf: contents[contents.len() - remaining..].as_ptr() as *const _,
             buf_len: remaining,
         });
 
-        nwritten = wasi::fd_pwrite(file_fd, ciovecs.as_slice(), offset.try_into().unwrap())
+        nwritten = wasip1::fd_pwrite(file_fd, ciovecs.as_slice(), offset.try_into().unwrap())
             .expect("writing bytes at offset 0");
 
         offset += nwritten;
@@ -77,16 +77,16 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
     loop {
         let buffer = &mut [0u8; 4];
         let iovecs = &[
-            wasi::Iovec {
+            wasip1::Iovec {
                 buf: buffer.as_mut_ptr() as *mut _,
                 buf_len: 2,
             },
-            wasi::Iovec {
+            wasip1::Iovec {
                 buf: buffer[2..].as_mut_ptr() as *mut _,
                 buf_len: 2,
             },
         ];
-        nread = wasi::fd_pread(file_fd, iovecs, offset as _).expect("reading bytes at offset 0");
+        nread = wasip1::fd_pread(file_fd, iovecs, offset as _).expect("reading bytes at offset 0");
         if nread == 0 {
             break;
         }
@@ -97,118 +97,118 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi::Fd) {
     assert_eq!(contents, &[0u8, 1, 2, 3], "file cursor was overwritten");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    nread = wasi::fd_pread(file_fd, &[iovec], 2).expect("reading bytes at offset 2");
+    nread = wasip1::fd_pread(file_fd, &[iovec], 2).expect("reading bytes at offset 2");
     assert_eq!(nread, 2, "nread bytes check");
     assert_eq!(contents, &[2u8, 3, 0, 0], "file cursor was overwritten");
 
     let contents = &[1u8, 0];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    nwritten = wasi::fd_pwrite(file_fd, &[ciovec], 2).expect("writing bytes at offset 2");
+    nwritten = wasip1::fd_pwrite(file_fd, &[ciovec], 2).expect("writing bytes at offset 2");
     assert_eq!(nwritten, 2, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    nread = wasi::fd_pread(file_fd, &[iovec], 0).expect("reading bytes at offset 0");
+    nread = wasip1::fd_pread(file_fd, &[iovec], 0).expect("reading bytes at offset 0");
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 1, 0], "file cursor was overwritten");
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
-unsafe fn test_file_pwrite_and_file_pos(dir_fd: wasi::Fd) {
+unsafe fn test_file_pwrite_and_file_pos(dir_fd: wasip1::Fd) {
     let path = "file2";
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         path,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Perform a 0-sized pwrite at an offset beyond the end of the file. Unix
     // semantics should pop out where nothing is actually written and the size
     // of the file isn't modified.
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);
-    let ciovec = wasi::Ciovec {
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 0);
+    let ciovec = wasip1::Ciovec {
         buf: [].as_ptr(),
         buf_len: 0,
     };
-    let n = wasi::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 2");
+    let n = wasip1::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 2");
     assert_eq!(n, 0);
 
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 0);
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 0);
 
     // Now write a single byte and make sure it actually works
     let buf = [0];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: buf.as_ptr(),
         buf_len: buf.len(),
     };
-    let n = wasi::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 50");
+    let n = wasip1::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 0);
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 51);
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, path).expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, path).expect("removing a file");
 }
 
-unsafe fn test_file_pwrite_and_append(dir_fd: wasi::Fd) {
+unsafe fn test_file_pwrite_and_append(dir_fd: wasip1::Fd) {
     let path = "file3";
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         path,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
-        wasi::FDFLAGS_APPEND,
+        wasip1::FDFLAGS_APPEND,
     )
     .expect("opening a file");
 
     // Inherit linux semantics for `pwrite` where if the file is opened in
     // append mode then the offset to `pwrite` is ignored.
     let buf = [0];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: buf.as_ptr(),
         buf_len: buf.len(),
     };
-    let n = wasi::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 50");
+    let n = wasip1::fd_pwrite(file_fd, &[ciovec], 50).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 1);
 
-    let n = wasi::fd_pwrite(file_fd, &[ciovec], 0).expect("writing bytes at offset 50");
+    let n = wasip1::fd_pwrite(file_fd, &[ciovec], 0).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 2);
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, path).expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, path).expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_read_write.rs
@@ -1,38 +1,38 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
+unsafe fn test_file_read_write(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     let contents = &[0u8, 1, 2, 3];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    let mut nwritten = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 0");
+    let mut nwritten = wasip1::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 0");
     assert_eq!(nwritten, 4, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking to offset 0");
-    let mut nread = wasi::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 0");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking to offset 0");
+    let mut nread = wasip1::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 0");
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 2, 3], "written bytes equal read bytes");
 
@@ -43,23 +43,24 @@ unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
     // See https://github.com/rust-lang/rust/issues/74825.
     let contents = &[0u8, 1, 2, 3];
     let mut offset = 0usize;
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking to offset 0");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking to offset 0");
     loop {
-        let mut ciovecs: Vec<wasi::Ciovec> = Vec::new();
+        let mut ciovecs: Vec<wasip1::Ciovec> = Vec::new();
         let mut remaining = contents.len() - offset;
         if remaining > 2 {
-            ciovecs.push(wasi::Ciovec {
+            ciovecs.push(wasip1::Ciovec {
                 buf: contents[offset..].as_ptr() as *const _,
                 buf_len: 2,
             });
             remaining -= 2;
         }
-        ciovecs.push(wasi::Ciovec {
+        ciovecs.push(wasip1::Ciovec {
             buf: contents[contents.len() - remaining..].as_ptr() as *const _,
             buf_len: remaining,
         });
 
-        nwritten = wasi::fd_write(file_fd, ciovecs.as_slice()).expect("writing bytes at offset 0");
+        nwritten =
+            wasip1::fd_write(file_fd, ciovecs.as_slice()).expect("writing bytes at offset 0");
 
         offset += nwritten;
         if offset == contents.len() {
@@ -75,20 +76,20 @@ unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
     // See https://github.com/rust-lang/rust/issues/74825.
     let contents = &mut [0u8; 4];
     let mut offset = 0usize;
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking to offset 0");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking to offset 0");
     loop {
         let buffer = &mut [0u8; 4];
         let iovecs = &[
-            wasi::Iovec {
+            wasip1::Iovec {
                 buf: buffer.as_mut_ptr() as *mut _,
                 buf_len: 2,
             },
-            wasi::Iovec {
+            wasip1::Iovec {
                 buf: buffer[2..].as_mut_ptr() as *mut _,
                 buf_len: 2,
             },
         ];
-        nread = wasi::fd_read(file_fd, iovecs).expect("reading bytes at offset 0");
+        nread = wasip1::fd_read(file_fd, iovecs).expect("reading bytes at offset 0");
         if nread == 0 {
             break;
         }
@@ -99,87 +100,87 @@ unsafe fn test_file_read_write(dir_fd: wasi::Fd) {
     assert_eq!(contents, &[0u8, 1, 2, 3], "file cursor was overwritten");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    wasi::fd_seek(file_fd, 2, wasi::WHENCE_SET).expect("seeking to offset 2");
-    nread = wasi::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 2");
+    wasip1::fd_seek(file_fd, 2, wasip1::WHENCE_SET).expect("seeking to offset 2");
+    nread = wasip1::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 2");
     assert_eq!(nread, 2, "nread bytes check");
     assert_eq!(contents, &[2u8, 3, 0, 0], "file cursor was overwritten");
 
     let contents = &[1u8, 0];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    wasi::fd_seek(file_fd, 2, wasi::WHENCE_SET).expect("seeking to offset 2");
-    nwritten = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
+    wasip1::fd_seek(file_fd, 2, wasip1::WHENCE_SET).expect("seeking to offset 2");
+    nwritten = wasip1::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
     assert_eq!(nwritten, 2, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking to offset 0");
-    nread = wasi::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 0");
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET).expect("seeking to offset 0");
+    nread = wasip1::fd_read(file_fd, &[iovec]).expect("reading bytes at offset 0");
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 1, 0], "file cursor was overwritten");
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
-unsafe fn test_file_write_and_file_pos(dir_fd: wasi::Fd) {
+unsafe fn test_file_write_and_file_pos(dir_fd: wasip1::Fd) {
     let path = "file2";
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         path,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Perform a 0-sized pwrite at an offset beyond the end of the file. Unix
     // semantics should pop out where nothing is actually written and the size
     // of the file isn't modified.
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 0);
-    let ciovec = wasi::Ciovec {
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 0);
+    let ciovec = wasip1::Ciovec {
         buf: [].as_ptr(),
         buf_len: 0,
     };
-    wasi::fd_seek(file_fd, 2, wasi::WHENCE_SET).expect("seeking to offset 2");
-    let n = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
+    wasip1::fd_seek(file_fd, 2, wasip1::WHENCE_SET).expect("seeking to offset 2");
+    let n = wasip1::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 2");
     assert_eq!(n, 0);
 
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 2);
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 2);
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 0);
 
     // Now write a single byte and make sure it actually works
     let buf = [0];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: buf.as_ptr(),
         buf_len: buf.len(),
     };
-    wasi::fd_seek(file_fd, 50, wasi::WHENCE_SET).expect("seeking to offset 50");
-    let n = wasi::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 50");
+    wasip1::fd_seek(file_fd, 50, wasip1::WHENCE_SET).expect("seeking to offset 50");
+    let n = wasip1::fd_write(file_fd, &[ciovec]).expect("writing bytes at offset 50");
     assert_eq!(n, 1);
 
-    assert_eq!(wasi::fd_tell(file_fd).unwrap(), 51);
-    let stat = wasi::fd_filestat_get(file_fd).unwrap();
+    assert_eq!(wasip1::fd_tell(file_fd).unwrap(), 51);
+    let stat = wasip1::fd_filestat_get(file_fd).unwrap();
     assert_eq!(stat.size, 51);
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, path).expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, path).expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_seek_tell.rs
+++ b/crates/test-programs/src/bin/preview1_file_seek_tell.rs
@@ -1,124 +1,124 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_file_seek_tell(dir_fd: wasi::Fd) {
+unsafe fn test_file_seek_tell(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Check current offset
-    let mut offset = wasi::fd_tell(file_fd).expect("getting initial file offset");
+    let mut offset = wasip1::fd_tell(file_fd).expect("getting initial file offset");
     assert_eq!(offset, 0, "current offset should be 0");
 
     // Write to file
     let data = &[0u8; 100];
-    let iov = wasi::Ciovec {
+    let iov = wasip1::Ciovec {
         buf: data.as_ptr() as *const _,
         buf_len: data.len(),
     };
-    let nwritten = wasi::fd_write(file_fd, &[iov]).expect("writing to a file");
+    let nwritten = wasip1::fd_write(file_fd, &[iov]).expect("writing to a file");
     assert_eq!(nwritten, 100, "should write 100 bytes to file");
 
     // Check current offset
-    offset = wasi::fd_tell(file_fd).expect("getting file offset after writing");
+    offset = wasip1::fd_tell(file_fd).expect("getting file offset after writing");
     assert_eq!(offset, 100, "offset after writing should be 100");
 
     // Seek to middle of the file
     let mut newoffset =
-        wasi::fd_seek(file_fd, -50, wasi::WHENCE_CUR).expect("seeking to the middle of a file");
+        wasip1::fd_seek(file_fd, -50, wasip1::WHENCE_CUR).expect("seeking to the middle of a file");
     assert_eq!(
         newoffset, 50,
         "offset after seeking to the middle should be at 50"
     );
 
     // Seek to the beginning of the file
-    newoffset =
-        wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET).expect("seeking to the beginning of the file");
+    newoffset = wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET)
+        .expect("seeking to the beginning of the file");
     assert_eq!(
         newoffset, 0,
         "offset after seeking to the beginning of the file should be at 0"
     );
 
     // Seek beyond the file should be possible
-    wasi::fd_seek(file_fd, 1000, wasi::WHENCE_CUR).expect("seeking beyond the end of the file");
+    wasip1::fd_seek(file_fd, 1000, wasip1::WHENCE_CUR).expect("seeking beyond the end of the file");
 
     // Seek before byte 0 is an error though
     assert_errno!(
-        wasi::fd_seek(file_fd, -2000, wasi::WHENCE_CUR)
+        wasip1::fd_seek(file_fd, -2000, wasip1::WHENCE_CUR)
             .expect_err("seeking before byte 0 should be an error"),
-        wasi::ERRNO_INVAL
+        wasip1::ERRNO_INVAL
     );
 
     // Check that fd_read properly updates the file offset
-    wasi::fd_seek(file_fd, 0, wasi::WHENCE_SET)
+    wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET)
         .expect("seeking to the beginning of the file again");
 
     let buffer = &mut [0u8; 100];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: buffer.as_mut_ptr(),
         buf_len: buffer.len(),
     };
-    let nread = wasi::fd_read(file_fd, &[iovec]).expect("reading file");
+    let nread = wasip1::fd_read(file_fd, &[iovec]).expect("reading file");
     assert_eq!(nread, buffer.len(), "should read {} bytes", buffer.len());
 
-    offset = wasi::fd_tell(file_fd).expect("getting file offset after reading");
+    offset = wasip1::fd_tell(file_fd).expect("getting file offset after reading");
     assert_eq!(offset, 100, "offset after reading should be 100");
 
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("deleting a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("deleting a file");
 }
 
 // Test that when a file is opened with `O_APPEND` that acquiring the current
 // position indicates the end of the file.
-unsafe fn seek_and_o_append(dir_fd: wasi::Fd) {
+unsafe fn seek_and_o_append(dir_fd: wasip1::Fd) {
     let path = "file2";
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         path,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
-        wasi::FDFLAGS_APPEND,
+        wasip1::FDFLAGS_APPEND,
     )
     .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
-    let mut offset = wasi::fd_seek(file_fd, 0, wasi::WHENCE_CUR).unwrap();
+    let mut offset = wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_CUR).unwrap();
     assert_eq!(offset, 0);
-    offset = wasi::fd_tell(file_fd).unwrap();
+    offset = wasip1::fd_tell(file_fd).unwrap();
     assert_eq!(offset, 0);
 
     let data = &[0u8; 100];
-    let iov = wasi::Ciovec {
+    let iov = wasip1::Ciovec {
         buf: data.as_ptr() as *const _,
         buf_len: data.len(),
     };
-    let nwritten = wasi::fd_write(file_fd, &[iov]).unwrap();
+    let nwritten = wasip1::fd_write(file_fd, &[iov]).unwrap();
     assert_eq!(nwritten, 100);
 
-    let mut offset = wasi::fd_seek(file_fd, 0, wasi::WHENCE_CUR).unwrap();
+    let mut offset = wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_CUR).unwrap();
     assert_eq!(offset, 100);
-    offset = wasi::fd_tell(file_fd).unwrap();
+    offset = wasip1::fd_tell(file_fd).unwrap();
     assert_eq!(offset, 100);
 
-    wasi::fd_close(file_fd).unwrap();
-    wasi::path_unlink_file(dir_fd, path).unwrap();
+    wasip1::fd_close(file_fd).unwrap();
+    wasip1::path_unlink_file(dir_fd, path).unwrap();
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_truncation.rs
+++ b/crates/test-programs/src/bin/preview1_file_truncation.rs
@@ -1,16 +1,16 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
+unsafe fn test_file_truncation(dir_fd: wasip1::Fd) {
     const FILENAME: &str = "test.txt";
 
     // Open a file for writing
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         FILENAME,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
@@ -18,9 +18,9 @@ unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
 
     // Write to the file
     let content = b"this content will be truncated!";
-    let nwritten = wasi::fd_write(
+    let nwritten = wasip1::fd_write(
         file_fd,
-        &[wasi::Ciovec {
+        &[wasip1::Ciovec {
             buf: content.as_ptr() as *const _,
             buf_len: content.len(),
         }],
@@ -28,15 +28,15 @@ unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
     .expect("writing file content");
     assert_eq!(nwritten, content.len(), "nwritten bytes check");
 
-    wasi::fd_close(file_fd).expect("closing the file");
+    wasip1::fd_close(file_fd).expect("closing the file");
 
     // Open the file for truncation
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         FILENAME,
-        wasi::OFLAGS_CREAT | wasi::OFLAGS_TRUNC,
-        wasi::RIGHTS_FD_WRITE | wasi::RIGHTS_FD_READ,
+        wasip1::OFLAGS_CREAT | wasip1::OFLAGS_TRUNC,
+        wasip1::RIGHTS_FD_WRITE | wasip1::RIGHTS_FD_READ,
         0,
         0,
     )
@@ -44,9 +44,9 @@ unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
 
     // Read the file's contents
     let buffer = &mut [0u8; 100];
-    let nread = wasi::fd_read(
+    let nread = wasip1::fd_read(
         file_fd,
-        &[wasi::Iovec {
+        &[wasip1::Iovec {
             buf: buffer.as_mut_ptr(),
             buf_len: buffer.len(),
         }],
@@ -56,7 +56,7 @@ unsafe fn test_file_truncation(dir_fd: wasi::Fd) {
     // The file should be empty due to truncation
     assert_eq!(nread, 0, "expected an empty file after truncation");
 
-    wasi::fd_close(file_fd).expect("closing the file");
+    wasip1::fd_close(file_fd).expect("closing the file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_file_unbuffered_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_unbuffered_write.rs
@@ -1,54 +1,54 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_unbuffered_write(dir_fd: wasi::Fd) {
+unsafe fn test_file_unbuffered_write(dir_fd: wasip1::Fd) {
     // Create and open file for reading
-    let fd_read = wasi::path_open(
+    let fd_read = wasip1::path_open(
         dir_fd,
         0,
         "file",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ,
         0,
         0,
     )
     .expect("create and open file for reading");
     assert!(
-        fd_read > libc::STDERR_FILENO as wasi::Fd,
+        fd_read > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Open the same file but for writing
-    let fd_write = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_WRITE, 0, 0)
+    let fd_write = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_WRITE, 0, 0)
         .expect("opening file for writing");
     assert!(
-        fd_write > libc::STDERR_FILENO as wasi::Fd,
+        fd_write > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Write to file
     let contents = &[1u8];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: contents.as_ptr() as *const _,
         buf_len: contents.len(),
     };
-    let nwritten = wasi::fd_write(fd_write, &[ciovec]).expect("writing byte to file");
+    let nwritten = wasip1::fd_write(fd_write, &[ciovec]).expect("writing byte to file");
     assert_eq!(nwritten, 1, "nwritten bytes check");
 
     // Read from file
     let contents = &mut [0u8; 1];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: contents.as_mut_ptr() as *mut _,
         buf_len: contents.len(),
     };
-    let nread = wasi::fd_read(fd_read, &[iovec]).expect("reading bytes from file");
+    let nread = wasip1::fd_read(fd_read, &[iovec]).expect("reading bytes from file");
     assert_eq!(nread, 1, "nread bytes check");
     assert_eq!(contents, &[1u8], "written bytes equal read bytes");
 
     // Clean up
-    wasi::fd_close(fd_write).expect("closing a file");
-    wasi::fd_close(fd_read).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::fd_close(fd_write).expect("closing a file");
+    wasip1::fd_close(fd_read).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 fn main() {
     let mut args = env::args();

--- a/crates/test-programs/src/bin/preview1_file_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_write.rs
@@ -1,14 +1,14 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
+unsafe fn test_file_long_write(dir_fd: wasip1::Fd, filename: &str) {
     // Open a file for writing
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         filename,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
@@ -23,9 +23,9 @@ unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
     }
 
     // Write to the file
-    let nwritten = wasi::fd_write(
+    let nwritten = wasip1::fd_write(
         file_fd,
-        &[wasi::Ciovec {
+        &[wasip1::Ciovec {
             buf: content.as_slice().as_ptr() as *const _,
             buf_len: content.len(),
         }],
@@ -33,23 +33,23 @@ unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
     .expect("writing file content");
     assert_eq!(nwritten, content.len(), "nwritten bytes check");
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+    let stat = wasip1::fd_filestat_get(file_fd).expect("reading file stats");
     assert_eq!(
         stat.size,
         content.len() as u64,
         "file should be size of content",
     );
 
-    wasi::fd_close(file_fd).expect("closing the file");
+    wasip1::fd_close(file_fd).expect("closing the file");
     // Open the file for reading
-    let file_fd = wasi::path_open(dir_fd, 0, filename, 0, wasi::RIGHTS_FD_READ, 0, 0)
+    let file_fd = wasip1::path_open(dir_fd, 0, filename, 0, wasip1::RIGHTS_FD_READ, 0, 0)
         .expect("open the file for reading");
 
     // Read the file's contents
     let buffer = &mut [0u8; 100];
-    let nread = wasi::fd_read(
+    let nread = wasip1::fd_read(
         file_fd,
-        &[wasi::Iovec {
+        &[wasip1::Iovec {
             buf: buffer.as_mut_ptr(),
             buf_len: buffer.len(),
         }],
@@ -64,12 +64,12 @@ unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
     );
 
     let end_cursor = content.len() - buffer.len();
-    wasi::fd_seek(file_fd, end_cursor as i64, wasi::WHENCE_SET)
+    wasip1::fd_seek(file_fd, end_cursor as i64, wasip1::WHENCE_SET)
         .expect("seeking to end of file minus buffer size");
 
-    let nread = wasi::fd_read(
+    let nread = wasip1::fd_read(
         file_fd,
-        &[wasi::Iovec {
+        &[wasip1::Iovec {
             buf: buffer.as_mut_ptr(),
             buf_len: buffer.len(),
         }],
@@ -79,32 +79,32 @@ unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
     assert_eq!(nread, buffer.len(), "read end chunk len");
     assert_eq!(buffer, &content[end_cursor..], "contents of end read chunk");
 
-    wasi::fd_close(file_fd).expect("closing the file");
+    wasip1::fd_close(file_fd).expect("closing the file");
 
     // Open a file for writing
     let filename = "test-zero-write-fails.txt";
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
         0,
         filename,
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("creating a file for writing");
-    wasi::fd_close(file_fd).expect("closing the file");
-    let file_fd = wasi::path_open(dir_fd, 0, filename, 0, wasi::RIGHTS_FD_READ, 0, 0)
+    wasip1::fd_close(file_fd).expect("closing the file");
+    let file_fd = wasip1::path_open(dir_fd, 0, filename, 0, wasip1::RIGHTS_FD_READ, 0, 0)
         .expect("opening a file for writing");
-    let res = wasi::fd_write(
+    let res = wasip1::fd_write(
         file_fd,
-        &[wasi::Ciovec {
+        &[wasip1::Ciovec {
             buf: 3 as *const u8,
             buf_len: 0,
         }],
     );
     assert!(
-        res == Err(wasi::ERRNO_BADF) || res == Err(wasi::ERRNO_PERM),
+        res == Err(wasip1::ERRNO_BADF) || res == Err(wasip1::ERRNO_PERM),
         "bad result {res:?}"
     )
 }

--- a/crates/test-programs/src/bin/preview1_interesting_paths.rs
+++ b/crates/test-programs/src/bin/preview1_interesting_paths.rs
@@ -1,25 +1,25 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
+unsafe fn test_interesting_paths(dir_fd: wasip1::Fd, arg: &str) {
     // Create a directory in the scratch directory.
-    wasi::path_create_directory(dir_fd, "dir").expect("creating dir");
+    wasip1::path_create_directory(dir_fd, "dir").expect("creating dir");
 
     // Create a directory in the directory we just created.
-    wasi::path_create_directory(dir_fd, "dir/nested").expect("creating a nested dir");
+    wasip1::path_create_directory(dir_fd, "dir/nested").expect("creating a nested dir");
 
     // Create a file in the nested directory.
     create_file(dir_fd, "dir/nested/file");
 
     // Now open it with an absolute path.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "/dir/nested/file", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "/dir/nested/file", 0, 0, 0, 0)
             .expect_err("opening a file with an absolute path"),
-        wasi::ERRNO_PERM
+        wasip1::ERRNO_PERM
     );
 
     // Now open it with a path containing "..".
-    let mut file_fd = wasi::path_open(
+    let mut file_fd = wasip1::path_open(
         dir_fd,
         0,
         "dir/.//nested/../../dir/nested/../nested///./file",
@@ -30,65 +30,65 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     )
     .expect("opening a file with \"..\" in the path");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 
     // Now open it with a trailing NUL. Windows will allow this.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "dir/nested/file\0", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "dir/nested/file\0", 0, 0, 0, 0)
             .expect_err("opening a file with a trailing NUL"),
-        unix => wasi::ERRNO_INVAL,
-        windows => wasi::ERRNO_NOENT
+        unix => wasip1::ERRNO_INVAL,
+        windows => wasip1::ERRNO_NOENT
     );
 
     // Now open it with a trailing slash.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "dir/nested/file/", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "dir/nested/file/", 0, 0, 0, 0)
             .expect_err("opening a file with a trailing slash should fail"),
-        wasi::ERRNO_NOTDIR,
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOTDIR,
+        wasip1::ERRNO_NOENT
     );
 
     // Now open it with trailing slashes.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "dir/nested/file///", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "dir/nested/file///", 0, 0, 0, 0)
             .expect_err("opening a file with trailing slashes should fail"),
-        wasi::ERRNO_NOTDIR,
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOTDIR,
+        wasip1::ERRNO_NOENT
     );
 
     // Now open the directory with a trailing slash.
-    file_fd = wasi::path_open(dir_fd, 0, "dir/nested/", 0, 0, 0, 0)
+    file_fd = wasip1::path_open(dir_fd, 0, "dir/nested/", 0, 0, 0, 0)
         .expect("opening a directory with a trailing slash");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 
     // Now open the directory with trailing slashes.
-    file_fd = wasi::path_open(dir_fd, 0, "dir/nested///", 0, 0, 0, 0)
+    file_fd = wasip1::path_open(dir_fd, 0, "dir/nested///", 0, 0, 0, 0)
         .expect("opening a directory with trailing slashes");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 
     // Now open it with a path containing too many ".."s.
     let bad_path = format!("dir/nested/../../../{arg}/dir/nested/file");
     assert_errno!(
-        wasi::path_open(dir_fd, 0, &bad_path, 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, &bad_path, 0, 0, 0, 0)
             .expect_err("opening a file with too many \"..\"s in the path should fail"),
-        wasi::ERRNO_PERM
+        wasip1::ERRNO_PERM
     );
-    wasi::path_unlink_file(dir_fd, "dir/nested/file")
+    wasip1::path_unlink_file(dir_fd, "dir/nested/file")
         .expect("unlink_file on a symlink should succeed");
-    wasi::path_remove_directory(dir_fd, "dir/nested")
+    wasip1::path_remove_directory(dir_fd, "dir/nested")
         .expect("remove_directory on a directory should succeed");
-    wasi::path_remove_directory(dir_fd, "dir")
+    wasip1::path_remove_directory(dir_fd, "dir")
         .expect("remove_directory on a directory should succeed");
 }
 

--- a/crates/test-programs/src/bin/preview1_nofollow_errors.rs
+++ b/crates/test-programs/src/bin/preview1_nofollow_errors.rs
@@ -1,89 +1,89 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
+unsafe fn test_nofollow_errors(dir_fd: wasip1::Fd) {
     // Create a directory for the symlink to point to.
-    wasi::path_create_directory(dir_fd, "target").expect("creating a dir");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a dir");
 
     // Create a symlink.
-    wasi::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
+    wasip1::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
 
     // Try to open it as a directory with O_NOFOLLOW again.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "symlink", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect_err("opening a directory symlink as a directory should fail"),
-        wasi::ERRNO_LOOP,
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_LOOP,
+        wasip1::ERRNO_NOTDIR
     );
 
     // Try to open it with just O_NOFOLLOW.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
             .expect_err("opening a symlink with O_NOFOLLOW should fail"),
-        wasi::ERRNO_LOOP,
-        wasi::ERRNO_ACCES
+        wasip1::ERRNO_LOOP,
+        wasip1::ERRNO_ACCES
     );
 
     // Try to open it as a directory without O_NOFOLLOW.
-    let file_fd = wasi::path_open(
+    let file_fd = wasip1::path_open(
         dir_fd,
-        wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+        wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW,
         "symlink",
-        wasi::OFLAGS_DIRECTORY,
+        wasip1::OFLAGS_DIRECTORY,
         0,
         0,
         0,
     )
     .expect("opening a symlink as a directory");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 
     // Replace the target directory with a file.
-    wasi::path_unlink_file(dir_fd, "symlink").expect("removing a file");
-    wasi::path_remove_directory(dir_fd, "target")
+    wasip1::path_unlink_file(dir_fd, "symlink").expect("removing a file");
+    wasip1::path_remove_directory(dir_fd, "target")
         .expect("remove_directory on a directory should succeed");
 
-    let file_fd =
-        wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_CREAT, 0, 0, 0).expect("creating a file");
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
+    let file_fd = wasip1::path_open(dir_fd, 0, "target", wasip1::OFLAGS_CREAT, 0, 0, 0)
+        .expect("creating a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
 
     // Try to open it as a directory with O_NOFOLLOW again.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "symlink", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect_err("opening a directory symlink as a directory should fail"),
-        wasi::ERRNO_LOOP,
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_LOOP,
+        wasip1::ERRNO_NOTDIR
     );
 
     // Try to open it with just O_NOFOLLOW.
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
             .expect_err("opening a symlink with NOFOLLOW should fail"),
-        wasi::ERRNO_LOOP
+        wasip1::ERRNO_LOOP
     );
 
     // Try to open it as a directory without O_NOFOLLOW.
     assert_errno!(
-        wasi::path_open(
+        wasip1::path_open(
             dir_fd,
-            wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+            wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW,
             "symlink",
-            wasi::OFLAGS_DIRECTORY,
+            wasip1::OFLAGS_DIRECTORY,
             0,
             0,
             0,
         )
         .expect_err("opening a symlink to a file as a directory"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
 
     // Clean up.
-    wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
-    wasi::path_unlink_file(dir_fd, "symlink").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "symlink").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_overwrite_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_overwrite_preopen.rs
@@ -1,18 +1,18 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_overwrite_preopen(dir_fd: wasi::Fd) {
-    let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
+unsafe fn test_overwrite_preopen(dir_fd: wasip1::Fd) {
+    let pre_fd: wasip1::Fd = (libc::STDERR_FILENO + 1) as wasip1::Fd;
 
     assert!(dir_fd > pre_fd, "dir_fd number");
 
-    let old_dir_filestat = wasi::fd_filestat_get(dir_fd).expect("failed fd_filestat_get");
+    let old_dir_filestat = wasip1::fd_filestat_get(dir_fd).expect("failed fd_filestat_get");
 
     // Try to renumber over a preopened directory handle.
-    wasi::fd_renumber(dir_fd, pre_fd).expect("renumbering over a preopened file descriptor");
+    wasip1::fd_renumber(dir_fd, pre_fd).expect("renumbering over a preopened file descriptor");
 
     // Ensure that pre_fd is still open.
-    let new_dir_filestat = wasi::fd_filestat_get(pre_fd).expect("failed fd_filestat_get");
+    let new_dir_filestat = wasip1::fd_filestat_get(pre_fd).expect("failed fd_filestat_get");
 
     // Ensure that we renumbered.
     assert_eq!(old_dir_filestat.dev, new_dir_filestat.dev);
@@ -20,8 +20,8 @@ unsafe fn test_overwrite_preopen(dir_fd: wasi::Fd) {
 
     // Ensure that dir_fd is closed.
     assert_errno!(
-        wasi::fd_fdstat_get(dir_fd).expect_err("failed fd_fdstat_get"),
-        wasi::ERRNO_BADF
+        wasip1::fd_fdstat_get(dir_fd).expect_err("failed fd_fdstat_get"),
+        wasip1::ERRNO_BADF
     );
 }
 

--- a/crates/test-programs/src/bin/preview1_path_exists.rs
+++ b/crates/test-programs/src/bin/preview1_path_exists.rs
@@ -1,57 +1,58 @@
 use std::{env, process};
 use test_programs::preview1::{create_file, open_scratch_directory};
 
-unsafe fn test_path_exists(dir_fd: wasi::Fd) {
+unsafe fn test_path_exists(dir_fd: wasip1::Fd) {
     // Create a temporary directory
-    wasi::path_create_directory(dir_fd, "subdir").expect("create directory");
+    wasip1::path_create_directory(dir_fd, "subdir").expect("create directory");
 
     // Check directory exists:
-    let file_stat = wasi::path_filestat_get(dir_fd, 0, "subdir").expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_DIRECTORY);
+    let file_stat = wasip1::path_filestat_get(dir_fd, 0, "subdir").expect("reading file stats");
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_DIRECTORY);
 
     // Should still exist with symlink follow flag:
-    let file_stat = wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "subdir")
+    let file_stat = wasip1::path_filestat_get(dir_fd, wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW, "subdir")
         .expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_DIRECTORY);
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_DIRECTORY);
 
     // Create a file:
     create_file(dir_fd, "subdir/file");
     // Check directory exists:
-    let file_stat = wasi::path_filestat_get(dir_fd, 0, "subdir/file").expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_REGULAR_FILE);
+    let file_stat =
+        wasip1::path_filestat_get(dir_fd, 0, "subdir/file").expect("reading file stats");
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_REGULAR_FILE);
 
     // Should still exist with symlink follow flag:
     let file_stat =
-        wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "subdir/file")
+        wasip1::path_filestat_get(dir_fd, wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW, "subdir/file")
             .expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_REGULAR_FILE);
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_REGULAR_FILE);
 
     // Create a symlink to a file:
-    wasi::path_symlink("subdir/file", dir_fd, "link1").expect("create symlink");
+    wasip1::path_symlink("subdir/file", dir_fd, "link1").expect("create symlink");
     // Check symlink exists:
-    let file_stat = wasi::path_filestat_get(dir_fd, 0, "link1").expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_SYMBOLIC_LINK);
+    let file_stat = wasip1::path_filestat_get(dir_fd, 0, "link1").expect("reading file stats");
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_SYMBOLIC_LINK);
 
     // Should still exist with symlink follow flag, pointing to regular file
-    let file_stat = wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "link1")
+    let file_stat = wasip1::path_filestat_get(dir_fd, wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW, "link1")
         .expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_REGULAR_FILE);
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_REGULAR_FILE);
 
     // Create a symlink to a dir:
-    wasi::path_symlink("subdir", dir_fd, "link2").expect("create symlink");
+    wasip1::path_symlink("subdir", dir_fd, "link2").expect("create symlink");
     // Check symlink exists:
-    let file_stat = wasi::path_filestat_get(dir_fd, 0, "link2").expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_SYMBOLIC_LINK);
+    let file_stat = wasip1::path_filestat_get(dir_fd, 0, "link2").expect("reading file stats");
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_SYMBOLIC_LINK);
 
     // Should still exist with symlink follow flag, pointing to directory
-    let file_stat = wasi::path_filestat_get(dir_fd, wasi::LOOKUPFLAGS_SYMLINK_FOLLOW, "link2")
+    let file_stat = wasip1::path_filestat_get(dir_fd, wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW, "link2")
         .expect("reading file stats");
-    assert_eq!(file_stat.filetype, wasi::FILETYPE_DIRECTORY);
+    assert_eq!(file_stat.filetype, wasip1::FILETYPE_DIRECTORY);
 
-    wasi::path_unlink_file(dir_fd, "link1").expect("clean up");
-    wasi::path_unlink_file(dir_fd, "link2").expect("clean up");
-    wasi::path_unlink_file(dir_fd, "subdir/file").expect("clean up");
-    wasi::path_remove_directory(dir_fd, "subdir").expect("clean up");
+    wasip1::path_unlink_file(dir_fd, "link1").expect("clean up");
+    wasip1::path_unlink_file(dir_fd, "link2").expect("clean up");
+    wasip1::path_unlink_file(dir_fd, "subdir/file").expect("clean up");
+    wasip1::path_remove_directory(dir_fd, "subdir").expect("clean up");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_open_create_existing.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_create_existing.rs
@@ -1,22 +1,22 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_path_open_create_existing(dir_fd: wasi::Fd) {
+unsafe fn test_path_open_create_existing(dir_fd: wasip1::Fd) {
     create_file(dir_fd, "file");
     assert_errno!(
-        wasi::path_open(
+        wasip1::path_open(
             dir_fd,
             0,
             "file",
-            wasi::OFLAGS_CREAT | wasi::OFLAGS_EXCL,
+            wasip1::OFLAGS_CREAT | wasip1::OFLAGS_EXCL,
             0,
             0,
             0,
         )
         .expect_err("trying to create a file that already exists"),
-        wasi::ERRNO_EXIST
+        wasip1::ERRNO_EXIST
     );
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_open_dirfd_not_dir.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_dirfd_not_dir.rs
@@ -1,17 +1,17 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_dirfd_not_dir(dir_fd: wasi::Fd) {
+unsafe fn test_dirfd_not_dir(dir_fd: wasip1::Fd) {
     // Open a file.
-    let file_fd =
-        wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).expect("opening a file");
+    let file_fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0)
+        .expect("opening a file");
     // Now try to open a file underneath it as if it were a directory.
     assert_errno!(
-        wasi::path_open(file_fd, 0, "foo", wasi::OFLAGS_CREAT, 0, 0, 0)
+        wasip1::path_open(file_fd, 0, "foo", wasip1::OFLAGS_CREAT, 0, 0, 0)
             .expect_err("non-directory base fd should get ERRNO_NOTDIR"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_open_lots.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_lots.rs
@@ -1,86 +1,86 @@
 use std::{env, process};
 use test_programs::preview1::{create_file, open_scratch_directory};
 
-unsafe fn test_path_open_lots(dir_fd: wasi::Fd) {
+unsafe fn test_path_open_lots(dir_fd: wasip1::Fd) {
     create_file(dir_fd, "file");
 
     for _ in 0..2000 {
-        let f_readonly = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_READ, 0, 0)
+        let f_readonly = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_READ, 0, 0)
             .expect("open file readonly");
 
         let buffer = &mut [0u8; 100];
-        let iovec = wasi::Iovec {
+        let iovec = wasip1::Iovec {
             buf: buffer.as_mut_ptr(),
             buf_len: buffer.len(),
         };
-        let nread = wasi::fd_read(f_readonly, &[iovec]).expect("reading readonly file");
+        let nread = wasip1::fd_read(f_readonly, &[iovec]).expect("reading readonly file");
         assert_eq!(nread, 0, "readonly file is empty");
 
-        wasi::fd_close(f_readonly).expect("close readonly");
+        wasip1::fd_close(f_readonly).expect("close readonly");
     }
 
     for _ in 0..2000 {
-        let f_readonly = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_READ, 0, 0)
+        let f_readonly = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_READ, 0, 0)
             .expect("open file readonly");
 
         let buffer = &mut [0u8; 100];
-        let iovec = wasi::Iovec {
+        let iovec = wasip1::Iovec {
             buf: buffer.as_mut_ptr(),
             buf_len: buffer.len(),
         };
-        let nread = wasi::fd_pread(f_readonly, &[iovec], 0).expect("reading readonly file");
+        let nread = wasip1::fd_pread(f_readonly, &[iovec], 0).expect("reading readonly file");
         assert_eq!(nread, 0, "readonly file is empty");
 
-        wasi::fd_close(f_readonly).expect("close readonly");
+        wasip1::fd_close(f_readonly).expect("close readonly");
     }
 
     for _ in 0..2000 {
-        let f = wasi::path_open(
+        let f = wasip1::path_open(
             dir_fd,
             0,
             "file",
             0,
-            wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+            wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
             0,
             0,
         )
         .unwrap();
 
         let buffer = &[0u8; 100];
-        let ciovec = wasi::Ciovec {
+        let ciovec = wasip1::Ciovec {
             buf: buffer.as_ptr(),
             buf_len: buffer.len(),
         };
-        let nwritten = wasi::fd_write(f, &[ciovec]).expect("write failed");
+        let nwritten = wasip1::fd_write(f, &[ciovec]).expect("write failed");
         assert_eq!(nwritten, 100);
 
-        wasi::fd_close(f).unwrap();
+        wasip1::fd_close(f).unwrap();
     }
 
     for _ in 0..2000 {
-        let f = wasi::path_open(
+        let f = wasip1::path_open(
             dir_fd,
             0,
             "file",
             0,
-            wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+            wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
             0,
             0,
         )
         .unwrap();
 
         let buffer = &[0u8; 100];
-        let ciovec = wasi::Ciovec {
+        let ciovec = wasip1::Ciovec {
             buf: buffer.as_ptr(),
             buf_len: buffer.len(),
         };
-        let nwritten = wasi::fd_pwrite(f, &[ciovec], 0).expect("write failed");
+        let nwritten = wasip1::fd_pwrite(f, &[ciovec], 0).expect("write failed");
         assert_eq!(nwritten, 100);
 
-        wasi::fd_close(f).unwrap();
+        wasip1::fd_close(f).unwrap();
     }
 
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_open_missing.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_missing.rs
@@ -1,14 +1,14 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_path_open_missing(dir_fd: wasi::Fd) {
+unsafe fn test_path_open_missing(dir_fd: wasip1::Fd) {
     assert_errno!(
-        wasi::path_open(
+        wasip1::path_open(
             dir_fd, 0, "file", 0, // not passing O_CREAT here
             0, 0, 0,
         )
         .expect_err("trying to open a file that doesn't exist"),
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOENT
     );
 }
 

--- a/crates/test-programs/src/bin/preview1_path_open_nonblock.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_nonblock.rs
@@ -1,9 +1,9 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn try_path_open(dir_fd: wasi::Fd) {
-    let _fd =
-        wasi::path_open(dir_fd, 0, ".", 0, 0, 0, wasi::FDFLAGS_NONBLOCK).expect("opening the dir");
+unsafe fn try_path_open(dir_fd: wasip1::Fd) {
+    let _fd = wasip1::path_open(dir_fd, 0, ".", 0, 0, 0, wasip1::FDFLAGS_NONBLOCK)
+        .expect("opening the dir");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_open_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_preopen.rs
@@ -1,18 +1,18 @@
 const FIRST_PREOPEN: u32 = 3;
 
 unsafe fn path_open_preopen() {
-    let prestat = wasi::fd_prestat_get(FIRST_PREOPEN).expect("fd 3 is a preopen");
+    let prestat = wasip1::fd_prestat_get(FIRST_PREOPEN).expect("fd 3 is a preopen");
     assert_eq!(
         prestat.tag,
-        wasi::PREOPENTYPE_DIR.raw(),
+        wasip1::PREOPENTYPE_DIR.raw(),
         "prestat is a directory"
     );
     let mut dst = Vec::with_capacity(prestat.u.dir.pr_name_len);
-    wasi::fd_prestat_dir_name(FIRST_PREOPEN, dst.as_mut_ptr(), dst.capacity())
+    wasip1::fd_prestat_dir_name(FIRST_PREOPEN, dst.as_mut_ptr(), dst.capacity())
         .expect("get preopen dir name");
     dst.set_len(prestat.u.dir.pr_name_len);
 
-    let fdstat = wasi::fd_fdstat_get(FIRST_PREOPEN).expect("get fdstat");
+    let fdstat = wasip1::fd_fdstat_get(FIRST_PREOPEN).expect("get fdstat");
 
     println!(
         "preopen dir: {:?} base {:?} inheriting {:?}",
@@ -34,7 +34,7 @@ unsafe fn path_open_preopen() {
     }
 
     // Open with same rights it has now:
-    let _ = wasi::path_open(
+    let _ = wasip1::path_open(
         FIRST_PREOPEN,
         0,
         ".",
@@ -46,19 +46,19 @@ unsafe fn path_open_preopen() {
     .expect("open with same rights");
 
     // Open with an empty set of rights:
-    let _ = wasi::path_open(FIRST_PREOPEN, 0, ".", 0, 0, 0, 0).expect("open with empty rights");
+    let _ = wasip1::path_open(FIRST_PREOPEN, 0, ".", 0, 0, 0, 0).expect("open with empty rights");
 
     // Open OFLAGS_DIRECTORY with an empty set of rights:
-    let _ = wasi::path_open(FIRST_PREOPEN, 0, ".", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+    let _ = wasip1::path_open(FIRST_PREOPEN, 0, ".", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
         .expect("open with O_DIRECTORY empty rights");
 
     // Open OFLAGS_DIRECTORY with just the read right:
-    let _ = wasi::path_open(
+    let _ = wasip1::path_open(
         FIRST_PREOPEN,
         0,
         ".",
-        wasi::OFLAGS_DIRECTORY,
-        wasi::RIGHTS_FD_READ,
+        wasip1::OFLAGS_DIRECTORY,
+        wasip1::RIGHTS_FD_READ,
         0,
         0,
     )
@@ -66,12 +66,12 @@ unsafe fn path_open_preopen() {
 
     if !test_programs::preview1::config().errno_expect_windows() {
         // Open OFLAGS_DIRECTORY and read/write rights should fail with isdir:
-        let err = wasi::path_open(
+        let err = wasip1::path_open(
             FIRST_PREOPEN,
             0,
             ".",
-            wasi::OFLAGS_DIRECTORY,
-            wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+            wasip1::OFLAGS_DIRECTORY,
+            wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
             0,
             0,
         )
@@ -79,17 +79,17 @@ unsafe fn path_open_preopen() {
         .expect("open with O_DIRECTORY and read/write should fail");
         assert_eq!(
             err,
-            wasi::ERRNO_ISDIR,
+            wasip1::ERRNO_ISDIR,
             "opening directory read/write should fail with ISDIR"
         );
     } else {
         // Open OFLAGS_DIRECTORY and read/write rights will succeed, only on windows:
-        let _ = wasi::path_open(
+        let _ = wasip1::path_open(
             FIRST_PREOPEN,
             0,
             ".",
-            wasi::OFLAGS_DIRECTORY,
-            wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+            wasip1::OFLAGS_DIRECTORY,
+            wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
             0,
             0,
         )
@@ -108,46 +108,58 @@ fn main() {
 // implementations expect (at least) this set of rights to be present on all
 // directories:
 
-fn directory_base_rights() -> Vec<(wasi::Rights, &'static str)> {
+fn directory_base_rights() -> Vec<(wasip1::Rights, &'static str)> {
     vec![
-        (wasi::RIGHTS_PATH_CREATE_DIRECTORY, "PATH_CREATE_DIRECTORY"),
-        (wasi::RIGHTS_PATH_CREATE_FILE, "PATH_CREATE_FILE"),
-        (wasi::RIGHTS_PATH_LINK_SOURCE, "PATH_LINK_SOURCE"),
-        (wasi::RIGHTS_PATH_LINK_TARGET, "PATH_LINK_TARGET"),
-        (wasi::RIGHTS_PATH_OPEN, "PATH_OPEN"),
-        (wasi::RIGHTS_FD_READDIR, "FD_READDIR"),
-        (wasi::RIGHTS_PATH_READLINK, "PATH_READLINK"),
-        (wasi::RIGHTS_PATH_RENAME_SOURCE, "PATH_RENAME_SOURCE"),
-        (wasi::RIGHTS_PATH_RENAME_TARGET, "PATH_RENAME_TARGET"),
-        (wasi::RIGHTS_PATH_SYMLINK, "PATH_SYMLINK"),
-        (wasi::RIGHTS_PATH_REMOVE_DIRECTORY, "PATH_REMOVE_DIRECTORY"),
-        (wasi::RIGHTS_PATH_UNLINK_FILE, "PATH_UNLINK_FILE"),
-        (wasi::RIGHTS_PATH_FILESTAT_GET, "PATH_FILESTAT_GET"),
         (
-            wasi::RIGHTS_PATH_FILESTAT_SET_TIMES,
+            wasip1::RIGHTS_PATH_CREATE_DIRECTORY,
+            "PATH_CREATE_DIRECTORY",
+        ),
+        (wasip1::RIGHTS_PATH_CREATE_FILE, "PATH_CREATE_FILE"),
+        (wasip1::RIGHTS_PATH_LINK_SOURCE, "PATH_LINK_SOURCE"),
+        (wasip1::RIGHTS_PATH_LINK_TARGET, "PATH_LINK_TARGET"),
+        (wasip1::RIGHTS_PATH_OPEN, "PATH_OPEN"),
+        (wasip1::RIGHTS_FD_READDIR, "FD_READDIR"),
+        (wasip1::RIGHTS_PATH_READLINK, "PATH_READLINK"),
+        (wasip1::RIGHTS_PATH_RENAME_SOURCE, "PATH_RENAME_SOURCE"),
+        (wasip1::RIGHTS_PATH_RENAME_TARGET, "PATH_RENAME_TARGET"),
+        (wasip1::RIGHTS_PATH_SYMLINK, "PATH_SYMLINK"),
+        (
+            wasip1::RIGHTS_PATH_REMOVE_DIRECTORY,
+            "PATH_REMOVE_DIRECTORY",
+        ),
+        (wasip1::RIGHTS_PATH_UNLINK_FILE, "PATH_UNLINK_FILE"),
+        (wasip1::RIGHTS_PATH_FILESTAT_GET, "PATH_FILESTAT_GET"),
+        (
+            wasip1::RIGHTS_PATH_FILESTAT_SET_TIMES,
             "PATH_FILESTAT_SET_TIMES",
         ),
-        (wasi::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
-        (wasi::RIGHTS_FD_FILESTAT_SET_TIMES, "FD_FILESTAT_SET_TIMES"),
+        (wasip1::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
+        (
+            wasip1::RIGHTS_FD_FILESTAT_SET_TIMES,
+            "FD_FILESTAT_SET_TIMES",
+        ),
     ]
 }
 
-pub(crate) fn directory_inheriting_rights() -> Vec<(wasi::Rights, &'static str)> {
+pub(crate) fn directory_inheriting_rights() -> Vec<(wasip1::Rights, &'static str)> {
     let mut rights = directory_base_rights();
     rights.extend_from_slice(&[
-        (wasi::RIGHTS_FD_DATASYNC, "FD_DATASYNC"),
-        (wasi::RIGHTS_FD_READ, "FD_READ"),
-        (wasi::RIGHTS_FD_SEEK, "FD_SEEK"),
-        (wasi::RIGHTS_FD_FDSTAT_SET_FLAGS, "FD_FDSTAT_SET_FLAGS"),
-        (wasi::RIGHTS_FD_SYNC, "FD_SYNC"),
-        (wasi::RIGHTS_FD_TELL, "FD_TELL"),
-        (wasi::RIGHTS_FD_WRITE, "FD_WRITE"),
-        (wasi::RIGHTS_FD_ADVISE, "FD_ADVISE"),
-        (wasi::RIGHTS_FD_ALLOCATE, "FD_ALLOCATE"),
-        (wasi::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
-        (wasi::RIGHTS_FD_FILESTAT_SET_SIZE, "FD_FILESTAT_SET_SIZE"),
-        (wasi::RIGHTS_FD_FILESTAT_SET_TIMES, "FD_FILESTAT_SET_TIMES"),
-        (wasi::RIGHTS_POLL_FD_READWRITE, "POLL_FD_READWRITE"),
+        (wasip1::RIGHTS_FD_DATASYNC, "FD_DATASYNC"),
+        (wasip1::RIGHTS_FD_READ, "FD_READ"),
+        (wasip1::RIGHTS_FD_SEEK, "FD_SEEK"),
+        (wasip1::RIGHTS_FD_FDSTAT_SET_FLAGS, "FD_FDSTAT_SET_FLAGS"),
+        (wasip1::RIGHTS_FD_SYNC, "FD_SYNC"),
+        (wasip1::RIGHTS_FD_TELL, "FD_TELL"),
+        (wasip1::RIGHTS_FD_WRITE, "FD_WRITE"),
+        (wasip1::RIGHTS_FD_ADVISE, "FD_ADVISE"),
+        (wasip1::RIGHTS_FD_ALLOCATE, "FD_ALLOCATE"),
+        (wasip1::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
+        (wasip1::RIGHTS_FD_FILESTAT_SET_SIZE, "FD_FILESTAT_SET_SIZE"),
+        (
+            wasip1::RIGHTS_FD_FILESTAT_SET_TIMES,
+            "FD_FILESTAT_SET_TIMES",
+        ),
+        (wasip1::RIGHTS_POLL_FD_READWRITE, "POLL_FD_READWRITE"),
     ]);
     rights
 }

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -1,32 +1,32 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
+unsafe fn test_path_open_read_write(dir_fd: wasip1::Fd) {
     create_file(dir_fd, "file");
 
-    let f_readonly = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_READ, 0, 0)
+    let f_readonly = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_READ, 0, 0)
         .expect("open file readonly");
 
-    let stat = wasi::fd_fdstat_get(f_readonly).expect("get fdstat readonly");
+    let stat = wasip1::fd_fdstat_get(f_readonly).expect("get fdstat readonly");
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_READ == wasi::RIGHTS_FD_READ,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_READ == wasip1::RIGHTS_FD_READ,
         "readonly has read right"
     );
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_WRITE == 0,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_WRITE == 0,
         "readonly does not have write right"
     );
 
     let buffer = &mut [0u8; 100];
-    let iovec = wasi::Iovec {
+    let iovec = wasip1::Iovec {
         buf: buffer.as_mut_ptr(),
         buf_len: buffer.len(),
     };
-    let nread = wasi::fd_read(f_readonly, &[iovec]).expect("reading readonly file");
+    let nread = wasip1::fd_read(f_readonly, &[iovec]).expect("reading readonly file");
     assert_eq!(nread, 0, "readonly file is empty");
 
     let write_buffer = &[1u8; 50];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: write_buffer.as_ptr(),
         buf_len: write_buffer.len(),
     };
@@ -34,69 +34,69 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
     // fails on windows with BADF, so we can't use the `windows =>` syntax
     // because that doesn't support alternatives like the agnostic syntax does.
     assert_errno!(
-        wasi::fd_write(f_readonly, &[ciovec])
+        wasip1::fd_write(f_readonly, &[ciovec])
             .err()
             .expect("read of writeonly fails"),
-        wasi::ERRNO_PERM,
-        wasi::ERRNO_BADF
+        wasip1::ERRNO_PERM,
+        wasip1::ERRNO_BADF
     );
 
-    wasi::fd_close(f_readonly).expect("close readonly");
+    wasip1::fd_close(f_readonly).expect("close readonly");
 
     // =============== WRITE ONLY ==================
-    let f_writeonly = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_WRITE, 0, 0)
+    let f_writeonly = wasip1::path_open(dir_fd, 0, "file", 0, wasip1::RIGHTS_FD_WRITE, 0, 0)
         .expect("open file writeonly");
 
-    let stat = wasi::fd_fdstat_get(f_writeonly).expect("get fdstat writeonly");
+    let stat = wasip1::fd_fdstat_get(f_writeonly).expect("get fdstat writeonly");
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_READ == 0,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_READ == 0,
         "writeonly does not have read right"
     );
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_READDIR == 0,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_READDIR == 0,
         "writeonly does not have readdir right"
     );
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_WRITE == wasi::RIGHTS_FD_WRITE,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_WRITE == wasip1::RIGHTS_FD_WRITE,
         "writeonly has write right"
     );
 
     // See above for description of PERM
     assert_errno!(
-        wasi::fd_read(f_writeonly, &[iovec])
+        wasip1::fd_read(f_writeonly, &[iovec])
             .err()
             .expect("read of writeonly fails"),
-        wasi::ERRNO_PERM,
-        wasi::ERRNO_BADF
+        wasip1::ERRNO_PERM,
+        wasip1::ERRNO_BADF
     );
-    let bytes_written = wasi::fd_write(f_writeonly, &[ciovec]).expect("write to writeonly");
+    let bytes_written = wasip1::fd_write(f_writeonly, &[ciovec]).expect("write to writeonly");
     assert_eq!(bytes_written, write_buffer.len());
 
-    wasi::fd_close(f_writeonly).expect("close writeonly");
+    wasip1::fd_close(f_writeonly).expect("close writeonly");
 
     // ============== READ WRITE =======================
 
-    let f_readwrite = wasi::path_open(
+    let f_readwrite = wasip1::path_open(
         dir_fd,
         0,
         "file",
         0,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("open file readwrite");
-    let stat = wasi::fd_fdstat_get(f_readwrite).expect("get fdstat readwrite");
+    let stat = wasip1::fd_fdstat_get(f_readwrite).expect("get fdstat readwrite");
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_READ == wasi::RIGHTS_FD_READ,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_READ == wasip1::RIGHTS_FD_READ,
         "readwrite has read right"
     );
     assert!(
-        stat.fs_rights_base & wasi::RIGHTS_FD_WRITE == wasi::RIGHTS_FD_WRITE,
+        stat.fs_rights_base & wasip1::RIGHTS_FD_WRITE == wasip1::RIGHTS_FD_WRITE,
         "readwrite has write right"
     );
 
-    let nread = wasi::fd_read(f_readwrite, &[iovec]).expect("reading readwrite file");
+    let nread = wasip1::fd_read(f_readwrite, &[iovec]).expect("reading readwrite file");
     assert_eq!(
         nread,
         write_buffer.len(),
@@ -104,23 +104,23 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
     );
 
     let write_buffer_2 = &[2u8; 25];
-    let ciovec = wasi::Ciovec {
+    let ciovec = wasip1::Ciovec {
         buf: write_buffer_2.as_ptr(),
         buf_len: write_buffer_2.len(),
     };
-    let bytes_written = wasi::fd_write(f_readwrite, &[ciovec]).expect("write to readwrite");
+    let bytes_written = wasip1::fd_write(f_readwrite, &[ciovec]).expect("write to readwrite");
     assert_eq!(bytes_written, write_buffer_2.len());
 
-    let filestat = wasi::fd_filestat_get(f_readwrite).expect("get filestat readwrite");
+    let filestat = wasip1::fd_filestat_get(f_readwrite).expect("get filestat readwrite");
     assert_eq!(
         filestat.size as usize,
         write_buffer.len() + write_buffer_2.len(),
         "total written is both write buffers"
     );
 
-    wasi::fd_close(f_readwrite).expect("close readwrite");
+    wasip1::fd_close(f_readwrite).expect("close readwrite");
 
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -1,133 +1,133 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_path_rename(dir_fd: wasi::Fd) {
+unsafe fn test_path_rename(dir_fd: wasip1::Fd) {
     // First, try renaming a dir to nonexistent path
     // Create source directory
-    wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "source").expect("creating a directory");
 
     // Try renaming the directory
-    wasi::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
+    wasip1::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
 
     // Check that source directory doesn't exist anymore
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "source", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect_err("opening a nonexistent path as a directory should fail"),
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOENT
     );
 
     // Check that target directory exists
-    let mut fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+    let mut fd = wasip1::path_open(dir_fd, 0, "target", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
         .expect("opening renamed path as a directory");
     assert!(
-        fd > libc::STDERR_FILENO as wasi::Fd,
+        fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
-    wasi::fd_close(fd).expect("closing a file");
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::fd_close(fd).expect("closing a file");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Now, try renaming renaming a dir to existing empty dir
-    wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
-    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
-    wasi::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
+    wasip1::path_create_directory(dir_fd, "source").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasip1::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a directory");
 
     // Check that source directory doesn't exist anymore
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "source", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect_err("opening a nonexistent path as a directory"),
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOENT
     );
 
     // Check that target directory exists
-    fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
+    fd = wasip1::path_open(dir_fd, 0, "target", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
         .expect("opening renamed path as a directory");
     assert!(
-        fd > libc::STDERR_FILENO as wasi::Fd,
+        fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
-    wasi::fd_close(fd).expect("closing a file");
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::fd_close(fd).expect("closing a file");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Now, try renaming a dir to existing non-empty dir
-    wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
-    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "source").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a directory");
     create_file(dir_fd, "target/file");
 
     assert_errno!(
-        wasi::path_rename(dir_fd, "source", dir_fd, "target")
+        wasip1::path_rename(dir_fd, "source", dir_fd, "target")
             .expect_err("renaming directory to a nonempty directory"),
-        wasi::ERRNO_NOTEMPTY
+        wasip1::ERRNO_NOTEMPTY
     );
 
     // Try renaming dir to a file
     assert_errno!(
-        wasi::path_rename(dir_fd, "source", dir_fd, "target/file")
+        wasip1::path_rename(dir_fd, "source", dir_fd, "target/file")
             .expect_err("renaming a directory to a file"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
-    wasi::path_unlink_file(dir_fd, "target/file").expect("removing a file");
-    wasi::path_remove_directory(dir_fd, "source").expect("removing a directory");
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::path_unlink_file(dir_fd, "target/file").expect("removing a file");
+    wasip1::path_remove_directory(dir_fd, "source").expect("removing a directory");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Now, try renaming a file to a nonexistent path
     create_file(dir_fd, "source");
-    wasi::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a file");
+    wasip1::path_rename(dir_fd, "source", dir_fd, "target").expect("renaming a file");
 
     // Check that source file doesn't exist anymore
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "source", 0, 0, 0, 0)
+        wasip1::path_open(dir_fd, 0, "source", 0, 0, 0, 0)
             .expect_err("opening a nonexistent path should fail"),
-        wasi::ERRNO_NOENT
+        wasip1::ERRNO_NOENT
     );
 
     // Check that target file exists
-    fd = wasi::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
+    fd = wasip1::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
     assert!(
-        fd > libc::STDERR_FILENO as wasi::Fd,
+        fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
-    wasi::fd_close(fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
+    wasip1::fd_close(fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
 
     // Now, try renaming file to an existing file
     create_file(dir_fd, "source");
     create_file(dir_fd, "target");
 
-    wasi::path_rename(dir_fd, "source", dir_fd, "target")
+    wasip1::path_rename(dir_fd, "source", dir_fd, "target")
         .expect("renaming file to another existing file");
 
     // Check that source file doesn't exist anymore
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "source", 0, 0, 0, 0).expect_err("opening a nonexistent path"),
-        wasi::ERRNO_NOENT
+        wasip1::path_open(dir_fd, 0, "source", 0, 0, 0, 0).expect_err("opening a nonexistent path"),
+        wasip1::ERRNO_NOENT
     );
 
     // Check that target file exists
-    fd = wasi::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
+    fd = wasip1::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
     assert!(
-        fd > libc::STDERR_FILENO as wasi::Fd,
+        fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
-    wasi::fd_close(fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
+    wasip1::fd_close(fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
 
     // Try renaming to an (empty) directory instead
     create_file(dir_fd, "source");
-    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a directory");
 
     assert_errno!(
-        wasi::path_rename(dir_fd, "source", dir_fd, "target")
+        wasip1::path_rename(dir_fd, "source", dir_fd, "target")
             .expect_err("renaming a file to existing directory should fail"),
-        windows => wasi::ERRNO_ACCES,
-        unix => wasi::ERRNO_ISDIR
+        windows => wasip1::ERRNO_ACCES,
+        unix => wasip1::ERRNO_ISDIR
     );
 
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
-    wasi::path_unlink_file(dir_fd, "source").expect("removing a file");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::path_unlink_file(dir_fd, "source").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_rename_dir_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename_dir_trailing_slashes.rs
@@ -1,18 +1,18 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_path_rename_trailing_slashes(dir_fd: wasi::Fd) {
+unsafe fn test_path_rename_trailing_slashes(dir_fd: wasip1::Fd) {
     // Test renaming a directory with a trailing slash in the name.
-    wasi::path_create_directory(dir_fd, "source").expect("creating a directory");
-    wasi::path_rename(dir_fd, "source/", dir_fd, "target")
+    wasip1::path_create_directory(dir_fd, "source").expect("creating a directory");
+    wasip1::path_rename(dir_fd, "source/", dir_fd, "target")
         .expect("renaming a directory with a trailing slash in the source name");
-    wasi::path_rename(dir_fd, "target", dir_fd, "source/")
+    wasip1::path_rename(dir_fd, "target", dir_fd, "source/")
         .expect("renaming a directory with a trailing slash in the destination name");
-    wasi::path_rename(dir_fd, "source/", dir_fd, "target/")
+    wasip1::path_rename(dir_fd, "source/", dir_fd, "target/")
         .expect("renaming a directory with a trailing slash in the source and destination names");
-    wasi::path_rename(dir_fd, "target", dir_fd, "source")
+    wasip1::path_rename(dir_fd, "target", dir_fd, "source")
         .expect("renaming a directory with no trailing slashes at all should work");
-    wasi::path_remove_directory(dir_fd, "source").expect("removing the directory");
+    wasip1::path_remove_directory(dir_fd, "source").expect("removing the directory");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_path_symlink_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_path_symlink_trailing_slashes.rs
@@ -1,62 +1,62 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, create_file, open_scratch_directory};
 
-unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
+unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasip1::Fd) {
     if config().support_dangling_filesystem() {
         // Dangling symlink: Link destination shouldn't end with a slash.
         assert_errno!(
-            wasi::path_symlink("source", dir_fd, "target/")
+            wasip1::path_symlink("source", dir_fd, "target/")
                 .expect_err("link destination ending with a slash should fail"),
-            wasi::ERRNO_NOENT
+            wasip1::ERRNO_NOENT
         );
 
         // Dangling symlink: Without the trailing slash, this should succeed.
-        wasi::path_symlink("source", dir_fd, "target")
+        wasip1::path_symlink("source", dir_fd, "target")
             .expect("link destination ending with a slash");
-        wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
+        wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
     }
 
     // Link destination already exists, target has trailing slash.
-    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a directory");
     assert_errno!(
-        wasi::path_symlink("source", dir_fd, "target/")
+        wasip1::path_symlink("source", dir_fd, "target/")
             .expect_err("link destination already exists"),
-        unix => wasi::ERRNO_EXIST,
-        windows => wasi::ERRNO_NOENT
+        unix => wasip1::ERRNO_EXIST,
+        windows => wasip1::ERRNO_NOENT
     );
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Link destination already exists, target has no trailing slash.
-    wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a directory");
     assert_errno!(
-        wasi::path_symlink("source", dir_fd, "target")
+        wasip1::path_symlink("source", dir_fd, "target")
             .expect_err("link destination already exists"),
-        unix => wasi::ERRNO_EXIST,
-        windows => wasi::ERRNO_NOENT
+        unix => wasip1::ERRNO_EXIST,
+        windows => wasip1::ERRNO_NOENT
     );
-    wasi::path_remove_directory(dir_fd, "target").expect("removing a directory");
+    wasip1::path_remove_directory(dir_fd, "target").expect("removing a directory");
 
     // Link destination already exists, target has trailing slash.
     create_file(dir_fd, "target");
 
     assert_errno!(
-        wasi::path_symlink("source", dir_fd, "target/")
+        wasip1::path_symlink("source", dir_fd, "target/")
             .expect_err("link destination already exists"),
-        unix => wasi::ERRNO_NOTDIR,
-        windows => wasi::ERRNO_NOENT
+        unix => wasip1::ERRNO_NOTDIR,
+        windows => wasip1::ERRNO_NOENT
     );
-    wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
 
     // Link destination already exists, target has no trailing slash.
     create_file(dir_fd, "target");
 
     assert_errno!(
-        wasi::path_symlink("source", dir_fd, "target")
+        wasip1::path_symlink("source", dir_fd, "target")
             .expect_err("link destination already exists"),
-        unix => wasi::ERRNO_EXIST,
-        windows => wasi::ERRNO_NOENT
+        unix => wasip1::ERRNO_EXIST,
+        windows => wasip1::ERRNO_NOENT
     );
-    wasi::path_unlink_file(dir_fd, "target").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_regular_file_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_regular_file_isatty.rs
@@ -1,12 +1,12 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn test_file_isatty(dir_fd: wasi::Fd) {
+unsafe fn test_file_isatty(dir_fd: wasip1::Fd) {
     // Create a file in the scratch directory and test if it's a tty.
-    let file_fd =
-        wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).expect("opening a file");
+    let file_fd = wasip1::path_open(dir_fd, 0, "file", wasip1::OFLAGS_CREAT, 0, 0, 0)
+        .expect("opening a file");
     assert!(
-        file_fd > libc::STDERR_FILENO as wasi::Fd,
+        file_fd > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
     assert_eq!(
@@ -14,8 +14,8 @@ unsafe fn test_file_isatty(dir_fd: wasi::Fd) {
         0,
         "file is a tty"
     );
-    wasi::fd_close(file_fd).expect("closing a file");
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_remove_directory.rs
+++ b/crates/test-programs/src/bin/preview1_remove_directory.rs
@@ -1,12 +1,12 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_remove_directory(dir_fd: wasi::Fd) {
+unsafe fn test_remove_directory(dir_fd: wasip1::Fd) {
     // Create a directory in the scratch directory.
-    wasi::path_create_directory(dir_fd, "dir").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "dir").expect("creating a directory");
 
     // Test that removing it succeeds.
-    wasi::path_remove_directory(dir_fd, "dir")
+    wasip1::path_remove_directory(dir_fd, "dir")
         .expect("remove_directory on a directory should succeed");
 
     // There isn't consistient behavior across operating systems of whether removing with a
@@ -18,19 +18,19 @@ unsafe fn test_remove_directory(dir_fd: wasi::Fd) {
 
     // Test that removing it with no trailing slash fails.
     assert_errno!(
-        wasi::path_remove_directory(dir_fd, "file")
+        wasip1::path_remove_directory(dir_fd, "file")
             .expect_err("remove_directory without a trailing slash on a file should fail"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
 
     // Test that removing it with a trailing slash fails.
     assert_errno!(
-        wasi::path_remove_directory(dir_fd, "file/")
+        wasip1::path_remove_directory(dir_fd, "file/")
             .expect_err("remove_directory with a trailing slash on a file should fail"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
 
-    wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasip1::path_unlink_file(dir_fd, "file").expect("removing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_remove_nonempty_directory.rs
+++ b/crates/test-programs/src/bin/preview1_remove_nonempty_directory.rs
@@ -1,24 +1,24 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_remove_nonempty_directory(dir_fd: wasi::Fd) {
+unsafe fn test_remove_nonempty_directory(dir_fd: wasip1::Fd) {
     // Create a directory in the scratch directory.
-    wasi::path_create_directory(dir_fd, "dir").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "dir").expect("creating a directory");
 
     // Create a directory in the directory we just created.
-    wasi::path_create_directory(dir_fd, "dir/nested").expect("creating a subdirectory");
+    wasip1::path_create_directory(dir_fd, "dir/nested").expect("creating a subdirectory");
 
     // Test that attempting to unlink the first directory returns the expected error code.
     assert_errno!(
-        wasi::path_remove_directory(dir_fd, "dir")
+        wasip1::path_remove_directory(dir_fd, "dir")
             .expect_err("remove_directory on a directory should return ENOTEMPTY"),
-        wasi::ERRNO_NOTEMPTY
+        wasip1::ERRNO_NOTEMPTY
     );
 
     // Removing the directories.
-    wasi::path_remove_directory(dir_fd, "dir/nested")
+    wasip1::path_remove_directory(dir_fd, "dir/nested")
         .expect("remove_directory on a nested directory should succeed");
-    wasi::path_remove_directory(dir_fd, "dir").expect("removing a directory");
+    wasip1::path_remove_directory(dir_fd, "dir").expect("removing a directory");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_renumber.rs
+++ b/crates/test-programs/src/bin/preview1_renumber.rs
@@ -1,59 +1,59 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 
-unsafe fn test_renumber(dir_fd: wasi::Fd) {
-    let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
+unsafe fn test_renumber(dir_fd: wasip1::Fd) {
+    let pre_fd: wasip1::Fd = (libc::STDERR_FILENO + 1) as wasip1::Fd;
 
     assert!(dir_fd > pre_fd, "dir_fd number");
 
     // Create a file in the scratch directory.
-    let fd_from = wasi::path_open(
+    let fd_from = wasip1::path_open(
         dir_fd,
         0,
         "file1",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        fd_from > libc::STDERR_FILENO as wasi::Fd,
+        fd_from > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Get fd_from fdstat attributes
     let fdstat_from =
-        wasi::fd_fdstat_get(fd_from).expect("calling fd_fdstat on the open file descriptor");
+        wasip1::fd_fdstat_get(fd_from).expect("calling fd_fdstat on the open file descriptor");
 
     // Create another file in the scratch directory.
-    let fd_to = wasi::path_open(
+    let fd_to = wasip1::path_open(
         dir_fd,
         0,
         "file2",
-        wasi::OFLAGS_CREAT,
-        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
         0,
         0,
     )
     .expect("opening a file");
     assert!(
-        fd_to > libc::STDERR_FILENO as wasi::Fd,
+        fd_to > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
 
     // Renumber fd of file1 into fd of file2
-    wasi::fd_renumber(fd_from, fd_to).expect("renumbering two descriptors");
+    wasip1::fd_renumber(fd_from, fd_to).expect("renumbering two descriptors");
 
     // Ensure that fd_from is closed
     assert_errno!(
-        wasi::fd_close(fd_from).expect_err("closing already closed file descriptor"),
-        wasi::ERRNO_BADF
+        wasip1::fd_close(fd_from).expect_err("closing already closed file descriptor"),
+        wasip1::ERRNO_BADF
     );
 
     // Ensure that fd_to is still open.
     let fdstat_to =
-        wasi::fd_fdstat_get(fd_to).expect("calling fd_fdstat on the open file descriptor");
+        wasip1::fd_fdstat_get(fd_to).expect("calling fd_fdstat on the open file descriptor");
     assert_eq!(
         fdstat_from.fs_filetype, fdstat_to.fs_filetype,
         "expected fd_to have the same fdstat as fd_from"
@@ -71,7 +71,7 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
         "expected fd_to have the same fdstat as fd_from"
     );
 
-    wasi::fd_close(fd_to).expect("closing a file");
+    wasip1::fd_close(fd_to).expect("closing a file");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_sched_yield.rs
+++ b/crates/test-programs/src/bin/preview1_sched_yield.rs
@@ -1,5 +1,5 @@
 unsafe fn test_sched_yield() {
-    wasi::sched_yield().expect("sched_yield");
+    wasip1::sched_yield().expect("sched_yield");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_stdio.rs
+++ b/crates/test-programs/src/bin/preview1_stdio.rs
@@ -2,8 +2,8 @@ use test_programs::preview1::{STDERR_FD, STDIN_FD, STDOUT_FD};
 
 unsafe fn test_stdio() {
     for fd in &[STDIN_FD, STDOUT_FD, STDERR_FD] {
-        wasi::fd_fdstat_get(*fd).expect("fd_fdstat_get on stdio");
-        wasi::fd_renumber(*fd, *fd + 100).expect("renumbering stdio");
+        wasip1::fd_fdstat_get(*fd).expect("fd_fdstat_get on stdio");
+        wasip1::fd_renumber(*fd, *fd + 100).expect("renumbering stdio");
     }
 }
 

--- a/crates/test-programs/src/bin/preview1_symlink_create.rs
+++ b/crates/test-programs/src/bin/preview1_symlink_create.rs
@@ -1,19 +1,19 @@
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 
-unsafe fn create_symlink_to_file(dir_fd: wasi::Fd) {
+unsafe fn create_symlink_to_file(dir_fd: wasip1::Fd) {
     // Create a directory for the symlink to point to.
-    let target_fd =
-        wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_CREAT, 0, 0, 0).expect("creating a file");
-    wasi::fd_close(target_fd).expect("closing file");
+    let target_fd = wasip1::path_open(dir_fd, 0, "target", wasip1::OFLAGS_CREAT, 0, 0, 0)
+        .expect("creating a file");
+    wasip1::fd_close(target_fd).expect("closing file");
 
     // Create a symlink.
-    wasi::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
+    wasip1::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
 
     // Try to open it as a directory without O_NOFOLLOW.
-    let target_file_via_symlink = wasi::path_open(
+    let target_file_via_symlink = wasip1::path_open(
         dir_fd,
-        wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+        wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW,
         "symlink",
         0,
         0,
@@ -22,49 +22,50 @@ unsafe fn create_symlink_to_file(dir_fd: wasi::Fd) {
     )
     .expect("opening a symlink as a directory");
     assert!(
-        target_file_via_symlink > libc::STDERR_FILENO as wasi::Fd,
+        target_file_via_symlink > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(target_file_via_symlink).expect("close the symlink file");
+    wasip1::fd_close(target_file_via_symlink).expect("close the symlink file");
 
     // Replace the target directory with a file.
-    wasi::path_unlink_file(dir_fd, "symlink").expect("removing the symlink");
-    wasi::path_unlink_file(dir_fd, "target").expect("removing the target file");
+    wasip1::path_unlink_file(dir_fd, "symlink").expect("removing the symlink");
+    wasip1::path_unlink_file(dir_fd, "target").expect("removing the target file");
 }
 
-unsafe fn create_symlink_to_directory(dir_fd: wasi::Fd) {
+unsafe fn create_symlink_to_directory(dir_fd: wasip1::Fd) {
     // Create a directory for the symlink to point to.
-    wasi::path_create_directory(dir_fd, "target").expect("creating a dir");
+    wasip1::path_create_directory(dir_fd, "target").expect("creating a dir");
 
     // Create a symlink.
-    wasi::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
+    wasip1::path_symlink("target", dir_fd, "symlink").expect("creating a symlink");
 
     // Try to open it as a directory without O_NOFOLLOW.
-    let target_dir_via_symlink = wasi::path_open(
+    let target_dir_via_symlink = wasip1::path_open(
         dir_fd,
-        wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+        wasip1::LOOKUPFLAGS_SYMLINK_FOLLOW,
         "symlink",
-        wasi::OFLAGS_DIRECTORY,
+        wasip1::OFLAGS_DIRECTORY,
         0,
         0,
         0,
     )
     .expect("opening a symlink as a directory");
     assert!(
-        target_dir_via_symlink > libc::STDERR_FILENO as wasi::Fd,
+        target_dir_via_symlink > libc::STDERR_FILENO as wasip1::Fd,
         "file descriptor range check",
     );
-    wasi::fd_close(target_dir_via_symlink).expect("closing a file");
+    wasip1::fd_close(target_dir_via_symlink).expect("closing a file");
 
     // Replace the target directory with a file.
-    wasi::path_unlink_file(dir_fd, "symlink").expect("remove symlink to directory");
-    wasi::path_remove_directory(dir_fd, "target")
+    wasip1::path_unlink_file(dir_fd, "symlink").expect("remove symlink to directory");
+    wasip1::path_remove_directory(dir_fd, "target")
         .expect("remove_directory on a directory should succeed");
 }
 
-unsafe fn create_symlink_to_root(dir_fd: wasi::Fd) {
+unsafe fn create_symlink_to_root(dir_fd: wasip1::Fd) {
     // Create a symlink.
-    wasi::path_symlink("/", dir_fd, "symlink").expect_err("creating a symlink to an absolute path");
+    wasip1::path_symlink("/", dir_fd, "symlink")
+        .expect_err("creating a symlink to an absolute path");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_symlink_loop.rs
+++ b/crates/test-programs/src/bin/preview1_symlink_loop.rs
@@ -1,20 +1,20 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, open_scratch_directory};
 
-unsafe fn test_symlink_loop(dir_fd: wasi::Fd) {
+unsafe fn test_symlink_loop(dir_fd: wasip1::Fd) {
     if config().support_dangling_filesystem() {
         // Create a self-referencing symlink.
-        wasi::path_symlink("symlink", dir_fd, "symlink").expect("creating a symlink");
+        wasip1::path_symlink("symlink", dir_fd, "symlink").expect("creating a symlink");
 
         // Try to open it.
         assert_errno!(
-            wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
+            wasip1::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
                 .expect_err("opening a self-referencing symlink"),
-            wasi::ERRNO_LOOP
+            wasip1::ERRNO_LOOP
         );
 
         // Clean up.
-        wasi::path_unlink_file(dir_fd, "symlink").expect("removing a file");
+        wasip1::path_unlink_file(dir_fd, "symlink").expect("removing a file");
     }
 }
 

--- a/crates/test-programs/src/bin/preview1_unicode_output.rs
+++ b/crates/test-programs/src/bin/preview1_unicode_output.rs
@@ -2,11 +2,11 @@ use test_programs::preview1::STDOUT_FD;
 fn main() {
     let text = "مرحبا بكم\n";
 
-    let ciovecs = [wasi::Ciovec {
+    let ciovecs = [wasip1::Ciovec {
         buf: text.as_bytes().as_ptr(),
         buf_len: text.as_bytes().len(),
     }];
-    let written = unsafe { wasi::fd_write(STDOUT_FD, &ciovecs) }.expect("write succeeds");
+    let written = unsafe { wasip1::fd_write(STDOUT_FD, &ciovecs) }.expect("write succeeds");
     assert_eq!(
         written,
         text.as_bytes().len(),

--- a/crates/test-programs/src/bin/preview1_unlink_file_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_unlink_file_trailing_slashes.rs
@@ -1,43 +1,43 @@
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 
-unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
+unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasip1::Fd) {
     // Create a directory in the scratch directory.
-    wasi::path_create_directory(dir_fd, "dir").expect("creating a directory");
+    wasip1::path_create_directory(dir_fd, "dir").expect("creating a directory");
 
     // Test that unlinking it fails.
     assert_errno!(
-        wasi::path_unlink_file(dir_fd, "dir")
+        wasip1::path_unlink_file(dir_fd, "dir")
             .expect_err("unlink_file on a directory should fail"),
-        macos => wasi::ERRNO_PERM,
-        unix => wasi::ERRNO_ISDIR,
-        windows => wasi::ERRNO_ACCES
+        macos => wasip1::ERRNO_PERM,
+        unix => wasip1::ERRNO_ISDIR,
+        windows => wasip1::ERRNO_ACCES
     );
 
     // Test that unlinking it with a trailing flash fails.
     assert_errno!(
-        wasi::path_unlink_file(dir_fd, "dir/")
+        wasip1::path_unlink_file(dir_fd, "dir/")
             .expect_err("unlink_file on a directory should fail"),
-        macos => wasi::ERRNO_PERM,
-        unix => wasi::ERRNO_ISDIR,
-        windows => wasi::ERRNO_ACCES
+        macos => wasip1::ERRNO_PERM,
+        unix => wasip1::ERRNO_ISDIR,
+        windows => wasip1::ERRNO_ACCES
     );
 
     // Clean up.
-    wasi::path_remove_directory(dir_fd, "dir").expect("removing a directory");
+    wasip1::path_remove_directory(dir_fd, "dir").expect("removing a directory");
 
     // Create a temporary file.
     create_file(dir_fd, "file");
 
     // Test that unlinking it with a trailing flash fails.
     assert_errno!(
-        wasi::path_unlink_file(dir_fd, "file/")
+        wasip1::path_unlink_file(dir_fd, "file/")
             .expect_err("unlink_file with a trailing slash should fail"),
-        wasi::ERRNO_NOTDIR
+        wasip1::ERRNO_NOTDIR
     );
 
     // Test that unlinking it with no trailing flash succeeds.
-    wasi::path_unlink_file(dir_fd, "file")
+    wasip1::path_unlink_file(dir_fd, "file")
         .expect("unlink_file with no trailing slash should succeed");
 }
 

--- a/crates/test-programs/src/bin/preview2_adapter_badfd.rs
+++ b/crates/test-programs/src/bin/preview2_adapter_badfd.rs
@@ -2,45 +2,48 @@ fn main() {
     #[link(wasm_import_module = "wasi_snapshot_preview1")]
     unsafe extern "C" {
         #[cfg_attr(target_arch = "wasm32", link_name = "adapter_open_badfd")]
-        fn adapter_open_badfd(fd: *mut u32) -> wasi::Errno;
+        fn adapter_open_badfd(fd: *mut u32) -> wasip1::Errno;
 
         #[cfg_attr(target_arch = "wasm32", link_name = "adapter_close_badfd")]
-        fn adapter_close_badfd(fd: u32) -> wasi::Errno;
+        fn adapter_close_badfd(fd: u32) -> wasip1::Errno;
     }
 
     unsafe {
         let mut fd = 0;
-        assert_eq!(adapter_open_badfd(&mut fd), wasi::ERRNO_SUCCESS);
+        assert_eq!(adapter_open_badfd(&mut fd), wasip1::ERRNO_SUCCESS);
 
-        assert_eq!(wasi::fd_close(fd), Err(wasi::ERRNO_BADF));
+        assert_eq!(wasip1::fd_close(fd), Err(wasip1::ERRNO_BADF));
 
-        assert_eq!(wasi::fd_fdstat_get(fd).map(drop), Err(wasi::ERRNO_BADF));
+        assert_eq!(wasip1::fd_fdstat_get(fd).map(drop), Err(wasip1::ERRNO_BADF));
 
-        assert_eq!(wasi::fd_fdstat_set_rights(fd, 0, 0), Err(wasi::ERRNO_BADF));
+        assert_eq!(
+            wasip1::fd_fdstat_set_rights(fd, 0, 0),
+            Err(wasip1::ERRNO_BADF)
+        );
 
         let mut buffer = [0_u8; 1];
         assert_eq!(
-            wasi::fd_read(
+            wasip1::fd_read(
                 fd,
-                &[wasi::Iovec {
+                &[wasip1::Iovec {
                     buf: buffer.as_mut_ptr(),
                     buf_len: 1
                 }]
             ),
-            Err(wasi::ERRNO_BADF)
+            Err(wasip1::ERRNO_BADF)
         );
 
         assert_eq!(
-            wasi::fd_write(
+            wasip1::fd_write(
                 fd,
-                &[wasi::Ciovec {
+                &[wasip1::Ciovec {
                     buf: buffer.as_ptr(),
                     buf_len: 1
                 }]
             ),
-            Err(wasi::ERRNO_BADF)
+            Err(wasip1::ERRNO_BADF)
         );
 
-        assert_eq!(adapter_close_badfd(fd), wasi::ERRNO_SUCCESS);
+        assert_eq!(adapter_close_badfd(fd), wasip1::ERRNO_SUCCESS);
     }
 }

--- a/crates/test-programs/src/preview1.rs
+++ b/crates/test-programs/src/preview1.rs
@@ -7,30 +7,32 @@ pub fn config() -> &'static TestConfig {
 
 // The `wasi` crate version 0.9.0 and beyond, doesn't
 // seem to define these constants, so we do it ourselves.
-pub const STDIN_FD: wasi::Fd = 0x0;
-pub const STDOUT_FD: wasi::Fd = 0x1;
-pub const STDERR_FD: wasi::Fd = 0x2;
+pub const STDIN_FD: wasip1::Fd = 0x0;
+pub const STDOUT_FD: wasip1::Fd = 0x1;
+pub const STDERR_FD: wasip1::Fd = 0x2;
 
 /// Opens a fresh file descriptor for `path` where `path` should be a preopened
 /// directory.
-pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
+pub fn open_scratch_directory(path: &str) -> Result<wasip1::Fd, String> {
     unsafe {
         for i in 3.. {
-            let stat = match wasi::fd_prestat_get(i) {
+            let stat = match wasip1::fd_prestat_get(i) {
                 Ok(s) => s,
                 Err(_) => break,
             };
-            if stat.tag != wasi::PREOPENTYPE_DIR.raw() {
+            if stat.tag != wasip1::PREOPENTYPE_DIR.raw() {
                 continue;
             }
             let mut dst = Vec::with_capacity(stat.u.dir.pr_name_len);
-            if wasi::fd_prestat_dir_name(i, dst.as_mut_ptr(), dst.capacity()).is_err() {
+            if wasip1::fd_prestat_dir_name(i, dst.as_mut_ptr(), dst.capacity()).is_err() {
                 continue;
             }
             dst.set_len(stat.u.dir.pr_name_len);
             if dst == path.as_bytes() {
-                return Ok(wasi::path_open(i, 0, ".", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                    .expect("failed to open dir"));
+                return Ok(
+                    wasip1::path_open(i, 0, ".", wasip1::OFLAGS_DIRECTORY, 0, 0, 0)
+                        .expect("failed to open dir"),
+                );
             }
         }
 
@@ -38,11 +40,11 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
     }
 }
 
-pub unsafe fn create_file(dir_fd: wasi::Fd, filename: &str) {
-    let file_fd =
-        wasi::path_open(dir_fd, 0, filename, wasi::OFLAGS_CREAT, 0, 0, 0).expect("creating a file");
+pub unsafe fn create_file(dir_fd: wasip1::Fd, filename: &str) {
+    let file_fd = wasip1::path_open(dir_fd, 0, filename, wasip1::OFLAGS_CREAT, 0, 0, 0)
+        .expect("creating a file");
     assert!(file_fd > STDERR_FD, "file descriptor range check",);
-    wasi::fd_close(file_fd).expect("closing a file");
+    wasip1::fd_close(file_fd).expect("closing a file");
 }
 
 // Small workaround to get the crate's macros, through the


### PR DESCRIPTION
This better reflects how the test programs currently have access to both versions, so make sure they're both named to disambiguate against the other.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
