### PR TITLE
Analyze whether a module requires a GC heap during its compilation

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -27,10 +27,10 @@ use std::path;
 use std::sync::{Arc, Mutex};
 use wasmparser::{FuncValidatorAllocations, FunctionBody};
 use wasmtime_environ::{
-    AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, DefinedFuncIndex, FlagValue,
-    FunctionBodyData, FunctionLoc, HostCall, ModuleTranslation, ModuleTypesBuilder, PtrSize,
-    RelocationTarget, StackMapSection, StaticModuleIndex, TrapEncodingBuilder, TrapSentinel,
-    TripleExt, Tunables, VMOffsets, WasmFuncType, WasmValType,
+    AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, CompiledFunctionBody,
+    DefinedFuncIndex, FlagValue, FunctionBodyData, FunctionLoc, HostCall, ModuleTranslation,
+    ModuleTypesBuilder, PtrSize, RelocationTarget, StackMapSection, StaticModuleIndex,
+    TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables, VMOffsets, WasmFuncType, WasmValType,
 };
 
 #[cfg(feature = "component-model")]
@@ -187,7 +187,7 @@ impl wasmtime_environ::Compiler for Compiler {
         func_index: DefinedFuncIndex,
         input: FunctionBodyData<'_>,
         types: &ModuleTypesBuilder,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let module = &translation.module;
         let func_index = module.func_index(func_index);
@@ -284,7 +284,10 @@ impl wasmtime_environ::Compiler for Compiler {
         log::debug!("{:?} translated in {:?}", func_index, timing.total());
         log::trace!("{:?} timing info\n{}", func_index, timing);
 
-        Ok(Box::new(func))
+        Ok(CompiledFunctionBody {
+            code: Box::new(func),
+            needs_gc_heap: func_env.needs_gc_heap(),
+        })
     }
 
     fn compile_array_to_wasm_trampoline(
@@ -292,7 +295,7 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
         def_func_index: DefinedFuncIndex,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         let func_index = translation.module.func_index(def_func_index);
         let sig = translation.module.functions[func_index]
             .signature
@@ -359,16 +362,16 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&[true_return]);
         builder.finalize();
 
-        Ok(Box::new(compiler.finish(&format!(
-            "array_to_wasm_{}",
-            func_index.as_u32(),
-        ))?))
+        Ok(CompiledFunctionBody {
+            code: Box::new(compiler.finish(&format!("array_to_wasm_{}", func_index.as_u32(),))?),
+            needs_gc_heap: false,
+        })
     }
 
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &WasmFuncType,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let pointer_type = isa.pointer_type();
         let wasm_call_sig = wasm_call_signature(isa, wasm_func_ty, &self.tunables);
@@ -432,9 +435,10 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        Ok(Box::new(compiler.finish(&format!(
-            "wasm_to_array_trampoline_{wasm_func_ty}"
-        ))?))
+        Ok(CompiledFunctionBody {
+            code: Box::new(compiler.finish(&format!("wasm_to_array_trampoline_{wasm_func_ty}"))?),
+            needs_gc_heap: false,
+        })
     }
 
     fn append_code(
@@ -582,7 +586,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_builtin(
         &self,
         index: BuiltinFunctionIndex,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let ptr_size = isa.pointer_bytes();
         let pointer_type = isa.pointer_type();
@@ -651,9 +655,10 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        Ok(Box::new(
-            compiler.finish(&format!("wasm_to_builtin_{}", index.name()))?,
-        ))
+        Ok(CompiledFunctionBody {
+            code: Box::new(compiler.finish(&format!("wasm_to_builtin_{}", index.name()))?),
+            needs_gc_heap: false,
+        })
     }
 
     fn compiled_function_relocation_targets<'a>(

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -6,9 +6,8 @@ use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags, Value};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_frontend::FunctionBuilder;
-use std::any::Any;
-use wasmtime_environ::component::*;
 use wasmtime_environ::fact::SYNC_ENTER_FIXED_PARAMS;
