### PR TITLE
Convert docs and error trapping to single quote approach

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -48,25 +48,30 @@ The `run` command accepts an optional `--invoke` argument, which is the name of
 an exported function of the module to run.
 
 ```sh
-$ wasmtime run --invoke "initialize()" foo.wasm
+$ wasmtime run --invoke 'initialize()' foo.wasm
 ```
 
-The exported function's name and exported function's parentheses must both be enclosed in one set of double quotes, i.e. `"initialize()"`. 
+The exported function's name and exported function's parentheses must both be enclosed in one set of single quotes, i.e. `'initialize()'`. 
 This treats the exported function as a single argument and prevents issues with shell interpretation.
 The presence of the parenthesis `()` signifies function invocation, as apposed to the function name just being referenced.
 This convention helps to distinguish function calls from other kinds of string arguments.
 
-**Note:** If your function takes a string argument, ensure that you use escaped double quotes inside the parentheses. For example:
+**Note:** If your function takes a string argument, ensure that you surround the string argument in double quotes. For example:
 
 ```sh
-$ wasmtime run --invoke "initialize(\"hello\")" foo.wasm
+$ wasmtime run --invoke 'initialize("hello")' foo.wasm
 ```
 
 Each individual argument within the parentheses must be separated by a comma:
 
 ```sh
-$ wasmtime run --invoke "initialize(\"Pi\", 3.14)" foo.wasm
-$ wasmtime run --invoke "add(1, 2)" foo.wasm
+$ wasmtime run --invoke 'initialize("Pi", 3.14)' foo.wasm
+$ wasmtime run --invoke 'add(1, 2)' foo.wasm
+```
+
+**Please note:** If you enclose your whole function call using double quotes, your string argument will require its double quotes to be escaped (escaping quotes is more complicated and harder to read and therefore not ideal). For example:
+```bash
+wasmtime run - invoke "initialize(\"hello\")" foo.wasm
 ```
 
 ## `serve`

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -554,7 +554,7 @@ impl RunCommand {
                 let single_string_arg = format!("'{trimmed_invoke}(\"hello\")'");
                 let multiple_args = format!("'{trimmed_invoke}(\"Pi\", 3.14)'");
                 format!(
-                    "Failed to parse invoke '{raw_invoke}': function calls must include parentheses and must be enveloped in single quotes. For example,{empty_args}. String arguments must use double quotes {single_string_arg}, and multiple arguments must be separated by commas. For example, {multiple_args}.",
+                    "Failed to parse invoke '{raw_invoke}': function calls must include parentheses and must be enveloped in single quotes. For example, {empty_args}. String arguments must use double quotes {single_string_arg}, and commas must separate multiple arguments. For example, {multiple_args}.",
                 )
         })?;
 


### PR DESCRIPTION
This PR contains proposed updates to https://github.com/bytecodealliance/wasmtime/pull/10054

An erroneous invocation (i.e. missing parentheses) will produce the following message:

```console
$ wasmtime run --invoke 'get-answer' target/wasm32-wasip1/debug/wasm_answer.wasm
Error: failed to run main module `target/wasm32-wasip1/debug/wasm_answer.wasm`

Caused by:
    0: Failed to parse invoke '"get-answer"': function calls must include parentheses and must be enveloped in single quotes. For example, 'get-answer()'. String arguments must use double quotes 'get-answer("hello")', and commas must separate multiple arguments. For example, 'get-answer("Pi", 3.14)'.
    1: unexpected end of input at 10..10
```