### PR TITLE
Fix a bug where arrays of GC refs were misreporting their count of GC edges

### DIFF
--- a/crates/cranelift/src/gc/enabled.rs
+++ b/crates/cranelift/src/gc/enabled.rs
@@ -1137,12 +1137,11 @@ fn emit_array_size(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
     array_layout: &GcArrayLayout,
-    init: ArrayInit<'_>,
+    len: ir::Value,
 ) -> ir::Value {
     let base_size = builder
         .ins()
         .iconst(ir::types::I32, i64::from(array_layout.base_size));
-    let len = init.len(&mut builder.cursor());
 
     // `elems_size = len * elem_size`
     //
@@ -1155,6 +1154,7 @@ fn emit_array_size(
     // i64 values, doing a 64-bit multiplication, and then checking the high
     // 32 bits of the multiplication's result. If the high 32 bits are not
     // all zeros, then the multiplication overflowed.
+    debug_assert_eq!(builder.func.dfg.value_type(len), ir::types::I32);
     let len = builder.ins().uextend(ir::types::I64, len);
     let elems_size_64 = builder
         .ins()

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -320,9 +320,10 @@ impl GcCompiler for DrcCompiler {
 
         // First, compute the array's total size from its base size, element
         // size, and length.
-        let size = emit_array_size(func_env, builder, &array_layout, init);
+        let len = init.len(&mut builder.cursor());
+        let size = emit_array_size(func_env, builder, &array_layout, len);
         let num_gc_refs = if array_layout.elems_are_gc_refs {
-            size
+            len
         } else {
             builder.ins().iconst(ir::types::I32, 0)
         };

--- a/crates/cranelift/src/gc/enabled/null.rs
+++ b/crates/cranelift/src/gc/enabled/null.rs
@@ -166,7 +166,8 @@ impl GcCompiler for NullCompiler {
 
         // First, compute the array's total size from its base size, element
         // size, and length.
-        let size = emit_array_size(func_env, builder, &array_layout, init);
+        let len = init.len(&mut builder.cursor());
+        let size = emit_array_size(func_env, builder, &array_layout, len);
 
         // Next, allocate the array.
         assert!(align.is_power_of_two());

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1173,7 +1173,7 @@ fn drc_transitive_drop_nested_arrays_tree() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(miri, skip)]
+#[cfg_attr(miri, ignore)]
 fn drc_traces_the_correct_number_of_gc_refs_in_arrays() -> Result<()> {
     let _ = env_logger::try_init();
 

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -1,0 +1,138 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=drc"
+;;! test = "optimize"
+
+(module
+  (type $ty (array (mut anyref)))
+
+  (func (param anyref anyref anyref) (result (ref $ty))
+    (array.new_fixed $ty 3 (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     ss1 = explicit_slot 4, align = 4
+;;     ss2 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     fn0 = colocated u1:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;;                                     v131 = stack_addr.i64 ss2
+;;                                     store notrap v2, v131
+;;                                     v132 = stack_addr.i64 ss1
+;;                                     store notrap v3, v132
+;;                                     v133 = stack_addr.i64 ss0
+;;                                     store notrap v4, v133
+;;                                     v171 = iconst.i64 0
+;; @0025                               trapnz v171, user18  ; v171 = 0
+;; @0025                               v7 = iconst.i32 28
+;;                                     v172 = iconst.i32 12
+;; @0025                               v12 = uadd_overflow_trap v7, v172, user18  ; v7 = 28, v172 = 12
+;;                                     v173 = iconst.i32 -1476395005
+;; @0025                               v16 = iconst.i32 0
+;; @0025                               v17 = iconst.i32 8
+;; @0025                               v18 = call fn0(v0, v173, v16, v12, v17), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v173 = -1476395005, v16 = 0, v17 = 8
+;; @0025                               v6 = iconst.i32 3
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v19 = ireduce.i32 v18
+;; @0025                               v22 = uextend.i64 v19
+;; @0025                               v23 = iadd v21, v22
+;;                                     v136 = iconst.i64 24
+;; @0025                               v24 = iadd v23, v136  ; v136 = 24
+;; @0025                               store notrap aligned v6, v24  ; v6 = 3
+;;                                     v130 = load.i32 notrap v131
+;;                                     v138 = iconst.i32 1
+;; @0025                               v29 = band v130, v138  ; v138 = 1
+;; @0025                               v30 = icmp eq v130, v16  ; v16 = 0
+;; @0025                               v31 = uextend.i32 v30
+;; @0025                               v32 = bor v29, v31
+;; @0025                               brif v32, block3, block2
+;;
+;;                                 block2:
+;; @0025                               v37 = uextend.i64 v130
+;; @0025                               v96 = iconst.i64 8
+;; @0025                               v39 = uadd_overflow_trap v37, v96, user1  ; v96 = 8
+;; @0025                               v41 = uadd_overflow_trap v39, v96, user1  ; v96 = 8
+;; @0025                               v94 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v42 = icmp ule v41, v94
+;; @0025                               trapz v42, user1
+;; @0025                               v43 = iadd.i64 v21, v39
+;; @0025                               v44 = load.i64 notrap aligned v43
+;;                                     v158 = iconst.i64 1
+;; @0025                               v45 = iadd v44, v158  ; v158 = 1
+;; @0025                               store notrap aligned v45, v43
+;; @0025                               jump block3
+;;
+;;                                 block3:
+;;                                     v126 = load.i32 notrap v131
+;;                                     v181 = iconst.i64 28
+;;                                     v187 = iadd.i64 v23, v181  ; v181 = 28
+;; @0025                               store notrap aligned little v126, v187
+;;                                     v125 = load.i32 notrap v132
+;;                                     v211 = iconst.i32 1
+;;                                     v212 = band v125, v211  ; v211 = 1
+;;                                     v213 = iconst.i32 0
+;;                                     v214 = icmp eq v125, v213  ; v213 = 0
+;; @0025                               v60 = uextend.i32 v214
+;; @0025                               v61 = bor v212, v60
+;; @0025                               brif v61, block5, block4
+;;
+;;                                 block4:
+;; @0025                               v66 = uextend.i64 v125
+;;                                     v215 = iconst.i64 8
+;; @0025                               v68 = uadd_overflow_trap v66, v215, user1  ; v215 = 8
+;; @0025                               v70 = uadd_overflow_trap v68, v215, user1  ; v215 = 8
+;;                                     v216 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v71 = icmp ule v70, v216
+;; @0025                               trapz v71, user1
+;; @0025                               v72 = iadd.i64 v21, v68
+;; @0025                               v73 = load.i64 notrap aligned v72
+;;                                     v217 = iconst.i64 1
+;; @0025                               v74 = iadd v73, v217  ; v217 = 1
+;; @0025                               store notrap aligned v74, v72
+;; @0025                               jump block5
+;;
+;;                                 block5:
+;;                                     v121 = load.i32 notrap v132
+;;                                     v135 = iconst.i64 32
+;;                                     v194 = iadd.i64 v23, v135  ; v135 = 32
+;; @0025                               store notrap aligned little v121, v194
+;;                                     v120 = load.i32 notrap v133
+;;                                     v218 = iconst.i32 1
+;;                                     v219 = band v120, v218  ; v218 = 1
+;;                                     v220 = iconst.i32 0
+;;                                     v221 = icmp eq v120, v220  ; v220 = 0
+;; @0025                               v89 = uextend.i32 v221
+;; @0025                               v90 = bor v219, v89
+;; @0025                               brif v90, block7, block6
+;;
+;;                                 block6:
+;; @0025                               v95 = uextend.i64 v120
+;;                                     v222 = iconst.i64 8
+;; @0025                               v97 = uadd_overflow_trap v95, v222, user1  ; v222 = 8
+;; @0025                               v99 = uadd_overflow_trap v97, v222, user1  ; v222 = 8
+;;                                     v223 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v100 = icmp ule v99, v223
+;; @0025                               trapz v100, user1
+;; @0025                               v101 = iadd.i64 v21, v97
+;; @0025                               v102 = load.i64 notrap aligned v101
+;;                                     v224 = iconst.i64 1
+;; @0025                               v103 = iadd v102, v224  ; v224 = 1
+;; @0025                               store notrap aligned v103, v101
+;; @0025                               jump block7
+;;
+;;                                 block7:
+;;                                     v116 = load.i32 notrap v133
+;;                                     v196 = iconst.i64 36
+;;                                     v202 = iadd.i64 v23, v196  ; v196 = 36
+;; @0025                               store notrap aligned little v116, v202
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;; @0029                               return v19
+;; }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -21,21 +21,21 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;;                                     v45 = iconst.i64 0
 ;; @0025                               trapnz v45, user18  ; v45 = 0
-;; @0025                               v6 = iconst.i32 32
+;; @0025                               v7 = iconst.i32 32
 ;;                                     v46 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v6, v46, user18  ; v6 = 32, v46 = 24
+;; @0025                               v12 = uadd_overflow_trap v7, v46, user18  ; v7 = 32, v46 = 24
 ;; @0025                               v15 = iconst.i32 -1476395008
 ;; @0025                               v13 = iconst.i32 0
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v13, v12, v18)  ; v15 = -1476395008, v13 = 0, v18 = 8
-;; @0025                               v7 = iconst.i32 3
+;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v20 = ireduce.i32 v19
 ;; @0025                               v23 = uextend.i64 v20
 ;; @0025                               v24 = iadd v22, v23
 ;;                                     v37 = iconst.i64 24
 ;; @0025                               v25 = iadd v24, v37  ; v37 = 24
-;; @0025                               store notrap aligned v7, v25  ; v7 = 3
+;; @0025                               store notrap aligned v6, v25  ; v6 = 3
 ;;                                     v34 = iconst.i64 32
 ;;                                     v59 = iadd v24, v34  ; v34 = 32
 ;; @0025                               store notrap aligned little v2, v59

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -3,25 +3,24 @@
 ;;! test = "optimize"
 
 (module
-  (type $ty (array (mut i64)))
+  (type $ty (array (mut anyref)))
 
-  (func (param i64 i64 i64) (result (ref $ty))
+  (func (param anyref anyref anyref) (result (ref $ty))
     (array.new_fixed $ty 3 (local.get 0) (local.get 1) (local.get 2))
   )
 )
-;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     stack_limit = gv2
 ;;
-;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v58 = iconst.i64 0
-;; @0025                               trapnz v58, user18  ; v58 = 0
-;; @0025                               v7 = iconst.i32 16
-;;                                     v59 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v7, v59, user18  ; v7 = 16, v59 = 24
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;;                                     v59 = iconst.i64 0
+;; @0025                               trapnz v59, user18  ; v59 = 0
+;; @0025                               v7 = iconst.i32 12
+;; @0025                               v12 = uadd_overflow_trap v7, v7, user18  ; v7 = 12, v7 = 12
 ;; @0025                               v14 = iconst.i32 -134217728
 ;; @0025                               v15 = band v12, v14  ; v14 = -134217728
 ;; @0025                               trapnz v15, user18
@@ -47,21 +46,21 @@
 ;; @0025                               store notrap aligned v37, v32+4
 ;; @0025                               store notrap aligned v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v46 = iconst.i64 8
-;; @0025                               v38 = iadd v32, v46  ; v46 = 8
+;;                                     v48 = iconst.i64 8
+;; @0025                               v38 = iadd v32, v48  ; v48 = 8
 ;; @0025                               store notrap aligned v6, v38  ; v6 = 3
-;;                                     v71 = iconst.i64 16
-;;                                     v77 = iadd v32, v71  ; v71 = 16
-;; @0025                               store notrap aligned little v2, v77
-;;                                     v50 = iconst.i64 24
-;;                                     v84 = iadd v32, v50  ; v50 = 24
+;;                                     v50 = iconst.i64 12
+;;                                     v76 = iadd v32, v50  ; v50 = 12
+;; @0025                               store notrap aligned little v2, v76
+;;                                     v78 = iconst.i64 16
+;;                                     v84 = iadd v32, v78  ; v78 = 16
 ;; @0025                               store notrap aligned little v3, v84
-;;                                     v47 = iconst.i64 32
-;;                                     v91 = iadd v32, v47  ; v47 = 32
-;; @0025                               store notrap aligned little v4, v91
+;;                                     v86 = iconst.i64 20
+;;                                     v92 = iadd v32, v86  ; v86 = 20
+;; @0025                               store notrap aligned little v4, v92
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v100 = band.i32 v21, v67  ; v67 = -8
-;; @0029                               return v100
+;;                                     v101 = band.i32 v21, v67  ; v67 = -8
+;; @0029                               return v101
 ;; }


### PR DESCRIPTION
They were accidentally reporting the size of their GC reference elements, rather than the count.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
