### PR TITLE
Expose default value constructors for Wasm types in host API

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1143,7 +1143,7 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
             other_ty => match other_ty.default_value(&mut store) {
                 Some(item) => item,
                 None => {
-                    // log::warn!("couldn't create import: {}", e);
+                    log::warn!("couldn't create import for {import:?}");
                     return;
                 }
             },

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -680,7 +680,11 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
                 let nth = nth % funcs.len();
                 let f = &funcs[nth];
                 let ty = f.ty(&store);
-                if let Ok(params) = dummy::dummy_values(ty.params()) {
+                if let Some(params) = ty
+                    .params()
+                    .map(|p| p.default_value())
+                    .collect::<Option<Vec<_>>>()
+                {
                     let mut results = vec![Val::I32(0); ty.results().len()];
                     let _ = f.call(store, &params, &mut results);
                 }
@@ -1129,17 +1133,17 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
                         log::info!("yielding {} times in import", poll_amt);
                         YieldN(poll_amt).await;
                         for (ret_ty, result) in ty.results().zip(results) {
-                            *result = dummy::dummy_value(ret_ty)?;
+                            *result = ret_ty.default_value().unwrap();
                         }
                         Ok(())
                     })
                 })
                 .into()
             }
-            other_ty => match dummy::dummy_extern(&mut store, other_ty) {
-                Ok(item) => item,
-                Err(e) => {
-                    log::warn!("couldn't create import: {}", e);
+            other_ty => match other_ty.default_value(&mut store) {
+                Some(item) => item,
+                None => {
+                    // log::warn!("couldn't create import: {}", e);
                     return;
                 }
             },
@@ -1187,11 +1191,11 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
         let ty = func.ty(&store);
         let params = ty
             .params()
-            .map(|ty| dummy::dummy_value(ty).unwrap())
+            .map(|ty| ty.default_value().unwrap())
             .collect::<Vec<_>>();
         let mut results = ty
             .results()
-            .map(|ty| dummy::dummy_value(ty).unwrap())
+            .map(|ty| ty.default_value().unwrap())
             .collect::<Vec<_>>();
 
         log::info!("invoking export {:?}", name);

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -1,6 +1,5 @@
 //! Dummy implementations of things that a Wasm module can import.
 
-use anyhow::ensure;
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
@@ -8,74 +7,15 @@ pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T
     let mut linker = Linker::new(store.engine());
     linker.allow_shadowing(true);
     for import in module.imports() {
-        let extern_ = dummy_extern(store, import.ty())?;
+        let extern_ = import
+            .ty()
+            .default_value(&mut *store)
+            .ok_or(anyhow::anyhow!("ERROR"))?;
         linker
             .define(&store, import.module(), import.name(), extern_)
             .unwrap();
     }
     Ok(linker)
-}
-
-/// Construct a dummy `Extern` from its type signature
-pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
-    Ok(match ty {
-        ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)?),
-        ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)?),
-        ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
-        ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
-        ExternType::Tag(_tag_ty) => todo!(), // FIXME: #10252
-    })
-}
-
-/// Construct a dummy function for the given function type
-pub fn dummy_func<T>(store: &mut Store<T>, ty: FuncType) -> Result<Func> {
-    let dummy_results = ty.results().map(dummy_value).collect::<Result<Vec<_>>>()?;
-    Ok(Func::new(store, ty.clone(), move |_, _, results| {
-        for (slot, dummy) in results.iter_mut().zip(&dummy_results) {
-            *slot = *dummy;
-        }
-        Ok(())
-    }))
-}
-
-/// Construct a dummy value for the given value type.
-pub fn dummy_value(val_ty: ValType) -> Result<Val> {
-    Ok(match val_ty {
-        ValType::I32 => Val::I32(0),
-        ValType::I64 => Val::I64(0),
-        ValType::F32 => Val::F32(0),
-        ValType::F64 => Val::F64(0),
-        ValType::V128 => Val::V128(0.into()),
-        ValType::Ref(r) => {
-            ensure!(
-                r.is_nullable(),
-                "cannot construct a dummy value of type `{r}`"
-            );
-            Val::null_ref(r.heap_type())
-        }
-    })
-}
-
-/// Construct a sequence of dummy values for the given types.
-pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Result<Vec<Val>> {
-    val_tys.into_iter().map(dummy_value).collect()
-}
-
-/// Construct a dummy global for the given global type.
-pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Result<Global> {
-    let val = dummy_value(ty.content().clone())?;
-    Global::new(store, ty, val)
-}
-
-/// Construct a dummy table for the given table type.
-pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Result<Table> {
-    let init_val = dummy_value(ty.element().clone().into())?;
-    Table::new(store, ty, init_val.ref_().unwrap())
-}
-
-/// Construct a dummy memory for the given memory type.
-pub fn dummy_memory<T>(store: &mut Store<T>, ty: MemoryType) -> Result<Memory> {
-    Memory::new(store, ty)
 }
 
 #[cfg(test)]
