### PR TITLE
Remove `wasmtime_fuzzing::oracles::dummy::dummy_linker`

### DIFF
--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -3,19 +3,6 @@
 use anyhow::ensure;
 use wasmtime::*;
 
-/// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
-    let mut linker = Linker::new(store.engine());
-    linker.allow_shadowing(true);
-    for import in module.imports() {
-        let extern_ = dummy_extern(store, import.ty())?;
-        linker
-            .define(&store, import.module(), import.name(), extern_)
-            .unwrap();
-    }
-    Ok(linker)
-}
-
 /// Construct a dummy `Extern` from its type signature
 pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
     Ok(match ty {


### PR DESCRIPTION
Since that helper was written, we now have this same functionality built into `wasmtime::Linker`.

Unfortunately, we can't remove most of the `dummy` module, because it is used by the `api_calls` fuzzer to create dummy `wasmtime::Extern`s and we don't have off-the-shelf helpers for doing that in the core `wasmtime` API for that yet.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
