### PR TITLE
Fix broken link to WASI async

### DIFF
--- a/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
+++ b/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
@@ -493,7 +493,7 @@ pub mod _6_exported_resources;
 /// * async functions are used
 /// * enabled async in bindgen! macro
 ///
-/// See [wasi_async_example](https://github.com/bytecodealliance/wasmtime/tree/main/examples/wasi-async) for async function calls on a host.
+/// See [wasi_async_example](https://github.com/bytecodealliance/wasmtime/blob/main/examples/wasip1-async/main.rs) for async function calls on a host.
 ///
 /// ```rust
 /// use wasmtime::Result;


### PR DESCRIPTION
Old:
https://github.com/bytecodealliance/wasmtime/tree/main/examples/wasi-async

New:
https://github.com/bytecodealliance/wasmtime/blob/main/examples/wasip1-async/main.rs


The original link pointed to a non-existent folder (wasi-async), resulting in a 404.
The wasip1-async example is the current equivalent for demonstrating async WASI usage and should be referenced instead.