### PR TITLE
Remove some unnecessary `UnsafeCell`s in GC code

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -58,7 +58,6 @@ use core::{
     num::NonZeroUsize,
     ops::{Deref, DerefMut, Range},
     ptr::NonNull,
-    slice,
 };
 use wasmtime_environ::drc::DrcTypeLayouts;
 use wasmtime_environ::{GcArrayLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex};
@@ -773,15 +772,13 @@ unsafe impl GcHeap for DrcHeap {
     }
 
     fn heap_slice(&self) -> &[u8] {
-        let ptr = self.heap.as_ptr();
         let len = self.heap.len();
-        unsafe { slice::from_raw_parts(ptr, len) }
+        unsafe { self.heap.slice(0..len) }
     }
 
     fn heap_slice_mut(&mut self) -> &mut [u8] {
-        let ptr = self.heap.as_mut_ptr();
         let len = self.heap.len();
-        unsafe { slice::from_raw_parts_mut(ptr, len) }
+        unsafe { self.heap.slice_mut(0..len) }
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -18,7 +18,6 @@ use core::ptr::NonNull;
 use core::{
     alloc::Layout,
     any::Any,
-    cell::UnsafeCell,
     num::{NonZeroU32, NonZeroUsize},
 };
 use wasmtime_environ::{
@@ -202,8 +201,8 @@ unsafe impl GcHeap for NullHeap {
         self.no_gc_count -= 1;
     }
 
-    fn heap_slice(&self) -> &[UnsafeCell<u8>] {
-        let ptr = self.heap.as_ptr().cast();
+    fn heap_slice(&self) -> &[u8] {
+        let ptr = self.heap.as_ptr();
         let len = self.heap.len();
         unsafe { core::slice::from_raw_parts(ptr, len) }
     }

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -6,9 +6,7 @@ use crate::runtime::vm::{
     VMExternRef, VMGcHeader, VMGcObjectDataMut, VMGcRef, VMStructRef,
 };
 use core::ptr::NonNull;
-use core::{
-    alloc::Layout, any::Any, cell::UnsafeCell, marker, mem, num::NonZeroUsize, ops::Range, ptr,
-};
+use core::{alloc::Layout, any::Any, marker, mem, num::NonZeroUsize, ops::Range, ptr};
 use wasmtime_environ::{GcArrayLayout, GcStructLayout, GcTypeLayouts, VMSharedTypeIndex};
 
 /// Trait for integrating a garbage collector with the runtime.
@@ -387,7 +385,7 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// The heap slice must be the GC heap region, and the region must remain
     /// valid (i.e. not moved or resized) for JIT code until `self` is dropped
     /// or `self.reset()` is called.
-    fn heap_slice(&self) -> &[UnsafeCell<u8>];
+    fn heap_slice(&self) -> &[u8];
 
     /// Get a mutable slice of the raw bytes of the GC heap.
     ///


### PR DESCRIPTION
None of these are actually mutated while behind shared references. Everything, including interactions with JIT code, obeys Rust's borrowing rules. Running tests under MIRI still passes, verifying these claims. Therefore, we can remove these `UnsafeCell`s, which makes the code much easier to read and much less footgun-y since there is less `unsafe` code and less working with `UnsafeCell`s' raw pointers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
