### PR TITLE
Test the full error context in fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -332,7 +332,7 @@ fn compile_module(
                 // when arbitrary table element limits have been exceeded as
                 // there is currently no way to constrain the generated module
                 // table types.
-                let string = e.to_string();
+                let string = format!("{e:?}");
                 if string.contains("minimum element size") {
                     return None;
                 }


### PR DESCRIPTION
This fixes a regression from #10483 where fuzzing was testing for certain error messages but the error messages changed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
