### PR TITLE
Allow setting pooling allocation in the C API

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -58,5 +58,6 @@ cranelift = ['wasmtime/cranelift']
 winch = ['wasmtime/winch']
 debug-builtins = ['wasmtime/debug-builtins']
 wat = ['dep:wat', 'wasmtime/wat']
+pooling-allocator = ["wasmtime/pooling-allocator"]
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/artifact/Cargo.toml
+++ b/crates/c-api/artifact/Cargo.toml
@@ -39,6 +39,7 @@ default = [
   'cranelift',
   'winch',
   'debug-builtins',
+  'pooling-allocator',
   # ... if you add a line above this be sure to change the other locations
   # marked WASMTIME_FEATURE_LIST
 ]
@@ -60,5 +61,6 @@ gc-null = ["wasmtime-c-api/gc-null"]
 cranelift = ["wasmtime-c-api/cranelift"]
 winch = ["wasmtime-c-api/winch"]
 debug-builtins = ["wasmtime-c-api/debug-builtins"]
+pooling-allocator = ["wasmtime-c-api/pooling-allocator"]
 # ... if you add a line above this be sure to read the comment at the end of
 # `default`

--- a/crates/c-api/build.rs
+++ b/crates/c-api/build.rs
@@ -21,6 +21,7 @@ const FEATURES: &[&str] = &[
     "WINCH",
     "DEBUG_BUILTINS",
     "WAT",
+    "POOLING_ALLOCATOR",
 ];
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/cmake/features.cmake
+++ b/crates/c-api/cmake/features.cmake
@@ -44,5 +44,6 @@ feature(async ON)
 feature(cranelift ON)
 feature(winch ON)
 feature(debug-builtins ON)
+feature(pooling-allocator ON)
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/doxygen.conf.in
+++ b/crates/c-api/doxygen.conf.in
@@ -942,6 +942,7 @@ EXCLUDE_SYMBOLS        = assertions \
                          WASMTIME_DECLARE_OWN \
                          WASI_DECLARE_OWN \
                          WASMTIME_CONFIG_PROP \
+                         WASMTIME_POOLING_ALLOCATION_CONFIG_PROP \
                          own \
                          wasm_*_enum
 

--- a/crates/c-api/include/wasmtime/conf.h.in
+++ b/crates/c-api/include/wasmtime/conf.h.in
@@ -26,6 +26,7 @@
 #cmakedefine WASMTIME_FEATURE_CRANELIFT
 #cmakedefine WASMTIME_FEATURE_WINCH
 #cmakedefine WASMTIME_FEATURE_DEBUG_BUILTINS
+#cmakedefine WASMTIME_FEATURE_POOLING_ALLOCATOR
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST
 

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -548,6 +548,9 @@ typedef struct pooling_allocation_config_t pooling_allocation_config_t;
 
 WASM_API_EXTERN pooling_allocation_config_t *pooling_allocation_config_new();
 
