### PR TITLE
Cranelift: simplify some side-effectful instructions in ISLE

### DIFF
--- a/cranelift/codegen/meta/src/isle.rs
+++ b/cranelift/codegen/meta/src/isle.rs
@@ -111,6 +111,7 @@ pub fn get_isle_compilations(
                     src_opts.join("remat.isle"),
                     src_opts.join("selects.isle"),
                     src_opts.join("shifts.isle"),
+                    src_opts.join("skeleton.isle"),
                     src_opts.join("spaceship.isle"),
                     src_opts.join("spectre.isle"),
                     src_opts.join("vector.isle"),

--- a/cranelift/codegen/src/cursor.rs
+++ b/cranelift/codegen/src/cursor.rs
@@ -531,6 +531,17 @@ pub trait Cursor {
         inst
     }
 
+    /// Replace the instruction under the cursor with `new_inst`.
+    ///
+    /// The cursor is left pointing at the new instruction.
+    ///
+    /// The old instruction that was replaced is returned.
+    fn replace_inst(&mut self, new_inst: ir::Inst) -> ir::Inst {
+        let prev_inst = self.remove_inst();
+        self.insert_inst(new_inst);
+        prev_inst
+    }
+
     /// Insert a block at the current position and switch to it.
     ///
     /// As far as possible, this method behaves as if the block header were an instruction inserted

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -12,6 +12,7 @@ use crate::ir::{
     ValueListPool,
 };
 use crate::loop_analysis::LoopAnalysis;
+use crate::opts::generated_code::SkeletonInstSimplification;
 use crate::opts::IsleContext;
 use crate::scoped_hash_map::{Entry as ScopedEntry, ScopedHashMap};
 use crate::settings::Flags;
@@ -95,6 +96,7 @@ where
     pub(crate) rewrite_depth: usize,
     pub(crate) subsume_values: FxHashSet<Value>,
     optimized_values: SmallVec<[Value; MATCHES_LIMIT]>,
+    optimized_insts: SmallVec<[SkeletonInstSimplification; MATCHES_LIMIT]>,
 }
 
 /// For passing to `insert_pure_enode`. Sometimes the enode already
@@ -400,11 +402,24 @@ where
         }
     }
 
-    /// Optimize a "skeleton" instruction, possibly removing
-    /// it. Returns `true` if the instruction should be removed from
-    /// the layout.
-    fn optimize_skeleton_inst(&mut self, inst: Inst, block: Block) -> bool {
+    /// Optimize a "skeleton" instruction.
+    ///
+    /// Returns an optional command of how to continue processing the optimized
+    /// instruction (e.g. removing it or replacing it with a new instruction).
+    fn optimize_skeleton_inst(
+        &mut self,
+        inst: Inst,
+        block: Block,
+    ) -> Option<SkeletonInstSimplification> {
         self.stats.skeleton_inst += 1;
+
+        // If we have a rewrite rule for this instruction, do that first, so
+        // that GVN and alias analysis only see simplified skeleton
+        // instructions.
+        if let Some(cmd) = self.simplify_skeleton_inst(inst) {
+            self.stats.skeleton_inst_simplified += 1;
+            return Some(cmd);
+        }
 
         // First, can we try to deduplicate? We need to keep some copy
         // of the instruction around because it's side-effecting, but
@@ -447,7 +462,7 @@ where
                         }
                         (_, _) => unreachable!(),
                     }
-                    true
+                    Some(SkeletonInstSimplification::Remove)
                 }
                 ScopedEntry::Vacant(v) => {
                     // Otherwise, insert it into the value-map.
@@ -457,7 +472,7 @@ where
                     }
                     v.insert(result);
                     trace!(" -> inserts as new (no GVN)");
-                    false
+                    None
                 }
             }
         }
@@ -479,7 +494,7 @@ where
             self.value_to_opt_value[result] = new_result;
             self.available_block[result] = self.available_block[new_result];
             self.func.dfg.merge_facts(result, new_result);
-            true
+            Some(SkeletonInstSimplification::Remove)
         }
         // Otherwise, generic side-effecting op -- always keep it, and
         // set its results to identity-map to original values.
@@ -490,8 +505,213 @@ where
                 self.value_to_opt_value[result] = result;
                 self.available_block[result] = block;
             }
-            false
+            None
         }
+    }
+
+    /// Find the best simplification of the given skeleton instruction, if any,
+    /// by consulting our `simplify_skeleton` ISLE rules.
+    fn simplify_skeleton_inst(&mut self, inst: Inst) -> Option<SkeletonInstSimplification> {
+        // We cannot currently simplify terminators, or simplify into
+        // terminators. Anything that could change the control-flow graph is off
+        // limits.
+        //
+        // Consider the following CLIF snippet:
+        //
+        //     block0(v0: i64):
+        //         v1 = iconst.i32 0
+        //         trapz v1, user42
+        //         v2 = load.i32 v0
+        //         brif v1, block1, block2
+        //     block1:
+        //         return v2
+        //     block2:
+        //         v3 = iconst.i32 1
+        //         v4 = iadd v2, v3
+        //         return v4
+        //
+        // We would ideally like to perform simplifications like replacing the
+        // `trapz` with an unconditional `trap` and the conditional `brif`
+        // branch with an unconditional `jump`. Note, however, that blocks
+        // `block1` and `block2` are dominated by `block0` and therefore can and
+        // do use values defined in `block0`. This presents challenges:
+        //
+        // * If we replace the `brif` with a `jump`, then we've mutated the
+        //   control-flow graph and removed that domination property. The uses
+        //   of `v2` and `v3` in those blocks become invalid.
+        //
+        // * Even worse, if we turn the `trapz` into a `trap`, we are
+        //   introducing a terminator into the middle of the block, which leaves
+        //   us with two choices to fix up the IR so that there aren't any
+        //   instructions following the terminator in the block:
+        //
+        //   1. We can split the unreachable instructions off into a new
+        //      block. However, there is no control-flow edge from the current
+        //      block to this new block and so, again, the new block isn't
+        //      dominated by the current block, and therefore the can't use
+        //      values defined in this block or any dominating it. The `load`
+        //      instruction uses `v0` but is not dominated by `v0`'s
+        //      definition.
+        //
+        //   2. Alternatively, we can simply delete the trailing instructions,
+        //      since they are unreachable. But then not only are the old
+        //      instructions' uses no longer dominated by their definitions, but
+        //      the definitions do not exist at all anymore!
+        //
+        // Whatever approach we would take, we would invalidate value uses, and
+        // would need to track and fix them up.
+        if self.func.dfg.insts[inst].opcode().is_branch() {
+            return None;
+        }
+
+        /// A small RAII helper for temporarily taking out our `optimized_insts`
+        /// vec and then replacing it upon drop.
+        struct WithOptimizedInsts<'a, 'opt, 'analysis> {
+            ctx: &'a mut OptimizeCtx<'opt, 'analysis>,
+            optimized_insts: SmallVec<[SkeletonInstSimplification; MATCHES_LIMIT]>,
+        }
+
+        impl Drop for WithOptimizedInsts<'_, '_, '_> {
+            fn drop(&mut self) {
+                self.optimized_insts.clear();
+                self.ctx.optimized_insts = std::mem::take(&mut self.optimized_insts);
+            }
+        }
+
+        impl<'a, 'b, 'c> WithOptimizedInsts<'a, 'b, 'c> {
+            fn new(ctx: &'a mut OptimizeCtx<'b, 'c>) -> Self {
+                let optimized_insts = std::mem::take(&mut ctx.optimized_insts);
+                debug_assert!(optimized_insts.is_empty());
+                WithOptimizedInsts {
+                    ctx,
+                    optimized_insts,
+                }
+            }
+        }
+
+        let mut guard = WithOptimizedInsts::new(self);
+        let WithOptimizedInsts {
+            ctx,
+            optimized_insts,
+        } = &mut guard;
+
+        crate::opts::generated_code::constructor_simplify_skeleton(
+            &mut IsleContext { ctx },
+            inst,
+            optimized_insts,
+        );
+
+        let simplifications_len = optimized_insts.len();
+        log::trace!(" -> simplify_skeleton: yielded {simplifications_len} simplification(s)");
+        if simplifications_len > MATCHES_LIMIT {
+            log::trace!("      too many candidate simplifications; truncating to {MATCHES_LIMIT}");
+            optimized_insts.truncate(MATCHES_LIMIT);
+        }
+
+        // Find the best simplification, if any, from our candidates.
+        //
+        // Unlike simplifying pure values, we do not add side-effectful
+        // instructions to the egraph, nor do we extract the best version via
+        // dynamic programming and considering the costs of operands. Instead,
+        // we greedily choose the best simplification. This is because there is
+        // an impedance mismatch: the egraph and our pure rewrites are centered
+        // around *values*, but we don't represent side-effects with values, we
+        // represent them implicitly in their *instructions*.
+        //
+        // The initial best choice is "no simplification, just use the original
+        // instruction" which has the original instruction's cost.
+        let mut best = None;
+        let mut best_cost = cost::Cost::of_skeleton_op(
+            ctx.func.dfg.insts[inst].opcode(),
+            ctx.func.dfg.inst_args(inst).len(),
+        );
+        while let Some(simplification) = optimized_insts.pop() {
+            let (new_inst, new_val) = match simplification {
+                // We can't do better than completely removing the skeleton
+                // instruction, so short-cicuit the loop and eagerly return the
+                // `Remove*` simplifications.
+                SkeletonInstSimplification::Remove => {
+                    log::trace!(" -> simplify_skeleton: remove inst");
+                    debug_assert!(ctx.func.dfg.inst_results(inst).is_empty());
+                    return Some(simplification);
+                }
+                SkeletonInstSimplification::RemoveWithVal { val } => {
+                    log::trace!(" -> simplify_skeleton: remove inst and use {val} as its result");
+                    if cfg!(debug_assertions) {
+                        let results = ctx.func.dfg.inst_results(inst);
+                        debug_assert_eq!(results.len(), 1);
+                        debug_assert_eq!(
+                            ctx.func.dfg.value_type(results[0]),
+                            ctx.func.dfg.value_type(val),
+                        );
+                    }
+                    return Some(simplification);
+                }
+
+                // For instruction replacement simplification, we want to check
+                // that the replacements define the same number and types of
+                // values as the original instruction, and also determine
+                // whether they are actually an improvement over (i.e. have
+                // lower cost than) the original instruction.
+                SkeletonInstSimplification::Replace { inst } => {
+                    log::trace!(
+                        " -> simplify_skeleton: replace inst with {inst}: {}",
+                        ctx.func.dfg.display_inst(inst)
+                    );
+                    (inst, None)
+                }
+                SkeletonInstSimplification::ReplaceWithVal { inst, val } => {
+                    log::trace!(
+                        " -> simplify_skeleton: replace inst with {val} and {inst}: {}",
+                        ctx.func.dfg.display_inst(inst)
+                    );
+                    (inst, Some(val))
+                }
+            };
+
+            if cfg!(debug_assertions) {
+                let opcode = ctx.func.dfg.insts[inst].opcode();
+                debug_assert!(
+                    !(opcode.is_terminator() || opcode.is_branch()),
+                    "simplifying control-flow instructions and terminators is not yet supported",
+                );
+
+                let old_vals = ctx.func.dfg.inst_results(inst);
+                let new_vals = if let Some(val) = new_val.as_ref() {
+                    std::slice::from_ref(val)
+                } else {
+                    ctx.func.dfg.inst_results(new_inst)
+                };
+                debug_assert_eq!(
+                    old_vals.len(),
+                    new_vals.len(),
+                    "skeleton simplification should result in the same number of result values",
+                );
+
+                for (old_val, new_val) in old_vals.iter().zip(new_vals) {
+                    let old_ty = ctx.func.dfg.value_type(*old_val);
+                    let new_ty = ctx.func.dfg.value_type(*new_val);
+                    debug_assert_eq!(
+                        old_ty, new_ty,
+                        "skeleton simplification should result in values of the correct type",
+                    );
+                }
+            }
+
+            // Our best simplification is the one with the least cost. Update
+            // `best` if necessary.
+            let cost = cost::Cost::of_skeleton_op(
+                ctx.func.dfg.insts[new_inst].opcode(),
+                ctx.func.dfg.inst_args(new_inst).len(),
+            );
+            if cost < best_cost {
+                best = Some(simplification);
+                best_cost = cost;
+            }
+        }
+
+        // Return the best simplification!
+        best
     }
 
     /// Helper to propagate facts on constant values: if PCC is
