### PR TITLE
s390x: Add try_call / try_call_indirect support

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -906,8 +906,8 @@ impl ABIMachineSpec for S390xMachineDeps {
         call_conv_of_callee: isa::CallConv,
         is_exception: bool,
     ) -> PRegSet {
-        assert!(!is_exception);
         match call_conv_of_callee {
+            _ if is_exception => ALL_CLOBBERS,
             isa::CallConv::Tail => TAIL_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
@@ -1008,6 +1008,14 @@ impl ABIMachineSpec for S390xMachineDeps {
 
     fn retval_temp_reg(_call_conv_of_callee: isa::CallConv) -> Writable<Reg> {
         panic!("Should not be called");
+    }
+
+    fn exception_payload_regs(call_conv: isa::CallConv) -> &'static [Reg] {
+        const PAYLOAD_REGS: &'static [Reg] = &[gpr(6), gpr(7)];
+        match call_conv {
+            isa::CallConv::SystemV | isa::CallConv::Tail => PAYLOAD_REGS,
+            _ => &[],
+        }
     }
 }
 
@@ -1377,6 +1385,59 @@ const fn tail_clobbers() -> PRegSet {
         .with(vr_preg(31))
 }
 const TAIL_CLOBBERS: PRegSet = tail_clobbers();
+
+const fn all_clobbers() -> PRegSet {
+    PRegSet::empty()
+        .with(gpr_preg(0))
+        .with(gpr_preg(1))
+        .with(gpr_preg(2))
+        .with(gpr_preg(3))
+        .with(gpr_preg(4))
+        .with(gpr_preg(5))
+        .with(gpr_preg(6))
+        .with(gpr_preg(7))
+        .with(gpr_preg(8))
+        .with(gpr_preg(9))
+        .with(gpr_preg(10))
+        .with(gpr_preg(11))
+        .with(gpr_preg(12))
+        .with(gpr_preg(13))
+        .with(gpr_preg(14))
+        .with(gpr_preg(15))
+        .with(vr_preg(0))
+        .with(vr_preg(1))
+        .with(vr_preg(2))
+        .with(vr_preg(3))
+        .with(vr_preg(4))
+        .with(vr_preg(5))
+        .with(vr_preg(6))
+        .with(vr_preg(7))
+        .with(vr_preg(8))
+        .with(vr_preg(9))
+        .with(vr_preg(10))
+        .with(vr_preg(11))
+        .with(vr_preg(12))
+        .with(vr_preg(13))
+        .with(vr_preg(14))
+        .with(vr_preg(15))
+        .with(vr_preg(16))
+        .with(vr_preg(17))
+        .with(vr_preg(18))
+        .with(vr_preg(19))
+        .with(vr_preg(20))
+        .with(vr_preg(21))
+        .with(vr_preg(22))
+        .with(vr_preg(23))
+        .with(vr_preg(24))
+        .with(vr_preg(25))
+        .with(vr_preg(26))
+        .with(vr_preg(27))
+        .with(vr_preg(28))
+        .with(vr_preg(29))
+        .with(vr_preg(30))
+        .with(vr_preg(31))
+}
+const ALL_CLOBBERS: PRegSet = all_clobbers();
 
 fn sysv_create_machine_env() -> MachineEnv {
     MachineEnv {

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -2669,10 +2669,9 @@
         dst))
 
 ;; Helper for emitting `MInst.Call` instructions.
-(decl call_impl (WritableReg CallSiteInfo) InstOutput)
-(rule (call_impl reg (call_site_info info output))
-      (let ((_ Unit (emit (MInst.Call reg info))))
-        output))
+(decl call_impl (WritableReg BoxCallInfo) SideEffectNoResult)
+(rule (call_impl reg info)
+      (SideEffectNoResult.Inst (MInst.Call reg info)))
 
 ;; Helper for emitting `MInst.ReturnCall` instructions.
 (decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
@@ -3478,6 +3477,9 @@
 (decl abi_call_site_info (Sig CallInstDest CallArgList) CallSiteInfo)
 (extern constructor abi_call_site_info abi_call_site_info)
 
+(decl abi_try_call_info (Sig CallInstDest CallArgList ExceptionTable MachLabelSlice) BoxCallInfo)
+(extern constructor abi_try_call_info abi_try_call_info)
+
 (decl abi_return_call_info (Sig CallInstDest CallArgList) BoxReturnCallInfo)
 (extern constructor abi_return_call_info abi_return_call_info)
 
@@ -3495,12 +3497,19 @@
 
 (decl abi_call (Sig CallInstDest CallArgList) InstOutput)
 (rule (abi_call abi dest uses)
-      (let ((info CallSiteInfo (abi_call_site_info abi dest uses)))
-        (call_impl (writable_link_reg) info)))
+      (abi_call_impl (abi_call_site_info abi dest uses)))
+(decl abi_call_impl (CallSiteInfo) InstOutput)
+(rule (abi_call_impl (call_site_info info output))
+      (let ((_ Unit (emit_side_effect (call_impl (writable_link_reg) info))))
+        output))
 
 (decl abi_return_call (Sig CallInstDest CallArgList) SideEffectNoResult)
 (rule (abi_return_call abi dest uses)
       (return_call_impl (abi_return_call_info abi dest uses)))
+
+(decl abi_try_call (Sig CallInstDest CallArgList ExceptionTable MachLabelSlice) SideEffectNoResult)
+(rule (abi_try_call abi dest uses et targets)
+      (call_impl (writable_link_reg) (abi_try_call_info abi dest uses et targets)))
 
 (decl abi_lane_order (Sig) LaneOrder)
 (extern constructor abi_lane_order abi_lane_order)

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -10,8 +10,8 @@ use crate::machinst::*;
 // Registers, the Universe thereof, and printing
 
 /// Get a reference to a GPR (integer register).
-pub fn gpr(num: u8) -> Reg {
-    Reg::from(gpr_preg(num))
+pub const fn gpr(num: u8) -> Reg {
+    Reg::from_real_reg(gpr_preg(num))
 }
 
 pub(crate) const fn gpr_preg(num: u8) -> PReg {
@@ -25,8 +25,8 @@ pub fn writable_gpr(num: u8) -> Writable<Reg> {
 }
 
 /// Get a reference to a VR (vector register).
-pub fn vr(num: u8) -> Reg {
-    Reg::from(vr_preg(num))
+pub const fn vr(num: u8) -> Reg {
+    Reg::from_real_reg(vr_preg(num))
 }
 
 pub(crate) const fn vr_preg(num: u8) -> PReg {

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3926,6 +3926,30 @@
         (args_builder_finish uses)))
 
 
+;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Direct call to an in-range function.
+(rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
+        (emit_side_effect (abi_try_call abi (CallInstDest.Direct name) uses et targets))))
+
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower_branch (try_call (func_ref_data sig_ref name _) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args))
+            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0))))
+        (emit_side_effect (abi_try_call abi (CallInstDest.Indirect target) uses et targets))))
+
+;; Indirect call.
+(rule (lower_branch (try_call_indirect ptr args et) targets)
+      (if-let (exception_sig sig_ref) et)
+      (let ((abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
+        (emit_side_effect (abi_try_call abi (CallInstDest.Indirect target) uses et targets))))
+
+
 ;;;; Common helpers for argument lowering ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Lower function arguments (part 1): prepare buffer copies.

--- a/cranelift/filetests/filetests/isa/s390x/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/exceptions.clif
@@ -1,0 +1,239 @@
+test compile precise-output
+target s390x
+
+function %f0(i32) -> i32, f32, f64 {
+    sig0 = (i32) -> f32 tail
+    fn0 = colocated %g(i32) -> f32 tail
+
+    block0(v1: i32):
+        v2 = f64const 0x1.0
+        try_call fn0(v1), sig0, block1(ret0, v2), [ default: block2(exn0) ]
+
+    block1(v3: f32, v4: f64):
+        v5 = iconst.i32 1
+        return v5, v3, v4
+
+    block2(v6: i64):
+        v7 = ireduce.i32 v6
+        v8 = iadd_imm.i32 v7, 1
+        v9 = f32const 0x0.0        
+        return v8, v9, v2
+}
+
+; VCode:
+;   stmg %r6, %r15, 48(%r15)
+;   aghi %r15, -240
+;   std %f8, 176(%r15)
+;   std %f9, 184(%r15)
+;   std %f10, 192(%r15)
+;   std %f11, 200(%r15)
+;   std %f12, 208(%r15)
+;   std %f13, 216(%r15)
+;   std %f14, 224(%r15)
+;   std %f15, 232(%r15)
+; block0:
+;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
+;   vst %v2, 160(%r15)
+;   brasl %r14, %g; jg MachLabel(1); catch [None: MachLabel(2)]
+; block1:
+;   lhi %r2, 1
+;   vl %v2, 160(%r15)
+;   ld %f8, 176(%r15)
+;   ld %f9, 184(%r15)
+;   ld %f10, 192(%r15)
+;   ld %f11, 200(%r15)
+;   ld %f12, 208(%r15)
+;   ld %f13, 216(%r15)
+;   ld %f14, 224(%r15)
+;   ld %f15, 232(%r15)
+;   lmg %r6, %r15, 288(%r15)
+;   br %r14
+; block2:
+;   vl %v2, 160(%r15)
+;   ahik %r2, %r6, 1
+;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   ld %f8, 176(%r15)
+;   ld %f9, 184(%r15)
+;   ld %f10, 192(%r15)
+;   ld %f11, 200(%r15)
+;   ld %f12, 208(%r15)
+;   ld %f13, 216(%r15)
+;   ld %f14, 224(%r15)
+;   ld %f15, 232(%r15)
+;   lmg %r6, %r15, 288(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r6, %r15, 0x30(%r15)
+;   aghi %r15, -0xf0
+;   std %f8, 0xb0(%r15)
+;   std %f9, 0xb8(%r15)
+;   std %f10, 0xc0(%r15)
+;   std %f11, 0xc8(%r15)
+;   std %f12, 0xd0(%r15)
+;   std %f13, 0xd8(%r15)
+;   std %f14, 0xe0(%r15)
+;   std %f15, 0xe8(%r15)
+; block1: ; offset 0x2a
+;   bras %r1, 0x36
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f2, 0(%r1)
+;   vst %v2, 0xa0(%r15)
+;   brasl %r14, 0x40 ; reloc_external PLTRel32Dbl %g 2
+; block2: ; offset 0x46
+;   lhi %r2, 1
+;   vl %v2, 0xa0(%r15)
+;   ld %f8, 0xb0(%r15)
+;   ld %f9, 0xb8(%r15)
+;   ld %f10, 0xc0(%r15)
+;   ld %f11, 0xc8(%r15)
+;   ld %f12, 0xd0(%r15)
+;   ld %f13, 0xd8(%r15)
+;   ld %f14, 0xe0(%r15)
+;   ld %f15, 0xe8(%r15)
+;   lmg %r6, %r15, 0x120(%r15)
+;   br %r14
+; block3: ; offset 0x78
+;   vl %v2, 0xa0(%r15)
+;   ahik %r2, %r6, 1
+;   bras %r1, 0x8c
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   le %f0, 0(%r1)
+;   ld %f8, 0xb0(%r15)
+;   ld %f9, 0xb8(%r15)
+;   ld %f10, 0xc0(%r15)
+;   ld %f11, 0xc8(%r15)
+;   ld %f12, 0xd0(%r15)
+;   ld %f13, 0xd8(%r15)
+;   ld %f14, 0xe0(%r15)
+;   ld %f15, 0xe8(%r15)
+;   lmg %r6, %r15, 0x120(%r15)
+;   br %r14
+
+function %f2(i32) -> i32, f32, f64 {
+    sig0 = (i32) -> f32 tail
+    fn0 = %g(i32) -> f32 tail
+
+    block0(v1: i32):
+        v2 = f64const 0x1.0
+        v10 = func_addr.i64 fn0
+        try_call_indirect v10(v1), sig0, block1(ret0, v2), [ default: block2(exn0) ]
+
+    block1(v3: f32, v4: f64):
+        v5 = iconst.i32 1
+        return v5, v3, v4
+
+    block2(v6: i64):
+        v7 = ireduce.i32 v6
+        v8 = iadd_imm.i32 v7, 1
+        v9 = f32const 0x0.0        
+        return v8, v9, v2
+}
+
+; VCode:
+;   stmg %r6, %r15, 48(%r15)
+;   aghi %r15, -240
+;   std %f8, 176(%r15)
+;   std %f9, 184(%r15)
+;   std %f10, 192(%r15)
+;   std %f11, 200(%r15)
+;   std %f12, 208(%r15)
+;   std %f13, 216(%r15)
+;   std %f14, 224(%r15)
+;   std %f15, 232(%r15)
+; block0:
+;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
+;   vst %v2, 160(%r15)
+;   bras %r1, 12 ; data %g + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5; jg MachLabel(1); catch [None: MachLabel(2)]
+; block1:
+;   lhi %r2, 1
+;   vl %v2, 160(%r15)
+;   ld %f8, 176(%r15)
+;   ld %f9, 184(%r15)
+;   ld %f10, 192(%r15)
+;   ld %f11, 200(%r15)
+;   ld %f12, 208(%r15)
+;   ld %f13, 216(%r15)
+;   ld %f14, 224(%r15)
+;   ld %f15, 232(%r15)
+;   lmg %r6, %r15, 288(%r15)
+;   br %r14
+; block2:
+;   vl %v2, 160(%r15)
+;   ahik %r2, %r6, 1
+;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   ld %f8, 176(%r15)
+;   ld %f9, 184(%r15)
+;   ld %f10, 192(%r15)
+;   ld %f11, 200(%r15)
+;   ld %f12, 208(%r15)
+;   ld %f13, 216(%r15)
+;   ld %f14, 224(%r15)
+;   ld %f15, 232(%r15)
+;   lmg %r6, %r15, 288(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r6, %r15, 0x30(%r15)
+;   aghi %r15, -0xf0
+;   std %f8, 0xb0(%r15)
+;   std %f9, 0xb8(%r15)
+;   std %f10, 0xc0(%r15)
+;   std %f11, 0xc8(%r15)
+;   std %f12, 0xd0(%r15)
+;   std %f13, 0xd8(%r15)
+;   std %f14, 0xe0(%r15)
+;   std %f15, 0xe8(%r15)
+; block1: ; offset 0x2a
+;   bras %r1, 0x36
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f2, 0(%r1)
+;   vst %v2, 0xa0(%r15)
+;   bras %r1, 0x4c
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
+; block2: ; offset 0x54
+;   lhi %r2, 1
+;   vl %v2, 0xa0(%r15)
+;   ld %f8, 0xb0(%r15)
+;   ld %f9, 0xb8(%r15)
+;   ld %f10, 0xc0(%r15)
+;   ld %f11, 0xc8(%r15)
+;   ld %f12, 0xd0(%r15)
+;   ld %f13, 0xd8(%r15)
+;   ld %f14, 0xe0(%r15)
+;   ld %f15, 0xe8(%r15)
+;   lmg %r6, %r15, 0x120(%r15)
+;   br %r14
+; block3: ; offset 0x86
+;   vl %v2, 0xa0(%r15)
+;   ahik %r2, %r6, 1
+;   bras %r1, 0x9a
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   le %f0, 0(%r1)
+;   ld %f8, 0xb0(%r15)
+;   ld %f9, 0xb8(%r15)
+;   ld %f10, 0xc0(%r15)
+;   ld %f11, 0xc8(%r15)
+;   ld %f12, 0xd0(%r15)
+;   ld %f13, 0xd8(%r15)
+;   ld %f14, 0xe0(%r15)
+;   ld %f15, 0xe8(%r15)
+;   lmg %r6, %r15, 0x120(%r15)
+;   br %r14
+


### PR DESCRIPTION
Following-up on https://github.com/bytecodealliance/wasmtime/pull/10510 this adds the corresponding support to the s390x target.

Due to the separate ABI implementation, this currently needs to duplicate some of the underlying logic.  I hope to be able to refactor ABI handling in the future to be able to share more of that code across all targets.

FYI @cfallin 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
