### PR TITLE
Update release branch CI to trigger manually

### DIFF
--- a/.github/workflows/ci-cron-trigger.yml
+++ b/.github/workflows/ci-cron-trigger.yml
@@ -50,4 +50,4 @@ jobs:
         name: Trigger release branch CI weekly
         env:
           GH_TOKEN: ${{ github.token }}
-        if: github.event.schedule == '34 2 * * 1'
+        if: "github.event.schedule == '34 2 * * 1' || !github.event.schedule"


### PR DESCRIPTION
Updates a condition from #10438 to trigger historical release CI on manual trigger, not just the schedule.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