@@ -653,7 +873,10 @@ impl<'a> EgraphPass<'a> {
                         available_block[param] = block;
                     }
                     while let Some(inst) = cursor.next_inst() {
-                        trace!("Processing inst {}", inst);
+                        trace!(
+                            "Processing inst {inst}: {}",
+                            cursor.func.dfg.display_inst(inst),
+                        );
 
                         // Rewrite args of *all* instructions using the
                         // value-to-opt-value map.
@@ -685,6 +908,7 @@ impl<'a> EgraphPass<'a> {
                             flags: self.flags,
                             ctrl_plane: self.ctrl_plane,
                             optimized_values: Default::default(),
+                            optimized_insts: Default::default(),
                         };
 
                         if is_pure_for_egraph(ctx.func, inst) {
@@ -698,8 +922,13 @@ impl<'a> EgraphPass<'a> {
                             // enode in the eclass, so we can remove it.
                             cursor.remove_inst_and_step_back();
                         } else {
-                            if ctx.optimize_skeleton_inst(inst, block) {
-                                cursor.remove_inst_and_step_back();
+                            if let Some(cmd) = ctx.optimize_skeleton_inst(inst, block) {
+                                Self::execute_skeleton_inst_simplification(
+                                    cmd,
+                                    &mut cursor,
+                                    &mut value_to_opt_value,
+                                    inst,
+                                );
                             }
                         }
                     }
@@ -710,6 +939,63 @@ impl<'a> EgraphPass<'a> {
                 }
             }
         }
+    }
+
+    /// Execute a simplification of an instruction in the side-effectful
+    /// skeleton.
+    fn execute_skeleton_inst_simplification(
+        simplification: SkeletonInstSimplification,
+        cursor: &mut FuncCursor,
+        value_to_opt_value: &mut SecondaryMap<Value, Value>,
+        old_inst: Inst,
+    ) {
+        let mut forward_val = |cursor: &mut FuncCursor, old_val, new_val| {
+            cursor.func.dfg.change_to_alias(old_val, new_val);
+            value_to_opt_value[old_val] = new_val;
+        };
+
+        let (new_inst, new_val) = match simplification {
+            SkeletonInstSimplification::Remove => {
+                cursor.remove_inst_and_step_back();
+                return;
+            }
+            SkeletonInstSimplification::RemoveWithVal { val } => {
+                cursor.remove_inst_and_step_back();
+                let old_val = cursor.func.dfg.first_result(old_inst);
+                cursor.func.dfg.detach_inst_results(old_inst);
+                forward_val(cursor, old_val, val);
+                return;
+            }
+            SkeletonInstSimplification::Replace { inst } => (inst, None),
+            SkeletonInstSimplification::ReplaceWithVal { inst, val } => (inst, Some(val)),
+        };
+
+        // Replace the old instruction with the new one.
+        cursor.replace_inst(new_inst);
+        debug_assert!(!cursor.func.dfg.insts[new_inst].opcode().is_terminator());
+
+        // Redirect the old instruction's result values to our new instruction's
+        // result values.
+        let mut i = 0;
+        let mut next_new_val = |dfg: &crate::ir::DataFlowGraph| -> Value {
+            if let Some(val) = new_val {
+                val
+            } else {
+                let val = dfg.inst_results(new_inst)[i];
+                i += 1;
+                val
+            }
+        };
+        for i in 0..cursor.func.dfg.inst_results(old_inst).len() {
+            let old_val = cursor.func.dfg.inst_results(old_inst)[i];
+            let new_val = next_new_val(&cursor.func.dfg);
+            forward_val(cursor, old_val, new_val);
+        }
+
+        // Back up so that the next iteration of the outer egraph loop will
+        // process the new instruction.
+        cursor.goto_inst(new_inst);
+        cursor.prev_inst();
     }
 
     /// Scoped elaboration: compute a final ordering of op computation
@@ -812,6 +1098,7 @@ pub(crate) struct Stats {
     pub(crate) pure_inst_insert_orig: u64,
     pub(crate) pure_inst_insert_new: u64,
     pub(crate) skeleton_inst: u64,
+    pub(crate) skeleton_inst_simplified: u64,
     pub(crate) skeleton_inst_gvn: u64,
     pub(crate) alias_analysis_removed: u64,
     pub(crate) new_inst: u64,

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -1049,7 +1049,7 @@ impl DataFlowGraph {
     pub fn first_result(&self, inst: Inst) -> Value {
         self.results[inst]
             .first(&self.value_lists)
-            .expect("Instruction has no results")
+            .unwrap_or_else(|| panic!("{inst} has no results"))
     }
 
     /// Test if `inst` has any result values currently.
@@ -1360,6 +1360,15 @@ impl DataFlowGraph {
     /// with `change_to_alias()`.
     pub fn detach_block_params(&mut self, block: Block) -> ValueList {
         self.blocks[block].params.take()
+    }
+
+    /// Detach all of an instruction's result values.
+    ///
+    /// This is a quite low-level operation. A sensible thing to do with the
+    /// detached results is to change them into aliases with
+    /// `change_to_alias()`.
+    pub fn detach_inst_results(&mut self, inst: Inst) {
+        self.results[inst].clear(&mut self.value_lists);
     }
 
     /// Merge the facts for two values. If both values have facts and

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -57,6 +57,10 @@ where
     fn new(lower_ctx: &'a mut Lower<'b, InstAndKind<P>>, backend: &'a PulleyBackend<P>) -> Self {
         Self { lower_ctx, backend }
     }
+
+    pub(crate) fn dfg(&self) -> &crate::ir::DataFlowGraph {
+        &self.lower_ctx.f.dfg
+    }
 }
 
 impl<P> generated_code::Context for PulleyIsleContext<'_, '_, InstAndKind<P>, PulleyBackend<P>>

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -56,6 +56,10 @@ impl<'a, 'b> RV64IsleContext<'a, 'b, MInst, Riscv64Backend> {
             min_vec_reg_size: backend.isa_flags.min_vec_reg_size(),
         }
     }
+
+    pub(crate) fn dfg(&self) -> &crate::ir::DataFlowGraph {
+        &self.lower_ctx.f.dfg
+    }
 }
 
 impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> {

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -74,6 +74,22 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn checked_add_with_type(&mut self, ty: Type, a: u64, b: u64) -> Option<u64> {
+            let c = a.checked_add(b)?;
+            let ty_mask = self.ty_mask(ty);
+            if (c & !ty_mask) == 0 {
+                Some(c)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        fn add_overflows_with_type(&mut self, ty: Type, a: u64, b: u64) -> bool {
+            self.checked_add_with_type(ty, a, b).is_none()
+        }
+
+        #[inline]
         fn u64_add(&mut self, x: u64, y: u64) -> u64 {
             x.wrapping_add(y)
         }
@@ -1159,6 +1175,11 @@ macro_rules! isle_common_prelude_methods {
 
         fn f128_copysign(&mut self, a: Ieee128, b: Ieee128) -> Ieee128 {
             a.copysign(b)
+        }
+
+        #[inline]
+        fn def_inst(&mut self, val: Value) -> Option<Inst> {
+            self.dfg().value_def(val).inst()
         }
     };
 }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -211,13 +211,8 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
-        fn inst_data(&mut self, inst: Inst) -> InstructionData {
+        fn inst_data_value(&mut self, inst: Inst) -> InstructionData {
             self.lower_ctx.dfg().insts[inst]
-        }
-
-        #[inline]
-        fn def_inst(&mut self, val: Value) -> Option<Inst> {
-            self.lower_ctx.dfg().value_def(val).inst()
         }
 
         #[inline]
@@ -914,4 +909,14 @@ where
 {
     pub lower_ctx: &'a mut Lower<'b, I>,
     pub backend: &'a B,
+}
+
+impl<I, B> IsleContext<'_, '_, I, B>
+where
+    I: VCodeInst,
+    B: LowerBackend,
+{
+    pub(crate) fn dfg(&self) -> &crate::ir::DataFlowGraph {
+        &self.lower_ctx.f.dfg
+    }
 }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -170,7 +170,7 @@ pub trait LowerBackend {
 /// from original Inst to MachInsts.
 pub struct Lower<'func, I: VCodeInst> {
     /// The function to lower.
-    f: &'func Function,
+    pub(crate) f: &'func Function,
 
     /// Lowered machine instructions.
     vcode: VCodeBuilder<I>,

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -76,14 +76,8 @@
       (ineg ty x))
 
 ;; x/1 == x.
-(rule (simplify (sdiv ty
-                      x
-                      (iconst_u ty 1)))
-      (subsume x))
-(rule (simplify (udiv ty
-                      x
-                      (iconst_u ty 1)))
-      (subsume x))
+(rule (simplify_skeleton (sdiv x (iconst_s ty 1))) x)
+(rule (simplify_skeleton (udiv x (iconst_u ty 1))) x)
 
 ;; TODO: strength reduction: div to shifts
 ;; TODO: div/rem by constants -> magic multiplications

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -18,19 +18,17 @@
              (iconst ty (u64_from_imm64 k2))))
       (subsume (iconst ty (imm64_masked ty (u64_mul k1 k2)))))
 
