### PR TITLE
Fix some `unreachable!()` with wasm components

### DIFF
--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -204,6 +204,7 @@ struct InlinerFrame<'a> {
     memories: PrimaryMap<MemoryIndex, dfg::CoreExport<EntityIndex>>,
     tables: PrimaryMap<TableIndex, dfg::CoreExport<EntityIndex>>,
     globals: PrimaryMap<GlobalIndex, dfg::CoreExport<EntityIndex>>,
+    tags: PrimaryMap<GlobalIndex, dfg::CoreExport<EntityIndex>>,
     modules: PrimaryMap<ModuleIndex, ModuleDef<'a>>,
 
     // component model index spaces
@@ -1164,6 +1165,15 @@ impl<'a> Inliner<'a> {
                 );
             }
 
+            AliasExportTag(instance, name) => {
+                frame.tags.push(
+                    match self.core_def_of_module_instance_export(frame, *instance, *name) {
+                        dfg::CoreDef::Export(e) => e,
+                        _ => unreachable!(),
+                    },
+                );
+            }
+
             AliasComponentExport(instance, name) => {
                 match &frame.component_instances[*instance] {
                     // Aliasing an export from an imported instance means that
@@ -1480,6 +1490,7 @@ impl<'a> InlinerFrame<'a> {
             memories: Default::default(),
             tables: Default::default(),
             globals: Default::default(),
+            tags: Default::default(),
 
             component_instances: Default::default(),
             component_funcs: Default::default(),


### PR DESCRIPTION
This commit resolves a few panics in Wasmtime's compilation of components with respect to tags and the exception-handling wasm proposal. Despite exception-handling not being enabled in Wasmtime at this time these panics were still reachable due to an issue in wasm-tools's validation not being exhaustive enough for this proposal feature combination: bytecodealliance/wasm-tools#2114.

This is not full support for exceptions since it can't be tested yet, but this should be enough to ensure that the validator will get far enough to flag components as otherwise invalid due to using tags that can't be present (as core wasm tags can't be present in core modules right now, the `EXCEPTIONS` feature is always disabled).

