### PR TITLE
Update wasm spec test suite, add exception feature flags

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -382,7 +382,7 @@ wasmtime_option_group! {
         pub extended_const: Option<bool>,
         /// Configure support for the exceptions proposal.
         pub exceptions: Option<bool>,
-        /// Configure support for the legacy exceptions proposal.
+        /// DEPRECATED: Configure support for the legacy exceptions proposal.
         pub legacy_exceptions: Option<bool>,
     }
 
@@ -991,6 +991,7 @@ impl CommonOptions {
             config.wasm_exceptions(enable);
         }
         if let Some(enable) = self.wasm.legacy_exceptions.or(all) {
+            #[expect(deprecated, reason = "forwarding CLI flag")]
             config.wasm_legacy_exceptions(enable);
         }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -380,6 +380,10 @@ wasmtime_option_group! {
         pub wide_arithmetic: Option<bool>,
         /// Configure support for the extended-const proposal.
         pub extended_const: Option<bool>,
+        /// Configure support for the exceptions proposal.
+        pub exceptions: Option<bool>,
+        /// Configure support for the legacy exceptions proposal.
+        pub legacy_exceptions: Option<bool>,
     }
 
     enum Wasm {
@@ -982,6 +986,12 @@ impl CommonOptions {
         }
         if let Some(enable) = self.wasm.extended_const.or(all) {
             config.wasm_extended_const(enable);
+        }
+        if let Some(enable) = self.wasm.exceptions.or(all) {
+            config.wasm_exceptions(enable);
+        }
+        if let Some(enable) = self.wasm.legacy_exceptions.or(all) {
+            config.wasm_legacy_exceptions(enable);
         }
 
         macro_rules! handle_conditionally_compiled {

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1237,7 +1237,7 @@ pub fn translate_operator(
             translate_fcmp(FloatCC::LessThanOrEqual, builder, state)
         }
         Operator::RefNull { hty } => {
-            let hty = environ.convert_heap_type(*hty);
+            let hty = environ.convert_heap_type(*hty)?;
             state.push1(environ.translate_ref_null(builder.cursor(), hty)?)
         }
         Operator::RefIsNull => {
@@ -2748,7 +2748,7 @@ pub fn translate_operator(
         }
         Operator::RefTestNonNull { hty } => {
             let r = state.pop1();
-            let heap_type = environ.convert_heap_type(*hty);
+            let heap_type = environ.convert_heap_type(*hty)?;
             let result = environ.translate_ref_test(
                 builder,
                 WasmRefType {
@@ -2761,7 +2761,7 @@ pub fn translate_operator(
         }
         Operator::RefTestNullable { hty } => {
             let r = state.pop1();
-            let heap_type = environ.convert_heap_type(*hty);
+            let heap_type = environ.convert_heap_type(*hty)?;
             let result = environ.translate_ref_test(
                 builder,
                 WasmRefType {
@@ -2774,7 +2774,7 @@ pub fn translate_operator(
         }
         Operator::RefCastNonNull { hty } => {
             let r = state.pop1();
-            let heap_type = environ.convert_heap_type(*hty);
+            let heap_type = environ.convert_heap_type(*hty)?;
             let cast_okay = environ.translate_ref_test(
                 builder,
                 WasmRefType {
@@ -2788,7 +2788,7 @@ pub fn translate_operator(
         }
         Operator::RefCastNullable { hty } => {
             let r = state.pop1();
-            let heap_type = environ.convert_heap_type(*hty);
+            let heap_type = environ.convert_heap_type(*hty)?;
             let cast_okay = environ.translate_ref_test(
                 builder,
                 WasmRefType {
@@ -2809,7 +2809,7 @@ pub fn translate_operator(
         } => {
             let r = state.peek1();
 
-            let to_ref_type = environ.convert_ref_type(*to_ref_type);
+            let to_ref_type = environ.convert_ref_type(*to_ref_type)?;
             let cast_is_okay = environ.translate_ref_test(builder, to_ref_type, r)?;
 
             let (cast_succeeds_block, inputs) = translate_br_if_args(*relative_depth, state);
@@ -2842,7 +2842,7 @@ pub fn translate_operator(
         } => {
             let r = state.peek1();
 
-            let to_ref_type = environ.convert_ref_type(*to_ref_type);
+            let to_ref_type = environ.convert_ref_type(*to_ref_type)?;
             let cast_is_okay = environ.translate_ref_test(builder, to_ref_type, r)?;
 
             let (cast_fails_block, inputs) = translate_br_if_args(*relative_depth, state);

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -202,7 +202,7 @@ fn declare_locals(
             )
         }
         Ref(rt) => {
-            let hty = environ.convert_heap_type(rt.heap_type());
+            let hty = environ.convert_heap_type(rt.heap_type())?;
             let (ty, needs_stack_map) = environ.reference_type(hty);
             let init = if rt.is_nullable() {
                 Some(environ.translate_ref_null(builder.cursor(), hty)?)

--- a/crates/cranelift/src/translate/translation_utils.rs
+++ b/crates/cranelift/src/translate/translation_utils.rs
@@ -63,7 +63,7 @@ pub fn block_with_params<PE: TargetEnvironment + ?Sized>(
                 builder.append_block_param(block, ir::types::F64);
             }
             wasmparser::ValType::Ref(rt) => {
-                let hty = environ.convert_heap_type(rt.heap_type());
+                let hty = environ.convert_heap_type(rt.heap_type())?;
                 let (ty, needs_stack_map) = environ.reference_type(hty);
                 let val = builder.append_block_param(block, ty);
                 if needs_stack_map {

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -312,7 +312,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         }
                         TypeRef::Global(ty) => {
                             self.result.module.num_imported_globals += 1;
-                            EntityType::Global(self.convert_global_type(&ty))
+                            EntityType::Global(self.convert_global_type(&ty)?)
                         }
                         TypeRef::Table(ty) => {
                             self.result.module.num_imported_tables += 1;
@@ -408,7 +408,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     for f in escaped {
                         self.flag_func_escaped(f);
                     }
-                    let ty = self.convert_global_type(&ty);
+                    let ty = self.convert_global_type(&ty)?;
                     self.result.module.globals.push(ty);
                     self.result.module.global_initializers.push(initializer);
                 }
@@ -545,7 +545,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     let mut locals = Vec::new();
                     for pair in body.get_locals_reader()? {
                         let (cnt, ty) = pair?;
-                        let ty = self.convert_valtype(ty);
+                        let ty = self.convert_valtype(ty)?;
                         locals.push((cnt, ty));
                     }
                     self.result

--- a/crates/environ/src/compile/module_types.rs
+++ b/crates/environ/src/compile/module_types.rs
@@ -114,7 +114,7 @@ impl ModuleTypesBuilder {
                 unreachable!("no need to lookup indexes; we already have core type IDs")
             })
             .with_rec_group(validator_types, rec_group_id)
-            .convert_sub_type(ty);
+            .convert_sub_type(ty)?;
             self.wasm_sub_type_in_rec_group(id, wasm_ty);
         }
 

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -540,7 +540,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                 for ty in s {
                     match ty? {
                         wasmparser::ComponentType::Resource { rep, dtor } => {
-                            let rep = self.types.convert_valtype(rep);
+                            let rep = self.types.convert_valtype(rep)?;
                             let id = types
                                 .component_any_type_at(component_type_index)
                                 .unwrap_resource();

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -382,7 +382,7 @@ impl ComponentTypesBuilder {
             }),
             Table(ty) => EntityType::Table(self.convert_table_type(ty)?),
             Memory(ty) => EntityType::Memory((*ty).into()),
-            Global(ty) => EntityType::Global(self.convert_global_type(ty)),
+            Global(ty) => EntityType::Global(self.convert_global_type(ty)?),
             Tag(_) => bail!("exceptions proposal not implemented"),
         })
     }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -142,6 +142,8 @@ impl Config {
             component_model_async_builtins,
             component_model_async_stackful,
             simd,
+            exceptions,
+            legacy_exceptions,
 
             hogs_memory: _,
             nan_canonicalization: _,
@@ -157,6 +159,7 @@ impl Config {
             component_model_async_builtins.unwrap_or(false);
         self.module_config.component_model_async_stackful =
             component_model_async_stackful.unwrap_or(false);
+        self.module_config.legacy_exceptions = legacy_exceptions.unwrap_or(false);
 
         // Enable/disable proposals that wasm-smith has knobs for which will be
         // read when creating `wasmtime::Config`.
@@ -175,6 +178,7 @@ impl Config {
             || self.module_config.function_references_enabled
             || reference_types.unwrap_or(false);
         config.extended_const_enabled = extended_const.unwrap_or(false);
+        config.exceptions_enabled = exceptions.unwrap_or(false);
         if multi_memory.unwrap_or(false) {
             config.max_memories = limits::MEMORIES_PER_MODULE as usize;
         } else {
@@ -294,6 +298,8 @@ impl Config {
         cfg.wasm.tail_call = Some(self.module_config.config.tail_call_enabled);
         cfg.wasm.threads = Some(self.module_config.config.threads_enabled);
         cfg.wasm.wide_arithmetic = Some(self.module_config.config.wide_arithmetic_enabled);
+        cfg.wasm.exceptions = Some(self.module_config.config.exceptions_enabled);
+        cfg.wasm.legacy_exceptions = Some(self.module_config.legacy_exceptions);
         if !self.module_config.config.simd_enabled {
             cfg.wasm.relaxed_simd = Some(false);
         }

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -18,6 +18,7 @@ pub struct ModuleConfig {
     pub component_model_async: bool,
     pub component_model_async_builtins: bool,
     pub component_model_async_stackful: bool,
+    pub legacy_exceptions: bool,
 }
 
 impl<'a> Arbitrary<'a> for ModuleConfig {
@@ -66,6 +67,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
             component_model_async: false,
             component_model_async_builtins: false,
             component_model_async_stackful: false,
+            legacy_exceptions: false,
             function_references_enabled: config.gc_enabled,
             config,
         })

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -92,6 +92,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         .wasm_component_model_async_builtins(component_model_async_builtins)
         .wasm_component_model_async_stackful(component_model_async_stackful)
         .wasm_exceptions(exceptions)
-        .wasm_legacy_exceptions(legacy_exceptions)
         .cranelift_nan_canonicalization(nan_canonicalization);
+    #[expect(deprecated, reason = "forwarding legacy-exceptions")]
+    config.wasm_legacy_exceptions(legacy_exceptions);
 }

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -41,6 +41,8 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         component_model_async_stackful,
         nan_canonicalization,
         simd,
+        exceptions,
+        legacy_exceptions,
 
         hogs_memory: _,
         gc_types: _,
@@ -61,6 +63,8 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let component_model_async_stackful = component_model_async_stackful.unwrap_or(false);
     let nan_canonicalization = nan_canonicalization.unwrap_or(false);
     let relaxed_simd = relaxed_simd.unwrap_or(false);
+    let exceptions = exceptions.unwrap_or(false);
+    let legacy_exceptions = legacy_exceptions.unwrap_or(false);
 
     // Some proposals in wasm depend on previous proposals. For example the gc
     // proposal depends on function-references which depends on reference-types.
@@ -87,5 +91,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         .wasm_component_model_async(component_model_async)
         .wasm_component_model_async_builtins(component_model_async_builtins)
         .wasm_component_model_async_stackful(component_model_async_stackful)
+        .wasm_exceptions(exceptions)
+        .wasm_legacy_exceptions(legacy_exceptions)
         .cranelift_nan_canonicalization(nan_canonicalization);
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1152,6 +1152,9 @@ impl Config {
     }
 
     #[doc(hidden)] // FIXME(#3427) - if/when implemented then un-hide this
+    #[deprecated = "This configuration option only exists for internal \
+                    usage with the spec testsuite. It may be removed at \
+                    any time and without warning. Do not rely on it!"]
     pub fn wasm_legacy_exceptions(&mut self, enable: bool) -> &mut Self {
         self.wasm_feature(WasmFeatures::LEGACY_EXCEPTIONS, enable);
         self

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -194,6 +194,7 @@ struct WasmFeatures {
     threads: bool,
     multi_memory: bool,
     exceptions: bool,
+    legacy_exceptions: bool,
     memory64: bool,
     relaxed_simd: bool,
     extended_const: bool,
@@ -253,7 +254,6 @@ impl Metadata<'_> {
         assert!(!cm_nested_names);
         assert!(!cm_values);
         assert!(!shared_everything_threads);
-        assert!(!legacy_exceptions);
 
         Metadata {
             target: engine.compiler().triple().to_string(),
@@ -270,6 +270,7 @@ impl Metadata<'_> {
                 tail_call,
                 multi_memory,
                 exceptions,
+                legacy_exceptions,
                 memory64,
                 relaxed_simd,
                 extended_const,
@@ -482,6 +483,7 @@ impl Metadata<'_> {
             threads,
             multi_memory,
             exceptions,
+            legacy_exceptions,
             memory64,
             relaxed_simd,
             extended_const,
@@ -547,6 +549,11 @@ impl Metadata<'_> {
             exceptions,
             other.contains(F::EXCEPTIONS),
             "WebAssembly exceptions support",
+        )?;
+        Self::check_bool(
+            legacy_exceptions,
+            other.contains(F::LEGACY_EXCEPTIONS),
+            "WebAssembly legacy exceptions support",
         )?;
         Self::check_bool(
             memory64,

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -12,7 +12,7 @@ fn wasm_export_tags() -> Result<()> {
         "#;
     let _ = env_logger::try_init();
     let mut config = Config::new();
-    config.wasm_stack_switching(true);
+    config.wasm_exceptions(true).wasm_stack_switching(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
     let module = Module::new(&engine, source)?;
@@ -61,7 +61,7 @@ fn wasm_import_tags() -> Result<()> {
         "#;
     let _ = env_logger::try_init();
     let mut config = Config::new();
-    config.wasm_stack_switching(true);
+    config.wasm_exceptions(true).wasm_stack_switching(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
     let m1 = Module::new(&engine, m1_src)?;

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -60,7 +60,7 @@ impl DefinedLocals {
             let ty = reader.read()?;
             validator.define_locals(position, count, ty)?;
 
-            let ty = types.convert_valtype(ty);
+            let ty = types.convert_valtype(ty)?;
             for _ in 0..count {
                 let ty_size = <A as ABI>::sizeof(&ty);
                 next_stack = align_to(next_stack, ty_size as u32) + (ty_size as u32);

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1917,7 +1917,7 @@ where
 
     fn visit_if(&mut self, blockty: BlockType) -> Self::Output {
         self.control_frames.push(ControlStackFrame::r#if(
-            self.env.resolve_block_sig(blockty),
+            self.env.resolve_block_sig(blockty)?,
             self.masm,
             &mut self.context,
         )?);
@@ -1939,7 +1939,7 @@ where
 
     fn visit_block(&mut self, blockty: BlockType) -> Self::Output {
         self.control_frames.push(ControlStackFrame::block(
-            self.env.resolve_block_sig(blockty),
+            self.env.resolve_block_sig(blockty)?,
             self.masm,
             &mut self.context,
         )?);
@@ -1949,7 +1949,7 @@ where
 
     fn visit_loop(&mut self, blockty: BlockType) -> Self::Output {
         self.control_frames.push(ControlStackFrame::r#loop(
-            self.env.resolve_block_sig(blockty),
+            self.env.resolve_block_sig(blockty)?,
             self.masm,
             &mut self.context,
         )?);


### PR DESCRIPTION
This commit performs an update of the spec test suite submodule to the next-to-latest commit. The latest commit will require updating the `wast` dependency which isn't published yet.

This update brings in the `wasm-3.0` folder of tests since it's been awhile since the last update. That update notably means that the exception-handling proposal is mixed in with all the others with various tests. Getting tests as flagged as passing or failing as a result was unexpectedly difficult.

The solution I ended up settling on was to preemptively implement some infrastructure for the exceptions proposal:

* `wasmtime::Config` methods
* `wasmtime` CLI flags
* integration with wast testing
* various updates to `should_fail`

It turns out we can run a few tests with the exception proposal, notably due to tags being implemented for stack switching. That meant that this couldn't blanket ignore the exceptions proposal and say it's expected to fail. Instead the proposal is said "this passes!" and tests are individually listed as "this is expected to fail".

This then required changing an `unsupported!` panic to plumbing errors around to avoid actually implementing the exceptions proposal here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
