### PR TITLE
Rename `VMTableImport` to `VMTable`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -807,7 +807,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                 .unwrap();
                 (vmctx, base_offset, current_elements_offset)
             } else {
-                let from_offset = self.offsets.vmctx_vmtable_import_from(index);
+                let from_offset = self.offsets.vmctx_vmtable_from(index);
                 let table = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
                     offset: Offset32::new(i32::try_from(from_offset).unwrap()),

--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -8,7 +8,7 @@
 //      trampoline_func_refs: [VMFuncRef; component.num_trampolines],
 //      lowerings: [VMLowering; component.num_lowerings],
 //      memories: [*mut VMMemoryDefinition; component.num_runtime_memories],
-//      tables: [VMTableImport; component.num_runtime_tables],
+//      tables: [VMTable; component.num_runtime_tables],
 //      reallocs: [*mut VMFuncRef; component.num_runtime_reallocs],
 //      post_returns: [*mut VMFuncRef; component.num_runtime_post_returns],
 //      resource_destructors: [*mut VMFuncRef; component.num_resources],
@@ -151,7 +151,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             size(trampoline_func_refs) = cmul(ret.num_trampolines, ret.ptr.size_of_vm_func_ref()),
             size(lowerings) = cmul(ret.num_lowerings, ret.ptr.size() * 2),
             size(memories) = cmul(ret.num_runtime_memories, ret.ptr.size()),
-            size(tables) = cmul(ret.num_runtime_tables, ret.size_of_vmtable_import()),
+            size(tables) = cmul(ret.num_runtime_tables, ret.size_of_vmtable()),
             size(reallocs) = cmul(ret.num_runtime_reallocs, ret.ptr.size()),
             size(callbacks) = cmul(ret.num_runtime_callbacks, ret.ptr.size()),
             size(post_returns) = cmul(ret.num_runtime_post_returns, ret.ptr.size()),
@@ -279,13 +279,13 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     #[inline]
     pub fn runtime_table(&self, index: RuntimeTableIndex) -> u32 {
         assert!(index.as_u32() < self.num_runtime_tables);
-        self.runtime_tables() + index.as_u32() * u32::from(self.size_of_vmtable_import())
+        self.runtime_tables() + index.as_u32() * u32::from(self.size_of_vmtable())
     }
 
-    /// Return the size of `VMTableImport`, used here to hold the pointers to
-    /// the `VMTableDefinition` and `VMContext` (not because this is an import).
+    /// Return the size of `VMTable`, used here to hold the pointers to
+    /// the `VMTableDefinition` and `VMContext`.
     #[inline]
-    pub fn size_of_vmtable_import(&self) -> u8 {
+    pub fn size_of_vmtable(&self) -> u8 {
         2 * self.pointer_size()
     }
 

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -27,7 +27,7 @@
 //      memories: [*mut VMMemoryDefinition; module.num_defined_memories],
 //      owned_memories: [VMMemoryDefinition; module.num_owned_memories],
 //      imported_functions: [VMFunctionImport; module.num_imported_functions],
-//      imported_tables: [VMTableImport; module.num_imported_tables],
+//      imported_tables: [VMTable; module.num_imported_tables],
 //      imported_globals: [VMGlobalImport; module.num_imported_globals],
 //      imported_tags: [VMTagImport; module.num_imported_tags],
 //      tables: [VMTableDefinition; module.num_defined_tables],
@@ -520,7 +520,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             size(imported_functions)
                 = cmul(ret.num_imported_functions, ret.size_of_vmfunction_import()),
             size(imported_tables)
-                = cmul(ret.num_imported_tables, ret.size_of_vmtable_import()),
+                = cmul(ret.num_imported_tables, ret.size_of_vmtable()),
             size(imported_globals)
                 = cmul(ret.num_imported_globals, ret.size_of_vmglobal_import()),
             size(imported_tags)
@@ -578,23 +578,23 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 }
 
-/// Offsets for `VMTableImport`.
+/// Offsets for `VMTable`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `from` field.
     #[inline]
-    pub fn vmtable_import_from(&self) -> u8 {
+    pub fn vmtable_from(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
     #[inline]
-    pub fn vmtable_import_vmctx(&self) -> u8 {
+    pub fn vmtable_vmctx(&self) -> u8 {
         1 * self.pointer_size()
     }
 
-    /// Return the size of `VMTableImport`.
+    /// Return the size of `VMTable`.
     #[inline]
-    pub fn size_of_vmtable_import(&self) -> u8 {
+    pub fn size_of_vmtable(&self) -> u8 {
         2 * self.pointer_size()
     }
 }
@@ -767,12 +767,11 @@ impl<P: PtrSize> VMOffsets<P> {
             + index.as_u32() * u32::from(self.size_of_vmfunction_import())
     }
 
-    /// Return the offset to `VMTableImport` index `index`.
+    /// Return the offset to `VMTable` index `index`.
     #[inline]
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_tables);
-        self.vmctx_imported_tables_begin()
-            + index.as_u32() * u32::from(self.size_of_vmtable_import())
+        self.vmctx_imported_tables_begin() + index.as_u32() * u32::from(self.size_of_vmtable())
     }
 
     /// Return the offset to `VMMemoryImport` index `index`.
@@ -863,10 +862,11 @@ impl<P: PtrSize> VMOffsets<P> {
         self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_vmctx())
     }
 
-    /// Return the offset to the `from` field in `VMTableImport` index `index`.
+    /// Return the offset to the `from` field in the imported `VMTable` at index
+    /// `index`.
     #[inline]
-    pub fn vmctx_vmtable_import_from(&self, index: TableIndex) -> u32 {
-        self.vmctx_vmtable_import(index) + u32::from(self.vmtable_import_from())
+    pub fn vmctx_vmtable_from(&self, index: TableIndex) -> u32 {
+        self.vmctx_vmtable_import(index) + u32::from(self.vmtable_from())
     }
 
     /// Return the offset to the `base` field in `VMTableDefinition` index `index`.

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -414,9 +414,9 @@ impl Table {
         &data[self.0].table
     }
 
-    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTableImport {
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTable {
         let export = &store[self.0];
-        crate::runtime::vm::VMTableImport {
+        crate::runtime::vm::VMTable {
             from: export.definition.into(),
             vmctx: export.vmctx.into(),
         }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -2,7 +2,7 @@ use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     Imports, InstanceAllocationRequest, ModuleRuntimeInfo, StorePtr, VMFuncRef, VMFunctionImport,
-    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport, VMTagImport,
+    VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTable, VMTagImport,
 };
 use crate::store::{InstanceId, StoreOpaque, Stored};
 use crate::types::matching;
@@ -656,7 +656,7 @@ impl Instance {
 
 pub(crate) struct OwnedImports {
     functions: PrimaryMap<FuncIndex, VMFunctionImport>,
-    tables: PrimaryMap<TableIndex, VMTableImport>,
+    tables: PrimaryMap<TableIndex, VMTable>,
     memories: PrimaryMap<MemoryIndex, VMMemoryImport>,
     globals: PrimaryMap<GlobalIndex, VMGlobalImport>,
     tags: PrimaryMap<TagIndex, VMTagImport>,
@@ -739,7 +739,7 @@ impl OwnedImports {
                 });
             }
             crate::runtime::vm::Export::Table(t) => {
-                self.tables.push(VMTableImport {
+                self.tables.push(VMTable {
                     from: t.definition.into(),
                     vmctx: t.vmctx.into(),
                 });

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -95,7 +95,7 @@ pub use crate::runtime::vm::vmcontext::VMTableDefinition;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMStoreContext, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMStoreContext, VMTable, VMTagImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -9,7 +9,7 @@
 use crate::prelude::*;
 use crate::runtime::vm::{
     SendSyncPtr, VMArrayCallFunction, VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
-    VMOpaqueContext, VMStore, VMStoreRawPtr, VMTableDefinition, VMTableImport, VMWasmCallFunction,
+    VMOpaqueContext, VMStore, VMStoreRawPtr, VMTable, VMTableDefinition, VMWasmCallFunction,
     ValRaw, VmPtr, VmSafe,
 };
 use alloc::alloc::Layout;
@@ -295,12 +295,9 @@ impl ComponentInstance {
     ///
     /// This can only be called after `idx` has been initialized at runtime
     /// during the instantiation process of a component.
-    ///
-    /// Note that we use a `VMTableImport` here because of its structure, not
-    /// because these tables are actually imports.
-    pub fn runtime_table(&self, idx: RuntimeTableIndex) -> VMTableImport {
+    pub fn runtime_table(&self, idx: RuntimeTableIndex) -> VMTable {
         unsafe {
-            let ret = *self.vmctx_plus_offset::<VMTableImport>(self.offsets.runtime_table(idx));
+            let ret = *self.vmctx_plus_offset::<VMTable>(self.offsets.runtime_table(idx));
             debug_assert!(ret.from.as_ptr() as usize != INVALID_PTR);
             debug_assert!(ret.vmctx.as_ptr() as usize != INVALID_PTR);
             ret
@@ -436,14 +433,11 @@ impl ComponentInstance {
         ptr: NonNull<VMTableDefinition>,
         vmctx: NonNull<VMContext>,
     ) {
-        // Note that we use a `VMTableImport` here because of its structure, not
-        // because these tables are actually imports.
         unsafe {
-            let storage =
-                self.vmctx_plus_offset_mut::<VMTableImport>(self.offsets.runtime_table(idx));
+            let storage = self.vmctx_plus_offset_mut::<VMTable>(self.offsets.runtime_table(idx));
             debug_assert!((*storage).vmctx.as_ptr() as usize == INVALID_PTR);
             debug_assert!((*storage).from.as_ptr() as usize == INVALID_PTR);
-            *storage = VMTableImport {
+            *storage = VMTable {
                 vmctx: vmctx.into(),
                 from: ptr.into(),
             };

--- a/crates/wasmtime/src/runtime/vm/imports.rs
+++ b/crates/wasmtime/src/runtime/vm/imports.rs
@@ -1,5 +1,5 @@
 use crate::runtime::vm::vmcontext::{
-    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport, VMTagImport,
+    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTable, VMTagImport,
 };
 
 /// Resolved import pointers.
@@ -19,7 +19,7 @@ pub struct Imports<'a> {
     pub functions: &'a [VMFunctionImport],
 
     /// Resolved addresses for imported tables.
-    pub tables: &'a [VMTableImport],
+    pub tables: &'a [VMTable],
 
     /// Resolved addresses for imported memories.
     pub memories: &'a [VMMemoryImport],

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -8,8 +8,8 @@ use crate::runtime::vm::memory::{Memory, RuntimeMemoryCreator};
 use crate::runtime::vm::table::{Table, TableElement, TableElementType};
 use crate::runtime::vm::vmcontext::{
     VMBuiltinFunctionsArray, VMContext, VMFuncRef, VMFunctionImport, VMGlobalDefinition,
-    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext, VMStoreContext,
-    VMTableDefinition, VMTableImport, VMTagDefinition, VMTagImport,
+    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext, VMStoreContext, VMTable,
+    VMTableDefinition, VMTagDefinition, VMTagImport,
 };
 use crate::runtime::vm::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, ExportTag, GcStore, Imports,
@@ -428,8 +428,8 @@ impl Instance {
         unsafe { &*self.vmctx_plus_offset(self.offsets().vmctx_vmfunction_import(index)) }
     }
 
-    /// Return the index `VMTableImport`.
-    fn imported_table(&self, index: TableIndex) -> &VMTableImport {
+    /// Return the index `VMTable`.
+    fn imported_table(&self, index: TableIndex) -> &VMTable {
         unsafe { &*self.vmctx_plus_offset(self.offsets().vmctx_vmtable_import(index)) }
     }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -144,7 +144,7 @@ mod test_vmfunction_body {
 /// imported from another instance.
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
-pub struct VMTableImport {
+pub struct VMTable {
     /// A pointer to the imported table description.
     pub from: VmPtr<VMTableDefinition>,
 
@@ -153,46 +153,43 @@ pub struct VMTableImport {
 }
 
 // SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
-unsafe impl VmSafe for VMTableImport {}
+unsafe impl VmSafe for VMTable {}
 
 #[cfg(test)]
-mod test_vmtable_import {
-    use super::VMTableImport;
+mod test_vmtable {
+    use super::VMTable;
     use core::mem::offset_of;
     use std::mem::size_of;
     use wasmtime_environ::component::{Component, VMComponentOffsets};
     use wasmtime_environ::{HostPtr, Module, VMOffsets};
 
     #[test]
-    fn check_vmtable_import_offsets() {
+    fn check_vmtable_offsets() {
         let module = Module::new();
         let offsets = VMOffsets::new(HostPtr, &module);
+        assert_eq!(size_of::<VMTable>(), usize::from(offsets.size_of_vmtable()));
         assert_eq!(
-            size_of::<VMTableImport>(),
-            usize::from(offsets.size_of_vmtable_import())
+            offset_of!(VMTable, from),
+            usize::from(offsets.vmtable_from())
         );
         assert_eq!(
-            offset_of!(VMTableImport, from),
-            usize::from(offsets.vmtable_import_from())
-        );
-        assert_eq!(
-            offset_of!(VMTableImport, vmctx),
-            usize::from(offsets.vmtable_import_vmctx())
+            offset_of!(VMTable, vmctx),
+            usize::from(offsets.vmtable_vmctx())
         );
     }
 
     #[test]
     fn ensure_sizes_match() {
-        // Because we use `VMTableImport` for recording tables used by
-        // components, we want to make sure that the size calculations between
-        // `VMOffsets` and `VMComponentOffsets` stay the same.
+        // Because we use `VMTable` for recording tables used by components, we
+        // want to make sure that the size calculations between `VMOffsets` and
+        // `VMComponentOffsets` stay the same.
         let module = Module::new();
         let vm_offsets = VMOffsets::new(HostPtr, &module);
         let component = Component::default();
         let vm_component_offsets = VMComponentOffsets::new(HostPtr, &component);
         assert_eq!(
-            vm_offsets.size_of_vmtable_import(),
-            vm_component_offsets.size_of_vmtable_import()
+            vm_offsets.size_of_vmtable(),
+            vm_component_offsets.size_of_vmtable()
         );
     }
 }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -230,7 +230,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
                                 .vmctx_vmtable_definition_current_elements(defined),
                         ),
                         None => (
-                            Some(self.vmoffsets.vmctx_vmtable_import_from(index)),
+                            Some(self.vmoffsets.vmctx_vmtable_from(index)),
                             self.vmoffsets.vmtable_definition_base().into(),
                             self.vmoffsets.vmtable_definition_current_elements().into(),
                         ),


### PR DESCRIPTION
In #10499, I used the `struct VMTableImport` to hold the necessary pointers for accessing a core WebAssembly table from a component. Since `VMTableImport` no longer was exclusively used for imported tables, it seems reasonable to rename it to something less specific: `VMTable`. This changes all the functions referencing `vmtable_import*` as well except those that are specifically dealing with imported tables.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
