### PR TITLE
Avoid some unnecessary reduces and extends around GC libcalls

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2051,8 +2051,7 @@ impl FuncEnvironment<'_> {
             libcall,
             &[vmctx, interned_type_index, data_index, data_offset, len],
         );
-        let result = builder.func.dfg.first_result(call_inst);
-        Ok(builder.ins().ireduce(ir::types::I32, result))
+        Ok(builder.func.dfg.first_result(call_inst))
     }
 
     pub fn translate_array_new_elem(
@@ -2074,8 +2073,7 @@ impl FuncEnvironment<'_> {
             libcall,
             &[vmctx, interned_type_index, elem_index, elem_offset, len],
         );
-        let result = builder.func.dfg.first_result(call_inst);
-        Ok(builder.ins().ireduce(ir::types::I32, result))
+        Ok(builder.func.dfg.first_result(call_inst))
     }
 
     pub fn translate_array_copy(

--- a/crates/cranelift/src/gc/enabled/drc.rs
+++ b/crates/cranelift/src/gc/enabled/drc.rs
@@ -291,7 +291,6 @@ fn emit_gc_raw_alloc(
     );
 
     let gc_ref = builder.func.dfg.first_result(call_inst);
-    let gc_ref = builder.ins().ireduce(ir::types::I32, gc_ref);
     builder.declare_value_needs_stack_map(gc_ref);
     gc_ref
 }

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -89,7 +89,7 @@ macro_rules! foreach_builtin_function {
                 module_interned_type_index: u32,
                 size: u32,
                 align: u32
-            ) -> u64;
+            ) -> u32;
 
             // Intern a `funcref` into the GC heap, returning its
             // `FuncRefTableId`.
@@ -133,7 +133,7 @@ macro_rules! foreach_builtin_function {
                 data_index: u32,
                 data_offset: u32,
                 len: u32
-            ) -> u64;
+            ) -> u32;
 
             // Builtin implementation of the `array.new_elem` instruction.
             #[cfg(feature = "gc")]
@@ -143,7 +143,7 @@ macro_rules! foreach_builtin_function {
                 elem_index: u32,
                 elem_offset: u32,
                 len: u32
-            ) -> u64;
+            ) -> u32;
 
             // Builtin implementation of the `array.copy` instruction.
             #[cfg(feature = "gc")]
@@ -354,12 +354,15 @@ impl BuiltinFunctionIndex {
             (@get memory_atomic_wait32 u64) => (TrapSentinel::Negative);
             (@get memory_atomic_wait64 u64) => (TrapSentinel::Negative);
 
-            // GC-related functions return a 64-bit value which is negative to
-            // indicate a trap.
+            // GC returns an optional GC ref, encoded as a `u64` with a negative
+            // value indicating a trap.
             (@get gc u64) => (TrapSentinel::Negative);
-            (@get gc_alloc_raw u64) => (TrapSentinel::Negative);
-            (@get array_new_data u64) => (TrapSentinel::Negative);
-            (@get array_new_elem u64) => (TrapSentinel::Negative);
+
+            // GC allocation functions return a u32 which is zero to indicate a
+            // trap.
+            (@get gc_alloc_raw u32) => (TrapSentinel::Falsy);
+            (@get array_new_data u32) => (TrapSentinel::Falsy);
+            (@get array_new_elem u32) => (TrapSentinel::Falsy);
 
             // The final epoch represents a trap
             (@get new_epoch u64) => (TrapSentinel::NegativeOne);

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -332,7 +332,7 @@ impl AnyRef {
     pub(crate) unsafe fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
         let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
-        Ok(raw)
+        Ok(raw.get())
     }
 
     /// Get the type of this reference.

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -504,7 +504,7 @@ impl ExternRef {
     pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
         let raw = store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref);
-        Ok(raw)
+        Ok(raw.get())
     }
 }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -969,7 +969,7 @@ impl<T: GcRef> Rooted<T> {
     ) -> Result<()> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
         let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
-        ptr.write(val_raw(raw));
+        ptr.write(val_raw(raw.get()));
         Ok(())
     }
 
@@ -1757,7 +1757,7 @@ where
     ) -> Result<()> {
         let gc_ref = self.try_clone_gc_ref(store)?;
         let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
-        ptr.write(val_raw(raw));
+        ptr.write(val_raw(raw.get()));
         Ok(())
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -22,9 +22,9 @@ pub use i31::*;
 
 use crate::prelude::*;
 use crate::runtime::vm::GcHeapAllocationIndex;
-use core::alloc::Layout;
 use core::any::Any;
 use core::mem::MaybeUninit;
+use core::{alloc::Layout, num::NonZeroU32};
 use wasmtime_environ::{GcArrayLayout, GcStructLayout, VMGcKind, VMSharedTypeIndex};
 
 /// GC-related data that is one-to-one with a `wasmtime::Store`.
@@ -138,9 +138,8 @@ impl GcStore {
     /// Returns the raw representation of this GC ref, ready to be passed to
     /// Wasm.
     #[must_use]
-    pub fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) -> u32 {
-        let raw = gc_ref.as_raw_u32();
-        debug_assert_ne!(raw, 0);
+    pub fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) -> NonZeroU32 {
+        let raw = gc_ref.as_raw_non_zero_u32();
         if !gc_ref.is_i31() {
             log::trace!("exposing GC ref to Wasm: {gc_ref:p}");
             self.gc_heap.expose_gc_ref_to_wasm(gc_ref);

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -243,6 +243,12 @@ impl VMGcRef {
         }
     }
 
+    /// Get this GC reference as a raw, non-zero u32 value, regardless whether
+    /// it is actually a reference to a GC object or is an `i31ref`.
+    pub fn as_raw_non_zero_u32(&self) -> NonZeroU32 {
+        self.0
+    }
+
     /// Get this GC reference as a raw u32 value, regardless whether it is
     /// actually a reference to a GC object or is an `i31ref`.
     pub fn as_raw_u32(&self) -> u32 {

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -470,7 +470,7 @@ unsafe fn gc(store: &mut dyn VMStore, _instance: &mut Instance, gc_ref: u32) -> 
                 .store_opaque_mut()
                 .unwrap_gc_store_mut()
                 .expose_gc_ref_to_wasm(r);
-            Ok(raw)
+            Ok(raw.get())
         }
     }
 }
