### PR TITLE
asm: improve DSL's understanding of prefixes

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl.rs
+++ b/cranelift/assembler-x64/meta/src/dsl.rs
@@ -8,7 +8,10 @@ mod encoding;
 mod features;
 pub mod format;
 
-pub use encoding::{rex, vex, Encoding, LegacyPrefix, Rex};
+pub use encoding::{rex, vex};
+pub use encoding::{
+    Encoding, Group1Prefix, Group2Prefix, Group3Prefix, Group4Prefix, Opcodes, Prefixes, Rex,
+};
 pub use features::{Feature, Features, ALL_FEATURES};
 pub use format::{align, fmt, r, rw, sxl, sxq, sxw};
 pub use format::{Extension, Format, Location, Mutability, Operand, OperandKind};

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -98,12 +98,6 @@ pub struct Rex {
     /// the instruction's opcode."
     pub digit: Option<u8>,
     /// The number of bits used as an immediate operand to the instruction.
-    ///
-    /// From the reference manual: "a 1-byte (ib), 2-byte (iw), 4-byte (id) or
-    /// 8-byte (io) immediate operand to the instruction that follows the
-    /// opcode, ModR/M bytes or scale-indexing bytes. The opcode determines if
-    /// the operand is a signed value. All words, doublewords, and quadwords are
-    /// given with the low-order byte first."
     pub imm: Imm,
 }
 
