### PR TITLE
Adjust hints about using `WASMTIME_BACKTRACE_DETAILS`

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -491,9 +491,9 @@ impl Config {
             WasmBacktraceDetails::Enable => Some(true),
             WasmBacktraceDetails::Disable => Some(false),
             WasmBacktraceDetails::Environment => {
-                self.wasm_backtrace_details_env_used = true;
                 #[cfg(feature = "std")]
                 {
+                    self.wasm_backtrace_details_env_used = true;
                     std::env::var("WASMTIME_BACKTRACE_DETAILS")
                         .map(|s| Some(s == "1"))
                         .unwrap_or(Some(false))

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -323,7 +323,10 @@ impl WasmBacktrace {
                 // `Display` to indicate that more detailed information
                 // in a trap may be available.
                 let has_unparsed_debuginfo = module.compiled_module().has_unparsed_debuginfo();
-                if has_unparsed_debuginfo && wasm_backtrace_details_env_used {
+                if has_unparsed_debuginfo
+                    && wasm_backtrace_details_env_used
+                    && cfg!(feature = "addr2line")
+                {
                     hint_wasm_backtrace_details_env = true;
                 }
             }


### PR DESCRIPTION
This commit updates some infrastructure to hint that `WASMTIME_BACKTRACE_DETAILS` can be used to show more detail in backtraces. Notably this warning is suppressed if `feature = "std"` is turned off or if `feature = "addr2line"` is turned off since both are required.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