+use wasmtime_environ::{component::*, CompiledFunctionBody};
 use wasmtime_environ::{
     HostCall, ModuleInternedTypeIndex, PtrSize, TrapSentinel, Tunables, WasmFuncType, WasmValType,
 };
@@ -1450,7 +1449,7 @@ impl ComponentCompiler for Compiler {
         types: &ComponentTypesBuilder,
         index: TrampolineIndex,
         tunables: &Tunables,
-    ) -> Result<AllCallFunc<Box<dyn Any + Send>>> {
+    ) -> Result<AllCallFunc<CompiledFunctionBody>> {
         let compile = |abi: Abi| -> Result<_> {
             let mut compiler = self.function_compiler();
             let mut c = TrampolineCompiler::new(
@@ -1494,10 +1493,12 @@ impl ComponentCompiler for Compiler {
             c.translate(&component.trampolines[index]);
             c.builder.finalize();
 
-            Ok(Box::new(compiler.finish(&format!(
-                "component_trampoline_{}_{abi:?}",
-                index.as_u32(),
-            ))?))
+            Ok(CompiledFunctionBody {
+                code: Box::new(
+                    compiler.finish(&format!("component_trampoline_{}_{abi:?}", index.as_u32()))?,
+                ),
+                needs_gc_heap: false,
+            })
         };
         Ok(AllCallFunc {
             wasm_call: compile(Abi::Wasm)?,

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -14,7 +14,7 @@ use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, types};
 use cranelift_codegen::ir::{ArgumentPurpose, Function, InstBuilder, MemFlags};
 use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
-use cranelift_entity::packed_option::ReservedValue;
+use cranelift_entity::packed_option::ReservedValue as _;
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
 use cranelift_frontend::FunctionBuilder;
 use cranelift_frontend::Variable;
@@ -98,6 +98,7 @@ pub struct FuncEnvironment<'module_environment> {
     types: &'module_environment ModuleTypesBuilder,
     wasm_func_ty: &'module_environment WasmFuncType,
     sig_ref_to_ty: SecondaryMap<ir::SigRef, Option<&'module_environment WasmFuncType>>,
+    needs_gc_heap: bool,
 
     #[cfg(feature = "gc")]
     ty_to_gc_layout: std::collections::HashMap<
@@ -187,6 +188,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             types,
             wasm_func_ty,
             sig_ref_to_ty: SecondaryMap::default(),
+            needs_gc_heap: false,
 
             #[cfg(feature = "gc")]
             ty_to_gc_layout: std::collections::HashMap::new(),
@@ -1193,6 +1195,11 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             funcref,
             i32::from(self.offsets.ptr.vm_func_ref_type_index()),
         )
+    }
+
+    /// Does this function need a GC heap?
+    pub fn needs_gc_heap(&self) -> bool {
+        self.needs_gc_heap
     }
 }
 

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -163,15 +163,19 @@ pub mod builtins {
                     func: &mut ir::Function,
                 ) -> WasmResult<ir::FuncRef> {
                     #[cfg(feature = "gc")]
-                    return Ok(func_env.builtin_functions.$name(func));
+                    {
+                        func_env.needs_gc_heap = true;
+                        return Ok(func_env.builtin_functions.$name(func));
+                    }
 
                     #[cfg(not(feature = "gc"))]
-                    let _ = (func, func_env);
-                    #[cfg(not(feature = "gc"))]
-                    return Err(wasmtime_environ::wasm_unsupported!(
-                        "support for Wasm GC disabled at compile time because the `gc` cargo \
-                         feature was not enabled"
-                    ));
+                    {
+                        let _ = (func, func_env);
+                        return Err(wasmtime_environ::wasm_unsupported!(
+                            "support for Wasm GC disabled at compile time because the `gc` cargo \
+                             feature was not enabled"
+                        ));
+                    }
                 }
             )*
         };

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -21,7 +21,11 @@ mod drc;
 mod null;
 
 /// Get the default GC compiler.