@@ -93,7 +33,8 @@ mod tests {
     #[test]
     fn dummy_table_import() {
         let mut store = store();
-        let table = dummy_table(&mut store, TableType::new(RefType::EXTERNREF, 10, None)).unwrap();
+        let table_type = TableType::new(RefType::EXTERNREF, 10, None);
+        let table = table_type.default_value(&mut store).unwrap();
         assert_eq!(table.size(&store), 10);
         for i in 0..10 {
             assert!(table.get(&mut store, i).unwrap().unwrap_extern().is_none());
@@ -103,8 +44,8 @@ mod tests {
     #[test]
     fn dummy_global_import() {
         let mut store = store();
-        let global =
-            dummy_global(&mut store, GlobalType::new(ValType::I32, Mutability::Const)).unwrap();
+        let global_type = GlobalType::new(ValType::I32, Mutability::Const);
+        let global = global_type.default_value(&mut store).unwrap();
         assert!(global.ty(&store).content().is_i32());
         assert_eq!(global.ty(&store).mutability(), Mutability::Const);
     }
@@ -112,7 +53,8 @@ mod tests {
     #[test]
     fn dummy_memory_import() {
         let mut store = store();
-        let memory = dummy_memory(&mut store, MemoryType::new(1, None)).unwrap();
+        let memory_type = MemoryType::new(1, None);
+        let memory = memory_type.default_value(&mut store).unwrap();
         assert_eq!(memory.size(&store), 1);
     }
 
@@ -120,7 +62,7 @@ mod tests {
     fn dummy_function_import() {
         let mut store = store();
         let func_ty = FuncType::new(store.engine(), vec![ValType::I32], vec![ValType::I64]);
-        let func = dummy_func(&mut store, func_ty.clone()).unwrap();
+        let func = func_ty.default_value(&mut store).unwrap();
         let actual_ty = func.ty(&store);
         assert!(FuncType::eq(&actual_ty, &func_ty));
     }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -5,7 +5,7 @@ use crate::store::StoreOpaque;
 use crate::{prelude::*, IntoFunc};
 use crate::{
     AsContext, AsContextMut, Caller, Engine, Extern, ExternType, Func, FuncType, ImportType,
-    Instance, Module, StoreContextMut, Val, ValRaw, ValType,
+    Instance, Module, StoreContextMut, Val, ValRaw,
 };
 use alloc::sync::Arc;
 use core::fmt::{self, Debug};
@@ -269,48 +269,28 @@ impl<T> Linker<T> {
     /// # let module = Module::new(&engine, "(module (import \"unknown\" \"import\" (func)))")?;
     /// # let mut store = Store::new(&engine, ());
     /// let mut linker = Linker::new(&engine);
-    /// linker.define_unknown_imports_as_default_values(&module)?;
+    /// linker.define_unknown_imports_as_default_values(&mut store, &module)?;
     /// linker.instantiate(&mut store, &module)?;
     /// # Ok(())
     /// # }
     /// ```
     pub fn define_unknown_imports_as_default_values(
         &mut self,
+        store: &mut impl AsContextMut<Data = T>,
         module: &Module,
     ) -> anyhow::Result<()> {
         for import in module.imports() {
             if let Err(import_err) = self._get_by_import(&import) {
-                if let ExternType::Func(func_ty) = import_err.ty() {
-                    let result_tys: Vec<_> = func_ty.results().collect();
-
-                    for ty in &result_tys {
-                        if ty.as_ref().map_or(false, |r| !r.is_nullable()) {
-                            bail!("no default value exists for type `{ty}`")
-                        }
-                    }
-
-                    self.func_new(
-                        import.module(),
-                        import.name(),
-                        func_ty,
-                        move |_caller, _args, results| {
-                            for (result, ty) in results.iter_mut().zip(&result_tys) {
-                                *result = match ty {
-                                    ValType::I32 => Val::I32(0),
-                                    ValType::I64 => Val::I64(0),
-                                    ValType::F32 => Val::F32(0.0_f32.to_bits()),
-                                    ValType::F64 => Val::F64(0.0_f64.to_bits()),
-                                    ValType::V128 => Val::V128(0_u128.into()),
-                                    ValType::Ref(r) => {
-                                        debug_assert!(r.is_nullable());
-                                        Val::null_ref(r.heap_type())
-                                    }
-                                };
-                            }
-                            Ok(())
-                        },
-                    )?;
-                }
+                let default_extern =
+                    import_err.ty().default_value(&mut *store).ok_or_else(|| {
+                        anyhow!("no default value exists for type `{:?}`", import_err.ty())
+                    })?;
+                self.define(
+                    store.as_context(),
+                    import.module(),
+                    import.name(),
+                    default_extern,
+                )?;
             }
         }
         Ok(())

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -345,7 +345,7 @@ impl ValType {
             WasmValType::Ref(r) => Self::Ref(RefType::from_wasm_type(engine, r)),
         }
     }
-    ///
+    /// Construct a default value. Returns None for non-nullable Ref types, which have no default.
     pub fn default_value(&self) -> Option<Val> {
         match self {
             ValType::I32 => Some(Val::I32(0)),
@@ -1248,7 +1248,7 @@ impl ExternType {
             EntityType::Tag(ty) => TagType::from_wasmtime_tag(engine, ty).into(),
         }
     }
-    ///
+    /// Construct a default value, if possible for the underlying type. Tags do not have a default value.
     pub fn default_value(&self, store: impl AsContextMut) -> Option<Extern> {
         match self {
             ExternType::Func(func_ty) => func_ty.default_value(store).map(Extern::Func),
@@ -2433,7 +2433,7 @@ impl FuncType {
         debug_assert!(registered_type.is_func());
         Self { registered_type }
     }
-    ///
+    /// Construct a func which returns results of default value, if each result type has a default value.
     pub fn default_value(&self, mut store: impl AsContextMut) -> Option<Func> {
         let dummy_results = self
             .results()

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1,5 +1,9 @@
 use crate::prelude::*;
+use crate::runtime::externals::Global as RuntimeGlobal;
+use crate::runtime::externals::Table as RuntimeTable;
+use crate::runtime::Memory as RuntimeMemory;
 use crate::{type_registry::RegisteredType, Engine};
+use crate::{AsContextMut, Extern, Func, Val};
 use core::fmt::{self, Display, Write};
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, EntityType, Global, IndexType, Limits, Memory, ModuleTypes, Table,
@@ -339,6 +343,23 @@ impl ValType {
             WasmValType::F64 => Self::F64,
             WasmValType::V128 => Self::V128,
             WasmValType::Ref(r) => Self::Ref(RefType::from_wasm_type(engine, r)),
+        }
+    }
+    ///
+    pub fn default_value(&self) -> Option<Val> {
+        match self {
+            ValType::I32 => Some(Val::I32(0)),
+            ValType::I64 => Some(Val::I64(0)),
+            ValType::F32 => Some(Val::F32(0)),
+            ValType::F64 => Some(Val::F64(0)),
+            ValType::V128 => Some(Val::V128(0.into())),
+            ValType::Ref(r) => {
+                if r.is_nullable() {
+                    Some(Val::null_ref(r.heap_type()))
+                } else {
+                    None
+                }
+            }
         }
     }
 }
@@ -1225,6 +1246,16 @@ impl ExternType {
             EntityType::Memory(ty) => MemoryType::from_wasmtime_memory(ty).into(),
             EntityType::Table(ty) => TableType::from_wasmtime_table(engine, ty).into(),
             EntityType::Tag(ty) => TagType::from_wasmtime_tag(engine, ty).into(),
+        }
+    }
+    ///
+    pub fn default_value(&self, store: impl AsContextMut) -> Option<Extern> {
+        match self {
+            ExternType::Func(func_ty) => func_ty.default_value(store).map(Extern::Func),
+            ExternType::Global(global_ty) => global_ty.default_value(store).map(Extern::Global),
+            ExternType::Table(table_ty) => table_ty.default_value(store).map(Extern::Table),
+            ExternType::Memory(mem_ty) => mem_ty.default_value(store).map(Extern::Memory),
+            ExternType::Tag(_) => None, // FIXME: #10252
         }
     }
 }
@@ -2402,6 +2433,19 @@ impl FuncType {
         debug_assert!(registered_type.is_func());
         Self { registered_type }
     }
+    ///
+    pub fn default_value(&self, mut store: impl AsContextMut) -> Option<Func> {
+        let dummy_results = self
+            .results()
+            .map(|ty| ty.default_value())
+            .collect::<Option<Vec<_>>>()?;
+        Some(Func::new(&mut store, self.clone(), move |_, _, results| {
+            for (slot, dummy) in results.iter_mut().zip(dummy_results.iter()) {
+                *slot = *dummy;
+            }
+            Ok(())
+        }))
+    }
 }
 
 // Global Types
@@ -2456,6 +2500,11 @@ impl GlobalType {
             Mutability::Const
         };
         GlobalType::new(ty, mutability)
+    }
+    ///
+    pub fn default_value(&self, store: impl AsContextMut) -> Option<RuntimeGlobal> {
+        let val = self.content().default_value()?;
+        RuntimeGlobal::new(store, self.clone(), val).ok()
     }
 }
 
@@ -2586,6 +2635,12 @@ impl TableType {
 
     pub(crate) fn wasmtime_table(&self) -> &Table {
         &self.ty
+    }
+    ///
+    pub fn default_value(&self, store: impl AsContextMut) -> Option<RuntimeTable> {
+        let val: ValType = self.element().clone().into();
+        let init_val = val.default_value()?.ref_()?;
+        RuntimeTable::new(store, self.clone(), init_val).ok()
     }
 }
 
@@ -2917,6 +2972,10 @@ impl MemoryType {
 
     pub(crate) fn wasmtime_memory(&self) -> &Memory {
         &self.ty
+    }
+    ///
+    pub fn default_value(&self, store: impl AsContextMut) -> Option<RuntimeMemory> {
+        RuntimeMemory::new(store, self.clone()).ok()
     }
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -421,7 +421,7 @@ impl RunCommand {
         if self.run.common.wasm.unknown_imports_default == Some(true) {
             match linker {
                 CliLinker::Core(linker) => {
-                    linker.define_unknown_imports_as_default_values(module.unwrap_core())?;
+                    linker.define_unknown_imports_as_default_values(store, module.unwrap_core())?;
                 }
                 _ => bail!("cannot use `--default-values-unknown-imports` with components"),
             }

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -420,7 +420,7 @@ fn test_default_value_unknown_import() -> Result<()> {
     let module = Module::new(store.engine(), WAT).expect("failed to create module");
     let mut linker = Linker::new(store.engine());
 
-    linker.define_unknown_imports_as_default_values(&module)?;
+    linker.define_unknown_imports_as_default_values(&mut store, &module)?;
     let instance = linker.instantiate(&mut store, &module)?;
 
     // "run" calls an import function which will not be defined, so it should


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
## Description:

This pull request addresses issue #10437 by adding default_value(&self, store: impl AsContextMut) -> Option<T> methods to various Wasm types (e.g., ExternType, GlobalType, MemoryType, ValType, etc.), enabling default value construction for the host API.

## Changes:

- Implemented new default_value in different types in types.rs.
- Refactored duplicate code from the fuzzing utility by moving default value construction to these new methods.
- Removed the majority of the code from the wasmtime_fuzzing::oracles::dummy module.
- Modified code that used dummy functions


## Additional Notes:

- No documentation comments were added.
- The error in oracles.rs was commented out because the variable e no longer exists.
- For dummy.rs/dummy_linker, a placeholder error “ERROR” has been added, because I didn't know what error to put on it.
- The comment // FIXME #10252 was relocated to the corresponding default_value method implementation.