### PR TITLE
A couple minor refactorings to `wasmtime-cranelift` and `FuncEnvironment`

### DIFF
--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -3203,7 +3203,7 @@ fn prepare_addr(
         // If our offset fits within a u32, then we can place the it into the
         // offset immediate of the `heap_addr` instruction.
         Ok(offset) => {
-            bounds_check_and_compute_addr(builder, environ, &heap, index, offset, access_size)?
+            bounds_check_and_compute_addr(builder, environ, &heap, index, offset, access_size)
         }
 
         // If the offset doesn't fit within a u32, then we can't pass it
@@ -3242,7 +3242,7 @@ fn prepare_addr(
                 offset,
                 ir::TrapCode::HEAP_OUT_OF_BOUNDS,
             );
-            bounds_check_and_compute_addr(builder, environ, &heap, adjusted_index, 0, access_size)?
+            bounds_check_and_compute_addr(builder, environ, &heap, adjusted_index, 0, access_size)
         }
     };
     let addr = match addr {


### PR DESCRIPTION
* Stop returning a `WasmResult` from the bounds-checking code; it is actually infallible and we were just plumbing around results for no reason.

* Split out a few small helper methods from `FuncEnvironment::make_heap`. This allows for reusing them in https://github.com/bytecodealliance/wasmtime/pull/10503

Split off from https://github.com/bytecodealliance/wasmtime/pull/10503

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