-pub fn gc_compiler(func_env: &FuncEnvironment<'_>) -> WasmResult<Box<dyn GcCompiler>> {
+pub fn gc_compiler(func_env: &mut FuncEnvironment<'_>) -> WasmResult<Box<dyn GcCompiler>> {
+    // If this function requires a GC compiler, that is not too bad of an
+    // over-approximation for it requiring a GC heap.
+    func_env.needs_gc_heap = true;
+
     match func_env.tunables.collector {
         #[cfg(feature = "gc-drc")]
         Some(Collector::DeferredReferenceCounting) => Ok(Box::new(drc::DrcCompiler::default())),

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,8 +1,6 @@
 use crate::component::{AllCallFunc, ComponentTranslation, ComponentTypesBuilder, TrampolineIndex};
-use crate::prelude::*;
-use crate::Tunables;
+use crate::{CompiledFunctionBody, Tunables};
 use anyhow::Result;
-use std::any::Any;
 
 /// Compilation support necessary for components.
 pub trait ComponentCompiler: Send + Sync {
@@ -18,5 +16,5 @@ pub trait ComponentCompiler: Send + Sync {
         types: &ComponentTypesBuilder,
         trampoline: TrampolineIndex,
         tunables: &Tunables,
-    ) -> Result<AllCallFunc<Box<dyn Any + Send>>>;
+    ) -> Result<AllCallFunc<CompiledFunctionBody>>;
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -336,6 +336,9 @@ pub struct Module {
     /// Number of imported or aliased tags in the module.
     pub num_imported_tags: usize,
 
+    /// Does this module need a GC heap to run?
+    pub needs_gc_heap: bool,
+
     /// Number of functions that "escape" from this module may need to have a
     /// `VMFuncRef` constructed for them.
     ///
@@ -616,6 +619,7 @@ impl TypeTrace for Module {
             num_imported_globals: _,
             num_imported_tags: _,
             num_escaped_funcs: _,
+            needs_gc_heap: _,
             functions,
             tables,
             memories: _,
@@ -665,6 +669,7 @@ impl TypeTrace for Module {
             num_imported_globals: _,
             num_imported_tags: _,
             num_escaped_funcs: _,
+            needs_gc_heap: _,
             functions,
             tables,
             memories: _,

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -35,6 +35,7 @@ use std::{
 
 #[cfg(feature = "component-model")]
 use wasmtime_environ::component::Translator;
+use wasmtime_environ::CompiledFunctionBody;
 use wasmtime_environ::{
     BuiltinFunctionIndex, CompiledFunctionInfo, CompiledModuleInfo, Compiler, DefinedFuncIndex,
     FilePos, FinishedObject, FunctionBodyData, ModuleEnvironment, ModuleInternedTypeIndex,
@@ -83,7 +84,12 @@ pub(crate) fn build_artifacts<T: FinishedObject>(
 
     let compile_inputs = CompileInputs::for_module(&types, &translation, functions);
     let unlinked_compile_outputs = compile_inputs.compile(engine)?;
-    let (compiled_funcs, function_indices) = unlinked_compile_outputs.pre_link();
+    let PreLinkOutput {
+        needs_gc_heap,
+        compiled_funcs,
+        indices,
+    } = unlinked_compile_outputs.pre_link();
+    translation.module.needs_gc_heap |= needs_gc_heap;
 
     // Emplace all compiled functions into the object file with any other
     // sections associated with code as well.
@@ -100,7 +106,7 @@ pub(crate) fn build_artifacts<T: FinishedObject>(
     engine.append_compiler_info(&mut object);
     engine.append_bti(&mut object);
 
-    let (mut object, compilation_artifacts) = function_indices.link_and_append_code(
+    let (mut object, compilation_artifacts) = indices.link_and_append_code(
         &types,
         object,
         engine,
@@ -158,13 +164,20 @@ pub(crate) fn build_component_artifacts<T: FinishedObject>(
     );
     let unlinked_compile_outputs = compile_inputs.compile(&engine)?;
 
-    let (compiled_funcs, function_indices) = unlinked_compile_outputs.pre_link();
+    let PreLinkOutput {
+        needs_gc_heap,
+        compiled_funcs,
+        indices,
+    } = unlinked_compile_outputs.pre_link();
+    for (_, t) in &mut module_translations {
+        t.module.needs_gc_heap |= needs_gc_heap
+    }
 
     let mut object = compiler.object(ObjectKind::Component)?;
     engine.append_compiler_info(&mut object);
     engine.append_bti(&mut object);
 
-    let (mut object, compilation_artifacts) = function_indices.link_and_append_code(
+    let (mut object, compilation_artifacts) = indices.link_and_append_code(
         types.module_types_builder(),
         object,
         engine,
@@ -318,7 +331,7 @@ impl<T> From<wasmtime_environ::component::AllCallFunc<T>> for CompiledFunction<T
 struct CompileOutput {
     key: CompileKey,
     symbol: String,
-    function: CompiledFunction<Box<dyn Any + Send>>,
+    function: CompiledFunction<CompiledFunctionBody>,
     start_srcloc: FilePos,
 }
 
@@ -391,12 +404,12 @@ impl<'a> CompileInputs<'a> {
             if let Some(sig) = types.find_resource_drop_signature() {
                 ret.push_input(move |compiler| {
                     let symbol = "resource_drop_trampoline".to_string();
-                    let trampoline = compiler
+                    let function = compiler
                         .compile_wasm_to_array_trampoline(types[sig].unwrap_func())
                         .with_context(|| format!("failed to compile `{symbol}`"))?;
                     Ok(CompileOutput {
                         key: CompileKey::resource_drop_wasm_to_array_trampoline(),
-                        function: CompiledFunction::Function(trampoline),
+                        function: CompiledFunction::Function(function),
                         symbol,
                         start_srcloc: FilePos::default(),
                     })
@@ -565,13 +578,12 @@ fn compile_required_builtins(engine: &Engine, raw_outputs: &mut Vec<CompileOutpu
     let compile_builtin = |builtin: BuiltinFunctionIndex| {
         Box::new(move |compiler: &dyn Compiler| {
             let symbol = format!("wasmtime_builtin_{}", builtin.name());
+            let trampoline = compiler
+                .compile_wasm_to_builtin(builtin)
+                .with_context(|| format!("failed to compile `{symbol}`"))?;
             Ok(CompileOutput {
                 key: CompileKey::wasm_to_builtin_trampoline(builtin),
-                function: CompiledFunction::Function(
-                    compiler
-                        .compile_wasm_to_builtin(builtin)
-                        .with_context(|| format!("failed to compile `{symbol}`"))?,
-                ),
+                function: CompiledFunction::Function(trampoline),
                 symbol,
                 start_srcloc: FilePos::default(),
             })
@@ -584,7 +596,7 @@ fn compile_required_builtins(engine: &Engine, raw_outputs: &mut Vec<CompileOutpu
             #[cfg(feature = "component-model")]
             CompiledFunction::AllCallFunc(_) => continue,
         };
-        for reloc in compiler.compiled_function_relocation_targets(&**f) {
+        for reloc in compiler.compiled_function_relocation_targets(&*f.code) {
             match reloc {
                 RelocationTarget::Builtin(i) => {
                     if builtins.insert(i) {
@@ -608,7 +620,7 @@ struct UnlinkedCompileOutputs {
 impl UnlinkedCompileOutputs {
     /// Flatten all our functions into a single list and remember each of their
     /// indices within it.
-    fn pre_link(self) -> (Vec<(String, Box<dyn Any + Send>)>, FunctionIndices) {
+    fn pre_link(self) -> PreLinkOutput {
         // The order the functions end up within `compiled_funcs` is the order
         // that they will be laid out in the ELF file, so try and group hot and
         // cold functions together as best we can. However, because we bucket by
@@ -616,43 +628,72 @@ impl UnlinkedCompileOutputs {
         // appearing in between hot Wasm functions.
         let mut compiled_funcs = vec![];
         let mut indices = FunctionIndices::default();
-        for x in self.outputs.into_iter().flat_map(|(_kind, xs)| xs) {
-            let index = match x.function {
+        let mut needs_gc_heap = false;
+
+        for output in self.outputs.into_iter().flat_map(|(_kind, outs)| outs) {
+            let index = match output.function {
                 CompiledFunction::Function(f) => {
+                    needs_gc_heap |= f.needs_gc_heap;
                     let index = compiled_funcs.len();
-                    compiled_funcs.push((x.symbol, f));
+                    compiled_funcs.push((output.symbol, f.code));
                     CompiledFunction::Function(index)
                 }
                 #[cfg(feature = "component-model")]
-                CompiledFunction::AllCallFunc(f) => {
-                    let array_call = compiled_funcs.len();
-                    compiled_funcs.push((format!("{}_array_call", x.symbol), f.array_call));
-                    let wasm_call = compiled_funcs.len();
-                    compiled_funcs.push((format!("{}_wasm_call", x.symbol), f.wasm_call));
+                CompiledFunction::AllCallFunc(wasmtime_environ::component::AllCallFunc {
+                    wasm_call,
+                    array_call,
+                }) => {
+                    needs_gc_heap |= array_call.needs_gc_heap;
+                    let array_call_idx = compiled_funcs.len();
+                    compiled_funcs.push((format!("{}_array_call", output.symbol), array_call.code));
+
+                    needs_gc_heap |= wasm_call.needs_gc_heap;
+                    let wasm_call_idx = compiled_funcs.len();
+                    compiled_funcs.push((format!("{}_wasm_call", output.symbol), wasm_call.code));
+
                     CompiledFunction::AllCallFunc(wasmtime_environ::component::AllCallFunc {
-                        array_call,
-                        wasm_call,
+                        array_call: array_call_idx,
+                        wasm_call: wasm_call_idx,
                     })
                 }
             };
 
-            if x.key.kind() == CompileKey::WASM_FUNCTION_KIND
-                || x.key.kind() == CompileKey::ARRAY_TO_WASM_TRAMPOLINE_KIND
+            if output.key.kind() == CompileKey::WASM_FUNCTION_KIND
+                || output.key.kind() == CompileKey::ARRAY_TO_WASM_TRAMPOLINE_KIND
             {
                 indices
                     .compiled_func_index_to_module
-                    .insert(index.unwrap_function(), x.key.module());
-                indices.start_srclocs.insert(x.key, x.start_srcloc);
+                    .insert(index.unwrap_function(), output.key.module());
+                indices
+                    .start_srclocs
+                    .insert(output.key, output.start_srcloc);
             }
 
             indices
                 .indices
-                .entry(x.key.kind())
+                .entry(output.key.kind())
                 .or_default()
-                .insert(x.key, index);
+                .insert(output.key, index);
         }
-        (compiled_funcs, indices)
+
+        PreLinkOutput {
+            needs_gc_heap,
+            compiled_funcs,
+            indices,
+        }
     }
+}
+
+/// Our pre-link functions that have been flattened into a single list.
+struct PreLinkOutput {
+    /// Whether or not any of these functions require a GC heap
+    needs_gc_heap: bool,
+    /// The flattened list of (symbol name, compiled function) pairs, as they
+    /// will be laid out in the object file.
+    compiled_funcs: Vec<(String, Box<dyn Any + Send>)>,
+    /// The `FunctionIndices` mapping our function keys to indices in that flat
+    /// list.
+    indices: FunctionIndices,
 }
 
 #[derive(Default)]

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -109,7 +109,7 @@ impl Table {
         unsafe {
             let table = Table::from_wasmtime_table(wasmtime_export, store);
             let wasmtime_table = table.wasmtime_table(store, iter::empty());
-            (*wasmtime_table).fill(store.optional_gc_store_mut()?, 0, init, ty.minimum())?;
+            (*wasmtime_table).fill(store.optional_gc_store_mut(), 0, init, ty.minimum())?;
             Ok(table)
         }
     }
@@ -155,7 +155,7 @@ impl Table {
     pub fn get(&self, mut store: impl AsContextMut, index: u64) -> Option<Ref> {
         let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
         let table = self.wasmtime_table(&mut store, iter::once(index));
-        let gc_store = store.optional_gc_store_mut().ok().and_then(|s| s);
+        let gc_store = store.optional_gc_store_mut();
         unsafe {
             match (*table).get(gc_store, index)? {
                 runtime::TableElement::FuncRef(f) => {
@@ -334,7 +334,7 @@ impl Table {
         let src_table = src_table.wasmtime_table(store, src_range);
         unsafe {
             runtime::Table::copy(
-                store.optional_gc_store_mut()?,
+                store.optional_gc_store_mut(),
                 dst_table,
                 src_table,
                 dst_index,
@@ -368,7 +368,7 @@ impl Table {
 
         let table = self.wasmtime_table(store, iter::empty());
         unsafe {
-            (*table).fill(store.optional_gc_store_mut()?, dst, val, len)?;
+            (*table).fill(store.optional_gc_store_mut(), dst, val, len)?;
         }
 
         Ok(())

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1211,9 +1211,8 @@ impl Func {
             let num_gc_refs = ty.as_wasm_func_type().non_i31_gc_ref_params_count();
             if let Some(num_gc_refs) = core::num::NonZeroUsize::new(num_gc_refs) {
                 return Ok(opaque
-                    .gc_store()?
-                    .gc_heap
-                    .need_gc_before_entering_wasm(num_gc_refs));
+                    .optional_gc_store()
+                    .is_some_and(|s| s.gc_heap.need_gc_before_entering_wasm(num_gc_refs)));
             }
         }
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -259,7 +259,7 @@ impl Instance {
         store.bump_resource_counts(module)?;
 
         // Allocate the GC heap, if necessary.
-        if store.engine().features().gc_types() {
+        if store.engine().features().gc_types() && module.env_module().needs_gc_heap {
             let _ = store.gc_store_mut()?;
         }
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -259,7 +259,7 @@ impl Instance {
         store.bump_resource_counts(module)?;
 
         // Allocate the GC heap, if necessary.
-        if store.engine().features().gc_types() && module.env_module().needs_gc_heap {
+        if module.env_module().needs_gc_heap {
             let _ = store.gc_store_mut()?;
         }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1453,15 +1453,30 @@ impl StoreOpaque {
     /// If this store is configured with a GC heap, return a mutable reference
     /// to it. Otherwise, return `None`.
     #[inline]
-    pub(crate) fn optional_gc_store_mut(&mut self) -> Result<Option<&mut GcStore>> {
+    pub(crate) fn optional_gc_store_mut(&mut self) -> Option<&mut GcStore> {
         if cfg!(not(feature = "gc")) || !self.engine.features().gc_types() {
-            Ok(None)
+            debug_assert!(self.gc_store.is_none());
+            None
         } else {
-            Ok(Some(self.gc_store_mut()?))
+            self.gc_store.as_mut()
+        }
+    }
+
+    /// If this store is configured with a GC heap, return a shared reference to
+    /// it. Otherwise, return `None`.
+    #[inline]
+    #[cfg(feature = "gc")]
+    pub(crate) fn optional_gc_store(&self) -> Option<&GcStore> {
+        if cfg!(not(feature = "gc")) || !self.engine.features().gc_types() {
+            debug_assert!(self.gc_store.is_none());
+            None
+        } else {
+            self.gc_store.as_ref()
         }
     }
 
     #[inline]
+    #[track_caller]
     #[cfg(feature = "gc")]
     pub(crate) fn unwrap_gc_store(&self) -> &GcStore {
         self.gc_store
@@ -1470,6 +1485,7 @@ impl StoreOpaque {
     }
 
     #[inline]
+    #[track_caller]
     pub(crate) fn unwrap_gc_store_mut(&mut self) -> &mut GcStore {
         self.gc_store
             .as_mut()

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -232,6 +232,14 @@ impl VMGcRef {
         VMGcRef(self.0)
     }
 
+    /// Copy this `i31` GC reference, which never requires any GC barriers.
+    ///
+    /// Panics if this is not an `i31`.
+    pub fn copy_i31(&self) -> Self {
+        assert!(self.is_i31());
+        self.unchecked_copy()
+    }
+
     /// Get this GC reference as a u32 index into its GC heap.
     ///
     /// Returns `None` for `i31ref`s.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -616,7 +616,15 @@ impl Instance {
             #[cfg(target_has_atomic = "64")]
             self.epoch_ptr()
                 .write(Some(NonNull::from(store.engine().epoch_counter()).into()));
-            self.set_gc_heap(store.gc_store_mut().ok());
+
+            if self.env_module().needs_gc_heap {
+                self.set_gc_heap(Some(store.gc_store_mut().expect(
+                    "if we need a GC heap, then `Instance::new_raw` should have already \
+                     allocated it for us",
+                )));
+            } else {
+                self.set_gc_heap(None);
+            }
         } else {
             self.vm_store_context().write(None);
             #[cfg(target_has_atomic = "64")]

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -270,7 +270,7 @@ unsafe fn table_fill_func_ref(
     match table.element_type() {
         TableElementType::Func => {
             let val = NonNull::new(val.cast::<VMFuncRef>());
-            table.fill(store.optional_gc_store_mut()?, dst, val.into(), len)?;
+            table.fill(store.optional_gc_store_mut(), dst, val.into(), len)?;
             Ok(())
         }
         TableElementType::GcRef => unreachable!(),
@@ -317,7 +317,7 @@ unsafe fn table_copy(
     // Lazy-initialize the whole range in the source table first.
     let src_range = src..(src.checked_add(len).unwrap_or(u64::MAX));
     let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
-    let gc_store = store.optional_gc_store_mut()?;
+    let gc_store = store.optional_gc_store_mut();
     Table::copy(gc_store, dst_table, src_table, dst, src, len)?;
     Ok(())
 }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -7,9 +7,9 @@ use std::sync::Mutex;
 use wasmparser::FuncValidatorAllocations;
 use wasmtime_cranelift::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
-    AddressMapSection, BuiltinFunctionIndex, CompileError, DefinedFuncIndex, FunctionBodyData,
-    FunctionLoc, ModuleTranslation, ModuleTypesBuilder, PrimaryMap, RelocationTarget,
-    StaticModuleIndex, TrapEncodingBuilder, Tunables, VMOffsets,
+    AddressMapSection, BuiltinFunctionIndex, CompileError, CompiledFunctionBody, DefinedFuncIndex,
+    FunctionBodyData, FunctionLoc, ModuleTranslation, ModuleTypesBuilder, PrimaryMap,
+    RelocationTarget, StaticModuleIndex, TrapEncodingBuilder, Tunables, VMOffsets,
 };
 use winch_codegen::{BuiltinFunctions, CallingConvention, TargetIsa};
 
@@ -95,7 +95,7 @@ impl wasmtime_environ::Compiler for Compiler {
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
         types: &ModuleTypesBuilder,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         let index = translation.module.func_index(index);
         let sig = translation.module.functions[index]
             .signature
@@ -132,7 +132,11 @@ impl wasmtime_environ::Compiler for Compiler {
             self.emit_unwind_info(&mut func)?;
         }
 
-        Ok(Box::new(func))
+        Ok(CompiledFunctionBody {
+            code: Box::new(func),
+            // TODO: Winch doesn't support GC objects and stack maps and all that yet.
+            needs_gc_heap: false,
+        })
     }
 
     fn compile_array_to_wasm_trampoline(
@@ -140,7 +144,7 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         self.trampolines
             .compile_array_to_wasm_trampoline(translation, types, index)
     }
@@ -148,7 +152,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &wasmtime_environ::WasmFuncType,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         self.trampolines
             .compile_wasm_to_array_trampoline(wasm_func_ty)
     }
@@ -230,7 +234,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_builtin(
         &self,
         index: BuiltinFunctionIndex,
-    ) -> Result<Box<dyn Any + Send>, CompileError> {
+    ) -> Result<CompiledFunctionBody, CompileError> {
         self.trampolines.compile_wasm_to_builtin(index)
     }
 


### PR DESCRIPTION
And avoid forcing the allocation of a GC heap for modules that will not use it.

Split out from https://github.com/bytecodealliance/wasmtime/issues/9350

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