+WASM_API_EXTERN void
+pooling_allocation_config_delete(pooling_allocation_config_t *);
+
 #define POOLING_ALLOCATION_CONFIG_PROP(name, ty)                               \
   WASM_API_EXTERN void pooling_allocation_config_##name##_set(                 \
       pooling_allocation_config_t *, ty);

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -542,6 +542,43 @@ wasmtime_config_host_memory_creator_set(wasm_config_t *,
  */
 WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
+typedef uint8_t mpk_enabled_t;
+
+enum mpk_enabled_enum
+{
+  MPK_ENABLED_AUTO,
+  MPK_ENABLED_ENABLE,
+  MPK_ENABLED_DISABLE,
+};
+
+typedef struct
+{
+  uint32_t max_unused_warm_slots;
+  size_t decommit_batch_size;
+  size_t async_stack_keep_resident;
+  size_t linear_memory_keep_resident;
+  size_t table_keep_resident;
+  uint32_t total_component_instances;
+  size_t max_component_instance_size;
+  uint32_t max_core_instances_per_component;
+  uint32_t max_memories_per_component;
+  uint32_t max_tables_per_component;
+  uint32_t total_memories;
+  uint32_t total_tables;
+  uint32_t total_stacks;
+  uint32_t total_core_instances;
+  size_t max_core_instance_size;
+  uint32_t max_tables_per_module;
+  size_t table_elements;
+  uint32_t max_memories_per_module;
+  size_t max_memory_size;
+  mpk_enabled_t memory_protection_keys;
+  size_t max_memory_protection_keys;
+  uint32_t total_gc_heaps;
+} pooling_instance_allocator_config_t;
+
+WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(wasm_config_t *, pooling_instance_allocator_config_t);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -544,12 +544,26 @@ WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
 #ifdef WASMTIME_FEATURE_POOLING_ALLOCATOR
 
+/**
+ * \brief A type containing configuration options for the pooling allocator.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html
+ */
 typedef struct wasmtime_pooling_allocation_config_t
     wasmtime_pooling_allocation_config_t;
 
+/**
+ * \brief Creates a new pooling allocation configuration object. Must be
+ * deallocated with a call to wasmtime_pooling_allocation_config_delete.
+ */
 WASM_API_EXTERN wasmtime_pooling_allocation_config_t *
 wasmtime_pooling_allocation_config_new();
 
+/**
+ * \brief Deallocates a pooling allocation configuration object created with a
+ * call to wasmtime_pooling_allocation_config_new.
+ */
 WASM_API_EXTERN void wasmtime_pooling_allocation_config_delete(
     wasmtime_pooling_allocation_config_t *);
 
@@ -737,10 +751,18 @@ WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_memory_size, size_t)
  */
 WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_gc_heaps, uint32_t)
 
+/**
+ * \brief Sets the Wasmtime allocation strategy to use the pooling allocator. It
+ * does not take ownership of the pooling allocation configuration object, which
+ * must be deleted with a call to wasmtime_pooling_allocation_config_delete.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.allocation_strategy.
+ */
 WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(
-    wasm_config_t *, wasmtime_pooling_allocation_config_t *);
+    wasm_config_t *, const wasmtime_pooling_allocation_config_t *);
 
