### PR TITLE
Just use `ir::Global`s for `VMStoreContext` pointer in `FuncEnvironment`

### DIFF
--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -9,33 +9,34 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     fn0 = colocated u1:16 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0016                               v5 = load.i64 notrap aligned v0+32
-;; @0016                               v6 = load.i64 notrap aligned v5
-;; @0016                               v3 = load.i64 notrap aligned readonly can_move v0+8
-;; @0016                               v7 = load.i64 notrap aligned v3+8
-;; @0016                               v8 = icmp uge v6, v7
-;; @0016                               brif v8, block3, block2(v7)
+;; @0016                               v3 = load.i64 notrap aligned v0+32
+;; @0016                               v4 = load.i64 notrap aligned v3
+;; @0016                               v5 = load.i64 notrap aligned readonly can_move v0+8
+;; @0016                               v6 = load.i64 notrap aligned v5+8
+;; @0016                               v7 = icmp uge v4, v6
+;; @0016                               brif v7, block3, block2(v6)
 ;;
 ;;                                 block3 cold:
-;; @0016                               v10 = call fn0(v0)
-;; @0016                               jump block2(v10)
+;; @0016                               v9 = call fn0(v0)
+;; @0016                               jump block2(v9)
 ;;
 ;;                                 block2(v21: i64):
 ;; @0017                               jump block4(v21)
 ;;
-;;                                 block4(v13: i64):
-;; @0017                               v12 = load.i64 notrap aligned v5
-;; @0017                               v14 = icmp uge v12, v13
-;; @0017                               brif v14, block7, block6(v13)
+;;                                 block4(v12: i64):
+;; @0017                               v11 = load.i64 notrap aligned v3
+;; @0017                               v13 = icmp uge v11, v12
+;; @0017                               brif v13, block7, block6(v12)
 ;;
 ;;                                 block7 cold:
-;; @0017                               v15 = load.i64 notrap aligned v3+8
-;; @0017                               v16 = icmp.i64 uge v12, v15
+;; @0017                               v15 = load.i64 notrap aligned v5+8
+;; @0017                               v16 = icmp.i64 uge v11, v15
 ;; @0017                               brif v16, block8, block6(v15)
 ;;
 ;;                                 block8 cold:


### PR DESCRIPTION
And let alias analysis dedupe and clean up multiple uses, instead of trying to do that manually in our Wasm-to-CLIF frontend by loading the pointer once in the entry block and trying to keep track of whether it is actually necessary to pre-declare the pointer and all that.

Split off from https://github.com/bytecodealliance/wasmtime/pull/10503

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
