### PR TITLE
Run CI tests through AddressSanitizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -769,6 +769,14 @@ jobs:
         touch ${{ runner.tool_cache }}/qemu/built
       if: matrix.qemu != ''
 
+    - name: Configure ASAN
+      run: |
+        echo CARGO_PROFILE_DEV_OPT_LEVEL=2 >> $GITHUB_ENV
+        echo CARGO_PROFILE_TEST_OPT_LEVEL=2 >> $GITHUB_ENV
+        echo RUSTFLAGS=-Zsanitizer=address >> $GITHUB_ENV
+        echo RUSTDOCFLAGS=-Zsanitizer=address >> $GITHUB_ENV
+      if: ${{ contains(matrix.name, 'ASAN') }}
+
     # Record some CPU details; this is helpful information if tests fail due
     # to CPU-specific features.
     - name: CPU information

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,14 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     set_commit_info_for_rustc();
+
+    println!("cargo:rustc-check-cfg=cfg(asan)");
+    match env::var("CARGO_CFG_SANITIZE") {
+        Ok(s) if s == "address" => {
+            println!("cargo:rustc-cfg=asan");
+        }
+        _ => {}
+    }
 }
 
 fn set_commit_info_for_rustc() {

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -72,6 +72,13 @@ const FULL_MATRIX = [
     "isa": "x64"
   },
   {
+    "os": ubuntu,
+    "name": "Test Linux x86_64 with ASAN",
+    "filter": "asan",
+    "rust": "wasmtime-ci-pinned-nightly",
+    "target": "x86_64-unknown-linux-gnu",
+  },
+  {
     "os": macos,
     "name": "Test macOS x86_64",
     "filter": "macos-x64",

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -343,6 +343,8 @@ mod tests {
                 // TODO: see comments in `arm.rs` about how this seems to work
                 // in gdb but not at runtime, unsure why at this time.
                 || cfg!(target_arch = "arm")
+                // asan does weird things
+                || cfg!(asan)
             );
         }
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -743,7 +743,13 @@ mod test {
         );
     }
 
-    #[cfg(all(unix, target_pointer_width = "64", feature = "async", not(miri)))]
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        feature = "async",
+        not(miri),
+        not(asan)
+    ))]
     #[test]
     fn test_stack_zeroed() -> Result<()> {
         let config = PoolingInstanceAllocatorConfig {
@@ -777,7 +783,13 @@ mod test {
         Ok(())
     }
 
-    #[cfg(all(unix, target_pointer_width = "64", feature = "async", not(miri)))]
+    #[cfg(all(
+        unix,
+        target_pointer_width = "64",
+        feature = "async",
+        not(miri),
+        not(asan)
+    ))]
     #[test]
     fn test_stack_unzeroed() -> Result<()> {
         let config = PoolingInstanceAllocatorConfig {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -239,7 +239,7 @@ impl StackPool {
     }
 }
 
-#[cfg(all(test, unix, feature = "async", not(miri)))]
+#[cfg(all(test, unix, feature = "async", not(miri), not(asan)))]
 mod tests {
     use super::*;
     use crate::runtime::vm::InstanceLimits;

--- a/crates/wasmtime/tests/host_segfault.rs
+++ b/crates/wasmtime/tests/host_segfault.rs
@@ -89,7 +89,7 @@ enum StackOverflow {
 }
 
 fn main() {
-    if cfg!(miri) {
+    if cfg!(miri) || cfg!(asan) {
         return;
     }
     // Skip this tests if it looks like we're in a cross-compiled situation and

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -140,6 +140,7 @@ fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(asan, ignore)]
 fn guards_present() -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
 
@@ -188,6 +189,7 @@ fn guards_present() -> Result<()> {
 
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(asan, ignore)]
 fn guards_present_pooling(config: &mut Config) -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
 
@@ -244,6 +246,7 @@ fn guards_present_pooling(config: &mut Config) -> Result<()> {
 
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(asan, ignore)]
 fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
     if !wasmtime::PoolingAllocationConfig::are_memory_protection_keys_available() {
         println!("skipping `guards_present_pooling_mpk` test; mpk is not supported");

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -128,6 +128,7 @@ fn config() -> (Store<()>, Arc<CustomStackCreator>) {
 }
 
 #[tokio::test]
+#[cfg_attr(asan, ignore)]
 async fn called_on_custom_heap_stack() -> Result<()> {
     let (mut store, stack_creator) = config();
     let module = Module::new(

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -55,8 +55,12 @@ fn wasi_testsuite() -> Result<()> {
         WASI_COMMON_IGNORE_LIST,
     )?;
 
-    // Only run threaded tests on platforms that support threads.
-    if crate::threads::engine().is_some() {
+    // Only run threaded tests on platforms that support threads. Also skip
+    // these tests with ASAN as it, rightfully, complains about a memory leak.
+    // The memory leak at this time is that child threads aren't joined with the
+    // main thread, meaning that allocations done on child threads are indeed
+    // leaked.
+    if crate::threads::engine().is_some() && !cfg!(asan) {
         run_all(
             "tests/wasi_testsuite/wasi-threads",
             &["-Sthreads", "-Wthreads"],

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -38,6 +38,7 @@ impl ResourceLimiter for MemoryGrowFailureDetector {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+#[cfg_attr(asan, ignore)]
 fn custom_limiter_detect_os_oom_failure() -> Result<()> {
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());


### PR DESCRIPTION
This is similar to running tests in Valgrind (which we should perhaps also do...) but can be useful for catching use-after-free style bugs faster than when a process crashes. Given the unsafe nature of Wasmtime this is something we should have probably enabled awhile back but otherwise so long as it doesn't take too long to run on CI seems like an easy win of a boost-of-confidence.

prtest:asan

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
