### PR TITLE
Add `--stack-maps` to `wasmtime objdump`

### DIFF
--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -265,12 +265,16 @@ fn assert_output(test: &Test, output: CompileOutput) -> Result<()> {
             cmd.arg("objdump")
                 .arg("--address-width=4")
                 .arg("--address-jumps")
-                .arg("--stack-maps")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
-            if let Some(args) = &test.config.objdump {
-                cmd.args(args.to_vec());
+            match &test.config.objdump {
+                Some(args) => {
+                    cmd.args(args.to_vec());
+                }
+                None => {
+                    cmd.arg("--traps=false");
+                }
             }
 
             let mut child = cmd.spawn().context("failed to run wasmtime")?;

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -265,6 +265,7 @@ fn assert_output(test: &Test, output: CompileOutput) -> Result<()> {
             cmd.arg("objdump")
                 .arg("--address-width=4")
                 .arg("--address-jumps")
+                .arg("--stack-maps")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -1,0 +1,76 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc"
+;;! test = "compile"
+
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param f32 i32 anyref) (result (ref $ty))
+    (struct.new $ty (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r10
+;;       movq    0x10(%r10), %r10
+;;       addq    $0x50, %r10
+;;       cmpq    %rsp, %r10
+;;       ja      0xe4
+;;   19: subq    $0x40, %rsp
+;;       movq    %r13, 0x20(%rsp)
+;;       movq    %r14, 0x28(%rsp)
+;;       movq    %r15, 0x30(%rsp)
+;;       movq    %rdx, %r15
+;;       movdqu  %xmm0, 8(%rsp)
+;;       leaq    (%rsp), %r14
+;;       movl    %ecx, (%r14)
+;;       movl    $0xb0000001, %esi
+;;       xorl    %edx, %edx
+;;       movl    $0x28, %ecx
+;;       movl    $8, %r8d
+;;       movq    %rdi, %r13
+;;       callq   0x195
+;;       movq    0x28(%r13), %r9
+;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[0]
+;;       movq    %rax, %r8
+;;       movl    %r8d, %r10d
+;;       movdqu  8(%rsp), %xmm0
+;;       movss   %xmm0, 0x1c(%r9, %r10)
+;;       movq    %r15, %rdx
+;;       movb    %dl, 0x20(%r9, %r10)
+;;       movl    (%r14), %r11d
+;;       movq    %r11, %rdx
+;;       andl    $1, %edx
+;;       testl   %r11d, %r11d
+;;       sete    %sil
+;;       movzbl  %sil, %esi
+;;       orl     %esi, %edx
+;;       testl   %edx, %edx
+;;       jne     0xc1
+;;   93: movl    %r11d, %edi
+;;       addq    $8, %rdi
+;;       jb      0xe6
+;;   a0: movq    %rdi, %rcx
+;;       addq    $8, %rcx
+;;       jb      0xe8
+;;   ad: cmpq    0x30(%r13), %rcx
+;;       ja      0xea
+;;   b7: movl    $1, %r11d
+;;       addq    %r11, (%r9, %rdi)
+;;       movl    (%r14), %r11d
+;;       movl    %r11d, 0x18(%r9, %r10)
+;;       movq    %r8, %rax
+;;       movq    0x20(%rsp), %r13
+;;       movq    0x28(%rsp), %r14
+;;       movq    0x30(%rsp), %r15
+;;       addq    $0x40, %rsp
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;   e4: ud2
+;;   e6: ud2
+;;   e8: ud2
+;;   ea: ud2


### PR DESCRIPTION
Follow-up to #10404 and #10405

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