-(rule (simplify
-       (sdiv (fits_in_64 ty)
-             (iconst ty (u64_from_imm64 k1))
-             (iconst ty (u64_from_imm64 k2))))
-      (if-let d (u64_sdiv k1 k2))
-      (subsume (iconst ty (imm64_masked ty d))))
+(rule (simplify_skeleton
+       (sdiv (iconst_s ty k1)
+             (iconst_s ty k2)))
+      (if-let d (u64_sdiv (i64_as_u64 k1) (i64_as_u64 k2)))
+      (iconst ty (imm64_masked ty d)))
 
-(rule (simplify
-       (udiv (fits_in_64 ty)
-             (iconst ty (u64_from_imm64 k1))
-             (iconst ty (u64_from_imm64 k2))))
+(rule (simplify_skeleton
+       (udiv (iconst_u ty k1)
+             (iconst_u ty k2)))
       (if-let d (u64_udiv k1 k2))
-      (subsume (iconst ty (imm64_masked ty d))))
+      (iconst ty (imm64_masked ty d)))
 
 (rule (simplify
        (bor (fits_in_64 ty)

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -19,10 +19,10 @@
       (subsume (iconst ty (imm64_masked ty (u64_mul k1 k2)))))
 
 (rule (simplify_skeleton
-       (sdiv (iconst_s ty k1)
-             (iconst_s ty k2)))
-      (if-let d (u64_sdiv (i64_as_u64 k1) (i64_as_u64 k2)))
-      (iconst ty (imm64_masked ty d)))
+       (sdiv (iconst ty k1)
+             (iconst _ k2)))
+      (if-let d (imm64_sdiv ty k1 k2))
+      (iconst ty d))
 
 (rule (simplify_skeleton
        (udiv (iconst_u ty k1)

--- a/cranelift/codegen/src/opts/skeleton.isle
+++ b/cranelift/codegen/src/opts/skeleton.isle
@@ -1,0 +1,38 @@
+;; Rewrites of side-effectful instructions.
+;;
+;; These are rules for the `simplify_skeleton` term, rather than `simplify`, and
+;; return a `SkeletonInstSimplification` variant rather than a rewritten-value.
+
+;; Conditional traps that will never trap.
+(rule (simplify_skeleton (trapz (iconst_u _ (u64_nonzero _)) _))
+      (remove_inst))
+(rule (simplify_skeleton (trapnz (iconst_u _ 0) _))
+      (remove_inst))
+
+;; Constant propagation through `uadd_overflow_trap`.
+(rule (simplify_skeleton (uadd_overflow_trap (iconst_u ty a) (iconst_u ty b) _))
+      (if-let c (checked_add_with_type ty a b))
+      (iconst_u ty c))
+
+;; Summing two zero-extended values cannot overflow.
+(rule (simplify_skeleton (uadd_overflow_trap a @ (uextend ty _) b @ (uextend ty _) _))
+      (iadd ty a b))
+
+;; TODO: We can't simplify into unconditional traps yet. See the comment in
+;; `simplify_skeleton_inst` for more details.
+;;
+;; (rule (simplify_skeleton (trapz (iconst_u _ 0) code))
+;;       (trap code))
+;; (rule (simplify_skeleton (trapnz (iconst_u _ (u64_nonzero _)) code))
+;;       (trap code))
+;;
+;; (rule (simplify_skeleton (uadd_overflow_trap (iconst_u ty a) (iconst_u ty b) code))
+;;       (if-let true (add_overflows_with_type ty a b))
+;;       (trap code))
+;;
+;; (rule (simplify_skeleton (udiv _ (iconst_u ty 0)))
+;;       (replace_with_val (trap (trap_code_division_by_zero))
+;;                         (iconst_u ty 0)))
+;; (rule (simplify_skeleton (sdiv _ (iconst_s ty 0)))
+;;       (replace_with_val (trap (trap_code_division_by_zero))
+;;                         (iconst_s ty 0)))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -33,6 +33,12 @@
 (type Value (primitive Value))
 (type ValueList (primitive ValueList))
 (type BlockCall (primitive BlockCall))
+(type Inst (primitive Inst))
+
+;; Match the instruction that defines the given value, if any.
+(spec (def_inst arg) (provide (= result arg)))
+(decl def_inst (Inst) Value)
+(extern extractor def_inst def_inst)
 
 ;; ISLE representation of `&[Value]`.
 (type ValueSlice (primitive ValueSlice))
@@ -204,6 +210,12 @@
       (require (not (bvsaddo x y))))
 (decl pure partial s32_add_fallible (i32 i32) i32)
 (extern constructor s32_add_fallible s32_add_fallible)
+
+(decl pure partial checked_add_with_type (Type u64 u64) u64)
+(extern constructor checked_add_with_type checked_add_with_type)
+
+(decl pure add_overflows_with_type (Type u64 u64) bool)
+(extern constructor add_overflows_with_type add_overflows_with_type)
 
 (decl pure u64_add (u64 u64) u64)
 (extern constructor u64_add u64_add)

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -228,9 +228,6 @@
 (decl pure u64_mul (u64 u64) u64)
 (extern constructor u64_mul u64_mul)
 
-(decl pure partial u64_sdiv (u64 u64) u64)
-(extern constructor u64_sdiv u64_sdiv)
-
 (decl pure partial u64_udiv (u64 u64) u64)
 (extern constructor u64_udiv u64_udiv)
 
@@ -245,6 +242,9 @@
 
 (decl pure u64_shl (u64 u64) u64)
 (extern constructor u64_shl u64_shl)
+
+(decl pure partial imm64_sdiv (Type Imm64 Imm64) Imm64)
+(extern constructor imm64_sdiv imm64_sdiv)
 
 (decl pure imm64_shl (Type Imm64 Imm64) Imm64)
 (extern constructor imm64_shl imm64_shl)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -3,9 +3,6 @@
 
 ;;;; Primitive and External Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; `cranelift-entity`-based identifiers.
-(type Inst (primitive Inst))
-
 ;; ISLE representation of `Vec<u8>`
 (type VecMask extern (enum))
 
@@ -283,8 +280,8 @@
 (extern extractor first_result first_result)
 
 ;; Extract the `InstructionData` for an `Inst`.
-(decl inst_data (InstructionData) Inst)
-(extern extractor infallible inst_data inst_data)
+(decl inst_data_value (InstructionData) Inst)
+(extern extractor infallible inst_data_value inst_data_value)
 
 ;; Extract the type of the instruction's first result.
 (decl result_type (Type) Inst)
@@ -300,11 +297,6 @@
 (extractor (has_type ty inst)
            (and (result_type ty)
                 inst))
-
-;; Match the instruction that defines the given value, if any.
-(spec (def_inst arg) (provide (= result arg)))
-(decl def_inst (Inst) Value)
-(extern extractor def_inst def_inst)
 
 (decl u8_from_iconst (u8) Value)
 (extractor (u8_from_iconst x)

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -5,21 +5,30 @@
 ;;;;; eclass and enode access ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Extract any node(s) for the given eclass ID.
-(decl multi inst_data (Type InstructionData) Value)
+(decl multi inst_data_value (Type InstructionData) Value)
+(extern extractor inst_data_value inst_data_value_etor)
+
+;; An extractor from an `Inst` to its `InstructionData`.
+(decl inst_data (InstructionData) Inst)
 (extern extractor inst_data inst_data_etor)
 
-;; Identical to `inst_data`, just with a different ISLE type.
-;; This is basically a manual version of `curry`/`uncurry` in Haskell:
-;; to compose extractors the outer one needs to be single-parameter,
-;; so this combines the two parameters of `inst_data` into one.
+;; Identical to `inst_data_value`, just with a different ISLE type.  This is
+;; basically a manual version of `curry`/`uncurry` in Haskell: to compose
+;; extractors the outer one needs to be single-parameter, so this combines the
+;; two parameters of `inst_data_value` into one.
 (type TypeAndInstructionData (primitive TypeAndInstructionData))
-(decl multi inst_data_tupled (TypeAndInstructionData) Value)
-(extern extractor inst_data_tupled inst_data_tupled_etor)
+(decl multi inst_data_value_tupled (TypeAndInstructionData) Value)
+(extern extractor inst_data_value_tupled inst_data_value_tupled_etor)
 
 ;; Construct a pure node, returning a new (or deduplicated
 ;; already-existing) eclass ID.
 (decl make_inst (Type InstructionData) Value)
 (extern constructor make_inst make_inst_ctor)
+
+;; Make a new side-effectful instruction, do not insert it into the layout, and
+;; return its `Inst`.
+(decl make_skeleton_inst (InstructionData) Inst)
+(extern constructor make_skeleton_inst make_skeleton_inst_ctor)
 
 ;; Constructors for value arrays.
 (decl value_array_2_ctor (Value Value) ValueArray2)
@@ -51,6 +60,55 @@
 ;; The main matcher rule invoked by the toplevel driver.
 (decl multi simplify (Value) Value)
 
+;; The kind of simplification to perform on a skeleton instruction.
+(type SkeletonInstSimplification
+      (enum
+        ;; Remove the instruction being simplified from the skeleton, it is
+        ;; unnecessary.
+        ;;
+        ;; The instruction must not define any results.
+        (Remove)
+
+        ;; Remove the instruction being simplified from the skeleton, and
+        ;; replace its result value with the given `val`.
+        (RemoveWithVal (val Value))
+
+        ;; Replace the instruction being simplified with the given instruction.
+        ;;
+        ;; The given instruction must not already be in a block and must define
+        ;; the same number and types of results as the old instruction that it
+        ;; is replacing.
+        (Replace (inst Inst))
+
+        ;; Like `Replace` but replace the old instruction's result value with
+        ;; the given `val`.
+        ;;
+        ;; The old instruction must define a single result value and `val` must
+        ;; match its type. The new instruction need not define the same number
+        ;; or types of results as the old instruction.
+        (ReplaceWithVal (inst Inst) (val Value))))
+
+(decl pure inst_to_skeleton_inst_simplification (Inst) SkeletonInstSimplification)
+(rule (inst_to_skeleton_inst_simplification inst)
+      (SkeletonInstSimplification.Replace inst))
+
+(decl pure value_to_skeleton_inst_simplification (Value) SkeletonInstSimplification)
+(rule (value_to_skeleton_inst_simplification val)
+      (SkeletonInstSimplification.RemoveWithVal val))
+
+(decl pure remove_inst () SkeletonInstSimplification)
+(rule (remove_inst) (SkeletonInstSimplification.Remove))
+
+(decl pure replace_with_val (Inst Value) SkeletonInstSimplification)
+(rule (replace_with_val inst val) (SkeletonInstSimplification.ReplaceWithVal inst val))
+
+(convert Inst SkeletonInstSimplification inst_to_skeleton_inst_simplification)
+(convert Value SkeletonInstSimplification value_to_skeleton_inst_simplification)
+
+;; The main term for simplifying side-effectful instructions, invoked by the
+;; egraph driver.
+(decl multi simplify_skeleton (Inst) SkeletonInstSimplification)
+
 ;; Mark a node as requiring remat when used in a different block.
 (decl remat (Value) Value)
 (extern constructor remat remat)
@@ -74,12 +132,12 @@
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.  If it fits, it'll be masked accordingly in the constant.
 (decl iconst_s (Type i64) Value)
-(extractor (iconst_s ty c) (inst_data_tupled (iconst_sextend_etor ty c)))
+(extractor (iconst_s ty c) (inst_data_value_tupled (iconst_sextend_etor ty c)))
 (rule 0 (iconst_s ty c)
-	(if-let c_masked (u64_and (i64_as_u64 c) (ty_umax ty)))
-	(if-let c_reextended (i64_sextend_u64 ty c_masked))
-	(if-let true (u64_eq (i64_as_u64 c) (i64_as_u64 c_reextended)))
-	(iconst ty (imm64 c_masked)))
+    (if-let c_masked (u64_and (i64_as_u64 c) (ty_umax ty)))
+    (if-let c_reextended (i64_sextend_u64 ty c_masked))
+    (if-let true (u64_eq (i64_as_u64 c) (i64_as_u64 c_reextended)))
+    (iconst ty (imm64 c_masked)))
 (rule 1 (iconst_s $I128 c) (sextend $I128 (iconst_s $I64 c)))
 
 ;; Construct an `iconst` from a `u64` or Extract a `u64` from an `iconst`
@@ -91,13 +149,13 @@
 (decl iconst_u (Type u64) Value)
 (extractor (iconst_u ty c) (iconst ty (u64_from_imm64 c)))
 (rule 0 (iconst_u ty c)
-	(if-let true (u64_le c (ty_umax ty)))
+    (if-let true (u64_le c (ty_umax ty)))
     (iconst ty (imm64 c)))
 (rule 1 (iconst_u $I128 c) (uextend $I128 (iconst_u $I64 c)))
 
-;; These take `Value`, rather than going through `inst_data_tupled`, because
-;; most of the time they want to return the original `Value`, and it would be
-;; a waste to need to re-GVN the instruction data in those cases.
+;; These take `Value`, rather than going through `inst_data_value_tupled`,
+;; because most of the time they want to return the original `Value`, and it
+;; would be a waste to need to re-GVN the instruction data in those cases.
 (decl multi sextend_maybe_etor (Type Value) Value)
 (extern extractor infallible sextend_maybe_etor sextend_maybe_etor)
 (decl multi uextend_maybe_etor (Type Value) Value)

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -89,3 +89,62 @@ block0(v0: i32):
     return v2
 }
 ; check: return v0
+
+;;;;;;;;;; Tests for `simplify_skeleton` TODOs ;;;;;;;;;;;;
+;;
+;; What follows are tests for patterns that `simplify_skeleton` *should* clean
+;; up, but is unable to at this moment in time.
+
+function %int_min_sdiv_neg_one() -> i32 {
+block0():
+    v0 = iconst.i32 0x80000000
+    v1 = iconst.i32 -1
+    v2 = sdiv v0, v1
+    return v2
+}
+; check:  v2 = sdiv v0, v1
+; nextln: return v2
+
+function %sdiv_zero(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = sdiv v0, v1
+    return v2
+}
+; check:  v2 = sdiv v0, v1
+; nextln: return v2
+
+function %udiv_zero(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = udiv v0, v1
+    return v2
+}
+; check:  v2 = udiv v0, v1
+; nextln: return v2
+
+function %always_trapping_trapz() -> i32 {
+block0:
+    v0 = iconst.i32 0
+    trapz v0, user42
+    return v0
+}
+; check: trapz v0, user42
+
+function %always_trapping_trapnz() -> i32 {
+block0:
+    v0 = iconst.i32 1
+    trapnz v0, user42
+    return v0
+}
+; check: trapnz v0, user42
+
+function %always_trapping_uadd_overflow_trap() -> i32 {
+block0:
+    v0 = iconst.i32 0xffffffff
+    v1 = iconst.i32 1
+    v2 = uadd_overflow_trap v0, v1, user42
+    return v2
+}
+; check:  v2 = uadd_overflow_trap v0, v1, user42
+; nextln: return v2

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -1,0 +1,91 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %remove_trapz() {
+block0:
+    v0 = iconst.i32 1
+    trapz v0, user42
+    return
+}
+; check:  block0:
+; nextln:     return
+
+function %remove_trapnz() {
+block0:
+    v0 = iconst.i32 0
+    trapnz v0, user42
+    return
+}
+; check:  block0:
+; nextln:     return
+
+function %cprop_uadd_overflow_trap() -> i64 {
+block0:
+    v0 = iconst.i64 2
+    v1 = iconst.i64 3
+    v2 = uadd_overflow_trap v0, v1, user42
+    return v2
+}
+; check: v3 = iconst.i64 5
+; check: return v3
+
+function %uadd_overflow_trap_of_uextends(i32, i32) -> i64 {
+block0(v0: i32, v1: i32):
+    v2 = uextend.i64 v0
+    v3 = uextend.i64 v1
+    v4 = uadd_overflow_trap v2, v3, user42
+    return v4
+}
+; check: v5 = iadd v2, v3
+; check: return v5
+
+;; Test that if we replace a side effectful instruction with a pure one, we then
+;; do further rewrites and GVN and all that on the pure instruction.
+function %gvn_after_uadd_overflow_trap_to_iadd(i32, i32) -> i64, i64 {
+block0(v0: i32, v1: i32):
+    v2 = uextend.i64 v0
+    v3 = uextend.i64 v1
+    v4 = iadd v2, v3
+    v5 = uextend.i64 v0
+    v6 = uextend.i64 v1
+    v7 = uadd_overflow_trap v5, v6, user42
+    return v4, v7
+}
+; check: return v4, v4
+
+function %cprop_udiv() -> i32 {
+block0:
+    v0 = iconst.i32 13
+    v1 = iconst.i32 7
+    v2 = udiv v0, v1
+    return v2
+}
+; check: v3 = iconst.i32 1
+; check: return v3
+
+function %cprop_sdiv() -> i32 {
+block0:
+    v0 = iconst.i32 -7
+    v1 = iconst.i32 7
+    v2 = sdiv v0, v1
+    return v2
+}
+; check: v3 = iconst.i32 -1
+; check: return v3
+
+function %udiv_by_one(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 1
+    v2 = udiv v0, v1
+    return v2
+}
+; check: return v0
+
+function %sdiv_by_one(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 1
+    v2 = sdiv v0, v1
+    return v2
+}
+; check: return v0

--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -28,12 +28,12 @@
 ;;       jae     0x64
 ;;       jmp     0x46
 ;;   57: movq    %r15, %rdi
-;;       callq   0x105
+;;       callq   0xf5
 ;;       jmp     0x46
 ;;   64: movq    8(%r13), %rax
 ;;       cmpq    %rax, %r11
 ;;       jb      0x46
 ;;   71: movq    %r15, %rdi
-;;       callq   0x105
+;;       callq   0xf5
 ;;       jmp     0x46
 ;;   7e: ud2

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -42,17 +42,17 @@
 ;;                                     v60 = ishl v17, v59  ; v59 = 3
 ;; @0027                               v25 = iconst.i32 24
 ;; @0027                               v26 = uadd_overflow_trap v60, v25, user1  ; v25 = 24
+;; @0027                               v37 = uextend.i64 v26
+;;                                     v72 = iadd v10, v37
+;; @0027                               v39 = icmp ule v72, v9
+;; @0027                               trapz v39, user1
 ;;                                     v67 = ishl v3, v59  ; v59 = 3
 ;;                                     v69 = iadd v67, v25  ; v25 = 24
 ;; @0027                               v35 = uextend.i64 v69
-;; @0027                               v36 = uadd_overflow_trap v10, v35, user1
-;; @0027                               v37 = uextend.i64 v26
-;; @0027                               v38 = uadd_overflow_trap v10, v37, user1
-;; @0027                               v39 = icmp ule v38, v9
-;; @0027                               trapz v39, user1
-;; @0027                               v40 = iadd v7, v36
-;;                                     v71 = ishl v5, v59  ; v59 = 3
-;; @0027                               v42 = uextend.i64 v71
+;;                                     v71 = iadd v10, v35
+;; @0027                               v40 = iadd v7, v71
+;;                                     v73 = ishl v5, v59  ; v59 = 3
+;; @0027                               v42 = uextend.i64 v73
 ;; @0027                               v43 = iadd v40, v42
 ;; @0027                               v20 = iconst.i64 8
 ;; @0027                               jump block2(v40)
@@ -63,9 +63,9 @@
 ;;
 ;;                                 block3:
 ;; @0027                               store.i64 notrap aligned little v4, v45
-;;                                     v73 = iconst.i64 8
-;;                                     v74 = iadd.i64 v45, v73  ; v73 = 8
-;; @0027                               jump block2(v74)
+;;                                     v75 = iconst.i64 8
+;;                                     v76 = iadd.i64 v45, v75  ; v75 = 8
+;; @0027                               jump block2(v76)
 ;;
 ;;                                 block4:
 ;; @002a                               jump block1

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -37,14 +37,14 @@
 ;; @0022                               trapnz v21, user1
 ;; @0022                               v23 = iconst.i32 20
 ;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v49 = iadd v9, v35
+;; @0022                               v37 = icmp ule v49, v8
+;; @0022                               trapz v37, user1
 ;; @0022                               v27 = iadd v3, v23  ; v23 = 20
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v48 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v48
 ;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -37,14 +37,14 @@
 ;; @0022                               trapnz v21, user1
 ;; @0022                               v23 = iconst.i32 20
 ;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 20
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v49 = iadd v9, v35
+;; @0022                               v37 = icmp ule v49, v8
+;; @0022                               trapz v37, user1
 ;; @0022                               v27 = iadd v3, v23  ; v23 = 20
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v48 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v48
 ;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -41,15 +41,15 @@
 ;;                                     v52 = ishl v16, v51  ; v51 = 3
 ;; @0022                               v23 = iconst.i32 24
 ;; @0022                               v24 = uadd_overflow_trap v52, v23, user1  ; v23 = 24
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v62 = iadd v9, v35
+;; @0022                               v37 = icmp ule v62, v8
+;; @0022                               trapz v37, user1
 ;;                                     v59 = ishl v3, v51  ; v51 = 3
 ;; @0022                               v27 = iadd v59, v23  ; v23 = 24
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v61 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v61
 ;; @0022                               v39 = load.i64 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -28,15 +28,11 @@
 ;;                                     store notrap v3, v130
 ;;                                     v131 = stack_addr.i64 ss0
 ;;                                     store notrap v4, v131
-;;                                     v169 = iconst.i64 0
-;; @0025                               trapnz v169, user18  ; v169 = 0
-;; @0025                               v7 = iconst.i32 20
-;;                                     v170 = iconst.i32 12
-;; @0025                               v12 = uadd_overflow_trap v7, v170, user18  ; v7 = 20, v170 = 12
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v15 = iconst.i32 0
+;;                                     v171 = iconst.i32 32
 ;; @0025                               v16 = iconst.i32 8
-;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v15 = 0, v16 = 8
+;; @0025                               v17 = call fn0(v0, v14, v15, v171, v16), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v15 = 0, v171 = 32, v16 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v19 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v20 = uextend.i64 v17
@@ -69,67 +65,67 @@
 ;;
 ;;                                 block3:
 ;;                                     v124 = load.i32 notrap v129
-;;                                     v172 = iconst.i64 20
-;;                                     v178 = iadd.i64 v21, v172  ; v172 = 20
-;; @0025                               store notrap aligned little v124, v178
+;;                                     v173 = iconst.i64 20
+;;                                     v179 = iadd.i64 v21, v173  ; v173 = 20
+;; @0025                               store notrap aligned little v124, v179
 ;;                                     v123 = load.i32 notrap v130
-;;                                     v202 = iconst.i32 1
-;;                                     v203 = band v123, v202  ; v202 = 1
-;;                                     v204 = iconst.i32 0
-;;                                     v205 = icmp eq v123, v204  ; v204 = 0
-;; @0025                               v58 = uextend.i32 v205
-;; @0025                               v59 = bor v203, v58
+;;                                     v203 = iconst.i32 1
+;;                                     v204 = band v123, v203  ; v203 = 1
+;;                                     v205 = iconst.i32 0
+;;                                     v206 = icmp eq v123, v205  ; v205 = 0
+;; @0025                               v58 = uextend.i32 v206
+;; @0025                               v59 = bor v204, v58
 ;; @0025                               brif v59, block5, block4
 ;;
 ;;                                 block4:
 ;; @0025                               v64 = uextend.i64 v123
-;;                                     v206 = iconst.i64 8
-;; @0025                               v66 = uadd_overflow_trap v64, v206, user1  ; v206 = 8
-;; @0025                               v68 = uadd_overflow_trap v66, v206, user1  ; v206 = 8
-;;                                     v207 = load.i64 notrap aligned readonly can_move v0+48
-;; @0025                               v69 = icmp ule v68, v207
+;;                                     v207 = iconst.i64 8
+;; @0025                               v66 = uadd_overflow_trap v64, v207, user1  ; v207 = 8
+;; @0025                               v68 = uadd_overflow_trap v66, v207, user1  ; v207 = 8
+;;                                     v208 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v69 = icmp ule v68, v208
 ;; @0025                               trapz v69, user1
 ;; @0025                               v70 = iadd.i64 v19, v66
 ;; @0025                               v71 = load.i64 notrap aligned v70
-;;                                     v208 = iconst.i64 1
-;; @0025                               v72 = iadd v71, v208  ; v208 = 1
+;;                                     v209 = iconst.i64 1
+;; @0025                               v72 = iadd v71, v209  ; v209 = 1
 ;; @0025                               store notrap aligned v72, v70
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
 ;;                                     v119 = load.i32 notrap v130
-;;                                     v180 = iconst.i64 24
-;;                                     v186 = iadd.i64 v21, v180  ; v180 = 24
-;; @0025                               store notrap aligned little v119, v186
+;;                                     v181 = iconst.i64 24
+;;                                     v187 = iadd.i64 v21, v181  ; v181 = 24
+;; @0025                               store notrap aligned little v119, v187
 ;;                                     v118 = load.i32 notrap v131
-;;                                     v209 = iconst.i32 1
-;;                                     v210 = band v118, v209  ; v209 = 1
-;;                                     v211 = iconst.i32 0
-;;                                     v212 = icmp eq v118, v211  ; v211 = 0
-;; @0025                               v87 = uextend.i32 v212
-;; @0025                               v88 = bor v210, v87
+;;                                     v210 = iconst.i32 1
+;;                                     v211 = band v118, v210  ; v210 = 1
+;;                                     v212 = iconst.i32 0
+;;                                     v213 = icmp eq v118, v212  ; v212 = 0
+;; @0025                               v87 = uextend.i32 v213
+;; @0025                               v88 = bor v211, v87
 ;; @0025                               brif v88, block7, block6
 ;;
 ;;                                 block6:
 ;; @0025                               v93 = uextend.i64 v118
-;;                                     v213 = iconst.i64 8
-;; @0025                               v95 = uadd_overflow_trap v93, v213, user1  ; v213 = 8
-;; @0025                               v97 = uadd_overflow_trap v95, v213, user1  ; v213 = 8
-;;                                     v214 = load.i64 notrap aligned readonly can_move v0+48
-;; @0025                               v98 = icmp ule v97, v214
+;;                                     v214 = iconst.i64 8
+;; @0025                               v95 = uadd_overflow_trap v93, v214, user1  ; v214 = 8
+;; @0025                               v97 = uadd_overflow_trap v95, v214, user1  ; v214 = 8
+;;                                     v215 = load.i64 notrap aligned readonly can_move v0+48
+;; @0025                               v98 = icmp ule v97, v215
 ;; @0025                               trapz v98, user1
 ;; @0025                               v99 = iadd.i64 v19, v95
 ;; @0025                               v100 = load.i64 notrap aligned v99
-;;                                     v215 = iconst.i64 1
-;; @0025                               v101 = iadd v100, v215  ; v215 = 1
+;;                                     v216 = iconst.i64 1
+;; @0025                               v101 = iadd v100, v216  ; v216 = 1
 ;; @0025                               store notrap aligned v101, v99
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
 ;;                                     v114 = load.i32 notrap v131
-;;                                     v188 = iconst.i64 28
-;;                                     v194 = iadd.i64 v21, v188  ; v188 = 28
-;; @0025                               store notrap aligned little v114, v194
+;;                                     v189 = iconst.i64 28
+;;                                     v195 = iadd.i64 v21, v189  ; v189 = 28
+;; @0025                               store notrap aligned little v114, v195
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -19,14 +19,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v42 = iconst.i64 0
-;; @0025                               trapnz v42, user18  ; v42 = 0
-;; @0025                               v7 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v7, v7, user18  ; v7 = 24, v7 = 24
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v15 = iconst.i32 0
+;;                                     v43 = iconst.i32 48
 ;; @0025                               v16 = iconst.i32 8
-;; @0025                               v17 = call fn0(v0, v14, v15, v12, v16)  ; v14 = -1476395008, v15 = 0, v16 = 8
+;; @0025                               v17 = call fn0(v0, v14, v15, v43, v16)  ; v14 = -1476395008, v15 = 0, v43 = 48, v16 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v19 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v20 = uextend.i64 v17
@@ -35,14 +32,14 @@
 ;; @0025                               v22 = iadd v21, v32  ; v32 = 16
 ;; @0025                               store notrap aligned v6, v22  ; v6 = 3
 ;;                                     v34 = iconst.i64 24
-;;                                     v49 = iadd v21, v34  ; v34 = 24
-;; @0025                               store notrap aligned little v2, v49
+;;                                     v50 = iadd v21, v34  ; v34 = 24
+;; @0025                               store notrap aligned little v2, v50
 ;;                                     v31 = iconst.i64 32
-;;                                     v56 = iadd v21, v31  ; v31 = 32
-;; @0025                               store notrap aligned little v3, v56
-;;                                     v58 = iconst.i64 40
-;;                                     v64 = iadd v21, v58  ; v58 = 40
-;; @0025                               store notrap aligned little v4, v64
+;;                                     v57 = iadd v21, v31  ; v31 = 32
+;; @0025                               store notrap aligned little v3, v57
+;;                                     v59 = iconst.i64 40
+;;                                     v65 = iadd v21, v59  ; v59 = 40
+;; @0025                               store notrap aligned little v4, v65
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -41,15 +41,15 @@
 ;;                                     v51 = ishl v16, v50  ; v50 = 3
 ;; @0024                               v23 = iconst.i32 24
 ;; @0024                               v24 = uadd_overflow_trap v51, v23, user1  ; v23 = 24
+;; @0024                               v35 = uextend.i64 v24
+;;                                     v61 = iadd v9, v35
+;; @0024                               v37 = icmp ule v61, v8
+;; @0024                               trapz v37, user1
 ;;                                     v58 = ishl v3, v50  ; v50 = 3
 ;; @0024                               v27 = iadd v58, v23  ; v23 = 24
 ;; @0024                               v33 = uextend.i64 v27
-;; @0024                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0024                               v35 = uextend.i64 v24
-;; @0024                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0024                               v37 = icmp ule v36, v8
-;; @0024                               trapz v37, user1
-;; @0024                               v38 = iadd v6, v34
+;;                                     v60 = iadd v9, v33
+;; @0024                               v38 = iadd v6, v60
 ;; @0024                               store notrap aligned little v4, v38
 ;; @0027                               jump block1
 ;;

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -42,23 +42,23 @@
 ;;                                     v90 = ishl v18, v89  ; v89 = 3
 ;; @0024                               v25 = iconst.i32 24
 ;; @0024                               v26 = uadd_overflow_trap v90, v25, user1  ; v25 = 24
+;; @0024                               v37 = uextend.i64 v26
+;;                                     v100 = iadd v11, v37
+;; @0024                               v39 = icmp ule v100, v10
+;; @0024                               trapz v39, user1
 ;;                                     v97 = ishl v3, v89  ; v89 = 3
 ;; @0024                               v29 = iadd v97, v25  ; v25 = 24
 ;; @0024                               v35 = uextend.i64 v29
-;; @0024                               v36 = uadd_overflow_trap v11, v35, user1
-;; @0024                               v37 = uextend.i64 v26
-;; @0024                               v38 = uadd_overflow_trap v11, v37, user1
-;; @0024                               v39 = icmp ule v38, v10
-;; @0024                               trapz v39, user1
-;; @0024                               v40 = iadd v8, v36
+;;                                     v99 = iadd v11, v35
+;; @0024                               v40 = iadd v8, v99
 ;; @0024                               v41 = load.i64 notrap aligned little v40
 ;; @002b                               v54 = icmp ult v4, v18
 ;; @002b                               trapz v54, user17
-;;                                     v99 = ishl v4, v89  ; v89 = 3
-;; @002b                               v64 = iadd v99, v25  ; v25 = 24
+;;                                     v101 = ishl v4, v89  ; v89 = 3
+;; @002b                               v64 = iadd v101, v25  ; v25 = 24
 ;; @002b                               v70 = uextend.i64 v64
-;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
-;; @002b                               v75 = iadd v8, v71
+;;                                     v103 = iadd v11, v70
+;; @002b                               v75 = iadd v8, v103
 ;; @002b                               v76 = load.i64 notrap aligned little v75
 ;; @002e                               jump block1
 ;;

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -40,14 +40,12 @@
 ;; @0021                               brif v50, block3, block2  ; v50 = 1
 ;;
 ;;                                 block2:
-;;                                     v72 = iconst.i64 0
-;; @0021                               v28 = iconst.i64 8
-;; @0021                               v29 = uadd_overflow_trap v72, v28, user1  ; v72 = 0, v28 = 8
-;; @0021                               v31 = uadd_overflow_trap v29, v28, user1  ; v28 = 8
 ;; @0021                               v26 = load.i64 notrap aligned readonly can_move v0+48
-;; @0021                               v32 = icmp ule v31, v26
-;; @0021                               trapz v32, user1
-;; @0021                               v33 = iadd.i64 v13, v29
+;;                                     v75 = iconst.i64 16
+;;                                     v76 = icmp uge v26, v75  ; v75 = 16
+;; @0021                               trapz v76, user1
+;; @0021                               v28 = iconst.i64 8
+;; @0021                               v33 = iadd.i64 v13, v28  ; v28 = 8
 ;; @0021                               v34 = load.i64 notrap aligned v33
 ;;                                     v52 = iconst.i64 1
 ;; @0021                               v35 = iadd v34, v52  ; v52 = 1
@@ -55,10 +53,10 @@
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v73 = iconst.i32 0
+;;                                     v77 = iconst.i32 0
 ;;                                     v49 = iconst.i64 24
 ;; @0021                               v18 = iadd.i64 v15, v49  ; v49 = 24
-;; @0021                               store notrap aligned little v73, v18  ; v73 = 0
+;; @0021                               store notrap aligned little v77, v18  ; v77 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -42,17 +42,17 @@
 ;;                                     v60 = ishl v17, v59  ; v59 = 3
 ;; @0027                               v25 = iconst.i32 16
 ;; @0027                               v26 = uadd_overflow_trap v60, v25, user1  ; v25 = 16
+;; @0027                               v37 = uextend.i64 v26
+;;                                     v72 = iadd v10, v37
+;; @0027                               v39 = icmp ule v72, v9
+;; @0027                               trapz v39, user1
 ;;                                     v67 = ishl v3, v59  ; v59 = 3
 ;;                                     v69 = iadd v67, v25  ; v25 = 16
 ;; @0027                               v35 = uextend.i64 v69
-;; @0027                               v36 = uadd_overflow_trap v10, v35, user1
-;; @0027                               v37 = uextend.i64 v26
-;; @0027                               v38 = uadd_overflow_trap v10, v37, user1
-;; @0027                               v39 = icmp ule v38, v9
-;; @0027                               trapz v39, user1
-;; @0027                               v40 = iadd v7, v36
-;;                                     v71 = ishl v5, v59  ; v59 = 3
-;; @0027                               v42 = uextend.i64 v71
+;;                                     v71 = iadd v10, v35
+;; @0027                               v40 = iadd v7, v71
+;;                                     v73 = ishl v5, v59  ; v59 = 3
+;; @0027                               v42 = uextend.i64 v73
 ;; @0027                               v43 = iadd v40, v42
 ;; @0027                               jump block2(v40)
 ;;
@@ -62,9 +62,9 @@
 ;;
 ;;                                 block3:
 ;; @0027                               store.i64 notrap aligned little v4, v45
-;;                                     v73 = iconst.i64 8
-;;                                     v74 = iadd.i64 v45, v73  ; v73 = 8
-;; @0027                               jump block2(v74)
+;;                                     v75 = iconst.i64 8
+;;                                     v76 = iadd.i64 v45, v75  ; v75 = 8
+;; @0027                               jump block2(v76)
 ;;
 ;;                                 block4:
 ;; @002a                               jump block1

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -37,14 +37,14 @@
 ;; @0022                               trapnz v21, user1
 ;; @0022                               v23 = iconst.i32 12
 ;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 12
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v49 = iadd v9, v35
+;; @0022                               v37 = icmp ule v49, v8
+;; @0022                               trapz v37, user1
 ;; @0022                               v27 = iadd v3, v23  ; v23 = 12
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v48 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v48
 ;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -37,14 +37,14 @@
 ;; @0022                               trapnz v21, user1
 ;; @0022                               v23 = iconst.i32 12
 ;; @0022                               v24 = uadd_overflow_trap v16, v23, user1  ; v23 = 12
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v49 = iadd v9, v35
+;; @0022                               v37 = icmp ule v49, v8
+;; @0022                               trapz v37, user1
 ;; @0022                               v27 = iadd v3, v23  ; v23 = 12
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v48 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v48
 ;; @0022                               v39 = load.i8 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -41,15 +41,15 @@
 ;;                                     v52 = ishl v16, v51  ; v51 = 3
 ;; @0022                               v23 = iconst.i32 16
 ;; @0022                               v24 = uadd_overflow_trap v52, v23, user1  ; v23 = 16
+;; @0022                               v35 = uextend.i64 v24
+;;                                     v62 = iadd v9, v35
+;; @0022                               v37 = icmp ule v62, v8
+;; @0022                               trapz v37, user1
 ;;                                     v59 = ishl v3, v51  ; v51 = 3
 ;; @0022                               v27 = iadd v59, v23  ; v23 = 16
 ;; @0022                               v33 = uextend.i64 v27
-;; @0022                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0022                               v35 = uextend.i64 v24
-;; @0022                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0022                               v37 = icmp ule v36, v8
-;; @0022                               trapz v37, user1
-;; @0022                               v38 = iadd v6, v34
+;;                                     v61 = iadd v9, v33
+;; @0022                               v38 = iadd v6, v61
 ;; @0022                               v39 = load.i64 notrap aligned little v38
 ;; @0025                               jump block1
 ;;

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -17,30 +17,23 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v59 = iconst.i64 0
-;; @0025                               trapnz v59, user18  ; v59 = 0
-;; @0025                               v7 = iconst.i32 12
-;; @0025                               v12 = uadd_overflow_trap v7, v7, user18  ; v7 = 12, v7 = 12
-;; @0025                               v14 = iconst.i32 -134217728
-;; @0025                               v15 = band v12, v14  ; v14 = -134217728
-;; @0025                               trapnz v15, user18
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+56
 ;; @0025                               v18 = load.i32 notrap aligned v17
-;;                                     v60 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v60, user18  ; v60 = 7
-;;                                     v67 = iconst.i32 -8
-;; @0025                               v23 = band v21, v67  ; v67 = -8
-;; @0025                               v24 = uadd_overflow_trap v23, v12, user18
+;;                                     v68 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v68, user18  ; v68 = 7
+;;                                     v75 = iconst.i32 -8
+;; @0025                               v23 = band v21, v75  ; v75 = -8
+;;                                     v60 = iconst.i32 24
+;; @0025                               v24 = uadd_overflow_trap v23, v60, user18  ; v60 = 24
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0025                               v30 = icmp ule v25, v29
 ;; @0025                               trapz v30, user18
-;; @0025                               v33 = iconst.i32 -1476395008
-;;                                     v68 = bor v12, v33  ; v33 = -1476395008
+;;                                     v76 = iconst.i32 -1476394984
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v31 = uextend.i64 v23
 ;; @0025                               v32 = iadd v27, v31
-;; @0025                               store notrap aligned v68, v32
+;; @0025                               store notrap aligned v76, v32  ; v76 = -1476394984
 ;; @0025                               v36 = load.i64 notrap aligned readonly can_move v0+64
 ;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
 ;; @0025                               store notrap aligned v37, v32+4
@@ -50,17 +43,17 @@
 ;; @0025                               v38 = iadd v32, v48  ; v48 = 8
 ;; @0025                               store notrap aligned v6, v38  ; v6 = 3
 ;;                                     v50 = iconst.i64 12
-;;                                     v76 = iadd v32, v50  ; v50 = 12
-;; @0025                               store notrap aligned little v2, v76
-;;                                     v78 = iconst.i64 16
-;;                                     v84 = iadd v32, v78  ; v78 = 16
-;; @0025                               store notrap aligned little v3, v84
-;;                                     v86 = iconst.i64 20
-;;                                     v92 = iadd v32, v86  ; v86 = 20
-;; @0025                               store notrap aligned little v4, v92
+;;                                     v89 = iadd v32, v50  ; v50 = 12
+;; @0025                               store notrap aligned little v2, v89
+;;                                     v91 = iconst.i64 16
+;;                                     v97 = iadd v32, v91  ; v91 = 16
+;; @0025                               store notrap aligned little v3, v97
+;;                                     v99 = iconst.i64 20
+;;                                     v105 = iadd v32, v99  ; v99 = 20
+;; @0025                               store notrap aligned little v4, v105
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v101 = band.i32 v21, v67  ; v67 = -8
-;; @0029                               return v101
+;;                                     v114 = band.i32 v21, v75  ; v75 = -8
+;; @0029                               return v114
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -17,31 +17,23 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;;                                     v58 = iconst.i64 0
-;; @0025                               trapnz v58, user18  ; v58 = 0
-;; @0025                               v7 = iconst.i32 16
-;;                                     v59 = iconst.i32 24
-;; @0025                               v12 = uadd_overflow_trap v7, v59, user18  ; v7 = 16, v59 = 24
-;; @0025                               v14 = iconst.i32 -134217728
-;; @0025                               v15 = band v12, v14  ; v14 = -134217728
-;; @0025                               trapnz v15, user18
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+56
 ;; @0025                               v18 = load.i32 notrap aligned v17
-;;                                     v60 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v60, user18  ; v60 = 7
-;;                                     v67 = iconst.i32 -8
-;; @0025                               v23 = band v21, v67  ; v67 = -8
-;; @0025                               v24 = uadd_overflow_trap v23, v12, user18
+;;                                     v68 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v68, user18  ; v68 = 7
+;;                                     v75 = iconst.i32 -8
+;; @0025                               v23 = band v21, v75  ; v75 = -8
+;;                                     v60 = iconst.i32 40
+;; @0025                               v24 = uadd_overflow_trap v23, v60, user18  ; v60 = 40
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+48
 ;; @0025                               v30 = icmp ule v25, v29
 ;; @0025                               trapz v30, user18
-;; @0025                               v33 = iconst.i32 -1476395008
-;;                                     v68 = bor v12, v33  ; v33 = -1476395008
+;;                                     v76 = iconst.i32 -1476394968
 ;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v31 = uextend.i64 v23
 ;; @0025                               v32 = iadd v27, v31
-;; @0025                               store notrap aligned v68, v32
+;; @0025                               store notrap aligned v76, v32  ; v76 = -1476394968
 ;; @0025                               v36 = load.i64 notrap aligned readonly can_move v0+64
 ;; @0025                               v37 = load.i32 notrap aligned readonly can_move v36
 ;; @0025                               store notrap aligned v37, v32+4
@@ -50,18 +42,18 @@
 ;;                                     v46 = iconst.i64 8
 ;; @0025                               v38 = iadd v32, v46  ; v46 = 8
 ;; @0025                               store notrap aligned v6, v38  ; v6 = 3
-;;                                     v71 = iconst.i64 16
-;;                                     v77 = iadd v32, v71  ; v71 = 16
-;; @0025                               store notrap aligned little v2, v77
+;;                                     v84 = iconst.i64 16
+;;                                     v90 = iadd v32, v84  ; v84 = 16
+;; @0025                               store notrap aligned little v2, v90
 ;;                                     v50 = iconst.i64 24
-;;                                     v84 = iadd v32, v50  ; v50 = 24
-;; @0025                               store notrap aligned little v3, v84
+;;                                     v97 = iadd v32, v50  ; v50 = 24
+;; @0025                               store notrap aligned little v3, v97
 ;;                                     v47 = iconst.i64 32
-;;                                     v91 = iadd v32, v47  ; v47 = 32
-;; @0025                               store notrap aligned little v4, v91
+;;                                     v104 = iadd v32, v47  ; v47 = 32
+;; @0025                               store notrap aligned little v4, v104
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v100 = band.i32 v21, v67  ; v67 = -8
-;; @0029                               return v100
+;;                                     v113 = band.i32 v21, v75  ; v75 = -8
+;; @0029                               return v113
 ;; }

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -41,15 +41,15 @@
 ;;                                     v51 = ishl v16, v50  ; v50 = 3
 ;; @0024                               v23 = iconst.i32 16
 ;; @0024                               v24 = uadd_overflow_trap v51, v23, user1  ; v23 = 16