@@ -188,11 +182,11 @@ impl Rex {
         assert!(!(self.r && self.digit.is_some()));
         assert!(!(self.r && self.imm != Imm::None));
         assert!(
-            !(self.w && (self.opcodes.prefix.contains_66())),
+            !(self.w && (self.opcodes.prefixes.has_operand_size_override())),
             "though valid, if REX.W is set then the 66 prefix is ignored--avoid encoding this"
         );
 
-        if self.opcodes.prefix.contains_66() {
+        if self.opcodes.prefixes.has_operand_size_override() {
             assert!(
                 operands.iter().all(|&op| matches!(
                     op.location.kind(),
@@ -225,14 +219,17 @@ impl From<Rex> for Encoding {
 
 impl fmt::Display for Rex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.opcodes.prefix {
-            LegacyPrefix::NoPrefix => {}
-            LegacyPrefix::_66 => write!(f, "0x66 + ")?,
-            LegacyPrefix::_F0 => write!(f, "0xF0 + ")?,
-            LegacyPrefix::_66F0 => write!(f, "0x66 0xF0 + ")?,
-            LegacyPrefix::_F2 => write!(f, "0xF2 + ")?,
-            LegacyPrefix::_F3 => write!(f, "0xF3 + ")?,
-            LegacyPrefix::_66F3 => write!(f, "0x66 0xF3 + ")?,
+        if let Some(group1) = &self.opcodes.prefixes.group1 {
+            write!(f, "{group1} + ")?;
+        }
+        if let Some(group2) = &self.opcodes.prefixes.group2 {
+            write!(f, "{group2} + ")?;
+        }
+        if let Some(group3) = &self.opcodes.prefixes.group3 {
+            write!(f, "{group3} + ")?;
+        }
+        if let Some(group4) = &self.opcodes.prefixes.group4 {
+            write!(f, "{group4} + ")?;
         }
         if self.w {
             write!(f, "REX.W + ")?;
@@ -289,7 +286,7 @@ impl fmt::Display for Rex {
 /// > sequence: `66 0F 38 01`. The first byte is the mandatory prefix.
 pub struct Opcodes {
     /// The prefix bytes for this instruction.
-    pub prefix: LegacyPrefix,
+    pub prefixes: Prefixes,
     /// Indicates the use of an escape opcode byte, `0x0f`.
     pub escape: bool,
     /// The primary opcode.
@@ -301,7 +298,7 @@ pub struct Opcodes {
 impl From<u8> for Opcodes {
     fn from(primary: u8) -> Opcodes {
         Opcodes {
-            prefix: LegacyPrefix::NoPrefix,
+            prefixes: Prefixes::default(),
             escape: false,
             primary,
             secondary: None,
@@ -309,109 +306,248 @@ impl From<u8> for Opcodes {
     }
 }
 
-impl From<[u8; 1]> for Opcodes {
-    fn from(bytes: [u8; 1]) -> Opcodes {
-        Opcodes::from(bytes[0])
+impl<const N: usize> From<[u8; N]> for Opcodes {
+    fn from(bytes: [u8; N]) -> Self {
+        let (prefixes, remaining) = Prefixes::parse(&bytes);
+        let (escape, primary, secondary) = match remaining {
+            [primary] => (false, *primary, None),
+            [0x0f, primary] => (true, *primary, None),
+            [0x0f, primary, secondary] => (true, *primary, Some(*secondary)),
+            _ => panic!("invalid opcodes after prefix; expected [opcode], [0x0f, opcode], or [0x0f, opcode, opcode], found {remaining:?}"),
+        };
+        Self { prefixes, escape, primary, secondary }
     }
 }
 
-impl From<[u8; 2]> for Opcodes {
-    fn from(bytes: [u8; 2]) -> Opcodes {
-        let [a, b] = bytes;
-        match (LegacyPrefix::try_from(a), b) {
-            (Ok(prefix), primary) => Opcodes { prefix, escape: false, primary, secondary: None },
-            (Err(0x0f), primary) => Opcodes {
-                prefix: LegacyPrefix::NoPrefix,
-                escape: true,
-                primary,
-                secondary: None,
-            },
-            _ => panic!("invalid opcodes; expected [prefix, opcode] or [0x0f, opcode]"),
+/// The allowed prefixes for an instruction. From the reference manual (section
+/// 2.1.1):
+///
+/// > Instruction prefixes are divided into four groups, each with a set of
+/// > allowable prefix codes. For each instruction, it is only useful to include
+/// > up to one prefix code from each of the four groups (Groups 1, 2, 3, 4).
+/// > Groups 1 through 4 may be placed in any order relative to each other.
+#[derive(Default)]
+pub struct Prefixes {
+    pub group1: Option<Group1Prefix>,
+    pub group2: Option<Group2Prefix>,
+    pub group3: Option<Group3Prefix>,
+    pub group4: Option<Group4Prefix>,
+}
+
+impl Prefixes {
+    /// Parse a slice of `bytes` into a set of prefixes, returning both the
+    /// configured [`Prefixes`] as well as any remaining bytes.
+    fn parse(mut bytes: &[u8]) -> (Self, &[u8]) {
+        let mut prefixes = Self::default();
+        while prefixes.try_assign(bytes[0]).is_ok() {
+            bytes = &bytes[1..];
         }
+        (prefixes, bytes)
     }
-}
 
-impl From<[u8; 3]> for Opcodes {
-    fn from(bytes: [u8; 3]) -> Opcodes {
-        let [a, b, c] = bytes;
-        match (LegacyPrefix::try_from(a), b, c) {
-            (Ok(prefix), 0x0f, primary) => Opcodes { prefix, escape: true, primary, secondary: None },
-            (Err(0x0f), primary, secondary) => Opcodes {
-                prefix: LegacyPrefix::NoPrefix,
-                escape: true,
-                primary,
-                secondary: Some(secondary),
-            },
-            _ => panic!("invalid opcodes; expected [prefix, 0x0f, opcode] or [0x0f, opcode, opcode]"),
-        }
-    }
-}
-
-impl From<[u8; 4]> for Opcodes {
-    fn from(bytes: [u8; 4]) -> Opcodes {
-        let [a, b, c, d] = bytes;
-        match (LegacyPrefix::try_from(a), b, c, d) {
-            (Ok(prefix), 0x0f, primary, secondary) => Opcodes {
-                prefix,
-                escape: false,
-                primary,
-                secondary: Some(secondary),
-            },
-            _ => panic!("invalid opcodes; expected [prefix, 0x0f, opcode, opcode]"),
-        }
-    }
-}
-
-/// A prefix byte for an instruction.
-#[derive(PartialEq)]
-pub enum LegacyPrefix {
-    /// No prefix bytes.
-    NoPrefix,
-    /// An operand size override typically denoting "16-bit operation" or "SSE instructions". But the
-    /// reference manual is more nuanced:
+    /// Attempt to parse a `byte` as a prefix and, if successful, assigns it to
+    /// the correct prefix group.
     ///
-    /// > The operand-size override prefix allows a program to switch between
-    /// > 16- and 32-bit operand sizes. Either size can be the default; use of
-    /// > the prefix selects the non-default.
-    /// > Some SSE2/SSE3/SSSE3/SSE4 instructions and instructions using a three-byte
-    /// > sequence of primary opcode bytes may use 66H as a mandatory prefix to express
-    /// > distinct functionality.
-    _66,
-    /// The lock prefix.
-    _F0,
-    /// Operand size override and lock.
-    _66F0,
-    /// REPNE, but no specific meaning here -- is just an opcode extension.
-    _F2,
-    /// REP/REPE, but no specific meaning here -- is just an opcode extension.
-    _F3,
-    /// Operand size override and same effect as F3.
-    _66F3,
-}
-
-impl LegacyPrefix {
-    #[must_use]
-    pub fn contains_66(&self) -> bool {
-        match self {
-            LegacyPrefix::_66 | LegacyPrefix::_66F0 | LegacyPrefix::_66F3 => true,
-            LegacyPrefix::NoPrefix | LegacyPrefix::_F0 | LegacyPrefix::_F2 | LegacyPrefix::_F3 => false,
+    /// # Panics
+    ///
+    /// This function panics if the prefix for a group is already set; this
+    /// disallows specifying multiple prefixes per group.
+    fn try_assign(&mut self, byte: u8) -> Result<(), ()> {
+        if let Ok(p) = Group1Prefix::try_from(byte) {
+            assert!(self.group1.is_none());
+            self.group1 = Some(p);
+            Ok(())
+        } else if let Ok(p) = Group2Prefix::try_from(byte) {
+            assert!(self.group2.is_none());
+            self.group2 = Some(p);
+            Ok(())
+        } else if let Ok(p) = Group3Prefix::try_from(byte) {
+            assert!(self.group3.is_none());
+            self.group3 = Some(p);
+            Ok(())
+        } else if let Ok(p) = Group4Prefix::try_from(byte) {
+            assert!(self.group4.is_none());
+            self.group4 = Some(p);
+            Ok(())
+        } else {
+            Err(())
         }
+    }
+
+    /// Check if the `0x66` prefix is present.
+    fn has_operand_size_override(&self) -> bool {
+        matches!(self.group3, Some(Group3Prefix::OperandSizeOverride))
+    }
+
+    /// Check if any prefix is present.
+    pub fn is_empty(&self) -> bool {
+        self.group1.is_none() && self.group2.is_none() && self.group3.is_none() && self.group4.is_none()
     }
 }
 
-impl TryFrom<u8> for LegacyPrefix {
+pub enum Group1Prefix {
+    /// The LOCK prefix (`0xf0`). From the reference manual:
+    ///
+    /// > The LOCK prefix (F0H) forces an operation that ensures exclusive use
+    /// > of shared memory in a multiprocessor environment. See "LOCK—Assert
+    /// > LOCK# Signal Prefix" in Chapter 3, Instruction Set Reference, A-L, for
+    /// > a description of this prefix.
+    Lock,
+    /// A REPNE/REPNZ prefix (`0xf2`) or a BND prefix under certain conditions.
+    /// `REP*` prefixes apply only to string and input/output instructions but
+    /// can be used as mandatory prefixes in other kinds of instructions (e.g.,
+    /// SIMD) From the reference manual:
+    ///
+    /// > Repeat prefixes (F2H, F3H) cause an instruction to be repeated for
+    /// > each element of a string. Use these prefixes only with string and I/O
+    /// > instructions (MOVS, CMPS, SCAS, LODS, STOS, INS, and OUTS). Use of
+    /// > repeat prefixes and/or undefined opcodes with other Intel 64 or IA-32
+    /// > instructions is reserved; such use may cause unpredictable behavior.
+    /// >
+    /// > Some instructions may use F2H, F3H as a mandatory prefix to express
+    /// > distinct functionality.
+    REPNorBND,
+    /// A REPE/REPZ prefix (`0xf3`); `REP*` prefixes apply only to string and
+    /// input/output instructions but can be used as mandatory prefixes in other
+    /// kinds of instructions (e.g., SIMD). See `REPNorBND` for more details.
+    REP_,
+}
+
+impl TryFrom<u8> for Group1Prefix {
     type Error = u8;
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
         Ok(match byte {
-            0x66 => LegacyPrefix::_66,
-            0xF0 => LegacyPrefix::_F0,
-            0xF2 => LegacyPrefix::_F2,
-            0xF3 => LegacyPrefix::_F3,
+            0xF0 => Group1Prefix::Lock,
+            0xF2 => Group1Prefix::REPNorBND,
+            0xF3 => Group1Prefix::REP_,
             byte => return Err(byte),
         })
     }
 }
 
+impl fmt::Display for Group1Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Group1Prefix::Lock => write!(f, "0xF0"),
+            Group1Prefix::REPNorBND => write!(f, "0xF2"),
+            Group1Prefix::REP_ => write!(f, "0xF3"),
+        }
+    }
+}
+
+/// Contains the segment override prefixes or a (deprecated) branch hint when
+/// used on a `Jcc` instruction. Note that using the segment override prefixes
+/// on a branch instruction is reserved. See section 2.1.1, "Instruction
+/// Prefixes," in the reference manual.
+pub enum Group2Prefix {
+    /// The CS segment override prefix (`0x2e`); also the "branch not taken"
+    /// hint.
+    CSorBNT,
+    /// The SS segment override prefix (`0x36`).
+    SS,
+    /// The DS segment override prefix (`0x3e`); also the "branch taken" hint.
+    DSorBT,
+    /// The ES segment override prefix (`0x26`).
+    ES,
+    /// The FS segment override prefix (`0x64`).
+    FS,
+    /// The GS segment override prefix (`0x65`).
+    GS,
+}
+
+impl TryFrom<u8> for Group2Prefix {
+    type Error = u8;
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        Ok(match byte {
+            0x2E => Group2Prefix::CSorBNT,
+            0x36 => Group2Prefix::SS,
+            0x3E => Group2Prefix::DSorBT,
+            0x26 => Group2Prefix::ES,
+            0x64 => Group2Prefix::FS,
+            0x65 => Group2Prefix::GS,
+            byte => return Err(byte),
+        })
+    }
+}
+
+impl fmt::Display for Group2Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Group2Prefix::CSorBNT => write!(f, "0x2E"),
+            Group2Prefix::SS => write!(f, "0x36"),
+            Group2Prefix::DSorBT => write!(f, "0x3E"),
+            Group2Prefix::ES => write!(f, "0x26"),
+            Group2Prefix::FS => write!(f, "0x64"),
+            Group2Prefix::GS => write!(f, "0x65"),
+        }
+    }
+}
+
+/// Contains the operand-size override prefix (`0x66`); also used as a SIMD
+/// prefix. From the reference manual:
+///
+/// > The operand-size override prefix allows a program to switch between 16-
+/// > and 32-bit operand sizes. Either size can be the default; use of the
+/// > prefix selects the non-default size. Some SSE2/SSE3/SSSE3/SSE4
+/// > instructions and instructions using a three-byte sequence of primary
+/// > opcode bytes may use 66H as a mandatory prefix to express distinct
+/// > functionality.
+pub enum Group3Prefix {
+    OperandSizeOverride,
+}
+
+impl TryFrom<u8> for Group3Prefix {
+    type Error = u8;
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        Ok(match byte {
+            0x66 => Group3Prefix::OperandSizeOverride,
+            byte => return Err(byte),
+        })
+    }
+}
+
+impl fmt::Display for Group3Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Group3Prefix::OperandSizeOverride => write!(f, "0x66"),
+        }
+    }
+}
+
+/// Contains the address-size override prefix (`0x67`). From the reference
+/// manual:
+///
+/// > The address-size override prefix (67H) allows programs to switch between
+/// > 16- and 32-bit addressing. Either size can be the default; the prefix
+/// > selects the non-default size.
+pub enum Group4Prefix {
+    AddressSizeOverride,
+}
+
+impl TryFrom<u8> for Group4Prefix {
+    type Error = u8;
+    fn try_from(byte: u8) -> Result<Self, Self::Error> {
+        Ok(match byte {
+            0x67 => Group4Prefix::AddressSizeOverride,
+            byte => return Err(byte),
+        })
+    }
+}
+
+impl fmt::Display for Group4Prefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Group4Prefix::AddressSizeOverride => write!(f, "0x67"),
+        }
+    }
+}
+
+/// Indicate the size of an immediate operand. From the reference manual:
+///
+/// > A 1-byte (ib), 2-byte (iw), 4-byte (id) or 8-byte (io) immediate operand
+/// > to the instruction that follows the opcode, ModR/M bytes or scale-indexing
+/// > bytes. The opcode determines if the operand is a signed value. All words,
+/// > doublewords, and quadwords are given with the low-order byte first.
 #[derive(Debug, PartialEq)]
 #[allow(non_camel_case_types, reason = "makes DSL definitions easier to read")]
 pub enum Imm {

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -339,7 +339,7 @@ impl Prefixes {
     /// configured [`Prefixes`] as well as any remaining bytes.
     fn parse(mut bytes: &[u8]) -> (Self, &[u8]) {
         let mut prefixes = Self::default();
-        while prefixes.try_assign(bytes[0]).is_ok() {
+        while !bytes.is_empty() && prefixes.try_assign(bytes[0]).is_ok() {
             bytes = &bytes[1..];
         }
         (prefixes, bytes)

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -25,7 +25,7 @@ impl dsl::Format {
     }
 
     pub fn generate_rex_encoding(&self, f: &mut Formatter, rex: &dsl::Rex) {
-        self.generate_legacy_prefix(f, rex);
+        self.generate_prefixes(f, rex);
         self.generate_rex_prefix(f, rex);
         self.generate_opcodes(f, rex);
         self.generate_modrm_byte(f, rex);
@@ -33,26 +33,22 @@ impl dsl::Format {
     }
 
     /// `buf.put1(...);`
-    fn generate_legacy_prefix(&self, f: &mut Formatter, rex: &dsl::Rex) {
-        use dsl::LegacyPrefix::*;
-        if rex.opcodes.prefix != NoPrefix {
+    fn generate_prefixes(&self, f: &mut Formatter, rex: &dsl::Rex) {
+        if !rex.opcodes.prefixes.is_empty() {
             f.empty_line();
-            f.comment("Emit legacy prefixes.");
-            match rex.opcodes.prefix {
-                NoPrefix => unreachable!(),
-                _66 => fmtln!(f, "buf.put1(0x66);"),
-                _F0 => fmtln!(f, "buf.put1(0xf0);"),
-                _66F0 => {
-                    fmtln!(f, "buf.put1(0x66);");
-                    fmtln!(f, "buf.put1(0xf0);");
-                }
-                _F2 => fmtln!(f, "buf.put1(0xf2);"),
-                _F3 => fmtln!(f, "buf.put1(0xf3);"),
-                _66F3 => {
-                    fmtln!(f, "buf.put1(0x66);");
-                    fmtln!(f, "buf.put1(0xf3);");
-                }
-            }
+            f.comment("Emit prefixes.");
+        }
+        if let Some(group1) = &rex.opcodes.prefixes.group1 {
+            fmtln!(f, "buf.put1({group1});");
+        }
+        if let Some(group2) = &rex.opcodes.prefixes.group2 {
+            fmtln!(f, "buf.put1({group2});");
+        }
+        if let Some(group3) = &rex.opcodes.prefixes.group3 {
+            fmtln!(f, "buf.put1({group3});");
+        }
+        if let Some(group4) = &rex.opcodes.prefixes.group4 {
+            fmtln!(f, "buf.put1({group4});");
         }
     }
 


### PR DESCRIPTION
Previously, Cranelift's x64 backend only understood a subset of the available prefixes that can be encoded and the documentation for these was quite sparse. This change upgrades the assembler to understand all kinds of prefixes, even those as yet unused, and drastically increases the amount of documentation around these prefixes. This, along with some new `Group`-based typing, should prevent accidental misuse but also increase confidence that this implementation is correctly covering the possible cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
