### PR TITLE
cranelift: Restore 16-bit TrapCodes

### DIFF
--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -2,7 +2,7 @@
 
 use crate::gpr;
 use crate::xmm;
-use std::{num::NonZeroU8, ops::Index, vec::Vec};
+use std::{num::NonZeroU16, ops::Index, vec::Vec};
 
 /// Describe how an instruction is emitted into a code buffer.
 pub trait CodeSink {
@@ -79,7 +79,7 @@ pub struct Constant(pub u32);
 /// Wrap [`CodeSink`]-specific trap codes.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
-pub struct TrapCode(pub NonZeroU8);
+pub struct TrapCode(pub NonZeroU16);
 
 /// A table mapping `KnownOffset` identifiers to their `i32` offset values.
 ///

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -1,7 +1,7 @@
 //! Trap codes describing the reason for a trap.
 
 use core::fmt::{self, Display, Formatter};
-use core::num::NonZeroU8;
+use core::num::NonZeroU16;
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
@@ -11,19 +11,19 @@ use serde_derive::{Deserialize, Serialize};
 /// All trap instructions have an explicit trap code.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct TrapCode(NonZeroU8);
+pub struct TrapCode(NonZeroU16);
 
 impl TrapCode {
     /// Number of reserved opcodes for Cranelift itself. This number of traps are
     /// defined below starting at the high end of the byte space (e.g. 255, 254,
     /// ...)
-    const RESERVED: u8 = 5;
-    const RESERVED_START: u8 = u8::MAX - Self::RESERVED + 1;
+    const RESERVED: u16 = 5;
+    const RESERVED_START: u16 = u16::MAX - Self::RESERVED + 1;
 
     /// Internal helper to create new reserved trap codes.
-    const fn reserved(byte: u8) -> TrapCode {
+    const fn reserved(byte: u16) -> TrapCode {
         if let Some(code) = byte.checked_add(Self::RESERVED_START) {
-            if let Some(nz) = NonZeroU8::new(code) {
+            if let Some(nz) = NonZeroU16::new(code) {
                 return TrapCode(nz);
             }
         }
@@ -51,33 +51,33 @@ impl TrapCode {
     ///
     /// Returns `None` if `code` is zero or too large and is reserved by
     /// Cranelift.
-    pub const fn user(code: u8) -> Option<TrapCode> {
+    pub const fn user(code: u16) -> Option<TrapCode> {
         if code >= Self::RESERVED_START {
             return None;
         }
-        match NonZeroU8::new(code) {
+        match NonZeroU16::new(code) {
             Some(nz) => Some(TrapCode(nz)),
             None => None,
         }
     }
 
     /// Alias for [`TrapCode::user`] with a panic built-in.
-    pub const fn unwrap_user(code: u8) -> TrapCode {
+    pub const fn unwrap_user(code: u16) -> TrapCode {
         match TrapCode::user(code) {
             Some(code) => code,
             None => panic!("invalid user trap code"),
         }
     }
 
-    /// Returns the raw byte representing this trap.
-    pub const fn as_raw(&self) -> NonZeroU8 {
+    /// Returns the raw u16 representing this trap.
+    pub const fn as_raw(&self) -> NonZeroU16 {
         self.0
     }
 
-    /// Creates a trap code from its raw byte, likely returned by
+    /// Creates a trap code from its raw u16, likely returned by
     /// [`TrapCode::as_raw`] previously.
-    pub const fn from_raw(byte: NonZeroU8) -> TrapCode {
-        TrapCode(byte)
+    pub const fn from_raw(value: NonZeroU16) -> TrapCode {
+        TrapCode(value)
     }
 
     /// Returns a slice of all traps except `TrapCode::User` traps
@@ -89,6 +89,38 @@ impl TrapCode {
             TrapCode::INTEGER_DIVISION_BY_ZERO,
             TrapCode::BAD_CONVERSION_TO_INTEGER,
         ]
+    }
+
+    /// Encodes this trap code as a byte for compact storage in other data
+    /// structures.
+    ///
+    /// Since [`MemFlags`] only has a limited number of bits available for
+    /// storing trap codes, this method attempts to encode the trap code as a
+    /// single byte. This is always possible for reserved trap codes, but user
+    /// trap codes are limited to the range that can fit in a signed 8-bit
+    /// integer.
+    ///
+    /// This implementation reinterprets the underlying u16 as signed, truncates
+    /// it to a signed i8, and then casts that to a u8.
+    ///
+    /// Note: We could also allow for a larger range of user trap codes here but
+    /// it might be nice to have the encodable range not depend on
+    /// [`Self::RESERVED_START`].
+    pub(crate) const fn encode_as_byte(self) -> Option<u8> {
+        let value = self.0.get() as i16;
+        if value >= i8::MIN as i16 && value <= i8::MAX as i16 {
+            Some(value as i8 as u8)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) const fn decode_from_byte(byte: u8) -> Option<TrapCode> {
+        let value = byte as i8 as i16 as u16;
+        match NonZeroU16::new(value) {
+            Some(code) => Some(TrapCode::from_raw(code)),
+            None => None,
+        }
     }
 }
 
@@ -143,5 +175,28 @@ mod tests {
         assert_eq!("user".parse::<TrapCode>(), Err(()));
         assert_eq!("user-1".parse::<TrapCode>(), Err(()));
         assert_eq!("users".parse::<TrapCode>(), Err(()));
+    }
+
+    #[test]
+    fn byte_encoding() {
+        // 0 doesn't decode
+        assert!(TrapCode::decode_from_byte(0).is_none());
+
+        // Encoding should round-trip.
+        for byte in 1..=u8::MAX {
+            let tc = TrapCode::decode_from_byte(byte).unwrap();
+            assert_eq!(tc.encode_as_byte(), Some(byte));
+        }
+
+        // All non-user traps should be encodable.
+        assert!(TrapCode::non_user_traps()
+            .iter()
+            .all(|tc| tc.encode_as_byte().is_some()));
+
+        // Low user traps can be encoded.
+        assert!(TrapCode::user(1).unwrap().encode_as_byte().is_some());
+        assert!(TrapCode::user(127).unwrap().encode_as_byte().is_some());
+        // Higher user traps cannot be encoded.
+        assert!(TrapCode::user(128).unwrap().encode_as_byte().is_none());
     }
 }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -39,29 +39,29 @@ mod translate;
 use self::compiler::Compiler;
 
 const TRAP_INTERNAL_ASSERT: TrapCode = TrapCode::unwrap_user(1);
-const TRAP_OFFSET: u8 = 2;
+const TRAP_OFFSET: u16 = 2;
 pub const TRAP_ALWAYS: TrapCode =
-    TrapCode::unwrap_user(Trap::AlwaysTrapAdapter as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::AlwaysTrapAdapter as u16 + TRAP_OFFSET);
 pub const TRAP_CANNOT_ENTER: TrapCode =
-    TrapCode::unwrap_user(Trap::CannotEnterComponent as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::CannotEnterComponent as u16 + TRAP_OFFSET);
 pub const TRAP_INDIRECT_CALL_TO_NULL: TrapCode =
-    TrapCode::unwrap_user(Trap::IndirectCallToNull as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::IndirectCallToNull as u16 + TRAP_OFFSET);
 pub const TRAP_BAD_SIGNATURE: TrapCode =
-    TrapCode::unwrap_user(Trap::BadSignature as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::BadSignature as u16 + TRAP_OFFSET);
 pub const TRAP_NULL_REFERENCE: TrapCode =
-    TrapCode::unwrap_user(Trap::NullReference as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::NullReference as u16 + TRAP_OFFSET);
 pub const TRAP_ALLOCATION_TOO_LARGE: TrapCode =
-    TrapCode::unwrap_user(Trap::AllocationTooLarge as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::AllocationTooLarge as u16 + TRAP_OFFSET);
 pub const TRAP_ARRAY_OUT_OF_BOUNDS: TrapCode =
-    TrapCode::unwrap_user(Trap::ArrayOutOfBounds as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::ArrayOutOfBounds as u16 + TRAP_OFFSET);
 pub const TRAP_UNREACHABLE: TrapCode =
-    TrapCode::unwrap_user(Trap::UnreachableCodeReached as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::UnreachableCodeReached as u16 + TRAP_OFFSET);
 pub const TRAP_HEAP_MISALIGNED: TrapCode =
-    TrapCode::unwrap_user(Trap::HeapMisaligned as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::HeapMisaligned as u16 + TRAP_OFFSET);
 pub const TRAP_TABLE_OUT_OF_BOUNDS: TrapCode =
-    TrapCode::unwrap_user(Trap::TableOutOfBounds as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::TableOutOfBounds as u16 + TRAP_OFFSET);
 pub const TRAP_CAST_FAILURE: TrapCode =
-    TrapCode::unwrap_user(Trap::CastFailure as u8 + TRAP_OFFSET);
+    TrapCode::unwrap_user(Trap::CastFailure as u16 + TRAP_OFFSET);
 
 /// Creates a new cranelift `Signature` with no wasm params/results for the
 /// given calling convention.
@@ -277,7 +277,7 @@ fn clif_trap_to_env_trap(trap: ir::TrapCode) -> Option<Trap> {
         // these, we let the signal crash the process.
         TRAP_INTERNAL_ASSERT => return None,
 
-        other => Trap::from_u8(other.as_raw().get() - TRAP_OFFSET).unwrap(),
+        other => Trap::from_u8((other.as_raw().get() - TRAP_OFFSET).try_into().unwrap()).unwrap(),
     })
 }
 


### PR DESCRIPTION
This allows users of Cranelift to have ~65k unique trap codes again.
The range of `TrapCode` was reduced in #9338 in order to be able to fit arbitrary trap codes inside of `MemFlags`.

I'm keeping MemFlags a u16 with this change and chose to only allow a _low subset_ of trap codes to be represented instead. Explicit traps can still use the full TrapCode range.

The implementation is a bit awkward but I've added exhaustive tests for the encoding part. Feel free to close this PR if the cons (panic in `MemFlags::with_trap_code`) outweigh the pros here (more flexibility with dynamically-assigned user traps). :slightly_smiling_face: 

Thanks!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