+;; @0024                               v35 = uextend.i64 v24
+;;                                     v61 = iadd v9, v35
+;; @0024                               v37 = icmp ule v61, v8
+;; @0024                               trapz v37, user1
 ;;                                     v58 = ishl v3, v50  ; v50 = 3
 ;; @0024                               v27 = iadd v58, v23  ; v23 = 16
 ;; @0024                               v33 = uextend.i64 v27
-;; @0024                               v34 = uadd_overflow_trap v9, v33, user1
-;; @0024                               v35 = uextend.i64 v24
-;; @0024                               v36 = uadd_overflow_trap v9, v35, user1
-;; @0024                               v37 = icmp ule v36, v8
-;; @0024                               trapz v37, user1
-;; @0024                               v38 = iadd v6, v34
+;;                                     v60 = iadd v9, v33
+;; @0024                               v38 = iadd v6, v60
 ;; @0024                               store notrap aligned little v4, v38
 ;; @0027                               jump block1
 ;;

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -19,8 +19,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
-;;                                     v35 = iconst.i32 0
-;; @0020                               trapnz v35, user18  ; v35 = 0
 ;; @0020                               v9 = load.i64 notrap aligned readonly v0+56
 ;; @0020                               v10 = load.i32 notrap aligned v9
 ;;                                     v42 = iconst.i32 7

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -42,23 +42,23 @@
 ;;                                     v90 = ishl v18, v89  ; v89 = 3
 ;; @0024                               v25 = iconst.i32 16
 ;; @0024                               v26 = uadd_overflow_trap v90, v25, user1  ; v25 = 16
