### PR TITLE
cranelift-jit: add bump memory allocator, make configurable

### DIFF
--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -9,6 +9,8 @@ mod backend;
 mod compiled_blob;
 mod memory;
 
+pub use memory::*;
+
 pub use crate::backend::{JITBuilder, JITModule};
 
 /// Version number of this crate.

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -9,9 +9,10 @@ mod backend;
 mod compiled_blob;
 mod memory;
 
-pub use memory::*;
-
 pub use crate::backend::{JITBuilder, JITModule};
+pub use crate::memory::{
+    ArenaMemoryProvider, BranchProtection, JITMemoryProvider, SystemMemoryProvider,
+};
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/cranelift/jit/src/memory/arena.rs
+++ b/cranelift/jit/src/memory/arena.rs
@@ -178,6 +178,9 @@ impl ArenaMemoryProvider {
         for segment in &mut self.segments {
             segment.finalize(branch_protection);
         }
+
+        // Flush any in-flight instructions from the pipeline
+        wasmtime_jit_icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");
     }
 
     /// Frees the allocated memory region, which would be leaked otherwise.

--- a/cranelift/jit/src/memory/arena.rs
+++ b/cranelift/jit/src/memory/arena.rs
@@ -1,0 +1,218 @@
+use std::io;
+use std::mem::ManuallyDrop;
+use std::ptr;
+
+use cranelift_module::ModuleResult;
+
+use super::{BranchProtection, JITMemoryProvider};
+
+fn align_up(addr: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (addr + align - 1) & !(align - 1)
+}
+
+#[derive(Debug)]
+struct Segment {
+    ptr: *mut u8,
+    len: usize,
+    position: usize,
+    target_prot: region::Protection,
+    finalized: bool,
+}
+
+impl Segment {
+    fn new(ptr: *mut u8, len: usize, target_prot: region::Protection) -> Self {
+        let mut segment = Segment {
+            ptr,
+            len,
+            target_prot,
+            position: 0,
+            finalized: false,
+        };
+        // set segment to read-write for initialization
+        segment.set_rw();
+        segment
+    }
+
+    fn set_rw(&mut self) {
+        unsafe {
+            region::protect(self.ptr, self.len, region::Protection::READ_WRITE)
+                .expect("unable to change memory protection for jit memory segment");
+        }
+    }
+
+    fn finalize(&mut self, branch_protection: BranchProtection) {
+        if self.finalized {
+            return;
+        }
+
+        if self.target_prot == region::Protection::READ_EXECUTE {
+            super::set_readable_and_executable(self.ptr, self.len, branch_protection)
+                .expect("unable to set memory protection for jit memory segment");
+        } else {
+            unsafe {
+                region::protect(self.ptr, self.len, self.target_prot)
+                    .expect("unable to change memory protection for jit memory segment");
+            }
+        }
+        self.finalized = true;
+    }
+
+    fn allocate(&mut self, size: usize, align: usize) -> *mut u8 {
+        assert!(self.has_space_for(size, align));
+        self.position = align_up(self.position, align);
+        let ptr = unsafe { self.ptr.add(self.position) };
+        self.position += size;
+        ptr
+    }
+
+    fn has_space_for(&self, size: usize, align: usize) -> bool {
+        !self.finalized && align_up(self.position, align) + size <= self.len
+    }
+}
+
+/// `ArenaMemoryProvider` allocates segments from a contiguous memory region
+/// that is reserved up-front.
+///
+/// The arena's memory is initially allocated with PROT_NONE and gradually
+/// updated as the JIT requires more space. This approach allows for stable
+/// addresses throughout the lifetime of the JIT.
+///
+/// Note: Memory will be leaked by default unless
+/// [`JITMemoryProvider::free_memory`] is called to ensure function pointers
+/// remain valid for the remainder of the program's life.
+pub struct ArenaMemoryProvider {
+    alloc: ManuallyDrop<Option<region::Allocation>>,
+    ptr: *mut u8,
+    size: usize,
+    position: usize,
+    segments: Vec<Segment>,
+}
+
+impl ArenaMemoryProvider {
+    /// Create a new memory region with the given size.
+    pub fn new_with_size(reserve_size: usize) -> Result<Self, region::Error> {
+        let size = align_up(reserve_size, region::page::size());
+        let mut alloc = region::alloc(reserve_size, region::Protection::NONE)?;
+        let ptr = alloc.as_mut_ptr();
+
+        Ok(Self {
+            alloc: ManuallyDrop::new(Some(alloc)),
+            segments: Vec::new(),
+            ptr,
+            size,
+            position: 0,
+        })
+    }
+
+    fn allocate(
+        &mut self,
+        size: usize,
+        align: usize,
+        protection: region::Protection,
+    ) -> io::Result<*mut u8> {
+        // Note: Add a fast path without a linear scan over segments here?
+
+        // can we fit this allocation into an existing segment
+        if let Some(segment) = self.segments.iter_mut().find(|seg| {
+            seg.target_prot == protection && !seg.finalized && seg.has_space_for(size, align)
+        }) {
+            return Ok(segment.allocate(size, align));
+        }
+
+        // can we resize the last segment?
+        if let Some(segment) = self.segments.iter_mut().last() {
+            if segment.target_prot == protection && !segment.finalized {
+                let align = align.max(region::page::size());
+                let additional_size = align_up(size, align);
+
+                // if our reserved arena can fit the additional size, extend the
+                // last segment
+                if self.position + additional_size <= self.size {
+                    segment.len += additional_size;
+                    segment.set_rw();
+                    self.position += additional_size;
+                    return Ok(segment.allocate(size, align));
+                }
+            }
+        }
+
+        // allocate new segment for given size and alignment
+        self.allocate_segment(align_up(size, align), protection)?;
+        let i = self.segments.len() - 1;
+        Ok(self.segments[i].allocate(size, align))
+    }
+
+    fn allocate_segment(
+        &mut self,
+        size: usize,
+        target_prot: region::Protection,
+    ) -> Result<(), io::Error> {
+        let size = align_up(size, region::page::size());
+        let ptr = unsafe { self.ptr.add(self.position) };
+        if self.position + size > self.size {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "pre-allocated jit memory region exhausted",
+            ));
+        }
+        self.position += size;
+        self.segments.push(Segment::new(ptr, size, target_prot));
+        Ok(())
+    }
+
+    pub(crate) fn finalize(&mut self, branch_protection: BranchProtection) {
+        for segment in &mut self.segments {
+            segment.finalize(branch_protection);
+        }
+    }
+
+    /// Frees the allocated memory region, which would be leaked otherwise.
+    /// Likely to invalidate existing function pointers, causing unsafety.
+    pub(crate) unsafe fn free_memory(&mut self) {
+        if self.ptr == ptr::null_mut() {
+            return;
+        }
+        self.segments.clear();
+        // Drop the allocation, freeing memory
+        let _: Option<region::Allocation> = self.alloc.take();
+        self.ptr = ptr::null_mut();
+    }
+}
+
+impl Drop for ArenaMemoryProvider {
+    fn drop(&mut self) {
+        if self.ptr == ptr::null_mut() {
+            return;
+        }
+        let is_live = self.segments.iter().any(|seg| seg.finalized);
+        if !is_live {
+            // Only free memory if it's not been finalized yet.
+            // Otherwise, leak it since JIT memory may still be in use.
+            unsafe { self.free_memory() };
+        }
+    }
+}
+
+impl JITMemoryProvider for ArenaMemoryProvider {
+    fn allocate_readexec(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.allocate(size, align as usize, region::Protection::READ_EXECUTE)
+    }
+
+    fn allocate_readwrite(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.allocate(size, align as usize, region::Protection::READ_WRITE)
+    }
+
+    fn allocate_readonly(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.allocate(size, align as usize, region::Protection::READ)
+    }
+
+    unsafe fn free_memory(&mut self) {
+        self.free_memory();
+    }
+
+    fn finalize(&mut self, branch_protection: BranchProtection) -> ModuleResult<()> {
+        self.finalize(branch_protection);
+        Ok(())
+    }
+}

