### PR TITLE
winch(x64): Remove stale comment in Winch CC

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1142,12 +1142,7 @@ fn get_intreg_for_retval(
             _ => None,
         },
 
-        CallConv::Winch => {
-            // TODO: Once Winch supports SIMD, this will need to be updated to support values
-            // returned in more than one register.
-            // https://github.com/bytecodealliance/wasmtime/issues/8093
-            is_last.then(|| regs::rax())
-        }
+        CallConv::Winch => is_last.then(|| regs::rax()),
         CallConv::Probestack => todo!(),
         CallConv::AppleAarch64 => unreachable!(),
     }


### PR DESCRIPTION
Cranelift's Winch calling convention will never have to deal with results in more than one register since Winch doesn't make use of the types that would trigger that case, namely, `types::I128`. In all SIMD cases types are bound to `types::MxN`, which map to a single float register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
