### PR TITLE
Cranelift/Wasmtime: disable fastalloc (single-pass) allocator for now.

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -38,10 +38,12 @@ pub(crate) fn define() -> SettingGroup {
 
             - `backtracking`: A backtracking allocator with range splitting; more expensive
                               but generates better code.
-            - `single_pass`: A single-pass algorithm that yields quick compilation but
-                             results in code with more register spills and moves.
+
+            Note that the `single_pass` option is currently disabled because it does not
+            have adequate support for the kinds of allocations required by exception
+            handling (https://github.com/bytecodealliance/regalloc2/issues/217).
         "#,
-        vec!["backtracking", "single_pass"],
+        vec!["backtracking"],
     );
 
     settings.add_enum(

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -66,7 +66,8 @@ pub fn compile<B: LowerBackend + TargetIsa>(
 
         options.algorithm = match b.flags().regalloc_algorithm() {
             RegallocAlgorithm::Backtracking => Algorithm::Ion,
-            RegallocAlgorithm::SinglePass => Algorithm::Fastalloc,
+            // Note: single-pass is currently disabled
+            // (https://github.com/bytecodealliance/regalloc2/issues/217).
         };
 
         regalloc2::run(&vcode, vcode.machine_env(), &options)

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1071,7 +1071,6 @@ mod tests {
         // Regalloc algorithm
         for (regalloc_value, expected) in [
             ("\"backtracking\"", Some(RegallocAlgorithm::Backtracking)),
-            ("\"single-pass\"", Some(RegallocAlgorithm::SinglePass)),
             ("\"hello\"", None), // should fail
             ("3", None),         // should fail
             ("true", None),      // should fail

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -486,7 +486,6 @@ impl WasmtimeOptionValue for wasmtime::RegallocAlgorithm {
     fn parse(val: Option<&str>) -> Result<Self> {
         match String::parse(val)?.as_str() {
             "backtracking" => Ok(wasmtime::RegallocAlgorithm::Backtracking),
-            "single-pass" => Ok(wasmtime::RegallocAlgorithm::SinglePass),
             other => bail!(
                 "unknown regalloc algorithm`{}`, only backtracking,single-pass accepted",
                 other
@@ -497,7 +496,6 @@ impl WasmtimeOptionValue for wasmtime::RegallocAlgorithm {
     fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             wasmtime::RegallocAlgorithm::Backtracking => f.write_str("backtracking"),
-            wasmtime::RegallocAlgorithm::SinglePass => f.write_str("single-pass"),
             _ => unreachable!(),
         }
     }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -847,7 +847,13 @@ impl RegallocAlgorithm {
     fn to_wasmtime(&self) -> wasmtime::RegallocAlgorithm {
         match self {
             RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
-            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::SinglePass,
+            // Note: we have disabled `single_pass` for now because of
+            // its limitations w.r.t. exception handling
+            // (https://github.com/bytecodealliance/regalloc2/issues/217). To
+            // avoid breaking all existing fuzzbugs by changing the
+            // `arbitrary` mappings, we keep the `RegallocAlgorithm`
+            // enum as it is and remap here to `Backtracking`.
+            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::Backtracking,
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -279,10 +279,9 @@ impl Config {
 
             // When running under MIRI try to optimize for compile time of wasm
             // code itself as much as possible. Disable optimizations by
-            // default and use the fastest regalloc available to us.
+            // default.
             if cfg!(miri) {
                 ret.cranelift_opt_level(OptLevel::None);
-                ret.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
             }
         }
 
@@ -1246,7 +1245,6 @@ impl Config {
     pub fn cranelift_regalloc_algorithm(&mut self, algo: RegallocAlgorithm) -> &mut Self {
         let val = match algo {
             RegallocAlgorithm::Backtracking => "backtracking",
-            RegallocAlgorithm::SinglePass => "single_pass",
         };
         self.compiler_config
             .settings
@@ -2830,16 +2828,6 @@ pub enum RegallocAlgorithm {
     /// results in better register utilization, producing fewer spills
     /// and moves, but can cause super-linear compile runtime.
     Backtracking,
-    /// Generates acceptable code very quickly.
-    ///
-    /// This algorithm performs a single pass through the code,
-    /// guaranteed to work in linear time.  (Note that the rest of
-    /// Cranelift is not necessarily guaranteed to run in linear time,
-    /// however.) It cannot undo earlier decisions, however, and it
-    /// cannot foresee constraints or issues that may occur further
-    /// ahead in the code, so the code may have more spills and moves as
-    /// a result.
-    SinglePass,
 }
 
 /// Select which profiling technique to support.

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2200,14 +2200,10 @@ fn config_cli_flag() -> Result<()> {
         br#"
         [optimize]
         opt-level = 2
-        regalloc-algorithm = "single-pass"
         signals-based-traps = false
 
         [codegen]
         collector = "null"
-
-        [debug]
-        debug-info = true
 
         [wasm]
         max-wasm-stack = 65536

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -147,7 +147,6 @@ fn big_stack_works_ok(config: &mut Config) -> Result<()> {
     // Disable cranelift optimizations to ensure that this test doesn't take too
     // long in debug mode due to the large size of its code.
     config.cranelift_opt_level(OptLevel::None);
-    config.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
     let engine = Engine::new(config)?;
 
     let mut store = Store::new(&engine, ());


### PR DESCRIPTION
Unfortunately, as discovered by a recent fuzzbug [1], the single-pass register allocator is not compatible with the approach to callsite defs that exception-handling support has forced us to take. In particular, we needed to move all call return-value defs onto the call instruction itself, so calls could be terminators; this unbounded number of defs is made to be a solvable allocation problem by using `any` constraints, which allow allocation directly into spillslots; but fastalloc appears to error out if it runs out of registers, regardless of this constraint.

Long-term, we should fix this, but unfortunately I don't have cycles to dive into fastalloc's internals at the moment, and it's (I think) a tier-3 feature. As such, this PR disables its use for now. I've filed a tracking issue in RA2 [2], and referenced this in the Cranelift configuration option docs at least.

To keep from shifting all fuzzbugs / fuzzing corpii by altering the `arbitrary` interpretation, I opted to keep the enum the same in the fuzzing crate, and remap `SinglePass` to `Backtracking` there. I'm happy to take the other approach and remove the option (thus invalidating all fuzzbugs) if we'd prefer that instead.

[1]: https://oss-fuzz.com/testcase-detail/5433312476987392
[2]: https://github.com/bytecodealliance/regalloc2/issues/217

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
