### PR TITLE
x64: Add a special case for i128-addition

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -112,6 +112,23 @@
           (iadd128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1)
                    y (RegMemImm.Imm 0))))
 
+;; Specialized lowering rule for `iadd` of two 64-bit unsigned integers, meaning
+;; that we can skip the `adc` and instead use `setb`. This is in some sense a
+;; way of modeling `uadd_overflow`.
+(rule 4 (lower (has_type $I128 (iadd (uextend x) (uextend y @ (value_type $I64)))))
+        (let (
+            (x Gpr (extend_to_gpr x $I64 (ExtendKind.Zero)))
+            (ret ValueRegs (with_flags (x64_add_with_flags_paired $I64 x y)
+                                       (x64_setcc_paired (CC.B))))
+          )
+          ;; FIXME: this `movzx` ideally would happen before the `add` itself to
+          ;; zero out the destination register with `xor %dst,%dst` and then
+          ;; the `setb` would just write to the lower bytes. That would probably
+          ;; require modeling this as a pseudo-inst which isn't quite worth it
+          ;; at this time.
+          (value_regs (value_regs_get ret 0)
+                      (x64_movzx (ExtMode.BQ) (value_regs_get ret 1)))))
+
 ;; Helper for lowering 128-bit addition with the 64-bit halves of the lhs/rhs
 ;; already split. The first two arguments are lo/hi for the lhs and the second
 ;; two are lo/hi for the rhs.

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1112,20 +1112,19 @@ block2(v8: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   xorq    %rax, %rax, %rax
-;   xorq    %r8, %r8, %r8
 ;   testb   %dl, %dl
 ;   jnz     label2; j label1
 ; block1:
 ;   addq    %rax, $2, %rax
-;   movq    %r8, %rdx
-;   adcq    %rdx, $0, %rdx
+;   setb    %dil
+;   movzbq  %dil, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movq    %r8, %rdx
 ;   addq    %rax, $1, %rax
-;   adcq    %rdx, $0, %rdx
+;   setb    %cl
+;   movzbq  %cl, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1136,20 +1135,19 @@ block2(v8: i128):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   xorq %rax, %rax
-;   xorq %r8, %r8
 ;   testb %dl, %dl
-;   jne 0x22
-; block2: ; offset 0x12
+;   jne 0x20
+; block2: ; offset 0xf
 ;   addq $2, %rax
-;   movq %r8, %rdx
-;   adcq $0, %rdx
+;   setb %dil
+;   movzbq %dil, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x22
-;   movq %r8, %rdx
+; block3: ; offset 0x20
 ;   addq $1, %rax
-;   adcq $0, %rdx
+;   setb %cl
+;   movzbq %cl, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2047,10 +2045,10 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rsi, %rax
 ;   addq    %rax, 0(%rdi), %rax
-;   adcq    %rdx, $0, %rdx
+;   setb    %r8b
+;   movzbq  %r8b, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -2060,10 +2058,10 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   xorq %rdx, %rdx
 ;   movq %rsi, %rax
 ;   addq (%rdi), %rax ; trap: heap_oob
-;   adcq $0, %rdx
+;   setb %r8b
+;   movzbq %r8b, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2180,4 +2178,38 @@ block0(v0: i128, v1: i128):
 ;   addb %ah, (%rax, %rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
+
+function %uadd_overflow_as_i128(i64, i64) -> i64, i64 {
+block0(v0: i64, v1: i64):
+    v2 = uextend.i128 v0
+    v3 = uextend.i128 v1
+    v4 = iadd v2, v3
+    v5, v6 = isplit v4
+    return v5, v6
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   addq    %rax, %rsi, %rax
+;   setb    %r8b
+;   movzbq  %r8b, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   addq %rsi, %rax
+;   setb %r8b
+;   movzbq %r8b, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/tests/misc_testsuite/wide-arithmetic.wast
+++ b/tests/misc_testsuite/wide-arithmetic.wast
@@ -323,3 +323,21 @@
                (i64.const -1) (i64.const 0))
 (assert_return (invoke "i64.mul_wide_u" (i64.const 1) (i64.const 0))
                (i64.const 0) (i64.const 0))
+
+(module
+  (func (export "u64::overflowing_add") (param i64 i64) (result i64 i64)
+    local.get 0
+    i64.const 0
+    local.get 1
+    i64.const 0
+    i64.add128)
+)
+
+(assert_return (invoke "u64::overflowing_add" (i64.const 0) (i64.const 0))
+               (i64.const 0) (i64.const 0))
+(assert_return (invoke "u64::overflowing_add" (i64.const 0) (i64.const 1))
+               (i64.const 1) (i64.const 0))
+(assert_return (invoke "u64::overflowing_add" (i64.const 1) (i64.const -1))
+               (i64.const 0) (i64.const 1))
+(assert_return (invoke "u64::overflowing_add" (i64.const -2) (i64.const -1))
+               (i64.const -3) (i64.const 1))


### PR DESCRIPTION
If the two halves are both zero-extended 64-bit numbers then an `adc` instruction can be skipped in favor of a `setb` which is predicted to be a bit easier on the CPU. Still not necessarily the best codegen but hopefully a tiny bit better than before.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
