### PR TITLE
Make a couple `vm::Memory` methods take `&self` instead of `&mut self`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -356,7 +356,7 @@ impl Memory {
         }
     }
 
-    /// Returns the number of allocated wasm pages.
+    /// Returns the size of this memory, in bytes.
     pub fn byte_size(&self) -> usize {
         match self {
             Memory::Local(mem) => mem.byte_size(),
@@ -407,7 +407,7 @@ impl Memory {
     }
 
     /// Return a `VMMemoryDefinition` for exposing the memory to compiled wasm code.
-    pub fn vmmemory(&mut self) -> VMMemoryDefinition {
+    pub fn vmmemory(&self) -> VMMemoryDefinition {
         match self {
             Memory::Local(mem) => mem.vmmemory(),
             // `vmmemory()` is used for writing the `VMMemoryDefinition` of a
@@ -701,7 +701,7 @@ impl LocalMemory {
         }
     }
 
-    pub fn vmmemory(&mut self) -> VMMemoryDefinition {
+    pub fn vmmemory(&self) -> VMMemoryDefinition {
         VMMemoryDefinition {
             base: self.alloc.base().as_non_null().into(),
             current_length: self.alloc.byte_size().into(),

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory.rs
@@ -40,7 +40,7 @@ impl SharedMemory {
     }
 
     /// Wrap an existing [Memory] with the locking provided by a [SharedMemory].
-    pub fn wrap(ty: &wasmtime_environ::Memory, mut memory: LocalMemory) -> Result<Self> {
+    pub fn wrap(ty: &wasmtime_environ::Memory, memory: LocalMemory) -> Result<Self> {
         if !ty.shared {
             bail!("shared memory must have a `shared` memory type");
         }


### PR DESCRIPTION
The `&mut self` was not necessary and also did not provide any help with using the resulting `VMMemoryDefinition`s and their raw pointers, so just make these methods take `&self`.

Split off from https://github.com/bytecodealliance/wasmtime/pull/10503

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
