### PR TITLE
winch(x64): Fix stack parameter alignment

### DIFF
--- a/tests/disas/winch/x64/v128_mixed_sig.wat
+++ b/tests/disas/winch/x64/v128_mixed_sig.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! test = "winch"
+(module
+  (func (export "x")
+    (param f32 f32 f32 f32 f32 f32 f32 f32 f32) (param $last v128)
+    (result v128)
+    local.get $last
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x67
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x30, %rsp
+;;       movq    %rdi, 0x28(%rsp)
+;;       movq    %rsi, 0x20(%rsp)
+;;       movss   %xmm0, 0x1c(%rsp)
+;;       movss   %xmm1, 0x18(%rsp)
+;;       movss   %xmm2, 0x14(%rsp)
+;;       movss   %xmm3, 0x10(%rsp)
+;;       movss   %xmm4, 0xc(%rsp)
+;;       movss   %xmm5, 8(%rsp)
+;;       movss   %xmm6, 4(%rsp)
+;;       movss   %xmm7, (%rsp)
+;;       movdqu  0x20(%rbp), %xmm0
+;;       addq    $0x30, %rsp
+;;       popq    %rbp
+;;       retq
+;;   67: ud2

--- a/tests/misc_testsuite/winch/issue-10460.wast
+++ b/tests/misc_testsuite/winch/issue-10460.wast
@@ -1,0 +1,23 @@
+;;! simd = true
+(module
+  (func (export "x")
+    (param f32 f32 f32 f32 f32 f32 f32 f32 f32) (param $last v128)
+    (result v128)
+    local.get $last
+  )
+)
+
+(assert_return
+  (invoke "x"
+    (f32.const 1)
+    (f32.const 2)
+    (f32.const 3)
+    (f32.const 4)
+    (f32.const 5)
+    (f32.const 6)
+    (f32.const 7)
+    (f32.const 8)
+    (f32.const 9)
+    (v128.const i64x2 10 11)
+  )
+  (v128.const i64x2 10 11))


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/10460

This commit ensures stack arguments greater than 8 bytes are correctly aligned.

Prior to this commit this wasn't an issue since for the default calling convention, all arguments were aligned to a fixed slot size (e.g, 8 bytes). With the introduction of vector types, namely, v128, we must ensure that arguments greater than 8 bytes in size are correctly type-sized aligned.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
