### PR TITLE
wasi-nn: Make Tensor properties public allowing external Engines to e…

### DIFF
--- a/crates/wasi-nn/src/lib.rs
+++ b/crates/wasi-nn/src/lib.rs
@@ -70,9 +70,9 @@ impl std::ops::Deref for Graph {
 /// https://github.com/WebAssembly/wasi-nn/pull/70).
 #[derive(Clone, PartialEq)]
 pub struct Tensor {
-    dimensions: Vec<u32>,
-    ty: wit::TensorType,
-    data: Vec<u8>,
+    pub dimensions: Vec<u32>,
+    pub ty: wit::TensorType,
+    pub data: Vec<u8>,
 }
 impl fmt::Debug for Tensor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
…xtend without being part of wasmtime-wasi-nn

Discussed here [#wasi-nn > Extending wasm-wasi-nn host impl with additional Backends](https://bytecodealliance.zulipchat.com/#narrow/channel/266558-wasi-nn/topic/Extending.20wasm-wasi-nn.20host.20impl.20with.20additional.20Backends)

This change will allow wasmtime-wasi-nn Backend Engines to be loaded with them having to be part of the wasmtime-wasi-nn crate.