### PR TITLE
Fix needs-stack-map propagation for variables' SSA block params

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -129,6 +129,7 @@ impl DrcHeap {
 
     /// Create a new DRC heap with the given capacity.
     fn with_capacity(capacity: usize) -> Result<Self> {
+        log::trace!("allocating new DRC heap with capacity {capacity:#x}");
         let heap = Mmap::with_at_least(capacity)?;
         let free_list = FreeList::new(heap.len());
         Ok(Self {
@@ -646,7 +647,7 @@ unsafe impl GcHeap for DrcHeap {
             ref_count: UnsafeCell::new(1),
             object_size: size,
         };
-        log::trace!("increment {gc_ref:#p} ref count -> 1");
+        log::trace!("new object: increment {gc_ref:#p} ref count -> 1");
         Ok(Some(gc_ref))
     }
 

--- a/tests/misc_testsuite/gc/issue-10397.wast
+++ b/tests/misc_testsuite/gc/issue-10397.wast
@@ -1,0 +1,39 @@
+;;! gc = true
+
+(module
+  (type $func (func))
+  (type $array (array (mut i32)))
+  (type $struct (sub (struct (field $field (ref $func)))))
+
+  (elem func $nop)
+  (func $nop)
+
+  (func (export "")
+    (local $local_array (ref $array))
+    (local $local_struct (ref $struct))
+    (local $i i32)
+
+    (local.set $local_struct (struct.new $struct (ref.func $nop)))
+
+    (loop $outer
+      (local.set $local_array (array.new $array (i32.const 0) (i32.const 1)))
+
+      (loop $inner
+        (array.set $array (ref.cast (ref $array) (local.get $local_array))
+                          (i32.const 0)
+                          (i32.const 1))
+        (br_if $inner (i32.const 0))
+      )
+
+      (call_ref $func (struct.get $struct $field (local.get $local_struct)))
+
+      (if (i32.gt_u (local.get $i) (i32.shl (i32.const 1) (i32.const 14)))
+        (then (return)))
+
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br $outer)
+    )
+  )
+)
+
+(assert_return (invoke ""))


### PR DESCRIPTION
We were previously propagating the needs-inclusion-in-stack-maps bit from a variable to the values resulting from `builder.use_var(my_var)` and passed to `builder.def_var(my_var, my_val)`. However, that does not cover every `ir::Value` generated for a given `ir::Variable`: it is missing block parameters that the SSA builder inserted and which are *not* then used directly as the result of `use_var`, but instead passed as arguments another block, and that block's parameter is then directly or indirectly used as the result of `builder.use_var(...)`. This chaining can go arbitrarily deep, based on the program's control flow. By not marking these block parameters as needing inclusion in stack maps, our stack maps would be incomplete, which meant that the GC could too-eagerly collect objects, which meant that we would then get use-after-free GC heap corruption bugs (still limited to within the GC heap because of our sandboxing approach) that would ultimately become (safe) panics when runtime code operated on corrupted objects.

The solution is for the `SSABuilder` to report all the block parameters that it inserted, and for which `ir::Variable` it inserted them. We already have a summary of the mutations that an `SSABuilder` performed, `SideEffects`, and which must be handled by the `FunctionBuilder` after, e.g., sealing a block, so we add this block-param-and-var information to it. Now, after the `FunctionBuilder` has the `SSABuilder` do its thing, it handles fixing up not only the modified blocks' status, which it was doing before, but also propagates the needs-inclusion-in-stack-maps metadata from variables to all those freshly-inserted block parameter values.

After this change, we successfully include *all* of a needs-inclusion-in-stack-maps variable's values in stack maps, which avoids the over-eager object reclamation and associated GC heap corruption.

Fixes #10397
Fixes #10398
Fixes #10399

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
