### PR TITLE
Update how traps are rendered

### DIFF
--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -362,7 +362,7 @@ impl fmt::Display for WasmBacktrace {
             write!(f, "  {i:>3}: ")?;
 
             if let Some(offset) = frame.module_offset() {
-                write!(f, "{offset:#6x} - ")?;
+                write!(f, "{offset:#8x} - ")?;
             }
 
             let write_raw_func_name = |f: &mut fmt::Formatter<'_>| {
@@ -374,7 +374,12 @@ impl fmt::Display for WasmBacktrace {
             } else {
                 for (i, symbol) in frame.symbols().iter().enumerate() {
                     if i > 0 {
-                        write!(f, "              - ")?;
+                        if needs_newline {
+                            writeln!(f, "")?;
+                        } else {
+                            needs_newline = true;
+                        }
+                        write!(f, "                - ")?;
                     } else {
                         // ...
                     }
@@ -397,7 +402,11 @@ impl fmt::Display for WasmBacktrace {
             }
         }
         if self.hint_wasm_backtrace_details_env {
-            write!(f, "\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information")?;
+            write!(
+                f,
+                "\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` \
+                 environment variable may show more debugging information"
+            )?;
         }
         Ok(())
     }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -129,6 +129,6 @@ impl ErrorExt for anyhow::Error {
             return;
         }
 
-        panic!("failed to find {msg:?} within error message {self:?}")
+        panic!("failed to find:\n{msg}\n\nwithin error message:\n{self:?}")
     }
 }


### PR DESCRIPTION
* Add 2 more columns to the default address width.
* Print newlines between inline symbols which accidentally weren't present.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