-#endif
+#endif // WASMTIME_FEATURE_POOLING_ALLOCATOR
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -542,42 +542,200 @@ wasmtime_config_host_memory_creator_set(wasm_config_t *,
  */
 WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
-typedef uint8_t mpk_enabled_t;
+#ifdef WASMTIME_FEATURE_POOLING_ALLOCATOR
 
-enum mpk_enabled_enum {
-  MPK_ENABLED_AUTO,
-  MPK_ENABLED_ENABLE,
-  MPK_ENABLED_DISABLE,
-};
+typedef struct pooling_allocation_config_t pooling_allocation_config_t;
 
-typedef struct {
-  uint32_t max_unused_warm_slots;
-  size_t decommit_batch_size;
-  size_t async_stack_keep_resident;
-  size_t linear_memory_keep_resident;
-  size_t table_keep_resident;
-  uint32_t total_component_instances;
-  size_t max_component_instance_size;
-  uint32_t max_core_instances_per_component;
-  uint32_t max_memories_per_component;
-  uint32_t max_tables_per_component;
-  uint32_t total_memories;
-  uint32_t total_tables;
-  uint32_t total_stacks;
-  uint32_t total_core_instances;
-  size_t max_core_instance_size;
-  uint32_t max_tables_per_module;
-  size_t table_elements;
-  uint32_t max_memories_per_module;
-  size_t max_memory_size;
-  mpk_enabled_t memory_protection_keys;
-  size_t max_memory_protection_keys;
-  uint32_t total_gc_heaps;
-} pooling_instance_allocator_config_t;
+WASM_API_EXTERN pooling_allocation_config_t *pooling_allocation_config_new();
+
+#define POOLING_ALLOCATION_CONFIG_PROP(name, ty)                               \
+  WASM_API_EXTERN void pooling_allocation_config_##name##_set(                 \
+      pooling_allocation_config_t *, ty);
+
+/**
+ * \brief Configures the maximum number of “unused warm slots” to retain in the
+ * pooling allocator.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_unused_warm_slots.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_unused_warm_slots, uint32_t)
+
+/**
+ * \brief The target number of decommits to do per batch.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.decommit_batch_size.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(decommit_batch_size, size_t)
+
+#ifdef WASMTIME_FEATURE_ASYNC
+/**
+ * \brief How much memory, in bytes, to keep resident for async stacks allocated
+ * with the pooling allocator.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.async_stack_keep_resident.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(async_stack_keep_resident, size_t)
+#endif
+
+/**
+ * \brief How much memory, in bytes, to keep resident for each linear memory
+ * after deallocation.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.linear_memory_keep_resident.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(linear_memory_keep_resident, size_t)
+
+/**
+ * \brief How much memory, in bytes, to keep resident for each table after
+ * deallocation.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_keep_resident.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(table_keep_resident, size_t)
+
+/**
+ * \brief The maximum number of concurrent component instances supported
+ * (default is 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_component_instances.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_component_instances, uint32_t)
+
+/**
+ * \brief The maximum size, in bytes, allocated for a component instance’s
+ * VMComponentContext metadata.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_component_instance_size.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_component_instance_size, size_t)
+
+/**
+ * \brief The maximum number of core instances a single component may contain
+ * (default is unlimited).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instances_per_component.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_core_instances_per_component, uint32_t)
+
+/**
+ * \brief The maximum number of Wasm linear memories that a single component may
+ * transitively contain (default is unlimited).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_component.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_component, uint32_t)
+
+/**
+ * \brief The maximum number of tables that a single component may transitively
+ * contain (default is unlimited).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_component.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_component, uint32_t)
+
+/**
+ * \brief The maximum number of concurrent Wasm linear memories supported
+ * (default is 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_memories.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_memories, uint32_t)
+
+/**
+ * \brief The maximum number of concurrent tables supported (default is 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_tables.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_tables, uint32_t)
+
+#ifdef WASMTIME_FEATURE_ASYNC
+/**
+ * \brief The maximum number of execution stacks allowed for asynchronous
+ * execution, when enabled (default is 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_stacks.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_stacks, uint32_t)
+#endif
+
+/**
+ * \brief The maximum number of concurrent core instances supported (default is
+ * 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_core_instances.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_core_instances, uint32_t)
+
+/**
+ * \brief The maximum size, in bytes, allocated for a core instance’s VMContext
+ * metadata.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instance_size.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_core_instance_size, size_t)
+
+/**
+ * \brief The maximum number of defined tables for a core module (default is 1).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_module.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_module, uint32_t)
+
+/**
+ * \brief The maximum table elements for any table defined in a module (default
+ * is 20000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_elements.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(table_elements, size_t)
+
+/**
+ * \brief The maximum number of defined linear memories for a module (default is
+ * 1).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_module.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_module, uint32_t)
+
+/**
+ * \brief The maximum byte size that any WebAssembly linear memory may grow to.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memory_size.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(max_memory_size, size_t)
+
+/**
+ * \brief The maximum number of concurrent GC heaps supported (default is 1000).
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_gc_heaps.
+ */
+POOLING_ALLOCATION_CONFIG_PROP(total_gc_heaps, uint32_t)
 
 WASM_API_EXTERN void
 wasmtime_pooling_allocation_strategy_set(wasm_config_t *,
-                                         pooling_instance_allocator_config_t);
+                                         pooling_allocation_config_t *);
+
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -544,16 +544,18 @@ WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
 #ifdef WASMTIME_FEATURE_POOLING_ALLOCATOR
 
-typedef struct pooling_allocation_config_t pooling_allocation_config_t;
+typedef struct wasmtime_pooling_allocation_config_t
+    wasmtime_pooling_allocation_config_t;
 
-WASM_API_EXTERN pooling_allocation_config_t *pooling_allocation_config_new();
+WASM_API_EXTERN wasmtime_pooling_allocation_config_t *
+wasmtime_pooling_allocation_config_new();
 
-WASM_API_EXTERN void
-pooling_allocation_config_delete(pooling_allocation_config_t *);
+WASM_API_EXTERN void wasmtime_pooling_allocation_config_delete(
+    wasmtime_pooling_allocation_config_t *);
 