@@ -486,7 +486,7 @@ unsafe fn gc_alloc_raw(
     module_interned_type_index: u32,
     size: u32,
     align: u32,
-) -> Result<u32> {
+) -> Result<core::num::NonZeroU32> {
     use crate::{vm::VMGcHeader, GcHeapOutOfMemory};
     use core::alloc::Layout;
     use wasmtime_environ::{ModuleInternedTypeIndex, VMGcKind};
@@ -604,7 +604,7 @@ unsafe fn array_new_data(
     data_index: u32,
     src: u32,
     len: u32,
-) -> Result<u32> {
+) -> Result<core::num::NonZeroU32> {
     use crate::{ArrayType, GcHeapOutOfMemory};
     use wasmtime_environ::ModuleInternedTypeIndex;
 
@@ -764,7 +764,7 @@ unsafe fn array_new_elem(
     elem_index: u32,
     src: u32,
     len: u32,
-) -> Result<u32> {
+) -> Result<core::num::NonZeroU32> {
     use crate::{
         store::AutoAssertNoGc,
         vm::const_expr::{ConstEvalContext, ConstExprEvaluator},

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -22,6 +22,7 @@ use crate::runtime::vm::sys::traphandlers;
 use crate::runtime::vm::{Instance, InterpreterRef, VMContext, VMStoreContext};
 use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
+use core::num::NonZeroU32;
 use core::ops::Range;
 use core::ptr::{self, NonNull};
 
@@ -266,6 +267,14 @@ unsafe impl HostResultHasUnwindSentinel for () {
     const SENTINEL: bool = false;
     fn into_abi(self) -> bool {
         true
+    }
+}
+
+unsafe impl HostResultHasUnwindSentinel for NonZeroU32 {
+    type Abi = u32;
+    const SENTINEL: Self::Abi = 0;
+    fn into_abi(self) -> Self::Abi {
+        self.get()
     }
 }
 

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -17,122 +17,121 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v131 = stack_addr.i64 ss2
-;;                                     store notrap v2, v131
-;;                                     v132 = stack_addr.i64 ss1
-;;                                     store notrap v3, v132
-;;                                     v133 = stack_addr.i64 ss0
-;;                                     store notrap v4, v133
-;;                                     v171 = iconst.i64 0
-;; @0025                               trapnz v171, user18  ; v171 = 0
+;;                                     v130 = stack_addr.i64 ss2
+;;                                     store notrap v2, v130
+;;                                     v131 = stack_addr.i64 ss1
+;;                                     store notrap v3, v131
+;;                                     v132 = stack_addr.i64 ss0
+;;                                     store notrap v4, v132
+;;                                     v170 = iconst.i64 0
+;; @0025                               trapnz v170, user18  ; v170 = 0
 ;; @0025                               v7 = iconst.i32 28
-;;                                     v172 = iconst.i32 12
-;; @0025                               v12 = uadd_overflow_trap v7, v172, user18  ; v7 = 28, v172 = 12
-;;                                     v173 = iconst.i32 -1476395005
+;;                                     v171 = iconst.i32 12
+;; @0025                               v12 = uadd_overflow_trap v7, v171, user18  ; v7 = 28, v171 = 12
+;;                                     v172 = iconst.i32 -1476395005
 ;; @0025                               v16 = iconst.i32 0
 ;; @0025                               v17 = iconst.i32 8
-;; @0025                               v18 = call fn0(v0, v173, v16, v12, v17), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v173 = -1476395005, v16 = 0, v17 = 8
+;; @0025                               v18 = call fn0(v0, v172, v16, v12, v17), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v172 = -1476395005, v16 = 0, v17 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v19 = ireduce.i32 v18
-;; @0025                               v22 = uextend.i64 v19
-;; @0025                               v23 = iadd v21, v22
-;;                                     v136 = iconst.i64 24
-;; @0025                               v24 = iadd v23, v136  ; v136 = 24
-;; @0025                               store notrap aligned v6, v24  ; v6 = 3
-;;                                     v130 = load.i32 notrap v131
-;;                                     v138 = iconst.i32 1
-;; @0025                               v29 = band v130, v138  ; v138 = 1
-;; @0025                               v30 = icmp eq v130, v16  ; v16 = 0
-;; @0025                               v31 = uextend.i32 v30
-;; @0025                               v32 = bor v29, v31
-;; @0025                               brif v32, block3, block2
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v21 = uextend.i64 v18
+;; @0025                               v22 = iadd v20, v21
+;;                                     v135 = iconst.i64 24
+;; @0025                               v23 = iadd v22, v135  ; v135 = 24
+;; @0025                               store notrap aligned v6, v23  ; v6 = 3
+;;                                     v129 = load.i32 notrap v130
+;;                                     v137 = iconst.i32 1
+;; @0025                               v28 = band v129, v137  ; v137 = 1
+;; @0025                               v29 = icmp eq v129, v16  ; v16 = 0
+;; @0025                               v30 = uextend.i32 v29
+;; @0025                               v31 = bor v28, v30
+;; @0025                               brif v31, block3, block2
 ;;
 ;;                                 block2:
-;; @0025                               v37 = uextend.i64 v130
-;; @0025                               v96 = iconst.i64 8
-;; @0025                               v39 = uadd_overflow_trap v37, v96, user1  ; v96 = 8
-;; @0025                               v41 = uadd_overflow_trap v39, v96, user1  ; v96 = 8
-;; @0025                               v94 = load.i64 notrap aligned readonly can_move v0+48
-;; @0025                               v42 = icmp ule v41, v94
-;; @0025                               trapz v42, user1
-;; @0025                               v43 = iadd.i64 v21, v39
-;; @0025                               v44 = load.i64 notrap aligned v43
-;;                                     v158 = iconst.i64 1
-;; @0025                               v45 = iadd v44, v158  ; v158 = 1
-;; @0025                               store notrap aligned v45, v43
+;; @0025                               v36 = uextend.i64 v129
+;; @0025                               v95 = iconst.i64 8
+;; @0025                               v38 = uadd_overflow_trap v36, v95, user1  ; v95 = 8
+;; @0025                               v40 = uadd_overflow_trap v38, v95, user1  ; v95 = 8
+;; @0025                               v93 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v41 = icmp ule v40, v93
+;; @0025                               trapz v41, user1
+;; @0025                               v42 = iadd.i64 v20, v38
+;; @0025                               v43 = load.i64 notrap aligned v42
+;;                                     v157 = iconst.i64 1
+;; @0025                               v44 = iadd v43, v157  ; v157 = 1
+;; @0025                               store notrap aligned v44, v42
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v126 = load.i32 notrap v131
-;;                                     v181 = iconst.i64 28
-;;                                     v187 = iadd.i64 v23, v181  ; v181 = 28
-;; @0025                               store notrap aligned little v126, v187
-;;                                     v125 = load.i32 notrap v132
-;;                                     v211 = iconst.i32 1
-;;                                     v212 = band v125, v211  ; v211 = 1
-;;                                     v213 = iconst.i32 0
-;;                                     v214 = icmp eq v125, v213  ; v213 = 0
-;; @0025                               v60 = uextend.i32 v214
-;; @0025                               v61 = bor v212, v60
-;; @0025                               brif v61, block5, block4
+;;                                     v125 = load.i32 notrap v130
+;;                                     v180 = iconst.i64 28
+;;                                     v186 = iadd.i64 v22, v180  ; v180 = 28
+;; @0025                               store notrap aligned little v125, v186
+;;                                     v124 = load.i32 notrap v131
+;;                                     v210 = iconst.i32 1
+;;                                     v211 = band v124, v210  ; v210 = 1
+;;                                     v212 = iconst.i32 0
+;;                                     v213 = icmp eq v124, v212  ; v212 = 0
+;; @0025                               v59 = uextend.i32 v213
+;; @0025                               v60 = bor v211, v59
+;; @0025                               brif v60, block5, block4
 ;;
 ;;                                 block4:
-;; @0025                               v66 = uextend.i64 v125
-;;                                     v215 = iconst.i64 8
-;; @0025                               v68 = uadd_overflow_trap v66, v215, user1  ; v215 = 8
-;; @0025                               v70 = uadd_overflow_trap v68, v215, user1  ; v215 = 8
-;;                                     v216 = load.i64 notrap aligned readonly can_move v0+48
-;; @0025                               v71 = icmp ule v70, v216
-;; @0025                               trapz v71, user1
-;; @0025                               v72 = iadd.i64 v21, v68
-;; @0025                               v73 = load.i64 notrap aligned v72
-;;                                     v217 = iconst.i64 1
-;; @0025                               v74 = iadd v73, v217  ; v217 = 1
-;; @0025                               store notrap aligned v74, v72
+;; @0025                               v65 = uextend.i64 v124
+;;                                     v214 = iconst.i64 8
+;; @0025                               v67 = uadd_overflow_trap v65, v214, user1  ; v214 = 8
+;; @0025                               v69 = uadd_overflow_trap v67, v214, user1  ; v214 = 8
+;;                                     v215 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v70 = icmp ule v69, v215
+;; @0025                               trapz v70, user1
+;; @0025                               v71 = iadd.i64 v20, v67
+;; @0025                               v72 = load.i64 notrap aligned v71
+;;                                     v216 = iconst.i64 1
+;; @0025                               v73 = iadd v72, v216  ; v216 = 1
+;; @0025                               store notrap aligned v73, v71
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v121 = load.i32 notrap v132
-;;                                     v135 = iconst.i64 32
-;;                                     v194 = iadd.i64 v23, v135  ; v135 = 32
-;; @0025                               store notrap aligned little v121, v194
-;;                                     v120 = load.i32 notrap v133
-;;                                     v218 = iconst.i32 1
-;;                                     v219 = band v120, v218  ; v218 = 1
-;;                                     v220 = iconst.i32 0
-;;                                     v221 = icmp eq v120, v220  ; v220 = 0
-;; @0025                               v89 = uextend.i32 v221
-;; @0025                               v90 = bor v219, v89
-;; @0025                               brif v90, block7, block6
+;;                                     v120 = load.i32 notrap v131
+;;                                     v134 = iconst.i64 32
+;;                                     v193 = iadd.i64 v22, v134  ; v134 = 32
+;; @0025                               store notrap aligned little v120, v193
+;;                                     v119 = load.i32 notrap v132
+;;                                     v217 = iconst.i32 1
+;;                                     v218 = band v119, v217  ; v217 = 1
+;;                                     v219 = iconst.i32 0
+;;                                     v220 = icmp eq v119, v219  ; v219 = 0
+;; @0025                               v88 = uextend.i32 v220
+;; @0025                               v89 = bor v218, v88
+;; @0025                               brif v89, block7, block6
 ;;
 ;;                                 block6:
-;; @0025                               v95 = uextend.i64 v120
-;;                                     v222 = iconst.i64 8
-;; @0025                               v97 = uadd_overflow_trap v95, v222, user1  ; v222 = 8
-;; @0025                               v99 = uadd_overflow_trap v97, v222, user1  ; v222 = 8
-;;                                     v223 = load.i64 notrap aligned readonly can_move v0+48
-;; @0025                               v100 = icmp ule v99, v223
-;; @0025                               trapz v100, user1
-;; @0025                               v101 = iadd.i64 v21, v97
-;; @0025                               v102 = load.i64 notrap aligned v101
-;;                                     v224 = iconst.i64 1
-;; @0025                               v103 = iadd v102, v224  ; v224 = 1
-;; @0025                               store notrap aligned v103, v101
+;; @0025                               v94 = uextend.i64 v119
+;;                                     v221 = iconst.i64 8
+;; @0025                               v96 = uadd_overflow_trap v94, v221, user1  ; v221 = 8
+;; @0025                               v98 = uadd_overflow_trap v96, v221, user1  ; v221 = 8
+;;                                     v222 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v99 = icmp ule v98, v222
+;; @0025                               trapz v99, user1
+;; @0025                               v100 = iadd.i64 v20, v96
+;; @0025                               v101 = load.i64 notrap aligned v100
+;;                                     v223 = iconst.i64 1
+;; @0025                               v102 = iadd v101, v223  ; v223 = 1
+;; @0025                               store notrap aligned v102, v100
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v116 = load.i32 notrap v133
-;;                                     v196 = iconst.i64 36
-;;                                     v202 = iadd.i64 v23, v196  ; v196 = 36
-;; @0025                               store notrap aligned little v116, v202
+;;                                     v115 = load.i32 notrap v132
+;;                                     v195 = iconst.i64 36
+;;                                     v201 = iadd.i64 v22, v195  ; v195 = 36
+;; @0025                               store notrap aligned little v115, v201
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v19
+;; @0029                               return v18
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -14,39 +14,38 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v45 = iconst.i64 0
-;; @0025                               trapnz v45, user18  ; v45 = 0
+;;                                     v44 = iconst.i64 0
+;; @0025                               trapnz v44, user18  ; v44 = 0
 ;; @0025                               v7 = iconst.i32 32
-;;                                     v46 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v7, v46, user18  ; v7 = 32, v46 = 24
+;;                                     v45 = iconst.i32 24
+;; @0025                               v12 = uadd_overflow_trap v7, v45, user18  ; v7 = 32, v45 = 24
 ;; @0025                               v15 = iconst.i32 -1476395008
 ;; @0025                               v13 = iconst.i32 0
 ;; @0025                               v18 = iconst.i32 8
 ;; @0025                               v19 = call fn0(v0, v15, v13, v12, v18)  ; v15 = -1476395008, v13 = 0, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v20 = ireduce.i32 v19
-;; @0025                               v23 = uextend.i64 v20
-;; @0025                               v24 = iadd v22, v23
-;;                                     v37 = iconst.i64 24
-;; @0025                               v25 = iadd v24, v37  ; v37 = 24
-;; @0025                               store notrap aligned v6, v25  ; v6 = 3
-;;                                     v34 = iconst.i64 32
-;;                                     v59 = iadd v24, v34  ; v34 = 32
-;; @0025                               store notrap aligned little v2, v59
-;;                                     v61 = iconst.i64 40
-;;                                     v67 = iadd v24, v61  ; v61 = 40
-;; @0025                               store notrap aligned little v3, v67
-;;                                     v69 = iconst.i64 48
-;;                                     v75 = iadd v24, v69  ; v69 = 48
-;; @0025                               store notrap aligned little v4, v75
+;; @0025                               v21 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v22 = uextend.i64 v19
+;; @0025                               v23 = iadd v21, v22
+;;                                     v36 = iconst.i64 24
+;; @0025                               v24 = iadd v23, v36  ; v36 = 24
+;; @0025                               store notrap aligned v6, v24  ; v6 = 3
+;;                                     v33 = iconst.i64 32
+;;                                     v58 = iadd v23, v33  ; v33 = 32
+;; @0025                               store notrap aligned little v2, v58
+;;                                     v60 = iconst.i64 40
+;;                                     v66 = iadd v23, v60  ; v60 = 40
+;; @0025                               store notrap aligned little v3, v66
+;;                                     v68 = iconst.i64 48
+;;                                     v74 = iadd v23, v68  ; v68 = 48
+;; @0025                               store notrap aligned little v4, v74
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v20
+;; @0029                               return v19
 ;; }

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -14,51 +14,50 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v37 = iconst.i64 3
-;;                                     v38 = ishl v6, v37  ; v37 = 3
-;;                                     v35 = iconst.i64 32
-;; @0022                               v8 = ushr v38, v35  ; v35 = 32
+;;                                     v36 = iconst.i64 3
+;;                                     v37 = ishl v6, v36  ; v36 = 3
+;;                                     v34 = iconst.i64 32
+;; @0022                               v8 = ushr v37, v34  ; v34 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 32
-;;                                     v44 = iconst.i32 3
-;;                                     v45 = ishl v3, v44  ; v44 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v45, user18  ; v5 = 32
+;;                                     v43 = iconst.i32 3
+;;                                     v44 = ishl v3, v43  ; v43 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v44, user18  ; v5 = 32
 ;; @0022                               v13 = iconst.i32 -1476395008
 ;; @0022                               v11 = iconst.i32 0
-;;                                     v42 = iconst.i32 8
-;; @0022                               v17 = call fn0(v0, v13, v11, v10, v42)  ; v13 = -1476395008, v11 = 0, v42 = 8
-;; @0022                               v20 = load.i64 notrap aligned readonly can_move v0+40
-;; @0022                               v18 = ireduce.i32 v17
-;; @0022                               v21 = uextend.i64 v18
-;; @0022                               v22 = iadd v20, v21
-;;                                     v36 = iconst.i64 24
-;; @0022                               v23 = iadd v22, v36  ; v36 = 24
-;; @0022                               store notrap aligned v3, v23
-;;                                     v60 = iadd v22, v35  ; v35 = 32
-;; @0022                               v29 = uextend.i64 v10
-;; @0022                               v30 = iadd v22, v29
-;;                                     v34 = iconst.i64 8
-;; @0022                               jump block2(v60)
+;;                                     v41 = iconst.i32 8
+;; @0022                               v17 = call fn0(v0, v13, v11, v10, v41)  ; v13 = -1476395008, v11 = 0, v41 = 8
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v20 = uextend.i64 v17
+;; @0022                               v21 = iadd v19, v20
+;;                                     v35 = iconst.i64 24
+;; @0022                               v22 = iadd v21, v35  ; v35 = 24
+;; @0022                               store notrap aligned v3, v22
+;;                                     v59 = iadd v21, v34  ; v34 = 32
+;; @0022                               v28 = uextend.i64 v10
+;; @0022                               v29 = iadd v21, v28
+;;                                     v33 = iconst.i64 8
+;; @0022                               jump block2(v59)
 ;;
-;;                                 block2(v31: i64):
-;; @0022                               v32 = icmp eq v31, v30
-;; @0022                               brif v32, block4, block3
+;;                                 block2(v30: i64):
+;; @0022                               v31 = icmp eq v30, v29
+;; @0022                               brif v31, block4, block3
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 notrap aligned little v2, v31
-;;                                     v72 = iconst.i64 8
-;;                                     v73 = iadd.i64 v31, v72  ; v72 = 8
-;; @0022                               jump block2(v73)
+;; @0022                               store.i64 notrap aligned little v2, v30
+;;                                     v71 = iconst.i64 8
+;;                                     v72 = iadd.i64 v30, v71  ; v71 = 8
+;; @0022                               jump block2(v72)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @0025                               return v18
+;; @0025                               return v17
 ;; }

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -15,7 +15,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     fn1 = colocated u1:28 sig1
@@ -27,20 +27,19 @@
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v10 = iconst.i32 8
 ;; @0020                               v11 = call fn0(v0, v7, v5, v4, v10)  ; v7 = -1342177280, v5 = 0, v4 = 32, v10 = 8
-;; @0020                               v12 = ireduce.i32 v11
-;;                                     v23 = stack_addr.i64 ss0
-;;                                     store notrap v12, v23
-;; @0020                               v19 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
-;; @0020                               v20 = ireduce.i32 v19
-;; @0020                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @0020                               v15 = uextend.i64 v12
-;; @0020                               v16 = iadd v14, v15
-;;                                     v25 = iconst.i64 24
-;; @0020                               v17 = iadd v16, v25  ; v25 = 24
-;; @0020                               store notrap aligned little v20, v17
-;;                                     v21 = load.i32 notrap v23
+;;                                     v22 = stack_addr.i64 ss0
+;;                                     store notrap v11, v22
+;; @0020                               v18 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v19 = ireduce.i32 v18
+;; @0020                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v14 = uextend.i64 v11
+;; @0020                               v15 = iadd v13, v14
+;;                                     v24 = iconst.i64 24
+;; @0020                               v16 = iadd v15, v24  ; v24 = 24
+;; @0020                               store notrap aligned little v19, v16
+;;                                     v20 = load.i32 notrap v22
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:
-;; @0023                               return v21
+;; @0023                               return v20
 ;; }

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -16,52 +16,51 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v56 = iconst.i32 -1342177279
+;;                                     v55 = iconst.i32 -1342177279
 ;; @0021                               v4 = iconst.i32 0
 ;; @0021                               v6 = iconst.i32 40
 ;; @0021                               v12 = iconst.i32 8
-;; @0021                               v13 = call fn0(v0, v56, v4, v6, v12)  ; v56 = -1342177279, v4 = 0, v6 = 40, v12 = 8
+;; @0021                               v13 = call fn0(v0, v55, v4, v6, v12)  ; v55 = -1342177279, v4 = 0, v6 = 40, v12 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @0021                               v14 = ireduce.i32 v13
-;; @0021                               v17 = uextend.i64 v14
-;; @0021                               v18 = iadd v16, v17
-;;                                     v50 = iconst.i64 28
-;; @0021                               v19 = iadd v18, v50  ; v50 = 28
-;; @0021                               store notrap aligned little v3, v19  ; v3 = 0.0
-;;                                     v51 = iconst.i64 32
-;; @0021                               v20 = iadd v18, v51  ; v51 = 32
-;; @0021                               istore8 notrap aligned little v4, v20  ; v4 = 0
+;; @0021                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v16 = uextend.i64 v13
+;; @0021                               v17 = iadd v15, v16
+;;                                     v49 = iconst.i64 28
+;; @0021                               v18 = iadd v17, v49  ; v49 = 28
+;; @0021                               store notrap aligned little v3, v18  ; v3 = 0.0
+;;                                     v50 = iconst.i64 32
+;; @0021                               v19 = iadd v17, v50  ; v50 = 32
+;; @0021                               istore8 notrap aligned little v4, v19  ; v4 = 0
 ;; @0021                               v7 = iconst.i32 1
 ;; @0021                               brif v7, block3, block2  ; v7 = 1
 ;;
 ;;                                 block2:
-;;                                     v82 = iconst.i64 0
-;; @0021                               v31 = iconst.i64 8
-;; @0021                               v32 = uadd_overflow_trap v82, v31, user1  ; v82 = 0, v31 = 8
-;; @0021                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
-;; @0021                               v29 = load.i64 notrap aligned readonly can_move v0+48
-;; @0021                               v35 = icmp ule v34, v29
-;; @0021                               trapz v35, user1
-;; @0021                               v36 = iadd.i64 v16, v32
-;; @0021                               v37 = load.i64 notrap aligned v36
-;;                                     v55 = iconst.i64 1
-;; @0021                               v38 = iadd v37, v55  ; v55 = 1
-;; @0021                               store notrap aligned v38, v36
+;;                                     v81 = iconst.i64 0
+;; @0021                               v30 = iconst.i64 8
+;; @0021                               v31 = uadd_overflow_trap v81, v30, user1  ; v81 = 0, v30 = 8
+;; @0021                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
+;; @0021                               v28 = load.i64 notrap aligned readonly can_move v0+48
+;; @0021                               v34 = icmp ule v33, v28
+;; @0021                               trapz v34, user1
+;; @0021                               v35 = iadd.i64 v15, v31
+;; @0021                               v36 = load.i64 notrap aligned v35
+;;                                     v54 = iconst.i64 1
+;; @0021                               v37 = iadd v36, v54  ; v54 = 1
+;; @0021                               store notrap aligned v37, v35
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v83 = iconst.i32 0
-;;                                     v52 = iconst.i64 24
-;; @0021                               v21 = iadd.i64 v18, v52  ; v52 = 24
-;; @0021                               store notrap aligned little v83, v21  ; v83 = 0
+;;                                     v82 = iconst.i32 0
+;;                                     v51 = iconst.i64 24
+;; @0021                               v20 = iadd.i64 v17, v51  ; v51 = 24
+;; @0021                               store notrap aligned little v82, v20  ; v82 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:
-;; @0024                               return v14
+;; @0024                               return v13
 ;; }

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -17,58 +17,57 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     store notrap v4, v55
-;;                                     v67 = iconst.i32 -1342177279
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v4, v54
+;;                                     v66 = iconst.i32 -1342177279
 ;; @002a                               v11 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 40
 ;; @002a                               v12 = iconst.i32 8
