### PR TITLE
fuzz: enable `relxed-simd` for the Wasmi oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60160ffa66a3f95ae969aaf9cac28591b919a677d68faf29810c4989d5b0cad8"
+checksum = "7bdd371943f36290dbb9abe6c66d6f134d0d04a04e841db1350323f9ce0bf853"
 dependencies = [
  "arrayvec",
  "multi-stash",
@@ -4078,18 +4078,18 @@ dependencies = [
 
 [[package]]
 name = "wasmi_collections"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38a962e32f510cd9732dc24308658bccbfe636df813bf53e798073c16c5ab8d"
+checksum = "5c4e8dc4d2633828f8d5889be2cb08f6aa3e96173d36ae39e0f13e4e68c85420"
 dependencies = [
  "string-interner",
 ]
 
 [[package]]
 name = "wasmi_core"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae83f6d1e9344c25ab2defb563a65c3bcfad6fbd910c342367a15222b9e9525"
+checksum = "e11b21ca7ed6e97e8b88c4f87849ac9dacfef19b1e612fe6f0d571a907738c4f"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi_ir"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9306bd1b4aa21dbfa9e4fc472d51cd40548c34add184e5ac38c3adf4214c356"
+checksum = "564cebf11f3ba5c708aeff606ca396322c28e742f2142be3c760caac1038d9ab"
 dependencies = [
  "wasmi_core",
 ]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -30,7 +30,7 @@ wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
 wasm-mutate = { workspace = true }
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
-wasmi = { version = "0.43.0", default-features = false, features = ["std", "simd"] }
+wasmi = { version = "0.44.0", default-features = false, features = ["std", "simd"] }
 futures = { workspace = true }
 wasmtime-test-util = { workspace = true, features = ['wast', 'component-fuzz', 'component'] }
 

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -14,7 +14,6 @@ impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
         // Force generated Wasm modules to never have features that Wasmi doesn't support.
-        config.relaxed_simd_enabled = false;
         config.threads_enabled = false;
         config.exceptions_enabled = false;
         config.gc_enabled = false;
@@ -35,6 +34,7 @@ impl WasmiEngine {
             .wasm_custom_page_sizes(config.custom_page_sizes_enabled)
             .wasm_memory64(config.memory64_enabled)
             .wasm_simd(config.simd_enabled)
+            .wasm_relaxed_simd(config.relaxed_simd_enabled)
             .wasm_wide_arithmetic(config.wide_arithmetic_enabled);
         Self {
             engine: wasmi::Engine::new(&wasmi_config),


### PR DESCRIPTION
This enables `relaxed-simd` for the Wasmi differential fuzzing oracle.

Note that the `relaxed-simd` proposal support is very new for Wasmi. I have only ran Wasmi's differential fuzzing for ~45 minutes before it crashed with [the already known Wasmtime bug](https://github.com/bytecodealliance/wasmtime/issues/10479).

Feel free to accept or close this PR.