### PR TITLE
asm: fix trace logging of XMM registers

### DIFF
--- a/cranelift/assembler-x64/src/xmm.rs
+++ b/cranelift/assembler-x64/src/xmm.rs
@@ -25,8 +25,8 @@ impl<R: AsReg> Xmm<R> {
     }
 
     /// Return the register name.
-    pub fn to_string(&self) -> &str {
-        enc::to_string(self.enc())
+    pub fn to_string(&self) -> String {
+        self.0.to_string(None)
     }
 }
 


### PR DESCRIPTION
Along the lines of #10389 and #10478, this change fixes the case where an XMM register is pretty-printed during logging, which may happen before register allocation has provided a true HW register.

Fixes #10529.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
