### PR TITLE
[DI] Dump value label assignments in a table

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -129,13 +129,17 @@ impl Context {
         isa: &dyn TargetIsa,
         ctrl_plane: &mut ControlPlane,
     ) -> CodegenResult<CompiledCodeStencil> {
-        let _tt = timing::compile();
+        let result;
+        trace!("****** START compiling {}", self.func.display_spec());
+        {
+            let _tt = timing::compile();
 
-        self.verify_if(isa)?;
-
-        self.optimize(isa, ctrl_plane)?;
-
-        isa.compile_function(&self.func, &self.domtree, self.want_disasm, ctrl_plane)
+            self.verify_if(isa)?;
+            self.optimize(isa, ctrl_plane)?;
+            result = isa.compile_function(&self.func, &self.domtree, self.want_disasm, ctrl_plane);
+        }
+        trace!("****** DONE compiling {}\n", self.func.display_spec());
+        result
     }
 
     /// Optimize the function, performing all compilation steps up to

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -11,7 +11,7 @@ use crate::ir::{
     StackSlot, StackSlotData, StackSlots, Type,
 };
 use crate::isa::CallConv;
-use crate::write::write_function;
+use crate::write::{write_function, write_function_spec};
 use crate::HashMap;
 #[cfg(feature = "enable-serde")]
 use alloc::string::String;
@@ -445,6 +445,11 @@ impl Function {
         DisplayFunction(self)
     }
 
+    /// Return an object that can display this function's name and signature.
+    pub fn display_spec(&self) -> DisplayFunctionSpec<'_> {
+        DisplayFunctionSpec(self)
+    }
+
     /// Sets an absolute source location for the given instruction.
     ///
     /// If no base source location has been set yet, records it at the same time.
@@ -491,5 +496,20 @@ impl fmt::Display for Function {
 impl fmt::Debug for Function {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write_function(fmt, self)
+    }
+}
+
+/// Wrapper type capable of displaying a 'Function's name and signature.
+pub struct DisplayFunctionSpec<'a>(&'a Function);
+
+impl<'a> fmt::Display for DisplayFunctionSpec<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write_function_spec(fmt, self.0)
+    }
+}
+
+impl<'a> fmt::Debug for DisplayFunctionSpec<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write_function_spec(fmt, self.0)
     }
 }

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -79,7 +79,7 @@ pub(crate) type SourceLocs = SecondaryMap<Inst, RelSourceLoc>;
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct ValueLabel(u32);
-entity_impl!(ValueLabel, "val");
+entity_impl!(ValueLabel, "VL");
 
 /// A label of a Value.
 #[derive(Debug, Clone, PartialEq, Hash)]

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -105,4 +105,13 @@ macro_rules! trace {
     };
 }
 
+/// Dynamic check for whether trace logging is enabled.
+#[macro_export]
+macro_rules! trace_log_enabled {
+    () => {
+        cfg!(any(feature = "trace-log", debug_assertions))
+            && ::log::log_enabled!(::log::Level::Trace)
+    };
+}
+
 include!(concat!(env!("OUT_DIR"), "/version.rs"));

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -19,11 +19,11 @@
 
 use crate::ir::pcc::*;
 use crate::ir::{self, types, Constant, ConstantData, ValueLabel};
-use crate::{machinst::*, trace_log_enabled};
 use crate::ranges::Ranges;
 use crate::timing;
 use crate::trace;
 use crate::CodegenError;
