### PR TITLE
asm: notate instruction alignment, SSE feature flags

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl.rs
+++ b/cranelift/assembler-x64/meta/src/dsl.rs
@@ -10,7 +10,7 @@ pub mod format;
 
 pub use encoding::{rex, vex, Encoding, LegacyPrefix, Rex};
 pub use features::{Feature, Features, ALL_FEATURES};
-pub use format::{fmt, r, rw, sxl, sxq, sxw};
+pub use format::{align, fmt, r, rw, sxl, sxq, sxw};
 pub use format::{Extension, Format, Location, Mutability, Operand, OperandKind};
 
 /// Abbreviated constructor for an x64 instruction.

--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -47,11 +47,15 @@ impl fmt::Display for Features {
 /// processors. It consists of two sub-modes:
 /// - __64-bit mode__: uses the full 64-bit address space
 /// - __compatibility mode__: allows use of legacy 32-bit code
+///
+/// Other features listed here should match the __CPUID Feature Flags__ column
+/// of the instruction tables of the x64 reference manual.
 #[derive(Clone, Copy, PartialEq)]
 #[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Feature {
     _64b,
     compat,
+    sse,
 }
 
 /// List all CPU features.
@@ -61,13 +65,14 @@ pub enum Feature {
 /// transcribe each variant to an `enum` available in the generated layer above.
 /// If this list is incomplete, we will (fortunately) see compile errors for
 /// generated functions that use the missing variants.
-pub const ALL_FEATURES: &[Feature] = &[Feature::_64b, Feature::compat];
+pub const ALL_FEATURES: &[Feature] = &[Feature::_64b, Feature::compat, Feature::sse];
 
 impl fmt::Display for Feature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Feature::_64b => write!(f, "_64b"),
             Feature::compat => write!(f, "compat"),
+            Feature::sse => write!(f, "sse"),
         }
     }
 }
@@ -88,5 +93,13 @@ impl BitOr for Feature {
     type Output = Features;
     fn bitor(self, rhs: Self) -> Self::Output {
         Features(vec![self, rhs])
+    }
+}
+
+impl BitOr<Feature> for Features {
+    type Output = Features;
+    fn bitor(mut self, rhs: Feature) -> Self::Output {
+        self.0.push(rhs);
+        self
     }
 }

--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -13,6 +13,13 @@ use std::ops::BitOr;
 /// let fs = Feature::_64b | Feature::compat;
 /// assert_eq!(fs.to_string(), "_64b | compat");
 /// ```
+///
+/// Duplicate features are not allowed and will cause a panic.
+///
+/// ```should_panic
+/// # use cranelift_assembler_x64_meta::dsl::Feature;
+/// let fs = Feature::_64b | Feature::_64b;
+/// ```
 #[derive(PartialEq)]
 pub struct Features(Vec<Feature>);
 
