### PR TITLE
Make `RegisteredType::root` panic when given bad type indices

### DIFF
--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -343,15 +343,12 @@ impl RegisteredType {
     ///
     /// This will prevent the associated type from being unregistered as long as
     /// the returned `RegisteredType` is kept alive.
-    ///
-    /// Returns `None` if `index` is not registered in the given engine's
-    /// registry.
-    pub fn root(engine: &Engine, index: VMSharedTypeIndex) -> Option<RegisteredType> {
+    pub fn root(engine: &Engine, index: VMSharedTypeIndex) -> RegisteredType {
         let (entry, ty, layout) = {
             let id = shared_type_index_to_slab_id(index);
             let inner = engine.signatures().0.read();
 
-            let ty = inner.types.get(id)?.clone();
+            let ty = inner.types[id].clone();
             let entry = inner.type_to_rec_group[index].clone().unwrap();
             let layout = inner.type_to_gc_layout.get(index).and_then(|l| l.clone());
 
@@ -366,13 +363,7 @@ impl RegisteredType {
             (entry, ty, layout)
         };
 
-        Some(RegisteredType::from_parts(
-            engine.clone(),
-            entry,
-            index,
-            ty,
-            layout,
-        ))
+        RegisteredType::from_parts(engine.clone(), entry, index, ty, layout)
     }
 
     /// Construct a new `RegisteredType`.

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1796,10 +1796,7 @@ impl StructType {
     }
 
     pub(crate) fn from_shared_type_index(engine: &Engine, index: VMSharedTypeIndex) -> StructType {
-        let ty = RegisteredType::root(engine, index).expect(
-            "VMSharedTypeIndex is not registered in the Engine! Wrong \
-             engine? Didn't root the index somewhere?",
-        );
+        let ty = RegisteredType::root(engine, index);
         Self::from_registered_type(ty)
     }
 
@@ -2040,10 +2037,7 @@ impl ArrayType {
     }
 
     pub(crate) fn from_shared_type_index(engine: &Engine, index: VMSharedTypeIndex) -> ArrayType {
-        let ty = RegisteredType::root(engine, index).expect(
-            "VMSharedTypeIndex is not registered in the Engine! Wrong \
-             engine? Didn't root the index somewhere?",
-        );
+        let ty = RegisteredType::root(engine, index);
         Self::from_registered_type(ty)
     }
 
@@ -2400,10 +2394,7 @@ impl FuncType {
     }
 
     pub(crate) fn from_shared_type_index(engine: &Engine, index: VMSharedTypeIndex) -> FuncType {
-        let ty = RegisteredType::root(engine, index).expect(
-            "VMSharedTypeIndex is not registered in the Engine! Wrong \
-             engine? Didn't root the index somewhere?",
-        );
+        let ty = RegisteredType::root(engine, index);
         Self::from_registered_type(ty)
     }
 


### PR DESCRIPTION
Rather than returning `None`.

All callers were unwrapping anyways, and if we ever hit this, it is really a bug in our code rather than an expected edge case we need to handle.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