+;; @0024                               v37 = uextend.i64 v26
+;;                                     v100 = iadd v11, v37
+;; @0024                               v39 = icmp ule v100, v10
+;; @0024                               trapz v39, user1
 ;;                                     v97 = ishl v3, v89  ; v89 = 3
 ;; @0024                               v29 = iadd v97, v25  ; v25 = 16
 ;; @0024                               v35 = uextend.i64 v29
-;; @0024                               v36 = uadd_overflow_trap v11, v35, user1
-;; @0024                               v37 = uextend.i64 v26
-;; @0024                               v38 = uadd_overflow_trap v11, v37, user1
-;; @0024                               v39 = icmp ule v38, v10
-;; @0024                               trapz v39, user1
-;; @0024                               v40 = iadd v8, v36
+;;                                     v99 = iadd v11, v35
+;; @0024                               v40 = iadd v8, v99
 ;; @0024                               v41 = load.i64 notrap aligned little v40
 ;; @002b                               v54 = icmp ult v4, v18
 ;; @002b                               trapz v54, user17
-;;                                     v99 = ishl v4, v89  ; v89 = 3
-;; @002b                               v64 = iadd v99, v25  ; v25 = 16
+;;                                     v101 = ishl v4, v89  ; v89 = 3
+;; @002b                               v64 = iadd v101, v25  ; v25 = 16
 ;; @002b                               v70 = uextend.i64 v64
