### PR TITLE
[29.0.0] Update cargo-nextest used on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1033,7 +1033,7 @@ jobs:
     name: Miri
     runs-on: ubuntu-latest
     env:
-      CARGO_NEXTEST_VERSION: 0.9.67
+      CARGO_NEXTEST_VERSION: 0.9.88
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Backport of #10211 to help address https://github.com/bytecodealliance/wasmtime/issues/10448

Closes #10448