@@ -50,7 +57,7 @@ impl fmt::Display for Features {
 ///
 /// Other features listed here should match the __CPUID Feature Flags__ column
 /// of the instruction tables of the x64 reference manual.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Feature {
     _64b,
@@ -92,6 +99,7 @@ impl From<Option<Feature>> for Features {
 impl BitOr for Feature {
     type Output = Features;
     fn bitor(self, rhs: Self) -> Self::Output {
+        assert_ne!(self, rhs, "duplicate feature: {self:?}");
         Features(vec![self, rhs])
     }
 }
@@ -99,6 +107,7 @@ impl BitOr for Feature {
 impl BitOr<Feature> for Features {
     type Output = Features;
     fn bitor(mut self, rhs: Feature) -> Self::Output {
+        assert!(!self.0.contains(&rhs), "duplicate feature: {rhs:?}");
         self.0.push(rhs);
         self
     }

--- a/cranelift/assembler-x64/meta/src/instructions/add.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/add.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
 use crate::dsl::{Feature::*, Inst, Location::*};
 
 pub fn list() -> Vec<Inst> {
@@ -21,9 +21,6 @@ pub fn list() -> Vec<Inst> {
         inst("addw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x3]).r(), _64b | compat),
         inst("addl", fmt("RM", [rw(r32), r(rm32)]), rex(0x3).r(), _64b | compat),
         inst("addq", fmt("RM", [rw(r64), r(rm64)]), rex(0x3).w().r(), _64b),
-        // SSE vector instructions
-        inst("addps", fmt("A", [rw(xmm), r(rm128)]), rex([0x0F, 0x58]).r(), _64b),
-        inst("addpd", fmt("A", [rw(xmm), r(rm128)]), rex([0x66, 0x0F, 0x58]).r(), _64b),
         // Add with carry.
         inst("adcb", fmt("I", [rw(al), r(imm8)]), rex(0x14).ib(), _64b | compat),
         inst("adcw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x15]).iw(), _64b | compat),
@@ -43,5 +40,8 @@ pub fn list() -> Vec<Inst> {
         inst("adcw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x13]).r(), _64b | compat),
         inst("adcl", fmt("RM", [rw(r32), r(rm32)]), rex(0x13).r(), _64b | compat),
         inst("adcq", fmt("RM", [rw(r64), r(rm64)]), rex(0x13).w().r(), _64b),
+        // Vector instructions.
+        inst("addps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x58]).r(), _64b | compat | sse),
+        inst("addpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x58]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/and.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/and.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
 use crate::dsl::{Feature::*, Inst, Location::*};
 
 pub fn list() -> Vec<Inst> {
@@ -28,8 +28,8 @@ pub fn list() -> Vec<Inst> {
         inst("andw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x23]).r(), _64b | compat),
         inst("andl", fmt("RM", [rw(r32), r(rm32)]), rex(0x23).r(), _64b | compat),
         inst("andq", fmt("RM", [rw(r64), r(rm64)]), rex(0x23).w().r(), _64b),
-        // SSE vector instructions
-        inst("andps", fmt("A", [rw(xmm), r(rm128)]), rex([0x0F, 0x54]).r(), _64b),
-        inst("andpd", fmt("A", [rw(xmm), r(rm128)]), rex([0x66, 0x0F, 0x54]).r(), _64b),
+        // Vector instructions.
+        inst("andps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x54]).r(), _64b | compat | sse),
+        inst("andpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x54]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/or.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/or.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
 use crate::dsl::{Feature::*, Inst, Location::*};
 
 pub fn list() -> Vec<Inst> {
@@ -21,8 +21,8 @@ pub fn list() -> Vec<Inst> {
         inst("orw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x0B]).r(), _64b | compat),
         inst("orl", fmt("RM", [rw(r32), r(rm32)]), rex(0x0B).r(), _64b | compat),
         inst("orq", fmt("RM", [rw(r64), r(rm64)]), rex(0x0B).w().r(), _64b),
-        // SSE vector instructions
-        inst("orps", fmt("A", [rw(xmm), r(rm128)]), rex([0x0F, 0x56]).r(), _64b),
-        inst("orpd", fmt("A", [rw(xmm), r(rm128)]), rex([0x66, 0x0F, 0x56]).r(), _64b),
+        // Vector instructions.
+        inst("orps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x56]).r(), _64b | compat | sse),
+        inst("orpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x56]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/sub.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/sub.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
 use crate::dsl::{Feature::*, Inst, Location::*};
 
 pub fn list() -> Vec<Inst> {
@@ -21,9 +21,6 @@ pub fn list() -> Vec<Inst> {
         inst("subw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x2B]).r(), _64b | compat),
         inst("subl", fmt("RM", [rw(r32), r(rm32)]), rex(0x2B).r(), _64b | compat),
         inst("subq", fmt("RM", [rw(r64), r(rm64)]), rex(0x2B).w().r(), _64b),
-        // SSE vector instructions
-        inst("subps", fmt("A", [rw(xmm), r(rm128)]), rex([0x0F, 0x5C]).r(), _64b),
-        inst("subpd", fmt("A", [rw(xmm), r(rm128)]), rex([0x66, 0x0F, 0x5C]).r(), _64b),
         // Subtract with borrow.
         inst("sbbb", fmt("I", [rw(al), r(imm8)]), rex(0x1C).ib(), _64b | compat),
         inst("sbbw", fmt("I", [rw(ax), r(imm16)]), rex([0x66, 0x1D]).iw(), _64b | compat),
@@ -43,5 +40,8 @@ pub fn list() -> Vec<Inst> {
         inst("sbbw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x1B]).r(), _64b | compat),
         inst("sbbl", fmt("RM", [rw(r32), r(rm32)]), rex(0x1B).r(), _64b | compat),
         inst("sbbq", fmt("RM", [rw(r64), r(rm64)]), rex(0x1B).w().r(), _64b),
+        // Vector instructions.
+        inst("subps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x5C]).r(), _64b | compat | sse),
+        inst("subpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x5C]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/xor.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/xor.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
 use crate::dsl::{Feature::*, Inst, Location::*};
 
 pub fn list() -> Vec<Inst> {
@@ -21,8 +21,8 @@ pub fn list() -> Vec<Inst> {
         inst("xorw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x33]).r(), _64b | compat),
         inst("xorl", fmt("RM", [rw(r32), r(rm32)]), rex(0x33).r(), _64b | compat),
         inst("xorq", fmt("RM", [rw(r64), r(rm64)]), rex(0x33).w().r(), _64b),
-        // SSE vector instructions
-        inst("xorps", fmt("A", [rw(xmm), r(rm128)]), rex([0x0F, 0x57]).r(), _64b),
-        inst("xorpd", fmt("A", [rw(xmm), r(rm128)]), rex([0x66, 0x0F, 0x57]).r(), _64b),
+        // Vector instructions.
+        inst("xorps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x57]).r(), _64b | compat | sse),
+        inst("xorpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x57]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -14,10 +14,14 @@ pub fn rust_param_raw(op: &Operand) -> String {
                 format!("u{bits}")
             }
         }
-        OperandKind::RegMem(rm) => match rm.bits() {
-            128 => "&XmmMemAligned".to_string(),
-            _ => "&GprMem".to_string(),
-        },
+        OperandKind::RegMem(rm) => {
+            let reg = match rm.bits() {
+                128 => "Xmm",
+                _ => "Gpr",
+            };
+            let aligned = if op.align { "Aligned" } else { "" };
+            format!("&{reg}Mem{aligned}")
+        }
         OperandKind::Reg(r) => match r.bits() {
             128 => "Xmm".to_string(),
             _ => "Gpr".to_string(),
@@ -203,10 +207,14 @@ pub fn isle_param_raw(op: &Operand) -> String {
             _ => "Gpr".to_string(),
         },
         OperandKind::FixedReg(_) => "Gpr".to_string(),
-        OperandKind::RegMem(rm) => match rm.bits() {
-            128 => "XmmMemAligned".to_string(),
-            _ => "GprMem".to_string(),
-        },
+        OperandKind::RegMem(rm) => {
+            let reg = match rm.bits() {
+                128 => "Xmm",
+                _ => "Gpr",
+            };
+            let aligned = if op.align { "Aligned" } else { "" };
+            format!("{reg}Mem{aligned}")
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -193,10 +193,11 @@ impl Inst {
 
             Inst::External { inst } => {
                 use cranelift_assembler_x64::Feature::*;
-                let features = smallvec![];
+                let mut features = smallvec![];
                 for f in inst.features() {
                     match f {
                         _64b | compat => {}
+                        sse => features.push(InstructionSet::SSE),
                     }
                 }
                 features


### PR DESCRIPTION
This change improves the definitions of the assembler's SSE instructions in two ways:
- vector instructions that require aligned memory accesses (i.e., most everything pre-AVX) are now noted with an `align` attribute in the AST. This is used for generating the expected `XmmMemAligned` types in `cranelift-codegen-meta` the "right way," resolving the temporary fix introduced in #10417.
- previously-added vector instructions did not have the correct feature flags; this change adds the `sse` feature and also tags the applicable instructions with the `compat` feature to allow their use in some future 32-bit target.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