-;; @002b                               v71 = uadd_overflow_trap v11, v70, user1
-;; @002b                               v75 = iadd v8, v71
+;;                                     v103 = iadd v11, v70
+;; @002b                               v75 = iadd v8, v103
 ;; @002b                               v76 = load.i64 notrap aligned little v75
 ;; @002e                               jump block1
 ;;

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -19,8 +19,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0021                               v4 = iconst.i32 0
-;; @0021                               trapnz v4, user18  ; v4 = 0
 ;; @0021                               v11 = load.i64 notrap aligned readonly v0+56
 ;; @0021                               v12 = load.i32 notrap aligned v11
 ;;                                     v44 = iconst.i32 7
@@ -46,6 +44,7 @@
 ;;                                     v35 = iconst.i64 8
 ;; @0021                               v32 = iadd v26, v35  ; v35 = 8
 ;; @0021                               store notrap aligned little v3, v32  ; v3 = 0.0
+;; @0021                               v4 = iconst.i32 0
 ;;                                     v36 = iconst.i64 12
 ;; @0021                               v33 = iadd v26, v36  ; v36 = 12
 ;; @0021                               istore8 notrap aligned little v4, v33  ; v4 = 0

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -19,8 +19,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v38 = iconst.i32 0
-;; @002a                               trapnz v38, user18  ; v38 = 0
 ;; @002a                               v11 = load.i64 notrap aligned readonly v0+56
 ;; @002a                               v12 = load.i32 notrap aligned v11
 ;;                                     v45 = iconst.i32 7

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -42,14 +42,12 @@
 ;; @0023                               brif v52, block3, block2  ; v52 = 1
 ;;
 ;;                                 block2:
