### PR TITLE
wasi-nn: improve example documentation

### DIFF
--- a/crates/wasi-nn/examples/classification-example-named/.gitignore
+++ b/crates/wasi-nn/examples/classification-example-named/.gitignore
@@ -1,0 +1,2 @@
+fixture
+mobilenet

--- a/crates/wasi-nn/examples/classification-example-named/README.md
+++ b/crates/wasi-nn/examples/classification-example-named/README.md
@@ -1,2 +1,42 @@
-This example project demonstrates using the `wasi-nn` API to perform ML inference. It consists of Rust code that is
-built using the `wasm32-wasip1` target. See `ci/run-wasi-nn-example.sh` for how this is used.
+# Named Model Example
+
+This example is mostly the same as the [`classification-example`] but uses
+wasi-nn's "named model" API to load the ML model before the WebAssembly program
+executes. Instead of loading the model bytes during program execution (which may
+be prohibitively slow for large models), this wasi-nn extension allows the model
+to be loaded by the engine prior to execution.
+
+### Pre-requisites
+
+The example pre-requisites are mostly the same as that of the
+[`classification-example`], except that we separate the model files that the
+engine pre-loads (`mobilenet/*`) from the image file read via WASI from the host
+(`fixture/*`):
+
+```
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/mobilenet.bin -O mobilenet/model.bin
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/mobilenet.xml -O mobilenet/model.xml
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/tensor-1x224x224x3-f32.bgr -O fixture/tensor.bgr
+```
+
+As before, this Rust [example] compiles to a WebAssembly program using the
+`wasm32-wasip1` target: `cargo build --target=wasm32-wasip1`.
+
+[example]: src/main.rs
+
+### Run
+
+The program is invoked with slightly different flags than the
+[`classification-example`]:
+
+```
+<path>/<to>/wasmtime run --dir=fixture --wasi=nn --wasi=nn-graph=openvino::mobilenet target/wasm32-wasip1/debug/wasi-nn-example-named.wasm
+```
+
+The primary difference is the addition of `--wasi=nn-graph=openvino::mobilenet`:
+this informs Wasmtime's wasi-nn implementation to pre-load a named model from
+the `mobilenet` directory using the `openvino` encoding. Note that, in this
+implementation, the model name (i.e., `mobilenet`) is derived from the base name
+of the path passed in `--nn-graph=<encoding>::<path>`.
+
+[`classification-example`]: ../classification-example

--- a/crates/wasi-nn/examples/classification-example/.gitignore
+++ b/crates/wasi-nn/examples/classification-example/.gitignore
@@ -1,0 +1,1 @@
+fixture

--- a/crates/wasi-nn/examples/classification-example/README.md
+++ b/crates/wasi-nn/examples/classification-example/README.md
@@ -1,2 +1,78 @@
-This example project demonstrates using the `wasi-nn` API to perform ML inference. It consists of Rust code that is
-built using the `wasm32-wasip1` target. See `ci/run-wasi-nn-example.sh` for how this is used.
+# Image Classification Example
+
+This example project demonstrates using the `wasi-nn` API to perform machine
+learning (ML) inference. It shows how to collect and use the various parts of a
+wasi-nn program:
+- an ML __framework__ ("backend" in wasi-nn terms)
+- an ML __model__ ("graph" terms in wasi-nn terms)
+- a WebAssembly __program__
+- a wasi-nn-compatible __engine__
+
+### Pre-requisite: Framework
+
+This example uses the OpenVINO framework: [installation
+instructions][openvino-install]. If you're interested in how the engine forwards
+calls from the WebAssembly program to this framework, see the
+[backend][openvino-backend] source code.
+
+[openvino-install]: https://docs.openvino.ai/2025/get-started/install-openvino.html
+[openvino-backend]: ../../src/backend/openvino.rs
+
+### Pre-requisite: Model
+
+MobileNet is a small, common model for classifying images; it returns the
+probabilities for words that best describe the image. To retrieve the files
+needed to use this model on OpenVINO, download:
+
+```
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/mobilenet.bin -O fixture/model.bin
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/mobilenet.xml -O fixture/model.xml
+wget https://download.01.org/openvinotoolkit/fixtures/mobilenet/tensor-1x224x224x3-f32.bgr -O fixture/tensor.bgr
+```
+
+The `.bgr` file is a tensor representation of an image file (more details
+[here]).
+
+[here]: https://download.01.org/openvinotoolkit/fixtures/mobilenet
+
+### Pre-requisite: Program
+
+Compile this Rust [example] to a WebAssembly program using the `wasm32-wasip1`
+target. This requires a Rust toolchain (e.g., [rustup]) and the appropriate
+compilation target (e.g., `rustup target add wasm32-wasip1`). To compile the
+program to a `*.wasm` file in the `target` directory:
+
+```
+cargo build --target=wasm32-wasip1
+```
+
+[example]: src/main.rs
+[rustup]: https://rustup.rs
+
+### Pre-requisites: Engine
+
+This example uses Wasmtime, which contains a wasi-nn [implementation][crate]. To
+use Wasmtime, follow the instructions to either [build] or [install] it.
+
+[build]: https://docs.wasmtime.dev/contributing-building.html
+[crate]: ../..
+[install]: https://docs.wasmtime.dev/cli-install.html
+
+### Run
+
+With the pre-requisites in place, run the example:
+
+```
+<path>/<to>/wasmtime run --wasi=nn --dir=fixture target/wasm32-wasip1/debug/wasi-nn-example.wasm
+```
+
+Some words of explanation: the `--wasi` flag enables the wasi-nn proposal (see
+`-S help`), the `--dir` maps our host-side `fixture` directory to a directory of
+the same name in the guest, and we pass the `*.wasm` module as the sole
+argument. For this model (see the [source][example]), we expect to see the list
+of tags that mostly likely describe the image:
+
+```
+...
+Found results, sorted top 5: [InferenceResult(885, 0.3958254), InferenceResult(904, 0.36464655), InferenceResult(84, 0.010480323), InferenceResult(911, 0.0082290955), InferenceResult(741, 0.007244849)]
+```


### PR DESCRIPTION
In a refactoring that moved all wasi-nn tests around (#7679), the script documenting the CLI use of the wasi-nn examples was removed. This left the documentation of these examples in a poor state, since the script they pointed to was now gone. Since I've recently received a few requests related to running these examples, it makes sense to improve the documentation. This change improves things by explaining the steps to run these examples.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
