### PR TITLE
cranelift: ISLE wrapper for constructing constants

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -529,6 +529,15 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn ty_vec(&mut self, ty: Type) -> Option<Type> {
+            if ty.is_vector() {
+                Some(ty)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
         fn ty_vec64_int(&mut self, ty: Type) -> Option<Type> {
             if ty.is_vector() && ty.bits() == 64 && ty.lane_type().is_int() {
                 Some(ty)

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -635,6 +635,10 @@
 (decl ty_dyn_vec128 (Type) Type)
 (extern extractor ty_dyn_vec128 ty_dyn_vec128)
 
+;; An extractor that only matches vector.
+(decl ty_vec (Type) Type)
+(extern extractor ty_vec ty_vec)
+
 ;; An extractor that only matches 64-bit vector types with integer
 ;; lanes (I8X8, I16X4, I32X2)
 (decl ty_vec64_int (Type) Type)

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -95,6 +95,15 @@
     (iconst ty (imm64 c)))
 (rule 1 (iconst_u $I128 c) (uextend $I128 (iconst_u $I64 c)))
 
+;; Constructs a constant value node from a 64-bit immediate, adapting it
+;; to the specified type. For 128-bit integers, the immediate is zero-extended;
+;; for other integer types, a direct iconst is generated; and for vector types,
+;; the constant is splatted across all lanes.
+(decl const (Type Imm64) Value)
+(rule 2 (const $I128 n) (uextend $I128 (iconst $I64 n)))
+(rule 1 (const (ty_int ty) n) (iconst ty n))
+(rule 0 (const (ty_vec ty) n) (splat ty (const (lane_type ty) n)))
+
 ;; These take `Value`, rather than going through `inst_data_tupled`, because
 ;; most of the time they want to return the original `Value`, and it would be
 ;; a waste to need to re-GVN the instruction data in those cases.


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
## Description:

This pull request addresses issue [#6038](https://github.com/bytecodealliance/wasmtime/issues/6038) by adding an ISLE wrapper for constructing constants. The goal is to allow mid-end optimization rules to generate constants generically without needing to know whether to use `iconst`, `vconst`, `f32const`, `f64const`, etc.

## Changes:

- Added a helper function `ty_vec` in `cranelift/codegen/src/isle_prelude.rs`
- Defined an extractor `ty_vec` in `cranelift/codegen/src/prelude.isle
- Introduced a new rule in `cranelift/codegen/src/prelude_opt.isle` for constructing constant nodes

## Additional Notes:

- It compiles without any problem and passes the `cranelift` test.