-;;                                     v75 = iconst.i64 0
-;; @0023                               v29 = iconst.i64 8
-;; @0023                               v30 = uadd_overflow_trap v75, v29, user1  ; v75 = 0, v29 = 8
-;; @0023                               v32 = uadd_overflow_trap v30, v29, user1  ; v29 = 8
 ;; @0023                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0023                               v33 = icmp ule v32, v27
-;; @0023                               trapz v33, user1
-;; @0023                               v34 = iadd.i64 v14, v30
+;;                                     v78 = iconst.i64 16
+;;                                     v79 = icmp uge v27, v78  ; v78 = 16
+;; @0023                               trapz v79, user1
+;; @0023                               v29 = iconst.i64 8
+;; @0023                               v34 = iadd.i64 v14, v29  ; v29 = 8
 ;; @0023                               v35 = load.i64 notrap aligned v34
 ;;                                     v54 = iconst.i64 1
 ;; @0023                               v36 = iadd v35, v54  ; v54 = 1
@@ -57,10 +55,10 @@
 ;; @0023                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v76 = iconst.i32 0
+;;                                     v80 = iconst.i32 0
 ;;                                     v51 = iconst.i64 24
 ;; @0023                               v19 = iadd.i64 v16, v51  ; v51 = 24
-;; @0023                               store notrap aligned little v76, v19  ; v76 = 0
+;; @0023                               store notrap aligned little v80, v19  ; v80 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;;                                     v55 = iconst.i64 32
 ;; @0023                               v48 = iadd.i64 v16, v55  ; v55 = 32

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -32,7 +32,7 @@
 ;;       movl    $0x20, %ecx
 ;;       movl    $8, %r8d
 ;;       movq    %rdi, %r13
