### PR TITLE
Simplify handling of caller-vmctx and `dyn VMStore` pointers

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -584,6 +584,10 @@ impl<T> Store<T> {
             data: ManuallyDrop::new(data),
         });
 
+        // Note the erasure of the lifetime here into `'static`, so in general
+        // usage of this trait object must be strictly bounded to the `Store`
+        // itself, and this is an invariant that we have to maintain throughout
+        // Wasmtime.
         inner.traitobj = StorePtr::new(unsafe {
             mem::transmute::<
                 NonNull<dyn crate::runtime::vm::VMStore + '_>,

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1712,8 +1712,8 @@ impl InstanceHandle {
     ///
     /// This is provided for the original `Store` itself to configure the first
     /// self-pointer after the original `Box` has been initialized.
-    pub unsafe fn set_store(&mut self, store: NonNull<dyn VMStore>) {
-        self.instance_mut().set_store(Some(store));
+    pub unsafe fn set_store(&mut self, store: Option<NonNull<dyn VMStore>>) {
+        self.instance_mut().set_store(store);
     }
 
     /// Returns a clone of this instance.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -94,6 +94,13 @@ pub struct InstanceAllocationRequest<'a> {
 /// InstanceAllocationRequest.
 pub struct StorePtr(Option<NonNull<dyn VMStore>>);
 
+// We can't make `VMStore: Send + Sync` because that requires making all of
+// Wastime's internals generic over the `Store`'s `T`. So instead, we take care
+// in the whole VM layer to only use the `VMStore` in ways that are `Send`- and
+// `Sync`-safe and we have to have these unsafe impls.
+unsafe impl Send for StorePtr {}
+unsafe impl Sync for StorePtr {}
+
 impl StorePtr {
     /// A pointer to no Store.
     pub fn empty() -> Self {


### PR DESCRIPTION
Just keep a copy of the trait object pointer in `StoreOpaque`, rather than trying to pluck it out of the default caller.

Clean up `CallThreadState` so that it doesn't need a caller-vmctx.

Split out from https://github.com/bytecodealliance/wasmtime/pull/10503

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
