### PR TITLE
Pin some more CI build images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -654,7 +654,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2025]
 
     steps:
     - uses: actions/checkout@v4
@@ -813,9 +813,9 @@ jobs:
     strategy:
       matrix:
         feature: ["openvino"]
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-24.04", "windows-2025"]
         include:
-          - os: windows-latest
+          - os: windows-2025
             feature: winml
     name: Test wasi-nn (${{ matrix.feature }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This updates a few more images off the `*-latest` version numbering for jobs doing nontrivial things internally. We're guaranteed to have to update these in the future but my hope is that the required updates are few and far between so it's not too costly. This is inspired by some breakage on the 24.0.0 branch where for the LTS nature of branches it's probably best to avoid `*-latest` for any CI container doing something nontrivial.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
