### PR TITLE
pulley: Fix frame calculation on non-tail ABIs

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -405,14 +405,14 @@ where
     }
 
     fn gen_return(
-        _call_conv: isa::CallConv,
+        call_conv: isa::CallConv,
         _isa_flags: &PulleyFlags,
         frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
 
         // Handle final stack adjustments for the tail-call ABI.
-        if frame_layout.tail_args_size > 0 {
+        if call_conv == isa::CallConv::Tail && frame_layout.tail_args_size > 0 {
             insts.extend(Self::gen_sp_reg_adjust(
                 frame_layout.tail_args_size.try_into().unwrap(),
             ));


### PR DESCRIPTION
This fixes the Pulley ABI code to only have a tail-call-specific adjustment on the tail ABI, not all ABIs. This matches what other backends such as riscv64 do as well. This is not exposed through wasm I believe because no native signature can exercise this code (I think) and all wasm code uses the `tail` ABI anyway.

This was discovered by running Cranelift filetests using ASAN which is something I hope to be able to add to our CI in the near future.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