--- a/cranelift/jit/src/memory/mod.rs
+++ b/cranelift/jit/src/memory/mod.rs
@@ -1,0 +1,80 @@
+mod arena;
+mod system;
+
+use std::io;
+
+use cranelift_module::ModuleResult;
+
+pub use arena::ArenaMemoryProvider;
+pub use system::SystemMemoryProvider;
+
+/// Type of branch protection to apply to executable memory.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BranchProtection {
+    /// No protection.
+    None,
+    /// Use the Branch Target Identification extension of the Arm architecture.
+    BTI,
+}
+
+/// A provider of memory for the JIT.
+pub trait JITMemoryProvider {
+    /// Allocate memory that will be executable once finalized.
+    fn allocate_readexec(&mut self, size: usize, align: u64) -> io::Result<*mut u8>;
+    /// Allocate writable memory.
+    fn allocate_readwrite(&mut self, size: usize, align: u64) -> io::Result<*mut u8>;
+    /// Allocate memory that will be read-only once finalized.
+    fn allocate_readonly(&mut self, size: usize, align: u64) -> io::Result<*mut u8>;
+
+    /// Free the memory region.
+    unsafe fn free_memory(&mut self);
+    /// Finalize the memory region and apply memory protections.
+    fn finalize(&mut self, branch_protection: BranchProtection) -> ModuleResult<()>;
+}
+
+/// Set all memory allocated in this `Memory` up to now as readable and executable.
+/// This function deals with icache coherence, branch protection, and pipeline flushing.
+pub(crate) fn set_readable_and_executable(
+    ptr: *mut u8,
+    len: usize,
+    branch_protection: BranchProtection,
+) -> ModuleResult<()> {
+    // Clear all the newly allocated code from cache if the processor requires it
+    //
+    // Do this before marking the memory as R+X, technically we should be able to do it after
+    // but there are some CPU's that have had errata about doing this with read only memory.
+    unsafe {
+        wasmtime_jit_icache_coherence::clear_cache(ptr as *const libc::c_void, len)
+            .expect("Failed cache clear")
+    };
+
+    unsafe {
+        region::protect(ptr, len, region::Protection::READ_EXECUTE).map_err(|e| {
+            cranelift_module::ModuleError::Backend(
+                anyhow::Error::new(e).context("unable to make memory readable+executable"),
+            )
+        })?;
+    }
+
+    // If BTI is requested, and the architecture supports it, use mprotect to set the PROT_BTI flag
+    if branch_protection == BranchProtection::BTI {
+        #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+        if is_bti && std::arch::is_aarch64_feature_detected!("bti") {
+            let prot = libc::PROT_EXEC | libc::PROT_READ | /* PROT_BTI */ 0x10;
+
+            unsafe {
+                if libc::mprotect(ptr as *mut libc::c_void, len, prot) < 0 {
+                    return Err(ModuleError::Backend(
+                        anyhow::Error::new(io::Error::last_os_error())
+                            .context("unable to make memory readable+executable"),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Flush any in-flight instructions from the pipeline
+    wasmtime_jit_icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");
+
+    Ok(())
+}

--- a/cranelift/jit/src/memory/mod.rs
+++ b/cranelift/jit/src/memory/mod.rs
@@ -1,4 +1,4 @@
-use cranelift_module::ModuleResult;
+use cranelift_module::{ModuleError, ModuleResult};
 use std::io;
 
 mod arena;
@@ -53,16 +53,16 @@ pub(crate) fn set_readable_and_executable(
 
     unsafe {
         region::protect(ptr, len, region::Protection::READ_EXECUTE).map_err(|e| {
-            cranelift_module::ModuleError::Backend(
+            ModuleError::Backend(
                 anyhow::Error::new(e).context("unable to make memory readable+executable"),
             )
         })?;
     }
 
-    // If BTI is requested, and the architecture supports it, use mprotect to set the PROT_BTI flag
+    // If BTI is requested, and the architecture supports it, use mprotect to set the PROT_BTI flag.
     if branch_protection == BranchProtection::BTI {
         #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-        if is_bti && std::arch::is_aarch64_feature_detected!("bti") {
+        if std::arch::is_aarch64_feature_detected!("bti") {
             let prot = libc::PROT_EXEC | libc::PROT_READ | /* PROT_BTI */ 0x10;
 
             unsafe {

--- a/cranelift/jit/src/memory/system.rs
+++ b/cranelift/jit/src/memory/system.rs
@@ -5,11 +5,12 @@ use memmap2::MmapMut;
 
 #[cfg(not(any(feature = "selinux-fix", windows)))]
 use std::alloc;
-use std::ffi::c_void;
 use std::io;
 use std::mem;
 use std::ptr;
-use wasmtime_jit_icache_coherence as icache_coherence;
+
+use super::BranchProtection;
+use super::JITMemoryProvider;
 
 /// A simple struct consisting of a pointer and length.
 struct PtrLen {
@@ -111,15 +112,6 @@ impl Drop for PtrLen {
 
 // TODO: add a `Drop` impl for `cfg(target_os = "windows")`
 
-/// Type of branch protection to apply to executable memory.
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum BranchProtection {
-    /// No protection.
-    None,
-    /// Use the Branch Target Identification extension of the Arm architecture.
-    BTI,
-}
-
 /// JIT memory manager. This manages pages of suitably aligned and
 /// accessible memory. Memory will be leaked by default to have
 /// function pointers remain valid for the remainder of the
@@ -129,19 +121,17 @@ pub(crate) struct Memory {
     already_protected: usize,
     current: PtrLen,
     position: usize,
-    branch_protection: BranchProtection,
 }
 
 unsafe impl Send for Memory {}
 
 impl Memory {
-    pub(crate) fn new(branch_protection: BranchProtection) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             allocations: Vec::new(),
             already_protected: 0,
             current: PtrLen::new(),
             position: 0,
-            branch_protection,
         }
     }
 
@@ -175,55 +165,15 @@ impl Memory {
     }
 
     /// Set all memory allocated in this `Memory` up to now as readable and executable.
-    pub(crate) fn set_readable_and_executable(&mut self) -> ModuleResult<()> {
+    pub(crate) fn set_readable_and_executable(
+        &mut self,
+        branch_protection: BranchProtection,
+    ) -> ModuleResult<()> {
         self.finish_current();
 
-        // Clear all the newly allocated code from cache if the processor requires it
-        //
-        // Do this before marking the memory as R+X, technically we should be able to do it after
-        // but there are some CPU's that have had errata about doing this with read only memory.
         for &PtrLen { ptr, len, .. } in self.non_protected_allocations_iter() {
-            unsafe {
-                icache_coherence::clear_cache(ptr as *const c_void, len)
-                    .expect("Failed cache clear")
-            };
+            super::set_readable_and_executable(ptr, len, branch_protection)?;
         }
-
-        let set_region_readable_and_executable = |ptr, len| -> ModuleResult<()> {
-            if self.branch_protection == BranchProtection::BTI {
-                #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-                if std::arch::is_aarch64_feature_detected!("bti") {
-                    let prot = libc::PROT_EXEC | libc::PROT_READ | /* PROT_BTI */ 0x10;
-
-                    unsafe {
-                        if libc::mprotect(ptr as *mut libc::c_void, len, prot) < 0 {
-                            return Err(ModuleError::Backend(
-                                anyhow::Error::new(io::Error::last_os_error())
-                                    .context("unable to make memory readable+executable"),
-                            ));
-                        }
-                    }
-
-                    return Ok(());
-                }
-            }
-
-            unsafe {
-                region::protect(ptr, len, region::Protection::READ_EXECUTE).map_err(|e| {
-                    ModuleError::Backend(
-                        anyhow::Error::new(e).context("unable to make memory readable+executable"),
-                    )
-                })?;
-            }
-            Ok(())
-        };
-
-        for &PtrLen { ptr, len, .. } in self.non_protected_allocations_iter() {
-            set_region_readable_and_executable(ptr, len)?;
-        }
-
-        // Flush any in-flight instructions from the pipeline
-        icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");
 
         self.already_protected = self.allocations.len();
         Ok(())
@@ -272,5 +222,53 @@ impl Drop for Memory {
         mem::replace(&mut self.allocations, Vec::new())
             .into_iter()
             .for_each(mem::forget);
+    }
+}
+
+/// A memory provider that allocates memory on-demand using the system
+/// allocator.
+///
+/// Note: Memory will be leaked by default unless
+/// [`JITMemoryProvider::free_memory`] is called to ensure function pointers
+/// remain valid for the remainder of the program's life.
+pub struct SystemMemoryProvider {
+    code: Memory,
+    readonly: Memory,
+    writable: Memory,
+}
+
+impl SystemMemoryProvider {
+    /// Create a new memory handle with the given branch protection.
+    pub fn new() -> Self {
+        Self {
+            code: Memory::new(),
+            readonly: Memory::new(),
+            writable: Memory::new(),
+        }
+    }
+}
+
+impl JITMemoryProvider for SystemMemoryProvider {
+    unsafe fn free_memory(&mut self) {
+        self.code.free_memory();
+        self.readonly.free_memory();
+        self.writable.free_memory();
+    }
+
+    fn finalize(&mut self, branch_protection: BranchProtection) -> ModuleResult<()> {
+        self.readonly.set_readonly()?;
+        self.code.set_readable_and_executable(branch_protection)
+    }
+
+    fn allocate_readexec(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.code.allocate(size, align)
+    }
+
+    fn allocate_readwrite(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.writable.allocate(size, align)
+    }
+
+    fn allocate_readonly(&mut self, size: usize, align: u64) -> io::Result<*mut u8> {
+        self.readonly.allocate(size, align)
     }
 }

--- a/cranelift/jit/src/memory/system.rs
+++ b/cranelift/jit/src/memory/system.rs
@@ -175,6 +175,9 @@ impl Memory {
             super::set_readable_and_executable(ptr, len, branch_protection)?;
         }
 
+        // Flush any in-flight instructions from the pipeline
+        wasmtime_jit_icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");
+
         self.already_protected = self.allocations.len();
         Ok(())
     }


### PR DESCRIPTION
Hey,
this is a stab at #4000 (and #4986) to resolve an issue with x86 relocation range that comes up in multi-threaded JITs.
I've added an option to swap out the memory allocator in `cranelift-jit` and have added an arena-based option that works with a pre-allocated `PROT_NONE` region.

I've marked this as draft because I could also see updating the PR to either
- just add the trait, have users provide their own option when in doubt?
- update the existing allocator to allow reserving an area up-front?
- split the changes into multiple commits if helpful

Let me know if this seems reasonable. Thanks! :slightly_smiling_face: 
