### PR TITLE
asm: fix trace logging again

### DIFF
--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -79,6 +79,11 @@ impl<R: AsReg> NonRspGpr<R> {
         Self(reg)
     }
 
+    /// See [`Gpr::to_string`].
+    pub fn to_string(&self, size: Size) -> String {
+        self.0.to_string(Some(size))
+    }
+
     /// See [`Gpr::enc`].
     ///
     /// # Panics

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2383,3 +2383,25 @@ fn numeric_args() -> Result<()> {
     assert_eq!(output.stdout, b"42\n");
     Ok(())
 }
+
+#[test]
+fn compilation_logs() -> Result<()> {
+    let temp = tempfile::NamedTempFile::new()?;
+    let output = get_wasmtime_command()?
+        .args(&[
+            "compile",
+            "-Wgc",
+            "tests/all/cli_tests/issue-10353.wat",
+            "--output",
+            &temp.path().display().to_string(),
+        ])
+        .env("WASMTIME_LOG", "trace")
+        .env("RUST_BACKTRACE", "1")
+        .output()?;
+    if !output.status.success() {
+        println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("wasmtime compilation failed when logs requested");
+    }
+    Ok(())
+}

--- a/tests/all/cli_tests/issue-10353.wat
+++ b/tests/all/cli_tests/issue-10353.wat
@@ -1,0 +1,7 @@
+(module
+  (table $t 10 (ref null none))
+  (func (export "f") (result (ref null none))
+    (i32.const 99)
+    (table.get $t)
+  )
+)


### PR DESCRIPTION
As pointed out in #10476, there are a few more locations in which the raw encoding of a register is used when pretty-printing memory operands. Using the raw encoding before register allocation results in a panic. This change ensures that the additional locations delegate to the `to_string()` method which is overriden in `cranelift-codegen` to know how to pretty-print virtual registers. Closes #10476.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
