### PR TITLE
`cranelift-frontend`: Propagate needs-stack-map from variables to values during finalization

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -287,7 +287,7 @@ pub use self::keys::Keys;
 pub use self::list::{EntityList, ListPool};
 pub use self::map::SecondaryMap;
 pub use self::primary::PrimaryMap;
-pub use self::set::EntitySet;
+pub use self::set::{EntitySet, SetIter};
 pub use self::signed::Signed;
 pub use self::sparse::{SparseMap, SparseMapValue, SparseSet};
 pub use self::unsigned::Unsigned;

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -713,8 +713,9 @@ impl<'a> FunctionBuilder<'a> {
 
         // Propagate the needs-stack-map bit from variables to each of their
         // associated values.
-        for var in self.func_ctx.stack_map_vars.keys() {
+        for var in self.func_ctx.stack_map_vars.iter() {
             for val in self.func_ctx.ssa.values_for_var(var) {
+                log::trace!("propagating needs-stack-map from {var:?} to {val:?}");
                 debug_assert_eq!(self.func.dfg.value_type(val), self.func_ctx.types[var]);
                 self.func_ctx.stack_map_values.insert(val);
             }

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -473,12 +473,6 @@ impl<'a> FunctionBuilder<'a> {
         };
         self.handle_ssa_side_effects(side_effects);
 
-        // If the variable was declared as needing stack maps, then we should
-        // have propagated that to the value as well.
-        if cfg!(debug_assertions) && self.func_ctx.stack_map_vars.contains(var) {
-            assert!(self.func_ctx.stack_map_values.contains(val));
-        }
-
         Ok(val)
     }
 
@@ -494,6 +488,8 @@ impl<'a> FunctionBuilder<'a> {
     /// an error if the value supplied does not match the type the variable was
     /// declared to have.
     pub fn try_def_var(&mut self, var: Variable, val: Value) -> Result<(), DefVariableError> {
+        log::trace!("try_def_var: {var:?} = {val:?}");
+
         let var_ty = *self
             .func_ctx
             .types
@@ -501,11 +497,6 @@ impl<'a> FunctionBuilder<'a> {
             .ok_or(DefVariableError::DefinedBeforeDeclared(var))?;
         if var_ty != self.func.dfg.value_type(val) {
             return Err(DefVariableError::TypeMismatch(var, val));
-        }
-
-        // If `var` needs inclusion in stack maps, then `val` does too.
-        if self.func_ctx.stack_map_vars.contains(var) {
-            self.declare_value_needs_stack_map(val);
         }
 
         self.func_ctx.ssa.def_var(var, val, self.position.unwrap());
@@ -720,6 +711,18 @@ impl<'a> FunctionBuilder<'a> {
             }
         }
 
+        // Propagate the needs-stack-map bit from variables to each of their
+        // associated values.
+        for var in self.func_ctx.stack_map_vars.keys() {
+            for val in self.func_ctx.ssa.values_for_var(var) {
+                debug_assert_eq!(self.func.dfg.value_type(val), self.func_ctx.types[var]);
+                self.func_ctx.stack_map_values.insert(val);
+            }
+        }
+
+        // If we have any values that need inclusion in stack maps, then we need
+        // to run our pass to spill those values to the stack at safepoints and
+        // generate stack maps.
         if !self.func_ctx.stack_map_values.is_empty() {
             self.func_ctx
                 .safepoints
@@ -1180,22 +1183,11 @@ impl<'a> FunctionBuilder<'a> {
     fn handle_ssa_side_effects(&mut self, side_effects: SideEffects) {
         let SideEffects {
             instructions_added_to_blocks,
-            params_added_to_blocks,
         } = side_effects;
 
         for modified_block in instructions_added_to_blocks {
             if self.is_pristine(modified_block) {
                 self.func_ctx.status[modified_block] = BlockStatus::Partial;
-            }
-        }
-
-        // Propagate needs-inclusion-in-stack-maps metadata from variables to
-        // their block parameter SSA values.
-        if !self.func_ctx.stack_map_vars.is_empty() {
-            for (val, var) in params_added_to_blocks {
-                if self.func_ctx.stack_map_vars.contains(var) {
-                    self.func_ctx.stack_map_values.insert(val);
-                }
             }
         }
     }

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -279,6 +279,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
             #should_panic
             #(#attrs)*
             #asyncness fn #test_name() {
+                let _ = env_logger::try_init();
                 let mut config = Config::new();
                 wasmtime_test_util::wasmtime_wast::apply_test_config(
                     &mut config,

--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -43,6 +43,8 @@ pub struct FunctionWithIsa {
 
 impl FunctionWithIsa {
     pub fn generate(u: &mut Unstructured) -> anyhow::Result<Self> {
+        let _ = env_logger::try_init();
+
         // We filter out targets that aren't supported in the current build
         // configuration after randomly choosing one, instead of randomly choosing
         // a supported one, so that the same fuzz input works across different build


### PR DESCRIPTION
Rather than trying to propagate the needs-stack-map bit from variables to values online, while we are building the IR and defining and using variables, wait until the function is being finalized, and then propagate everything all at once. This avoids potential repeated work and is easier to ensure that it is complete and covers all values associated with a variable, since by the time we are finalizing the function, we won't add any new values for a variable that we will need to keep track of and propagate this information to.

This also means that we can remove the `params_added_to_blocks` vector from the SSA side effects structure, since it was only used to online-update the `stack_map_values` set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