-#define POOLING_ALLOCATION_CONFIG_PROP(name, ty)                               \
-  WASM_API_EXTERN void pooling_allocation_config_##name##_set(                 \
-      pooling_allocation_config_t *, ty);
+#define WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(name, ty)                      \
+  WASM_API_EXTERN void wasmtime_pooling_allocation_config_##name##_set(        \
+      wasmtime_pooling_allocation_config_t *, ty);
 
 /**
  * \brief Configures the maximum number of “unused warm slots” to retain in the
@@ -562,7 +564,7 @@ pooling_allocation_config_delete(pooling_allocation_config_t *);
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_unused_warm_slots.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_unused_warm_slots, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_unused_warm_slots, uint32_t)
 
 /**
  * \brief The target number of decommits to do per batch.
@@ -570,7 +572,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_unused_warm_slots, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.decommit_batch_size.
  */
-POOLING_ALLOCATION_CONFIG_PROP(decommit_batch_size, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(decommit_batch_size, size_t)
 
 #ifdef WASMTIME_FEATURE_ASYNC
 /**
@@ -580,7 +582,7 @@ POOLING_ALLOCATION_CONFIG_PROP(decommit_batch_size, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.async_stack_keep_resident.
  */
-POOLING_ALLOCATION_CONFIG_PROP(async_stack_keep_resident, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(async_stack_keep_resident, size_t)
 #endif
 
 /**
@@ -590,7 +592,7 @@ POOLING_ALLOCATION_CONFIG_PROP(async_stack_keep_resident, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.linear_memory_keep_resident.
  */
-POOLING_ALLOCATION_CONFIG_PROP(linear_memory_keep_resident, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(linear_memory_keep_resident, size_t)
 
 /**
  * \brief How much memory, in bytes, to keep resident for each table after
@@ -599,7 +601,7 @@ POOLING_ALLOCATION_CONFIG_PROP(linear_memory_keep_resident, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_keep_resident.
  */
-POOLING_ALLOCATION_CONFIG_PROP(table_keep_resident, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(table_keep_resident, size_t)
 
 /**
  * \brief The maximum number of concurrent component instances supported
@@ -608,7 +610,7 @@ POOLING_ALLOCATION_CONFIG_PROP(table_keep_resident, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_component_instances.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_component_instances, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_component_instances, uint32_t)
 
 /**
  * \brief The maximum size, in bytes, allocated for a component instance’s
@@ -617,7 +619,7 @@ POOLING_ALLOCATION_CONFIG_PROP(total_component_instances, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_component_instance_size.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_component_instance_size, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_component_instance_size, size_t)
 
 /**
  * \brief The maximum number of core instances a single component may contain
@@ -626,7 +628,8 @@ POOLING_ALLOCATION_CONFIG_PROP(max_component_instance_size, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instances_per_component.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_core_instances_per_component, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_core_instances_per_component,
+                                        uint32_t)
 
 /**
  * \brief The maximum number of Wasm linear memories that a single component may
@@ -635,7 +638,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_core_instances_per_component, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_component.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_component, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_component, uint32_t)
 
 /**
  * \brief The maximum number of tables that a single component may transitively
@@ -644,7 +647,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_component, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_component.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_component, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_component, uint32_t)
 
 /**
  * \brief The maximum number of concurrent Wasm linear memories supported
@@ -653,7 +656,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_component, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_memories.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_memories, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_memories, uint32_t)
 
 /**
  * \brief The maximum number of concurrent tables supported (default is 1000).
@@ -661,7 +664,7 @@ POOLING_ALLOCATION_CONFIG_PROP(total_memories, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_tables.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_tables, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_tables, uint32_t)
 
 #ifdef WASMTIME_FEATURE_ASYNC
 /**
@@ -671,7 +674,7 @@ POOLING_ALLOCATION_CONFIG_PROP(total_tables, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_stacks.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_stacks, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_stacks, uint32_t)
 #endif
 
 /**
@@ -681,7 +684,7 @@ POOLING_ALLOCATION_CONFIG_PROP(total_stacks, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_core_instances.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_core_instances, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_core_instances, uint32_t)
 
 /**
  * \brief The maximum size, in bytes, allocated for a core instance’s VMContext
@@ -690,7 +693,7 @@ POOLING_ALLOCATION_CONFIG_PROP(total_core_instances, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instance_size.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_core_instance_size, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_core_instance_size, size_t)
 
 /**
  * \brief The maximum number of defined tables for a core module (default is 1).
@@ -698,7 +701,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_core_instance_size, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_module.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_module, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_module, uint32_t)
 
 /**
  * \brief The maximum table elements for any table defined in a module (default
@@ -707,7 +710,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_tables_per_module, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_elements.
  */
-POOLING_ALLOCATION_CONFIG_PROP(table_elements, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(table_elements, size_t)
 
 /**
  * \brief The maximum number of defined linear memories for a module (default is
@@ -716,7 +719,7 @@ POOLING_ALLOCATION_CONFIG_PROP(table_elements, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_module.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_module, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_module, uint32_t)
 
 /**
  * \brief The maximum byte size that any WebAssembly linear memory may grow to.
@@ -724,7 +727,7 @@ POOLING_ALLOCATION_CONFIG_PROP(max_memories_per_module, uint32_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memory_size.
  */
-POOLING_ALLOCATION_CONFIG_PROP(max_memory_size, size_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(max_memory_size, size_t)
 
 /**
  * \brief The maximum number of concurrent GC heaps supported (default is 1000).
@@ -732,11 +735,10 @@ POOLING_ALLOCATION_CONFIG_PROP(max_memory_size, size_t)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_gc_heaps.
  */
-POOLING_ALLOCATION_CONFIG_PROP(total_gc_heaps, uint32_t)
+WASMTIME_POOLING_ALLOCATION_CONFIG_PROP(total_gc_heaps, uint32_t)
 
-WASM_API_EXTERN void
-wasmtime_pooling_allocation_strategy_set(wasm_config_t *,
-                                         pooling_allocation_config_t *);
+WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(
+    wasm_config_t *, wasmtime_pooling_allocation_config_t *);
 
 #endif
 

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -544,15 +544,13 @@ WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
 typedef uint8_t mpk_enabled_t;
 
-enum mpk_enabled_enum
-{
+enum mpk_enabled_enum {
   MPK_ENABLED_AUTO,
   MPK_ENABLED_ENABLE,
   MPK_ENABLED_DISABLE,
 };
 
-typedef struct
-{
+typedef struct {
   uint32_t max_unused_warm_slots;
   size_t decommit_batch_size;
   size_t async_stack_keep_resident;
@@ -577,7 +575,9 @@ typedef struct
   uint32_t total_gc_heaps;
 } pooling_instance_allocator_config_t;
 
-WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(wasm_config_t *, pooling_instance_allocator_config_t);
+WASM_API_EXTERN void
+wasmtime_pooling_allocation_strategy_set(wasm_config_t *,
+                                         pooling_instance_allocator_config_t);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -452,26 +452,30 @@ pub extern "C" fn wasmtime_config_wasm_wide_arithmetic_set(c: &mut wasm_config_t
 #[repr(C)]
 #[derive(Clone)]
 #[cfg(feature = "pooling-allocator")]
-pub struct pooling_allocation_config_t {
+pub struct wasmtime_pooling_allocation_config_t {
     pub(crate) config: PoolingAllocationConfig,
 }
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_new() -> Box<pooling_allocation_config_t> {
-    Box::new(pooling_allocation_config_t {
+pub extern "C" fn wasmtime_pooling_allocation_config_new(
+) -> Box<wasmtime_pooling_allocation_config_t> {
+    Box::new(wasmtime_pooling_allocation_config_t {
         config: PoolingAllocationConfig::default(),
     })
 }
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_delete(_: Box<pooling_allocation_config_t>) {}
+pub extern "C" fn wasmtime_pooling_allocation_config_delete(
+    _: Box<wasmtime_pooling_allocation_config_t>,
+) {
+}
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_unused_warm_slots_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_unused_warm_slots_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     max: u32,
 ) {
     c.config.max_unused_warm_slots(max);
@@ -479,8 +483,8 @@ pub extern "C" fn pooling_allocation_config_max_unused_warm_slots_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_decommit_batch_size_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_decommit_batch_size_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     batch_size: usize,
 ) {
     c.config.decommit_batch_size(batch_size);
@@ -488,8 +492,8 @@ pub extern "C" fn pooling_allocation_config_decommit_batch_size_set(
 
 #[unsafe(no_mangle)]
 #[cfg(all(feature = "pooling-allocator", feature = "async"))]
-pub extern "C" fn pooling_allocation_config_async_stack_keep_resident_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_async_stack_keep_resident_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     size: usize,
 ) {
     c.config.async_stack_keep_resident(size);
@@ -497,8 +501,8 @@ pub extern "C" fn pooling_allocation_config_async_stack_keep_resident_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_linear_memory_keep_resident_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_linear_memory_keep_resident_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     size: usize,
 ) {
     c.config.linear_memory_keep_resident(size);
@@ -506,8 +510,8 @@ pub extern "C" fn pooling_allocation_config_linear_memory_keep_resident_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_table_keep_resident_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_table_keep_resident_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     size: usize,
 ) {
     c.config.table_keep_resident(size);
@@ -515,8 +519,8 @@ pub extern "C" fn pooling_allocation_config_table_keep_resident_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_total_component_instances_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_component_instances_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_component_instances(count);
@@ -524,8 +528,8 @@ pub extern "C" fn pooling_allocation_config_total_component_instances_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_component_instance_size_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_component_instance_size_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     size: usize,
 ) {
     c.config.max_component_instance_size(size);
@@ -533,8 +537,8 @@ pub extern "C" fn pooling_allocation_config_max_component_instance_size_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_core_instances_per_component_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_core_instances_per_component_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.max_core_instances_per_component(count);
@@ -542,8 +546,8 @@ pub extern "C" fn pooling_allocation_config_max_core_instances_per_component_set
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_memories_per_component_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_memories_per_component_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.max_memories_per_component(count);
@@ -551,8 +555,8 @@ pub extern "C" fn pooling_allocation_config_max_memories_per_component_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_tables_per_component_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_tables_per_component_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.max_tables_per_component(count);
@@ -560,8 +564,8 @@ pub extern "C" fn pooling_allocation_config_max_tables_per_component_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_total_memories_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_memories_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_memories(count);
@@ -569,8 +573,8 @@ pub extern "C" fn pooling_allocation_config_total_memories_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_total_tables_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_tables_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_tables(count);
@@ -578,8 +582,8 @@ pub extern "C" fn pooling_allocation_config_total_tables_set(
 
 #[unsafe(no_mangle)]
 #[cfg(all(feature = "pooling-allocator", feature = "async"))]
-pub extern "C" fn pooling_allocation_config_total_stacks_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_stacks_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_stacks(count);
@@ -587,8 +591,8 @@ pub extern "C" fn pooling_allocation_config_total_stacks_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_total_core_instances_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_core_instances_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_core_instances(count);
@@ -596,8 +600,8 @@ pub extern "C" fn pooling_allocation_config_total_core_instances_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_core_instance_size_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_core_instance_size_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     size: usize,
 ) {
     c.config.max_core_instance_size(size);
@@ -605,8 +609,8 @@ pub extern "C" fn pooling_allocation_config_max_core_instance_size_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_tables_per_module_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_tables_per_module_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     tables: u32,
 ) {
     c.config.max_tables_per_module(tables);
@@ -614,8 +618,8 @@ pub extern "C" fn pooling_allocation_config_max_tables_per_module_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_table_elements_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_table_elements_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     elements: usize,
 ) {
     c.config.table_elements(elements);
@@ -623,8 +627,8 @@ pub extern "C" fn pooling_allocation_config_table_elements_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_memories_per_module_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_memories_per_module_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     memories: u32,
 ) {
     c.config.max_memories_per_module(memories);
@@ -632,8 +636,8 @@ pub extern "C" fn pooling_allocation_config_max_memories_per_module_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
-pub extern "C" fn pooling_allocation_config_max_memory_size_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_max_memory_size_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     bytes: usize,
 ) {
     c.config.max_memory_size(bytes);
@@ -641,8 +645,8 @@ pub extern "C" fn pooling_allocation_config_max_memory_size_set(
 
 #[unsafe(no_mangle)]
 #[cfg(all(feature = "pooling-allocator", feature = "gc"))]
-pub extern "C" fn pooling_allocation_config_total_gc_heaps_set(
-    c: &mut pooling_allocation_config_t,
+pub extern "C" fn wasmtime_pooling_allocation_config_total_gc_heaps_set(
+    c: &mut wasmtime_pooling_allocation_config_t,
     count: u32,
 ) {
     c.config.total_gc_heaps(count);
@@ -652,7 +656,7 @@ pub extern "C" fn pooling_allocation_config_total_gc_heaps_set(
 #[cfg(feature = "pooling-allocator")]
 pub extern "C" fn wasmtime_pooling_allocation_strategy_set(
     c: &mut wasm_config_t,
-    pc: &pooling_allocation_config_t,
+    pc: &wasmtime_pooling_allocation_config_t,
 ) {
     c.config
         .allocation_strategy(InstanceAllocationStrategy::Pooling(pc.config.clone()));

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -449,86 +449,207 @@ pub extern "C" fn wasmtime_config_wasm_wide_arithmetic_set(c: &mut wasm_config_t
     c.config.wasm_wide_arithmetic(enable);
 }
 
-#[repr(u8)]
-#[derive(Clone)]
-pub enum mpk_enabled_t {
-    Auto,
-    Enable,
-    Disable,
-}
-
 #[repr(C)]
 #[derive(Clone)]
-pub struct pooling_instance_allocator_config_t {
-    max_unused_warm_slots: u32,
-    decommit_batch_size: usize,
-    async_stack_keep_resident: usize,
-    linear_memory_keep_resident: usize,
-    table_keep_resident: usize,
-    total_component_instances: u32,
-    max_component_instance_size: usize,
-    max_core_instances_per_component: u32,
-    max_memories_per_component: u32,
-    max_tables_per_component: u32,
-    total_memories: u32,
-    total_tables: u32,
-    total_stacks: u32,
-    total_core_instances: u32,
-    max_core_instance_size: usize,
-    max_tables_per_module: u32,
-    table_elements: usize,
-    max_memories_per_module: u32,
-    max_memory_size: usize,
-    memory_protection_keys: mpk_enabled_t,
-    max_memory_protection_keys: usize,
-    total_gc_heaps: u32,
+#[cfg(feature = "pooling-allocator")]
+pub struct pooling_allocation_config_t {
+    pub(crate) config: PoolingAllocationConfig,
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_new() -> Box<pooling_allocation_config_t> {
+    Box::new(pooling_allocation_config_t {
+        config: PoolingAllocationConfig::default(),
+    })
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_unused_warm_slots_set(
+    c: &mut pooling_allocation_config_t,
+    max: u32,
+) {
+    c.config.max_unused_warm_slots(max);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_decommit_batch_size_set(
+    c: &mut pooling_allocation_config_t,
+    batch_size: usize,
+) {
+    c.config.decommit_batch_size(batch_size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(all(feature = "pooling-allocator", feature = "async"))]
+pub extern "C" fn pooling_allocation_config_async_stack_keep_resident_set(
+    c: &mut pooling_allocation_config_t,
+    size: usize,
+) {
+    c.config.async_stack_keep_resident(size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_linear_memory_keep_resident_set(
+    c: &mut pooling_allocation_config_t,
+    size: usize,
+) {
+    c.config.linear_memory_keep_resident(size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_table_keep_resident_set(
+    c: &mut pooling_allocation_config_t,
+    size: usize,
+) {
+    c.config.table_keep_resident(size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_total_component_instances_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_component_instances(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_component_instance_size_set(
+    c: &mut pooling_allocation_config_t,
+    size: usize,
+) {
+    c.config.max_component_instance_size(size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_core_instances_per_component_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.max_core_instances_per_component(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_memories_per_component_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.max_memories_per_component(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_tables_per_component_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.max_tables_per_component(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_total_memories_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_memories(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_total_tables_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_tables(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(all(feature = "pooling-allocator", feature = "async"))]
+pub extern "C" fn pooling_allocation_config_total_stacks_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_stacks(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_total_core_instances_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_core_instances(count);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_core_instance_size_set(
+    c: &mut pooling_allocation_config_t,
+    size: usize,
+) {
+    c.config.max_core_instance_size(size);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_tables_per_module_set(
+    c: &mut pooling_allocation_config_t,
+    tables: u32,
+) {
+    c.config.max_tables_per_module(tables);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_table_elements_set(
+    c: &mut pooling_allocation_config_t,
+    elements: usize,
+) {
+    c.config.table_elements(elements);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_memories_per_module_set(
+    c: &mut pooling_allocation_config_t,
+    memories: u32,
+) {
+    c.config.max_memories_per_module(memories);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_max_memory_size_set(
+    c: &mut pooling_allocation_config_t,
+    bytes: usize,
+) {
+    c.config.max_memory_size(bytes);
+}
+
+#[unsafe(no_mangle)]
+#[cfg(all(feature = "pooling-allocator", feature = "gc"))]
+pub extern "C" fn pooling_allocation_config_total_gc_heaps_set(
+    c: &mut pooling_allocation_config_t,
+    count: u32,
+) {
+    c.config.total_gc_heaps(count);
 }
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
 pub extern "C" fn wasmtime_pooling_allocation_strategy_set(
     c: &mut wasm_config_t,
-    pc: pooling_instance_allocator_config_t,
+    pc: &pooling_allocation_config_t,
 ) {
-    let mut pooling_config = PoolingAllocationConfig::new();
-    pooling_config
-        .max_unused_warm_slots(pc.max_unused_warm_slots)
-        .decommit_batch_size(pc.decommit_batch_size)
-        .linear_memory_keep_resident(pc.linear_memory_keep_resident)
-        .table_keep_resident(pc.table_keep_resident)
-        .total_component_instances(pc.total_component_instances)
-        .max_component_instance_size(pc.max_component_instance_size)
-        .max_core_instances_per_component(pc.max_core_instances_per_component)
-        .max_memories_per_component(pc.max_memories_per_component)
-        .max_tables_per_component(pc.max_tables_per_component)
-        .total_memories(pc.total_memories)
-        .total_tables(pc.total_tables)
-        .total_core_instances(pc.total_core_instances)
-        .max_core_instance_size(pc.max_core_instance_size)
-        .max_tables_per_module(pc.max_tables_per_module)
-        .table_elements(pc.table_elements)
-        .max_memories_per_module(pc.max_memories_per_module)
-        .max_memory_size(pc.max_memory_size);
-    #[cfg(feature = "async")]
-    {
-        pooling_config
-            .async_stack_keep_resident(pc.async_stack_keep_resident)
-            .total_stacks(pc.total_stacks);
-    }
-    #[cfg(feature = "memory-protection-keys")]
-    {
-        pooling_config
-            .memory_protection_keys(match pc.memory_protection_keys {
-                mpk_enabled_t::Auto => wasmtime::MpkEnabled::Auto,
-                mpk_enabled_t::Enable => wasmtime::MpkEnabled::Enable,
-                mpk_enabled_t::Disable => wasmtime::MpkEnabled::Disable,
-            })
-            .max_memory_protection_keys(pc.max_memory_protection_keys);
-    }
-    #[cfg(feature = "gc")]
-    {
-        pooling_config.total_gc_heaps(pc.total_gc_heaps);
-    }
     c.config
-        .allocation_strategy(InstanceAllocationStrategy::Pooling(pooling_config));
+        .allocation_strategy(InstanceAllocationStrategy::Pooling(pc.config.clone()));
 }

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -466,6 +466,10 @@ pub extern "C" fn pooling_allocation_config_new() -> Box<pooling_allocation_conf
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "pooling-allocator")]
+pub extern "C" fn pooling_allocation_config_delete(_: Box<pooling_allocation_config_t>) {}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "pooling-allocator")]
 pub extern "C" fn pooling_allocation_config_max_unused_warm_slots_set(
     c: &mut pooling_allocation_config_t,
     max: u32,


### PR DESCRIPTION
We are troubleshooting performance / scaling issues in our project that uses Wasmtime and Pooling Allocation was recommended. Currently, we are not able to enable Pooling Allocation through the C API. 


Note: mpk options are not exposed.