### PR TITLE
Plumb initial translation of `thread.spawn_indirect`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1345,7 +1345,7 @@ impl<'a> TrampolineCompiler<'a> {
         let table = self
             .builder
             .ins()
-            .iconst(ir::types::I32, i64::from(self.offsets.runtime_table(table)));
+            .iconst(ir::types::I32, i64::from(table.as_u32()));
 
         self.translate_intrinsic_libcall(
             vmctx,

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -155,7 +155,7 @@ macro_rules! foreach_builtin_component_function {
             error_context_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
 
             #[cfg(feature = "threads")]
-            thread_spawn_indirect(vmctx: vmctx, table: u32, element: u32, context: u32 ) -> u64;
+            thread_spawn_indirect(vmctx: vmctx, func_ty: u32, table: u32, element: u32, context: u32 ) -> u64;
 
             trap(vmctx: vmctx, code: u8);
 

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -154,6 +154,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             error_context_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
 
+            #[cfg(feature = "threads")]
+            thread_spawn_indirect(vmctx: vmctx, table: u32, element: u32, context: u32 ) -> u64;
+
             trap(vmctx: vmctx, code: u8);
 
             utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8) -> bool;

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -66,6 +66,9 @@ pub struct ComponentDfg {
     /// Same as `reallocs`, but for post-return.
     pub memories: Intern<MemoryId, CoreExport<MemoryIndex>>,
 
+    /// Tables used by this component.
+    pub tables: Intern<TableId, CoreExport<TableIndex>>,
+
     /// Metadata about identified fused adapters.
     ///
     /// Note that this list is required to be populated in-order where the
@@ -393,6 +396,10 @@ pub enum Trampoline {
     FutureTransfer,
     StreamTransfer,
     ErrorContextTransfer,
+    ThreadSpawnIndirect {
+        ty: TypeFuncIndex,
+        table: TableId,
+    },
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
@@ -706,6 +713,15 @@ impl LinearizeDfg<'_> {
         )
     }
 
+    fn runtime_table(&mut self, tbl: TableId) -> RuntimeTableIndex {
+        self.intern(
+            tbl,
+            |me| &mut me.runtime_tables,
+            |me, tbl| me.core_export(&me.dfg.tables[tbl]),
+            |index, export| GlobalInitializer::ExtractTable(ExtractTable { index, export }),
+        )
+    }
+
     fn runtime_realloc(&mut self, realloc: ReallocId) -> RuntimeReallocIndex {
         self.intern(
             realloc,
@@ -896,6 +912,12 @@ impl LinearizeDfg<'_> {
             Trampoline::FutureTransfer => info::Trampoline::FutureTransfer,
             Trampoline::StreamTransfer => info::Trampoline::StreamTransfer,
             Trampoline::ErrorContextTransfer => info::Trampoline::ErrorContextTransfer,
+            Trampoline::ThreadSpawnIndirect { ty, table } => {
+                info::Trampoline::ThreadSpawnIndirect {
+                    ty: *ty,
+                    table: self.runtime_table(*table),
+                }
+            }
         };
         let i1 = self.trampolines.push(*signature);
         let i2 = self.trampoline_defs.push(trampoline);

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -997,9 +997,10 @@ pub enum Trampoline {
     /// The `thread.spawn_indirect` intrinsic to spawn a thread from a function
     /// of type `ty` stored in a `table`.
     ThreadSpawnIndirect {
-        /// TODO
+        /// The type of the function that is being spawned.
         ty: TypeFuncIndex,
-        /// TODO
+        /// The table from which to indirectly retrieve retrieve the spawn
+        /// function.
         table: RuntimeTableIndex,
     },
 }

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -970,34 +970,43 @@ pub enum Trampoline {
         post_return: Option<RuntimePostReturnIndex>,
     },
 
-    /// An intrinisic used by FACT-generated modules to (partially or entirely) transfer
+    /// An intrinsic used by FACT-generated modules to (partially or entirely) transfer
     /// ownership of a `future`.
     ///
-    /// Transfering a `future` can either mean giving away the readable end
+    /// Transferring a `future` can either mean giving away the readable end
     /// while retaining the writable end or only the former, depending on the
     /// ownership status of the `future`.
     FutureTransfer,
 
-    /// An intrinisic used by FACT-generated modules to (partially or entirely) transfer
+    /// An intrinsic used by FACT-generated modules to (partially or entirely) transfer
     /// ownership of a `stream`.
     ///
-    /// Transfering a `stream` can either mean giving away the readable end
+    /// Transferring a `stream` can either mean giving away the readable end
     /// while retaining the writable end or only the former, depending on the
     /// ownership status of the `stream`.
     StreamTransfer,
 
-    /// An intrinisic used by FACT-generated modules to (partially or entirely) transfer
+    /// An intrinsic used by FACT-generated modules to (partially or entirely) transfer
     /// ownership of an `error-context`.
     ///
     /// Unlike futures, streams, and resource handles, `error-context` handles
     /// are reference counted, meaning that sharing the handle with another
     /// component does not invalidate the handle in the original component.
     ErrorContextTransfer,
+
+    /// The `thread.spawn_indirect` intrinsic to spawn a thread from a function
+    /// of type `ty` stored in a `table`.
+    ThreadSpawnIndirect {
+        /// TODO
+        ty: TypeFuncIndex,
+        /// TODO
+        table: RuntimeTableIndex,
+    },
 }
 
 impl Trampoline {
     /// Returns the name to use for the symbol of this trampoline in the final
-    /// compiled artifact
+    /// compiled artifact.
     pub fn symbol_name(&self) -> String {
         use Trampoline::*;
         match self {
@@ -1053,6 +1062,7 @@ impl Trampoline {
             FutureTransfer => format!("future-transfer"),
             StreamTransfer => format!("stream-transfer"),
             ErrorContextTransfer => format!("error-context-transfer"),
+            ThreadSpawnIndirect { .. } => format!("thread-spawn-indirect"),
         }
     }
 }

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -328,6 +328,13 @@ enum LocalInitializer<'data> {
 
     // export section
     Export(ComponentItem),
+
+    // threads
+    ThreadSpawnIndirect {
+        ty: ComponentFuncTypeId,
+        table: TableIndex,
+        func: ModuleInternedTypeIndex,
+    },
 }
 
 /// The "closure environment" of components themselves.
@@ -810,10 +817,19 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::ErrorContextDrop { func }
                         }
+                        wasmparser::CanonicalFunction::ThreadSpawnIndirect {
+                            func_ty_index,
+                            table_index,
+                        } => {
+                            let ty = types.component_any_type_at(func_ty_index).unwrap_func();
+                            let func = self.core_func_signature(core_func_index)?;
+                            let table = TableIndex::from_u32(table_index);
+                            core_func_index += 1;
+                            LocalInitializer::ThreadSpawnIndirect { ty, func, table }
+                        }
                         wasmparser::CanonicalFunction::ContextGet(..)
                         | wasmparser::CanonicalFunction::ContextSet(..)
                         | wasmparser::CanonicalFunction::ThreadSpawnRef { .. }
-                        | wasmparser::CanonicalFunction::ThreadSpawnIndirect { .. }
                         | wasmparser::CanonicalFunction::ThreadAvailableParallelism => {
                             bail!("unsupported intrinsic")
                         }

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -991,6 +991,16 @@ impl<'a> Inliner<'a> {
                     .push((*func, dfg::Trampoline::ErrorContextDrop { ty }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
+            ThreadSpawnIndirect { func, ty, table } => {
+                let (table, _) = self.table(frame, types, *table);
+                let table = self.result.tables.push(table);
+                let ty = types.convert_component_func_type(frame.translation.types_ref(), *ty)?;
+                let index = self
+                    .result
+                    .trampolines
+                    .push((*func, dfg::Trampoline::ThreadSpawnIndirect { ty, table }));
+                frame.funcs.push(dfg::CoreDef::Trampoline(index));
+            }
 
             ModuleStatic(idx, ty) => {
                 frame.modules.push(ModuleDef::Static(*idx, *ty));
@@ -1315,6 +1325,41 @@ impl<'a> Inliner<'a> {
             },
         };
         (memory, memory64)
+    }
+
+    fn table(
+        &mut self,
+        frame: &InlinerFrame<'a>,
+        types: &ComponentTypesBuilder,
+        table: TableIndex,
+    ) -> (dfg::CoreExport<TableIndex>, bool) {
+        let table = frame.tables[table].clone().map_index(|i| match i {
+            EntityIndex::Table(i) => i,
+            _ => unreachable!(),
+        });
+        let table64 = match &self.runtime_instances[table.instance] {
+            InstanceModule::Static(idx) => match &table.item {
+                ExportItem::Index(i) => {
+                    let ty = &self.nested_modules[*idx].module.tables[*i];
+                    match ty.idx_type {
+                        IndexType::I32 => false,
+                        IndexType::I64 => true,
+                    }
+                }
+                ExportItem::Name(_) => unreachable!(),
+            },
+            InstanceModule::Import(ty) => match &table.item {
+                ExportItem::Name(name) => match types[*ty].exports[name] {
+                    EntityType::Memory(m) => match m.idx_type {
+                        IndexType::I32 => false,
+                        IndexType::I64 => true,
+                    },
+                    _ => unreachable!(),
+                },
+                ExportItem::Index(_) => unreachable!(),
+            },
+        };
+        (table, table64)
     }
 
     /// Translates a `LocalCanonicalOptions` which indexes into the `frame`

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -745,6 +745,75 @@ impl ComponentInstance {
         _ = (src_idx, src, dst);
         todo!()
     }
+
+    #[cfg(feature = "threads")]
+    pub(crate) fn thread_spawn_indirect(
+        &mut self,
+        table: u32,
+        element: u32,
+        _context: u32,
+    ) -> Result<u32> {
+        use crate::vm::{Instance, TableElement};
+        use crate::{Func, ValType};
+        use core::iter;
+
+        // Retrieve the table referenced by the canonical builtin (i.e.,
+        // `table`). By validation this is guaranteed to be a `shared funcref`
+        // table.
+        let VMTable { vmctx, from } = self.runtime_table(RuntimeTableIndex::from_u32(table));
+        let element = u64::from(element);
+        let table = unsafe {
+            Instance::from_vmctx(vmctx.as_non_null(), |handle| {
+                let idx = handle.table_index(from.as_non_null().as_ref());
+                handle
+                    .get_defined_table_with_lazy_init(idx, iter::once(element))
+                    .as_ref()
+            })
+        };
+        let table = *table
+            .as_ref()
+            .ok_or_else(|| anyhow!("failed to get table for thread spawn indirect"))?;
+
+        // Retrieve the actual function reference from the table. The CM
+        // specification tells us to trap if
+        let element = table.get(None, element);
+        let element = element
+            .ok_or_else(|| anyhow!("failed to get table element for thread spawn indirect"))?;
+        match element {
+            TableElement::FuncRef(Some(func)) => {
+                // Build a `Func` from the function reference--this is
+                // incorrect, but temporarily necessary! In the future this will
+                // require additional infrastructure to build a `SharedFunc` or
+                // some more-correct type. It is unclear yet how to do this from
+                // a `Store` (e.g., `SharedStore`) but this use here--never
+                // actually invoked!--makes the problem concrete (TODO).
+                let store = unsafe { (*self.store()).store_opaque_mut() };
+                let func = unsafe { Func::from_vm_func_ref(store, func) };
+
+                // Check the function signature matches what we expect.
+                // Currently, this is temporarily set to `[i32] -> []` but in
+                // the future, with some additional plumbing of the core type
+                // index, we must check that the function signature matches
+                // that (TODO).
+                let ty = func.load_ty(store);
+                if ty.params().len() != 1
+                    || !matches!(ty.params().nth(0).unwrap(), ValType::I32)
+                    || ty.results().len() != 0
+                {
+                    bail!("thread start function signature is invalid");
+                }
+
+                // At this point we should spawn the thread with the function
+                // provided, returning 0 on success, -1 otherwise. None of that
+                // infrastructure is built yet so we crash instead (TODO).
+                unimplemented!("`thread.spawn_indirect` is not implemented yet");
+            }
+            TableElement::FuncRef(None) => {
+                bail!("thread start function is not present in the table")
+            }
+            _ => bail!("thread start element is not a function reference"),
+        }
+    }
 }
 
 impl VMComponentContext {

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -749,7 +749,8 @@ impl ComponentInstance {
     #[cfg(feature = "threads")]
     pub(crate) fn thread_spawn_indirect(
         &mut self,
-        table: u32,
+        _func_ty: TypeFuncIndex,
+        table: RuntimeTableIndex,
         element: u32,
         _context: u32,
     ) -> Result<u32> {
@@ -760,7 +761,7 @@ impl ComponentInstance {
         // Retrieve the table referenced by the canonical builtin (i.e.,
         // `table`). By validation this is guaranteed to be a `shared funcref`
         // table.
-        let VMTable { vmctx, from } = self.runtime_table(RuntimeTableIndex::from_u32(table));
+        let VMTable { vmctx, from } = self.runtime_table(table);
         let element = u64::from(element);
         let table = unsafe {
             Instance::from_vmctx(vmctx.as_non_null(), |handle| {

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -1267,3 +1267,15 @@ unsafe fn error_context_drop(
             )
     })
 }
+
+#[cfg(feature = "threads")]
+unsafe fn thread_spawn_indirect(
+    vmctx: NonNull<VMComponentContext>,
+    table: u32,
+    element: u32,
+    context: u32,
+) -> Result<u32> {
+    ComponentInstance::from_vmctx(vmctx, |instance| {
+        instance.thread_spawn_indirect(table, element, context)
+    })
+}

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -1271,11 +1271,16 @@ unsafe fn error_context_drop(
 #[cfg(feature = "threads")]
 unsafe fn thread_spawn_indirect(
     vmctx: NonNull<VMComponentContext>,
+    func_ty: u32,
     table: u32,
     element: u32,
     context: u32,
 ) -> Result<u32> {
+    use wasmtime_environ::component::{RuntimeTableIndex, TypeFuncIndex};
+
+    let func_ty = TypeFuncIndex::from_bits(func_ty);
+    let table = RuntimeTableIndex::from_u32(table);
     ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.thread_spawn_indirect(table, element, context)
+        instance.thread_spawn_indirect(func_ty, table, element, context)
     })
 }

--- a/tests/misc_testsuite/shared-everything-threads/builtins.wast
+++ b/tests/misc_testsuite/shared-everything-threads/builtins.wast
@@ -1,0 +1,8 @@
+;;! shared_everything_threads = true
+;;! reference_types = true
+(component
+  (core type $start (shared (func (param $context i32))))
+  (core module $libc (table (export "start-table") shared 1 (ref null (shared func))))
+  (core instance $libc (instantiate $libc))
+  (core func $spawn_indirect (canon thread.spawn_indirect $start (table $libc "start-table")))
+)


### PR DESCRIPTION
This change in no way implements actual spawning of threads; it simply translates the CM builtin `thread.spawn_indirect` to invoke a real Wasmtime libcall that does some preliminary checks and panics. It is useful, though, to (1) exercise all the new table-related functions and (2) show the limits of Wasmtime's current state: we will need a way of interacting with shared functions and possibly some form of shared store.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
