### PR TITLE
Responding to review comments re: invoke CLI output and docs

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -44,25 +44,31 @@ as well as the text format for WebAssembly (`*.wat`):
 $ wasmtime foo.wat
 ```
 
-The `run` command accepts an optional `--invoke` argument, which is the name of
-an exported function of the module to run.
+**Wasm Modules**
+
+A Wasm **module** exports raw functions directly. The `run` command accepts an optional `--invoke` argument, which is the name of an exported raw function (of the module) to run:
+
+```sh
+$ wasmtime run --invoke initialize foo.wasm
+```
+
+**Wasm Components**
+
+A Wasm **component** uses typed interfaces defined by [the component model](https://component-model.bytecodealliance.org/design/components.html). The `run` command also accepts the optional `--invoke` argument for calling an exported function of a **component**. However, the calling of an exported function of a component uses [WAVE](https://github.com/bytecodealliance/wasm-tools/tree/a56e8d3d2a0b754e0465c668f8e4b68bad97590f/crates/wasm-wave#readme)(a human-oriented text encoding of Wasm Component Model values). For example:
 
 ```sh
 $ wasmtime run --invoke 'initialize()' foo.wasm
 ```
 
-The exported function's name and exported function's parentheses must both be enclosed in one set of single quotes, i.e. `'initialize()'`. 
-This treats the exported function as a single argument and prevents issues with shell interpretation.
-The presence of the parenthesis `()` signifies function invocation, as apposed to the function name just being referenced.
-This convention helps to distinguish function calls from other kinds of string arguments.
+You will notice that (when using WAVE) the exported function's name and exported function's parentheses are both enclosed in one set of single quotes, i.e. `'initialize()'`. This treats the exported function as a single argument, prevents issues with shell interpretation and signifies function invocation (as apposed to the function name just being referenced). Using WAVE (when calling exported functions of Wasm components) helps to distinguish function calls from other kinds of string arguments. Below are some more examples:
 
-**Note:** If your function takes a string argument, ensure that you surround the string argument in double quotes. For example:
+If your function takes a string argument, you surround the string argument in double quotes:
 
 ```sh
 $ wasmtime run --invoke 'initialize("hello")' foo.wasm
 ```
 
-Each individual argument within the parentheses must be separated by a comma:
+And each individual argument within the parentheses is separated by a comma:
 
 ```sh
 $ wasmtime run --invoke 'initialize("Pi", 3.14)' foo.wasm

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -544,17 +544,10 @@ impl RunCommand {
 
         // Check if the invoke string is present
         let invoke: &String = self.invoke.as_ref().unwrap();
-        // Create raw version of invoke for error messages
-        let raw_invoke = format!("{invoke:?}");
 
         let untyped_call = UntypedFuncCall::parse(invoke).with_context(|| {
-                let trimmed_invoke = invoke.trim_matches(['"', '\'']);
-                // Construct examples of valid function calls for error messages
-                let empty_args = format!("'{trimmed_invoke}()'");
-                let single_string_arg = format!("'{trimmed_invoke}(\"hello\")'");
-                let multiple_args = format!("'{trimmed_invoke}(\"Pi\", 3.14)'");
                 format!(
-                    "Failed to parse invoke '{raw_invoke}': function calls must include parentheses and must be enveloped in single quotes. For example, {empty_args}. String arguments must use double quotes {single_string_arg}, and commas must separate multiple arguments. For example, {multiple_args}.",
+                    "Failed to parse invoke '{invoke}': See https://docs.wasmtime.dev/cli-options.html#run for syntax",
                 )
         })?;
 


### PR DESCRIPTION
This cleans up the CLI output and docs in relation to some review comments from Alex; thanks, Alex.

Below are a few commands, for your convenience, that I ran using the new code (just so you get a sense of the output):

Calling an exported function of a **module**:

```console
$ wasmtime run --invoke 'initialize' wasm_mod_test.wasm 
initialize() was called!
```

```console
$ wasmtime run --invoke initialize wasm_mod_test.wasm  
initialize() was called!
```

Calling an exported function of a **component**:

```console
$ wasmtime run --invoke 'get-answer()' wasm_answer.wasm
42
```

Example of not using WAVE on purpose (when calling exported function of component) so that the error appears:

```console
$ wasmtime run --invoke 'get-answer' wasm_answer.wasm 
Error: failed to run main module `wasm_answer.wasm`
Caused by:    
    0: Failed to parse invoke 'get-answer': See https://docs.wasmtime.dev/cli-options.html#run for syntax    
    1: unexpected end of input at 10..10
```