### PR TITLE
Add some infrastructure for keeping old CI working

### DIFF
--- a/.github/workflows/ci-cron-trigger.yml
+++ b/.github/workflows/ci-cron-trigger.yml
@@ -1,0 +1,53 @@
+name: "Cron triggers for CI"
+on:
+  schedule:
+    # “At 02:34 on Monday.”
+    #
+    # https://crontab.guru/#34_2_*_*_1
+    #
+    # This is used to perform a weekly run of CI for all release branches,
+    # ideally in off-work-hours to not clog up the queue.
+    - cron: '34 2 * * 1'
+
+    # "At 02:34 on Sunday and every day-of-week from Tuesday through Saturday"
+    #
+    # https://crontab.guru/#34_2_*_*_0,2-6
+    #
+    # This is used to perform a daily run of CI for the `main` branch to prime
+    # caches for github actions and the merge queue. Note that this frequency
+    # doesn't overlap the above schedule to avoid triggering two builds on the
+    # same day.
+    - cron: '34 2 * * 0,2-6'
+
+  # Allow manually triggering this request via a button
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  actions: write
+
+jobs:
+  run:
+    if: "github.repository == 'bytecodealliance/wasmtime' || !github.event.schedule"
+    name: Trigger release branch CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Always trigger a CI run on the `main` branch to prime GHA caches.
+      - run: gh workflow run main.yml --ref main
+        name: Trigger main branch CI daily
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # If this is a once-a-week run then additionally trigger CI for release
+      # branches to ensure that the CI there is kept up-to-date.
+      - run: rustc ci/trigger-release-branch-ci.rs
+      - run: ./trigger-release-branch-ci
+        name: Trigger release branch CI weekly
+        env:
+          GH_TOKEN: ${{ github.token }}
+        if: github.event.schedule == '34 2 * * 1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,6 @@ on:
     - main
     - 'release-*'
 
-  # Run full CI on the `main` branch once a day to prime the GitHub Actions
-  # caches used by PRs and the merge queue.
-  schedule:
-  - cron: '13 4 * * *'
-
   # This is the CI that runs for PRs-to-merge.
   merge_group:
 
@@ -25,6 +20,9 @@ on:
     # tag at the end of CI if successful and the tag will trigger the artifact
     # uploads as well as publication to crates.io.
     - 'release-*'
+
+  # Allow manually triggering this request via a button or another workflow.
+  workflow_dispatch:
 
 defaults:
   run:
@@ -1274,3 +1272,29 @@ jobs:
         }
         EOF
       if: steps.tag.outputs.push_tag == 'yes'
+
+  # File an issue on the repo if this run failed and was triggered via
+  # `workflow_dispatch`, which mostly means that
+  # `.github/workflows/trigger-release-branch-ci.yml` will file issues on
+  # failure so we get to see a notification when a build fails for a historical
+  # release branch.
+  file-issue-on-error:
+    name: File an issue if this build failed and was cron-triggered
+    runs-on: ubuntu-latest
+    needs: ci-status
+    if: |
+      always()
+      && needs.ci-status.result != 'success'
+      && github.event_name == 'workflow_dispatch'
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `Failed CI build for ${context.ref}`,
+            body: `See https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+          })

--- a/ci/trigger-release-branch-ci.rs
+++ b/ci/trigger-release-branch-ci.rs
@@ -1,0 +1,67 @@
+//! Helper script used by `.github/workflows/ci-cron-trigger.yml`
+
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .arg("for-each-ref")
+        .arg("refs/remotes/origin")
+        .arg("--format")
+        .arg("%(refname)")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let mut releases = std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .lines()
+        .filter_map(|l| l.strip_prefix("refs/remotes/origin/release-"))
+        .filter_map(|l| {
+            let mut parts = l.split('.');
+            let major = parts.next()?.parse::<u32>().ok()?;
+            let minor = parts.next()?.parse::<u32>().ok()?;
+            let patch = parts.next()?.parse::<u32>().ok()?;
+            Some((major, minor, patch))
+        })
+        .collect::<Vec<_>>();
+    releases.sort();
+
+    let mut to_trigger: Vec<(u32, u32, u32)> = Vec::new();
+    let mut iter = releases.iter().rev();
+
+    // Pick the latest 3 release branches to keep up-to-date. Although we
+    // only promise the last 2 are going to be released with security fixes when
+    // a new release branch is made that means there's one "pending" release
+    // branch and two "active" release branches. In that situation we want to
+    // update 3 branches. If there's no "pending" branch then we'll just be
+    // keeping some older branch's CI working, which shouldn't be too hard.
+    to_trigger.extend(iter.by_ref().take(3));
+
+    // We support two LTS channels 12 versions apart. If one is already included
+    // in the above set of 3 latest releases, however, then we're only picking
+    // one historical LTS release.
+    let mut lts_channels = 2;
+    if to_trigger.iter().any(|(major, _, _)| *major % 12 == 0) {
+        lts_channels -= 1;
+    }
+
+    // Look for LTS releases, defined by every-12-versions which are after v24.
+    to_trigger.extend(
+        iter.filter(|(major, _, _)| *major % 12 == 0 && *major > 20)
+            .take(lts_channels),
+    );
+
+    println!("{to_trigger:?}");
+
+    for (major, minor, patch) in to_trigger {
+        dbg!(major, minor, patch);
+        let status = Command::new("gh")
+            .arg("workflow")
+            .arg("run")
+            .arg("main.yml")
+            .arg("--ref")
+            .arg(format!("release-{major}.{minor}.{patch}"))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+}


### PR DESCRIPTION
This commit is preparation for the infrastructure to be used when supporting [Wasmtime LTS releases][rfc]. The goal here is to add some automation and infrastructure to perform a weekly build of all active release branches which will file an issue on failure. This should ideally keep branches up-to-date and ensure that we don't forget to backport any fixes to older branches. Or rather when we do forget to backport fixes this'll be a reminder to go do that anyway.

The general architecture here is:

* A new `ci-cron-trigger.yml` workflow is added.
* This new workflow runs once-a-week and runs a small script that triggers CI for all active release branches.
* The main CI, `main.yml`, is updated to file an issue on failure when triggered in this fashion.

While I was here I additionally removed the `schedule:` from the `main.yml` to instead fold the daily scheduling of CI runs into this new script as well. That way all our cron CI jobs are gated in workflows that require this exact repository meaning that forks won't be running cron jobs.

[rfc]: https://github.com/bytecodealliance/rfcs/pull/42

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