-;; @002a                               v13 = call fn0(v0, v67, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v67 = -1342177279, v11 = 0, v6 = 40, v12 = 8
-;; @002a                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v14 = ireduce.i32 v13
-;; @002a                               v17 = uextend.i64 v14
-;; @002a                               v18 = iadd v16, v17
-;;                                     v56 = iconst.i64 28
-;; @002a                               v19 = iadd v18, v56  ; v56 = 28
-;; @002a                               store notrap aligned little v2, v19
-;;                                     v57 = iconst.i64 32
-;; @002a                               v20 = iadd v18, v57  ; v57 = 32
-;; @002a                               istore8 notrap aligned little v3, v20
-;;                                     v54 = load.i32 notrap v55
+;; @002a                               v13 = call fn0(v0, v66, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v66 = -1342177279, v11 = 0, v6 = 40, v12 = 8
+;; @002a                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v16 = uextend.i64 v13
+;; @002a                               v17 = iadd v15, v16
+;;                                     v55 = iconst.i64 28
+;; @002a                               v18 = iadd v17, v55  ; v55 = 28
+;; @002a                               store notrap aligned little v2, v18
+;;                                     v56 = iconst.i64 32
+;; @002a                               v19 = iadd v17, v56  ; v56 = 32
+;; @002a                               istore8 notrap aligned little v3, v19
+;;                                     v53 = load.i32 notrap v54
 ;; @002a                               v7 = iconst.i32 1
-;; @002a                               v22 = band v54, v7  ; v7 = 1
-;; @002a                               v23 = icmp eq v54, v11  ; v11 = 0
-;; @002a                               v24 = uextend.i32 v23
-;; @002a                               v25 = bor v22, v24
-;; @002a                               brif v25, block3, block2
+;; @002a                               v21 = band v53, v7  ; v7 = 1
+;; @002a                               v22 = icmp eq v53, v11  ; v11 = 0
+;; @002a                               v23 = uextend.i32 v22
+;; @002a                               v24 = bor v21, v23
+;; @002a                               brif v24, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v30 = uextend.i64 v54
-;; @002a                               v31 = iconst.i64 8
-;; @002a                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
-;; @002a                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
-;; @002a                               v29 = load.i64 notrap aligned readonly can_move v0+48
-;; @002a                               v35 = icmp ule v34, v29
-;; @002a                               trapz v35, user1
-;; @002a                               v36 = iadd.i64 v16, v32
-;; @002a                               v37 = load.i64 notrap aligned v36
-;;                                     v64 = iconst.i64 1
-;; @002a                               v38 = iadd v37, v64  ; v64 = 1
-;; @002a                               store notrap aligned v38, v36
+;; @002a                               v29 = uextend.i64 v53
+;; @002a                               v30 = iconst.i64 8
+;; @002a                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @002a                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
+;; @002a                               v28 = load.i64 notrap aligned readonly can_move v0+48
+;; @002a                               v34 = icmp ule v33, v28
+;; @002a                               trapz v34, user1
+;; @002a                               v35 = iadd.i64 v15, v31
+;; @002a                               v36 = load.i64 notrap aligned v35
+;;                                     v63 = iconst.i64 1
+;; @002a                               v37 = iadd v36, v63  ; v63 = 1
+;; @002a                               store notrap aligned v37, v35
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v50 = load.i32 notrap v55
-;;                                     v58 = iconst.i64 24
-;; @002a                               v21 = iadd.i64 v18, v58  ; v58 = 24
-;; @002a                               store notrap aligned little v50, v21
+;;                                     v49 = load.i32 notrap v54
+;;                                     v57 = iconst.i64 24
+;; @002a                               v20 = iadd.i64 v17, v57  ; v57 = 24
+;; @002a                               store notrap aligned little v49, v20
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v14
+;; @002d                               return v13
 ;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -17,57 +17,56 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v59 = iconst.i32 -1342177279
+;;                                     v58 = iconst.i32 -1342177279
 ;; @0023                               v4 = iconst.i32 0
 ;; @0023                               v7 = iconst.i32 64
 ;; @0023                               v13 = iconst.i32 16
-;; @0023                               v14 = call fn0(v0, v59, v4, v7, v13)  ; v59 = -1342177279, v4 = 0, v7 = 64, v13 = 16
+;; @0023                               v14 = call fn0(v0, v58, v4, v7, v13)  ; v58 = -1342177279, v4 = 0, v7 = 64, v13 = 16
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v17 = load.i64 notrap aligned readonly can_move v0+40
-;; @0023                               v15 = ireduce.i32 v14
-;; @0023                               v18 = uextend.i64 v15
-;; @0023                               v19 = iadd v17, v18
-;;                                     v52 = iconst.i64 48
-;; @0023                               v20 = iadd v19, v52  ; v52 = 48
-;; @0023                               store notrap aligned little v3, v20  ; v3 = 0.0
-;;                                     v53 = iconst.i64 52
-;; @0023                               v21 = iadd v19, v53  ; v53 = 52
-;; @0023                               istore8 notrap aligned little v4, v21  ; v4 = 0
+;; @0023                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0023                               v17 = uextend.i64 v14
+;; @0023                               v18 = iadd v16, v17
+;;                                     v51 = iconst.i64 48
+;; @0023                               v19 = iadd v18, v51  ; v51 = 48
+;; @0023                               store notrap aligned little v3, v19  ; v3 = 0.0
+;;                                     v52 = iconst.i64 52
+;; @0023                               v20 = iadd v18, v52  ; v52 = 52
+;; @0023                               istore8 notrap aligned little v4, v20  ; v4 = 0
 ;; @0023                               v8 = iconst.i32 1
 ;; @0023                               brif v8, block3, block2  ; v8 = 1
 ;;
 ;;                                 block2:
-;;                                     v85 = iconst.i64 0
-;; @0023                               v32 = iconst.i64 8
-;; @0023                               v33 = uadd_overflow_trap v85, v32, user1  ; v85 = 0, v32 = 8
-;; @0023                               v35 = uadd_overflow_trap v33, v32, user1  ; v32 = 8
-;; @0023                               v30 = load.i64 notrap aligned readonly can_move v0+48
-;; @0023                               v36 = icmp ule v35, v30
-;; @0023                               trapz v36, user1
-;; @0023                               v37 = iadd.i64 v17, v33
-;; @0023                               v38 = load.i64 notrap aligned v37
-;;                                     v57 = iconst.i64 1
-;; @0023                               v39 = iadd v38, v57  ; v57 = 1
-;; @0023                               store notrap aligned v39, v37
+;;                                     v84 = iconst.i64 0
+;; @0023                               v31 = iconst.i64 8
+;; @0023                               v32 = uadd_overflow_trap v84, v31, user1  ; v84 = 0, v31 = 8
+;; @0023                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
+;; @0023                               v29 = load.i64 notrap aligned readonly can_move v0+48
+;; @0023                               v35 = icmp ule v34, v29
+;; @0023                               trapz v35, user1
+;; @0023                               v36 = iadd.i64 v16, v32
+;; @0023                               v37 = load.i64 notrap aligned v36
+;;                                     v56 = iconst.i64 1
+;; @0023                               v38 = iadd v37, v56  ; v56 = 1
+;; @0023                               store notrap aligned v38, v36
 ;; @0023                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v86 = iconst.i32 0
-;;                                     v54 = iconst.i64 24
-;; @0023                               v22 = iadd.i64 v19, v54  ; v54 = 24
-;; @0023                               store notrap aligned little v86, v22  ; v86 = 0
+;;                                     v85 = iconst.i32 0
+;;                                     v53 = iconst.i64 24
+;; @0023                               v21 = iadd.i64 v18, v53  ; v53 = 24
+;; @0023                               store notrap aligned little v85, v21  ; v85 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
-;;                                     v58 = iconst.i64 32
-;; @0023                               v51 = iadd.i64 v19, v58  ; v58 = 32
-;; @0023                               store notrap aligned little v6, v51  ; v6 = const0
+;;                                     v57 = iconst.i64 32
+;; @0023                               v50 = iadd.i64 v18, v57  ; v57 = 32
+;; @0023                               store notrap aligned little v6, v50  ; v6 = const0
 ;; @0026                               jump block1
 ;;
 ;;                                 block1:
-;; @0026                               return v15
+;; @0026                               return v14
 ;; }

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -17,58 +17,57 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i64 tail
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u1:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     store notrap v4, v55
-;;                                     v67 = iconst.i32 -1342177279
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     store notrap v4, v54
+;;                                     v66 = iconst.i32 -1342177279
 ;; @002a                               v11 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 40
 ;; @002a                               v12 = iconst.i32 8
-;; @002a                               v13 = call fn0(v0, v67, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v67 = -1342177279, v11 = 0, v6 = 40, v12 = 8
-;; @002a                               v16 = load.i64 notrap aligned readonly can_move v0+40
-;; @002a                               v14 = ireduce.i32 v13
-;; @002a                               v17 = uextend.i64 v14
-;; @002a                               v18 = iadd v16, v17
-;;                                     v56 = iconst.i64 28
-;; @002a                               v19 = iadd v18, v56  ; v56 = 28
-;; @002a                               store notrap aligned little v2, v19
-;;                                     v57 = iconst.i64 32
-;; @002a                               v20 = iadd v18, v57  ; v57 = 32
-;; @002a                               istore8 notrap aligned little v3, v20
-;;                                     v54 = load.i32 notrap v55
+;; @002a                               v13 = call fn0(v0, v66, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v66 = -1342177279, v11 = 0, v6 = 40, v12 = 8
+;; @002a                               v15 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v16 = uextend.i64 v13
+;; @002a                               v17 = iadd v15, v16
+;;                                     v55 = iconst.i64 28
+;; @002a                               v18 = iadd v17, v55  ; v55 = 28
+;; @002a                               store notrap aligned little v2, v18
+;;                                     v56 = iconst.i64 32
+;; @002a                               v19 = iadd v17, v56  ; v56 = 32
+;; @002a                               istore8 notrap aligned little v3, v19
+;;                                     v53 = load.i32 notrap v54
 ;; @002a                               v7 = iconst.i32 1
-;; @002a                               v22 = band v54, v7  ; v7 = 1
-;; @002a                               v23 = icmp eq v54, v11  ; v11 = 0
-;; @002a                               v24 = uextend.i32 v23
-;; @002a                               v25 = bor v22, v24
-;; @002a                               brif v25, block3, block2
+;; @002a                               v21 = band v53, v7  ; v7 = 1
+;; @002a                               v22 = icmp eq v53, v11  ; v11 = 0
+;; @002a                               v23 = uextend.i32 v22
+;; @002a                               v24 = bor v21, v23
+;; @002a                               brif v24, block3, block2
 ;;
 ;;                                 block2:
-;; @002a                               v30 = uextend.i64 v54
-;; @002a                               v31 = iconst.i64 8
-;; @002a                               v32 = uadd_overflow_trap v30, v31, user1  ; v31 = 8
-;; @002a                               v34 = uadd_overflow_trap v32, v31, user1  ; v31 = 8
-;; @002a                               v29 = load.i64 notrap aligned readonly can_move v0+48
-;; @002a                               v35 = icmp ule v34, v29
-;; @002a                               trapz v35, user1
-;; @002a                               v36 = iadd.i64 v16, v32
-;; @002a                               v37 = load.i64 notrap aligned v36
-;;                                     v64 = iconst.i64 1
-;; @002a                               v38 = iadd v37, v64  ; v64 = 1
-;; @002a                               store notrap aligned v38, v36
+;; @002a                               v29 = uextend.i64 v53
+;; @002a                               v30 = iconst.i64 8
+;; @002a                               v31 = uadd_overflow_trap v29, v30, user1  ; v30 = 8
+;; @002a                               v33 = uadd_overflow_trap v31, v30, user1  ; v30 = 8
+;; @002a                               v28 = load.i64 notrap aligned readonly can_move v0+48
+;; @002a                               v34 = icmp ule v33, v28
+;; @002a                               trapz v34, user1
+;; @002a                               v35 = iadd.i64 v15, v31
+;; @002a                               v36 = load.i64 notrap aligned v35
+;;                                     v63 = iconst.i64 1
+;; @002a                               v37 = iadd v36, v63  ; v63 = 1
+;; @002a                               store notrap aligned v37, v35
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v50 = load.i32 notrap v55
-;;                                     v58 = iconst.i64 24
-;; @002a                               v21 = iadd.i64 v18, v58  ; v58 = 24
-;; @002a                               store notrap aligned little v50, v21
+;;                                     v49 = load.i32 notrap v54
+;;                                     v57 = iconst.i64 24
+;; @002a                               v20 = iadd.i64 v17, v57  ; v57 = 24
+;; @002a                               store notrap aligned little v49, v20
 ;; @002d                               jump block1
 ;;
 ;;                                 block1:
-;; @002d                               return v14
+;; @002d                               return v13
 ;; }


### PR DESCRIPTION
We are logically returning a `VMGcRef` from these libcalls, which is a `NonZeroU32` under the covers. We were representing that value as a `u32`, and then to represent traps and panics, we packed that into a `u64` and if the `u64` was negative that meant there was a trap/panic but otherwise we could unpack the bottom half and that was our result.

But because our GC refs are non-zero, we don't need to extend to a `u64` to get a sentinel for traps/panics; we can just use zero. That's what this commit does.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
