### PR TITLE
Apply argument extensions to component intrinsics too

### DIFF
--- a/src/commands/objdump.rs
+++ b/src/commands/objdump.rs
@@ -154,7 +154,7 @@ impl ObjdumpCommand {
                 Func::Wasm
             } else if name.contains("trampoline") {
                 Func::Trampoline
-            } else if name.contains("libcall") {
+            } else if name.contains("libcall") || name.starts_with("component") {
                 Func::Libcall
             } else {
                 panic!("unknown symbol: {name}")

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -1,0 +1,53 @@
+;;! target = "riscv64"
+;;! test = 'compile'
+;;! filter = '_wasm_call'
+;;! objdump = '--funcs all'
+
+(component
+  (type $a (resource (rep i32)))
+  (core func $f (canon resource.drop $a))
+
+  (core module $m (import "" "" (func (param i32))))
+  (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+)
+
+;; component-resource-drop[0]_wasm_call:
+;;       addi    sp, sp, -0x10
+;;       sd      ra, 8(sp)
+;;       sd      s0, 0(sp)
+;;       mv      s0, sp
+;;       addi    sp, sp, -0x10
+;;       sd      s1, 8(sp)
+;;       mv      s1, a1
+;;       lw      a1, 0(a0)
+;;       lui     a5, 0x706d7
+;;       addi    a3, a5, -0x9d
+;;       beq     a1, a3, 8
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       ld      a1, 0x10(a0)
+;;       ld      a3, 0(s0)
+;;       sd      a3, 0x18(a1)
+;;       ld      a3, 8(s0)
+;;       sd      a3, 0x20(a1)
+;;       ld      a3, 8(a0)
+;;       ld      a3, 0x10(a3)
+;;       mv      a4, zero
+;;       slli    a1, a4, 0x20
+;;       srai    a1, a1, 0x20
+;;       slli    a2, a2, 0x20
+;;       srai    a2, a2, 0x20
+;;       jalr    a3
+;;       addi    a3, zero, -1
+;;       beq     a0, a3, 0x1c
+;;       ld      s1, 8(sp)
+;;       addi    sp, sp, 0x10
+;;       ld      ra, 8(sp)
+;;       ld      s0, 0(sp)
+;;       addi    sp, sp, 0x10
+;;       ret
+;;       mv      a1, s1
+;;       ld      a4, 0x10(a1)
+;;       ld      a4, 0x138(a4)
+;;       mv      a0, a1
+;;       jalr    a4
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -1,0 +1,50 @@
+;;! target = "riscv64"
+;;! test = 'optimize'
+;;! filter = 'component_trampoline_0_Wasm'
+
+(component
+  (type $a (resource (rep i32)))
+  (core func $f (canon resource.drop $a))
+
+  (core module $m (import "" "" (func (param i32))))
+  (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+)
+
+;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     sig0 = (i64 sext, i32 sext, i32 sext) -> i64 sext system_v
+;;     sig1 = (i64 sext vmctx) system_v
+;;
+;; block0(v0: i64, v1: i64, v2: i32):
+;;     v3 = load.i32 notrap aligned little v0
+;;     v17 = iconst.i32 0x706d_6f63
+;;     v4 = icmp eq v3, v17  ; v17 = 0x706d_6f63
+;;     trapz v4, user1
+;;     v5 = load.i64 notrap aligned v0+16
+;;     v6 = get_frame_pointer.i64 
+;;     v7 = load.i64 notrap aligned v6
+;;     store notrap aligned v7, v5+24
+;;     v8 = get_return_address.i64 
+;;     store notrap aligned v8, v5+32
+;;     v10 = load.i64 notrap aligned readonly v0+8
+;;     v11 = load.i64 notrap aligned readonly v10+16
+;;     v9 = iconst.i32 0
+;;     v12 = call_indirect sig0, v11(v0, v9, v2)  ; v9 = 0
+;;     v13 = iconst.i64 -1
+;;     v14 = icmp ne v12, v13  ; v13 = -1
+;;     brif v14, block2, block1
+;;
+;; block1 cold:
+;;     v15 = load.i64 notrap aligned readonly v1+16
+;;     v16 = load.i64 notrap aligned readonly v15+312
+;;     call_indirect sig1, v16(v1)
+;;     trap user1
+;;
+;; block2:
+;;     brif.i64 v12, block3, block4
+;;
+;; block3:
+;;     jump block4
+;;
+;; block4:
+;;     return
+;; }


### PR DESCRIPTION
This commit fixes the definition of host signatures for component builtins to work in the same way that core builtins do which is to use platform-specific sign-extension-rules by default. This fixes a regression found in the wasip3-prototyping repository where new component intrinsics didn't have this set and subsequently were failing in riscv64 CI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
