### PR TITLE
Cranelift: tweak the ISLE-source-dir build script functionality.

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -63,6 +63,7 @@ fn main() {
     let crate_dir = cur_dir.as_path();
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=ISLE_SOURCE_DIR");
 
     let isle_dir = if let Ok(path) = std::env::var("ISLE_SOURCE_DIR") {
         // This will canonicalize any relative path in terms of the

--- a/cranelift/docs/isle-integration.md
+++ b/cranelift/docs/isle-integration.md
@@ -24,18 +24,15 @@ ISLE.
 
 Sometimes, it's desirable to see what code is actually generated. By default,
 the generated code is placed in a Cargo-managed path in `target/`. If you want
-to see the source instead, invoke Cargo with the optional feature
-`isle-in-source-tree` as follows:
+to see the source instead, invoke Cargo with the environment variable
+`ISLE_SOURCE_DIR` set to another directory, as follows:
 
 ```shell
-$ cargo check -p cranelift-codegen --features isle-in-source-tree
+$ ISLE_SOURCE_DIR=`pwd`/isle-sources cargo check -p cranelift-codegen
 ```
 
-This will place the ISLE source in `cranelift/codegen/isle_generated_code/`,
-where you can inspect it, debug by setting breakpoints in it, etc. Note that if
-you later build without this feature, the build system will require you to
-delete the directory. This is to ensure that no out-of-date copies exist, which
-could cause significant confusion.
+This will place the ISLE source in `./isle-sources`, where you can inspect it,
+debug by setting breakpoints in it, etc.
 
 If there are any errors during ISLE compilation (e.g., a type mismatch), you
 will see a basic error message with a file, line number, and one-line error. To


### PR DESCRIPTION
- Add a `cargo:rerun-if-env-changed` clause for the `ISLE_SOURCE_DIR` environment variable to properly rebuild if the config changes.
- Update docs to point to the new env-var-based approach rather than the old Cargo feature.

As per this Zulip conversation [1] and this GitHub comment [2].

[1]: https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/How.20to.20enable.20the.20isle-in-source-tree.20feature.3F/near/508028830
[2]: https://github.com/bytecodealliance/wasmtime/pull/9633#discussion_r2012230673

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