+use crate::{machinst::*, trace_log_enabled};
 use crate::{LabelValueLoc, ValueLocRange};
 use regalloc2::{
     Edit, Function as RegallocFunction, InstOrEdit, InstRange, MachineEnv, Operand,
@@ -31,11 +31,12 @@ use regalloc2::{
 };
 use rustc_hash::FxHashMap;
 
+use core::cmp::Ordering;
+use core::fmt::{self, Write};
 use core::mem::take;
 use cranelift_entity::{entity_impl, Keys};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::fmt;
 
 /// Index referring to an instruction in VCode.
 pub type InsnIndex = regalloc2::Inst;
@@ -721,9 +722,6 @@ impl<I: VCodeInst> VCode<I> {
     where
         I: VCodeInst,
     {
-        // To write into disasm string.
-        use core::fmt::Write;
-
         let _tt = timing::vcode_emit();
         let mut buffer = MachBuffer::new();
         buffer.set_log2_min_function_alignment(self.log2_min_function_alignment);
@@ -1146,24 +1144,13 @@ impl<I: VCodeInst> VCode<I> {
         }
 
         if trace_log_enabled!() {
-            trace!("Debug value ranges as computed by lowering:");
-            for (vreg, start, end, label) in &self.debug_value_labels {
-                trace!(
-                    "{:?} in {}: [Inst {}..Inst {})",
-                    ValueLabel::from_u32(*label),
-                    vreg,
-                    start.index(),
-                    end.index()
-                );
-            }
+            self.log_value_labels_ranges(regalloc, inst_offsets);
         }
 
         let mut value_labels_ranges: ValueLabelsRanges = HashMap::new();
         for &(label, from, to, alloc) in &regalloc.debug_locations {
             let label = ValueLabel::from_u32(label);
-            let ranges = value_labels_ranges
-                .entry(label)
-                .or_insert_with(|| vec![]);
+            let ranges = value_labels_ranges.entry(label).or_insert_with(|| vec![]);
             let from_offset = inst_offsets[from.inst().index()];
             let to_offset = if to.inst().index() == inst_offsets.len() {
                 func_body_len
@@ -1240,6 +1227,200 @@ impl<I: VCodeInst> VCode<I> {
         }
 
         value_labels_ranges
+    }
+
+    fn log_value_labels_ranges(&self, regalloc: &regalloc2::Output, inst_offsets: &[CodeOffset]) {
+        debug_assert!(trace_log_enabled!());
+
+        // What debug labels do we have? Note we'll skip those that have not been
+        // allocated any location at all. They will show up as numeric gaps in the table.
+        let mut labels = vec![];
+        for &(label, _, _, _) in &regalloc.debug_locations {
+            if Some(&label) == labels.last() {
+                continue;
+            }
+            labels.push(label);
+        }
+
+        // Reformat the data on what VRegs were the VLs assigned to by lowering, since
+        // the array we have is sorted by VReg, and we want it sorted by VL for easy
+        // access in the loop below.
+        let mut vregs = vec![];
+        for &(vreg, start, end, label) in &self.debug_value_labels {
+            if matches!(labels.binary_search(&label), Ok(_)) {
+                vregs.push((label, start, end, vreg));
+            }
+        }
+        vregs.sort_unstable_by(
+            |(l_label, l_start, _, _), (r_label, r_start, _, _)| match l_label.cmp(r_label) {
+                Ordering::Equal => l_start.cmp(r_start),
+                cmp => cmp,
+            },
+        );
+
+        #[derive(PartialEq)]
+        enum Mode {
+            Measure,
+            Emit,
+        }
+        #[derive(PartialEq)]
+        enum Row {
+            Head,
+            Line,
+            Inst(usize),
+        }
+
+        let mut widths = vec![0; 2 + 2 * labels.len()];
+        let mut row = String::new();
+        let mut output_row = |row_kind: Row, mode: Mode| {
+            let mut column_index = 0;
+            row.clear();
+
+            macro_rules! output_cell_impl {
+                ($fill:literal, $span:literal, $($cell_fmt:tt)*) => {
+                    let column_start = row.len();
+                    {
+                        row.push('|');
+                        write!(row, $($cell_fmt)*).unwrap();
+                    }
+
+                    let next_column_index = column_index + $span;
+                    let expected_width: usize = widths[column_index..next_column_index].iter().sum();
+                    if mode == Mode::Measure {
+                        let actual_width = row.len() - column_start;
+                        if actual_width > expected_width {
+                            widths[next_column_index - 1] += actual_width - expected_width;
+                        }
+                    } else {
+                        let column_end = column_start + expected_width;
+                        while row.len() != column_end {
+                            row.push($fill);
+                        }
+                    }
+                    column_index = next_column_index;
+                };
+            }
+            macro_rules! output_cell {
+                ($($cell_fmt:tt)*) => {
+                    output_cell_impl!(' ', 1, $($cell_fmt)*);
+                };
+            }
+
+            match row_kind {
+                Row::Head => {
+                    output_cell!("Inst");
+                    output_cell!("IP");
+                    for label in &labels {
+                        output_cell_impl!(' ', 2, "{:?}", ValueLabel::from_u32(*label));
+                    }
+                }
+                Row::Line => {
+                    debug_assert!(mode == Mode::Emit);
+                    output_cell_impl!('-', 1, "");
+                    output_cell_impl!('-', 1, "");
+                    for _ in &labels {
+                        output_cell_impl!('-', 2, "");
+                    }
+                }
+                Row::Inst(inst_index) => {
+                    output_cell!("Inst {inst_index} ");
+                    output_cell!("{} ", inst_offsets[inst_index]);
+
+                    // The ranges which we query below operate on the logic of
+                    // "IP(inst) == IP after inst", while the rows of our table
+                    // represent IPs 'before' "inst", so we need to convert "inst"
+                    // into these "IP after" coordinates.
+                    let inst_ip_index = inst_index.wrapping_sub(1);
+                    for label in &labels {
+                        // First, the VReg.
+                        use regalloc2::Inst;
+                        let vreg_cmp = |inst: usize,
+                                        vreg_label: &u32,
+                                        range_start: &Inst,
+                                        range_end: &Inst| {
+                            match vreg_label.cmp(&label) {
+                                Ordering::Equal => {
+                                    if range_end.index() <= inst {
+                                        Ordering::Less
+                                    } else if range_start.index() > inst {
+                                        Ordering::Greater
+                                    } else {
+                                        Ordering::Equal
+                                    }
+                                }
+                                cmp => cmp,
+                            }
+                        };
+                        let vreg_index =
+                            vregs.binary_search_by(|(l, s, e, _)| vreg_cmp(inst_ip_index, l, s, e));
+                        if let Ok(vreg_index) = vreg_index {
+                            let mut prev_vreg = None;
+                            if inst_ip_index > 0 {
+                                let prev_vreg_index = vregs.binary_search_by(|(l, s, e, _)| {
+                                    vreg_cmp(inst_ip_index - 1, l, s, e)
+                                });
+                                if let Ok(prev_vreg_index) = prev_vreg_index {
+                                    prev_vreg = Some(vregs[prev_vreg_index].3);
+                                }
+                            }
+
+                            let vreg = vregs[vreg_index].3;
+                            if Some(vreg) == prev_vreg {
+                                output_cell!("*");
+                            } else {
+                                output_cell!("{}", vreg);
+                            }
+                        } else {
+                            output_cell!("");
+                        }
+
+                        // Second, the allocated location.
+                        let range_index = regalloc.debug_locations.binary_search_by(
+                            |(range_label, range_start, range_end, _)| match range_label.cmp(label)
+                            {
+                                Ordering::Equal => {
+                                    if range_end.inst().index() <= inst_ip_index {
+                                        Ordering::Less
+                                    } else if range_start.inst().index() > inst_ip_index {
+                                        Ordering::Greater
+                                    } else {
+                                        Ordering::Equal
+                                    }
+                                }
+                                cmp => cmp,
+                            },
+                        );
+                        if let Ok(range_index) = range_index {
+                            // Live at this instruction, print the location.
+                            if let Some(reg) = regalloc.debug_locations[range_index].3.as_reg() {
+                                output_cell!("{:?}", Reg::from(reg));
+                            } else {
+                                output_cell!("Stk");
+                            }
+                        } else {
+                            // Not live at this instruction.
+                            output_cell!("");
+                        }
+                    }
+                }
+            }
+            row.push('|');
+
+            if mode == Mode::Emit {
+                trace!("{}", row.as_str());
+            }
+        };
+
+        for inst_index in 0..inst_offsets.len() {
+            output_row(Row::Inst(inst_index), Mode::Measure);
+        }
+        output_row(Row::Head, Mode::Measure);
+
+        output_row(Row::Head, Mode::Emit);
+        output_row(Row::Line, Mode::Emit);
+        for inst_index in 0..inst_offsets.len() {
+            output_row(Row::Inst(inst_index), Mode::Emit);
+        }
     }
 
     /// Get the IR block for a BlockIndex, if one exists.

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -180,7 +180,7 @@ pub fn decorate_function<FW: FuncWriter>(
     func: &Function,
 ) -> fmt::Result {
     write!(w, "function ")?;
-    write_spec(w, func)?;
+    write_function_spec(w, func)?;
     writeln!(w, " {{")?;
     let aliases = alias_map(func);
     let mut any = func_w.write_preamble(w, func)?;
@@ -198,7 +198,8 @@ pub fn decorate_function<FW: FuncWriter>(
 //
 // Function spec.
 
-fn write_spec(w: &mut dyn Write, func: &Function) -> fmt::Result {
+/// Writes the spec (name and signature) of 'func' to 'w' as text.
+pub fn write_function_spec(w: &mut dyn Write, func: &Function) -> fmt::Result {
     write!(w, "{}{}", func.name, func.signature)
 }
 


### PR DESCRIPTION
Further logging improvements, this time to Cranelift.

Two changes:
1) Dump compilation start/end - this makes it much easier to Ctrl+F through the trace log when you have multiple functions being compiled.
2) Add a table with the results of value label assignment, both on the "input" (to RA, represented by the VRegs) side, and on the "output" side (represented by the physical location). This should make investigating issues related to live ranges much simpler.

Example of the table:
```
|Inst    |IP  |VL0     |VL1      |VL3      |VL4     |VL5     |VL7     |VL10     |VL11    |VL4294967294|    
|--------|----|--------|---------|---------|--------|--------|--------|---------|--------|------------|    
|Inst 0  |53  |    |   |    |    |    |    |    |   |    |   |    |   |    |    |    |   |    |       |    
|Inst 1  |53  |    |   |    |    |    |    |    |   |    |   |    |   |    |    |    |   |    |       |    
|Inst 2  |60  |v194|p2i|v232|p12i|    |    |    |   |    |   |    |   |    |    |    |   |v192|p7i    |    
|Inst 3  |64  |*   |p2i|*   |p12i|v231|p13i|    |   |    |   |    |   |    |    |    |   |*   |p7i    |    
|Inst 4  |68  |*   |p2i|*   |p12i|*   |p13i|    |   |    |   |    |   |    |    |    |   |*   |p7i    |    
|Inst 5  |72  |*   |p2i|*   |p12i|*   |p13i|    |   |    |   |    |   |    |    |    |   |*   |p7i    |    
|Inst 6  |76  |*   |p2i|*   |p12i|*   |p13i|    |   |    |   |    |   |    |    |    |   |*   |p7i    |    
|Inst 7  |87  |*   |   |*   |p12i|*   |p13i|    |   |    |   |    |   |    |    |    |   |*   |p7i    |    
|Inst 8  |92  |*   |   |*   |p12i|*   |p13i|v227|p0i|    |   |    |   |    |    |    |   |*   |p15i   |    
|Inst 9  |94  |*   |   |v204|    |v204|    |v204|   |v204|   |v204|   |v204|    |v204|   |*   |p15i   |    
|Inst 10 |100 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 11 |105 |*   |   |*   |    |*   |    |*   |   |v226|p9i|*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 12 |109 |*   |   |*   |    |*   |    |*   |   |*   |   |v225|p9i|*   |    |*   |   |*   |p15i   |    
|Inst 13 |114 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 14 |119 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 15 |125 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 16 |129 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |v223|p11i|*   |   |*   |p15i   |    
|Inst 17 |134 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 18 |134 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |   |*   |p15i   |    
|Inst 19 |139 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |v222|p0i|*   |p15i   |    
|Inst 20 |143 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |p0i|*   |p15i   |    
|Inst 21 |143 |*   |   |*   |    |*   |    |*   |   |*   |   |*   |   |*   |    |*   |p0i|*   |       |    
```
Related to #9716.