### PR TITLE
Fix a few stray references to "runtime limits"

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -249,7 +249,7 @@ impl wasmtime_environ::Compiler for Compiler {
                 .create_global_value(ir::GlobalValueData::VMContext);
             let interrupts_ptr = context.func.create_global_value(ir::GlobalValueData::Load {
                 base: vmctx,
-                offset: i32::from(func_env.offsets.ptr.vmctx_runtime_limits()).into(),
+                offset: i32::from(func_env.offsets.ptr.vmctx_store_context()).into(),
                 global_type: isa.pointer_type(),
                 flags: MemFlags::trusted().with_readonly(),
             });
@@ -329,12 +329,12 @@ impl wasmtime_environ::Compiler for Compiler {
         // what we are assuming with our offsets below.
         debug_assert_vmctx_kind(isa, &mut builder, vmctx, wasmtime_environ::VMCONTEXT_MAGIC);
         let offsets = VMOffsets::new(isa.pointer_bytes(), &translation.module);
-        let vm_runtime_limits_offset = offsets.ptr.vmctx_runtime_limits();
+        let vm_store_context_offset = offsets.ptr.vmctx_store_context();
         save_last_wasm_entry_fp(
             &mut builder,
             pointer_type,
             &offsets.ptr,
-            vm_runtime_limits_offset.into(),
+            vm_store_context_offset.into(),
             vmctx,
         );
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -314,7 +314,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         let pointer_type = self.pointer_type();
         let vmctx = self.vmctx(builder.func);
         let base = builder.ins().global_value(pointer_type, vmctx);
-        let offset = i32::from(self.offsets.ptr.vmctx_runtime_limits());
+        let offset = i32::from(self.offsets.ptr.vmctx_store_context());
         debug_assert!(self.vmstore_context_ptr.is_reserved_value());
         self.vmstore_context_ptr = builder.ins().load(
             pointer_type,

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -107,7 +107,7 @@ pub trait PtrSize {
     /// Returns the pointer size, in bytes, for the target.
     fn size(&self) -> u8;
 
-    /// The offset of the `VMContext::runtime_limits` field
+    /// The offset of the `VMContext::store_context` field
     fn vmcontext_store_context(&self) -> u8 {
         u8::try_from(align(
             u32::try_from(core::mem::size_of::<u32>()).unwrap(),
@@ -247,14 +247,14 @@ pub trait PtrSize {
 
     /// Return the offset to the `VMStoreContext` structure
     #[inline]
-    fn vmctx_runtime_limits(&self) -> u8 {
+    fn vmctx_store_context(&self) -> u8 {
         self.vmctx_magic() + self.size()
     }
 
     /// Return the offset to the `VMBuiltinFunctionsArray` structure
     #[inline]
     fn vmctx_builtin_functions(&self) -> u8 {
-        self.vmctx_runtime_limits() + self.size()
+        self.vmctx_store_context() + self.size()
     }
 
     /// Return the offset to the `callee` member in this `VMContext`.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -583,7 +583,7 @@ impl Instance {
     /// Return a pointer to the interrupts structure
     #[inline]
     pub fn vm_store_context(&mut self) -> NonNull<Option<VmPtr<VMStoreContext>>> {
-        unsafe { self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_runtime_limits()) }
+        unsafe { self.vmctx_plus_offset_mut(self.offsets().ptr.vmctx_store_context()) }
     }
 
     /// Return a pointer to the global epoch counter used by this instance.

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1143,10 +1143,11 @@ where
     /// Emits a series of instructions that load the `fuel_consumed` field from
     /// `VMStoreContext`.
     fn emit_load_fuel_consumed(&mut self, fuel_reg: Reg) -> Result<()> {
-        let limits_offset = self.env.vmoffsets.ptr.vmctx_runtime_limits();
+        let store_context_offset = self.env.vmoffsets.ptr.vmctx_store_context();
         let fuel_offset = self.env.vmoffsets.ptr.vmstore_context_fuel_consumed();
         self.masm.load_ptr(
-            self.masm.address_at_vmctx(u32::from(limits_offset))?,
+            self.masm
+                .address_at_vmctx(u32::from(store_context_offset))?,
             writable!(fuel_reg),
         )?;
 
@@ -1221,7 +1222,7 @@ where
         epoch_counter_reg: Reg,
     ) -> Result<()> {
         let epoch_ptr_offset = self.env.vmoffsets.ptr.vmctx_epoch_ptr();
-        let runtime_limits_offset = self.env.vmoffsets.ptr.vmctx_runtime_limits();
+        let store_context_offset = self.env.vmoffsets.ptr.vmctx_store_context();
         let epoch_deadline_offset = self.env.vmoffsets.ptr.vmstore_context_epoch_deadline();
 
         // Load the current epoch value into `epoch_counter_var`.
@@ -1241,7 +1242,7 @@ where
         // Load the `VMStoreContext`.
         self.masm.load_ptr(
             self.masm
-                .address_at_vmctx(u32::from(runtime_limits_offset))?,
+                .address_at_vmctx(u32::from(store_context_offset))?,
             writable!(epoch_deadline_reg),
         )?;
 
@@ -1262,13 +1263,14 @@ where
             return Ok(());
         }
 
-        let limits_offset = self.env.vmoffsets.ptr.vmctx_runtime_limits();
+        let store_context_offset = self.env.vmoffsets.ptr.vmctx_store_context();
         let fuel_offset = self.env.vmoffsets.ptr.vmstore_context_fuel_consumed();
         let limits_reg = self.context.any_gpr(self.masm)?;
 
         // Load `VMStoreContext` into the `limits_reg` reg.
         self.masm.load_ptr(
-            self.masm.address_at_vmctx(u32::from(limits_offset))?,
+            self.masm
+                .address_at_vmctx(u32::from(store_context_offset))?,
             writable!(limits_reg),
         )?;
 


### PR DESCRIPTION
`VMRuntimeLimits` was renamed to `VMStoreContext` a little while back.

Split off from https://github.com/bytecodealliance/wasmtime/pull/10503

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