-;;       callq   0x195
+;;       callq   0x183
 ;;       movq    0x28(%r13), %r9
 ;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[0]
 ;;       movq    %rax, %r8

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x7, x6, 0x9    // target = 0x26
 ;;   24: pop_frame
 ;;       ret
-;;   26: call 0x9e    // target = 0xc4
+;;   26: call 0x8a    // target = 0xb0
 ;;   2b: jump -0x7    // target = 0x24

--- a/tests/disas/pulley/memory-inbounds.wat
+++ b/tests/disas/pulley/memory-inbounds.wat
@@ -86,14 +86,13 @@
 ;;
 ;; wasm[0]::function[8]::maybe_inbounds_v2:
 ;;       push_frame
+;;       xload64le_o32 x9, x0, 88
 ;;       xzero x10
-;;       xconst32 x11, 131072
-;;       xadd64_uoverflow_trap x11, x10, x11
-;;       xload64le_o32 x12, x0, 88
-;;       xload64le_o32 x13, x0, 80
-;;       xadd64_u32 x13, x13, 131068
-;;       xult64 x9, x12, x11
-;;       xselect64 x11, x9, x10, x13
+;;       xload64le_o32 x11, x0, 80
+;;       xadd64_u32 x11, x11, 131068
+;;       xconst32 x7, 131072
+;;       xult64 x9, x9, x7
+;;       xselect64 x11, x9, x10, x11
 ;;       xload32le_z x0, x11, 0
 ;;       pop_frame
 ;;       ret

--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -81,7 +81,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x3fc
+;;       bl      #0x3ec
 ;;   d0: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]
@@ -151,7 +151,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28, #0xc]
-;;       bl      #0x3fc
+;;       bl      #0x3ec
 ;;  1e8: add     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -78,7 +78,7 @@
 ;;       mov     x16, #0
 ;;       mov     w1, w16
 ;;       ldur    w2, [x28]
-;;       bl      #0x424
+;;       bl      #0x3ec
 ;;   ec: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       ldur    x9, [x28, #0x14]

--- a/tests/disas/winch/x64/atomic/notify/notify.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify.wat
@@ -27,7 +27,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x18e
+;;       callq   0x169
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/notify/notify_offset.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify_offset.wat
@@ -28,7 +28,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x192
+;;       callq   0x16d
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32.wat
@@ -30,7 +30,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x19b
+;;       callq   0x176
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x19f
+;;       callq   0x17a
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64.wat
@@ -29,7 +29,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x198
+;;       callq   0x173
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
@@ -33,7 +33,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x19c
+;;       callq   0x177
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -76,7 +76,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x2f8
+;;       callq   0x2e6
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
@@ -128,7 +128,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x2f8
+;;       callq   0x2e6
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -72,7 +72,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x331
+;;       callq   0x2f0
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14

--- a/tests/disas/winch/x64/epoch/func.wat
+++ b/tests/disas/winch/x64/epoch/func.wat
@@ -23,7 +23,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x14a
+;;       callq   0x126
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/epoch/loop.wat
+++ b/tests/disas/winch/x64/epoch/loop.wat
@@ -25,7 +25,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x174
+;;       callq   0x150
 ;;       movq    8(%rsp), %r14
 ;;       movq    0x20(%r14), %rdx
 ;;       movq    (%rdx), %rdx
@@ -34,7 +34,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x174
+;;       callq   0x150
 ;;       movq    8(%rsp), %r14
 ;;       jmp     0x51
 ;;   7b: addq    $0x10, %rsp

--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -28,7 +28,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x201
+;;       callq   0x1dd
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
@@ -74,7 +74,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x108
 ;;   fb: movq    %r14, %rdi
-;;       callq   0x201
+;;       callq   0x1dd
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/fuel/func.wat
+++ b/tests/disas/winch/x64/fuel/func.wat
@@ -24,7 +24,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x151
+;;       callq   0x12d
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/fuel/loop.wat
+++ b/tests/disas/winch/x64/fuel/loop.wat
@@ -26,14 +26,14 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x182
+;;       callq   0x15e
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rcx
 ;;       movq    (%rcx), %rcx
 ;;       cmpq    $0, %rcx
 ;;       jl      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x182
+;;       callq   0x15e
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
 ;;       movl    $0, %edx
-;;       callq   0x2ed
+;;       callq   0x2d3
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x58(%rsp), %r14

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x4d4
+;;       callq   0x470
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
@@ -133,7 +133,7 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x515
+;;       callq   0x4b1
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2f1
+;;       callq   0x2bc
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -30,7 +30,7 @@
 ;;       movl    $0, %esi
 ;;       movl    $0xa, %edx
 ;;       movq    8(%rsp), %rcx
-;;       callq   0x175
+;;       callq   0x164
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x929
+;;       callq   0x87e
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x988
+;;       callq   0x8dd
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x929
+;;       callq   0x87e
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x988
+;;       callq   0x8dd
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c7
+;;       callq   0x91c
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c7
+;;       callq   0x91c
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x9c7
+;;       callq   0x91c
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x9c7
+;;       callq   0x91c
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x9c7
+;;       callq   0x91c
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xa26
+;;       callq   0x97b
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -109,7 +109,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x4cd
+;;       callq   0x473
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14


### PR DESCRIPTION
This commit adds a new top-level ISLE entrypoint specifically for instructions in the side-effectful skeleton: `simplify_skeleton`. While these rewrites are processed during the egraph pass, values from skeleton instructions still do not get inserted into the egraph. Indeed, `simplify_skeleton` operates on *instructions* rather than *values* because we do not represent side effects as values; values do not have side effects in CLIF, instructions do. Therefore, rather than doing a whole dynamic-programming style extraction of the best candidate simplification like we do with the egraph, we take an eager and greedy approach.

Furthermore, `simplify_skeleton` is limited only to skeleton instructions that do not involve control-flow or terminators right now. This is because changing the control-flow graph can change whether a use is dominated by a def or not, and we do not currently have the machinery to track and fix up invalidated uses. Addressing this is left for future commits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
