### PR TITLE
Enable the `unsafe-op-in-unsafe-fn` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ rust-2024-prelude-collisions = 'warn'
 rust-2024-incompatible-pat = 'warn'
 missing-unsafe-on-extern = 'warn'
 impl-trait-overcaptures = 'warn'
+unsafe-op-in-unsafe-fn = 'warn'
 
 # Don't warn about unknown cfgs for pulley
 [workspace.lints.rust.unexpected_cfgs]

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -231,13 +231,13 @@ impl DataValue {
     /// Write a [DataValue] to a memory location in native-endian byte order.
     pub unsafe fn write_value_to(&self, p: *mut u128) {
         let size = self.ty().bytes() as usize;
-        self.write_to_slice_ne(std::slice::from_raw_parts_mut(p as *mut u8, size));
+        self.write_to_slice_ne(unsafe { std::slice::from_raw_parts_mut(p as *mut u8, size) });
     }
 
     /// Read a [DataValue] from a memory location using a given [Type] in native-endian byte order.
     pub unsafe fn read_value_from(p: *const u128, ty: Type) -> Self {
         DataValue::read_from_slice_ne(
-            std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
+            unsafe { std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize) },
             ty,
         )
     }

--- a/cranelift/entity/src/boxed_slice.rs
+++ b/cranelift/entity/src/boxed_slice.rs
@@ -33,7 +33,7 @@ where
     /// This relies on `raw` pointing to a valid slice of `V`s.
     pub unsafe fn from_raw(raw: *mut [V]) -> Self {
         Self {
-            elems: Box::from_raw(raw),
+            elems: unsafe { Box::from_raw(raw) },
             unused: PhantomData,
         }
     }

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -394,14 +394,16 @@ impl<'a> Trampoline<'a> {
             | Architecture::Pulley32be
             | Architecture::Pulley64be => {
                 let mut state = pulley::Vm::new();
-                state.call(
-                    NonNull::new(trampoline_ptr.cast_mut()).unwrap(),
-                    &[
-                        pulley::XRegVal::new_ptr(function_ptr.cast_mut()).into(),
-                        pulley::XRegVal::new_ptr(arguments_address).into(),
-                    ],
-                    [],
-                );
+                unsafe {
+                    state.call(
+                        NonNull::new(trampoline_ptr.cast_mut()).unwrap(),
+                        &[
+                            pulley::XRegVal::new_ptr(function_ptr.cast_mut()).into(),
+                            pulley::XRegVal::new_ptr(arguments_address).into(),
+                        ],
+                        [],
+                    );
+                }
             }
 
             // Other targets natively execute this machine code.

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -4,6 +4,7 @@
 //! which shows how to use some of the features of `cranelift_jit`.
 
 #![deny(missing_docs, unreachable_pub)]
+#![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]
 
 mod backend;
 mod compiled_blob;

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -13,6 +13,7 @@
 //! specific to Wasmtime and has fewer gymnastics to implement.
 
 #![expect(non_camel_case_types, reason = "matching C style, not Rust")]
+#![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]
 
 pub use wasmtime;
 

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -103,7 +103,7 @@ impl<'a> StackMap<'a> {
     /// map is associated with.
     pub unsafe fn sp(&self, fp: *mut usize) -> *mut usize {
         let frame_size = usize::try_from(self.frame_size).unwrap();
-        fp.byte_sub(frame_size)
+        unsafe { fp.byte_sub(frame_size) }
     }
 
     /// Given the stack pointer, get a reference to each live GC reference in
@@ -117,7 +117,7 @@ impl<'a> StackMap<'a> {
         self.offsets().map(move |i| {
             log::trace!("Live GC ref in frame at frame offset {:#x}", i);
             let i = usize::try_from(i).unwrap();
-            let ptr_to_gc_ref = sp.byte_add(i);
+            let ptr_to_gc_ref = unsafe { sp.byte_add(i) };
 
             // Assert that the pointer is inside this stack map's frame.
             assert!({

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -70,9 +70,9 @@ impl FiberStack {
     /// The caller must properly allocate the stack space with a guard page and
     /// make the pages accessible for correct behavior.
     pub unsafe fn from_raw_parts(bottom: *mut u8, guard_size: usize, len: usize) -> Result<Self> {
-        Ok(Self(imp::FiberStack::from_raw_parts(
-            bottom, guard_size, len,
-        )?))
+        Ok(Self(unsafe {
+            imp::FiberStack::from_raw_parts(bottom, guard_size, len)?
+        }))
     }
 
     /// Gets the top of the stack.

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -374,15 +374,19 @@ mod asan {
         // trigger false positives in ASAN. That leads to the design of this
         // module as-is where this function exists to have these three
         // functions very close to one another.
-        __sanitizer_start_switch_fiber(private_asan_pointer_ref, prev.bottom, prev.size);
-        super::wasmtime_fiber_switch(top_of_stack);
-        __sanitizer_finish_switch_fiber(private_asan_pointer, &mut prev.bottom, &mut prev.size);
+        unsafe {
+            __sanitizer_start_switch_fiber(private_asan_pointer_ref, prev.bottom, prev.size);
+            super::wasmtime_fiber_switch(top_of_stack);
+            __sanitizer_finish_switch_fiber(private_asan_pointer, &mut prev.bottom, &mut prev.size);
+        }
     }
 
     /// Hook for when a fiber first starts, used to configure ASAN.
     pub unsafe fn fiber_start_complete() -> PreviousStack {
         let mut ret = PreviousStack::default();
-        __sanitizer_finish_switch_fiber(std::ptr::null_mut(), &mut ret.bottom, &mut ret.size);
+        unsafe {
+            __sanitizer_finish_switch_fiber(std::ptr::null_mut(), &mut ret.bottom, &mut ret.size);
+        }
         ret
     }
 

--- a/crates/test-programs/src/bin/cli_export_cabi_realloc.rs
+++ b/crates/test-programs/src/bin/cli_export_cabi_realloc.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 //! `wit-component` handles modules which export `cabi_realloc` in a special way, using it instead of `memory.grow`
 //! to allocate the adapter stack, hence this test.
 

--- a/crates/test-programs/src/bin/preview1_clock_time_get.rs
+++ b/crates/test-programs/src/bin/preview1_clock_time_get.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.

--- a/crates/test-programs/src/bin/preview1_close_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_close_preopen.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_dangling_fd.rs
+++ b/crates/test-programs/src/bin/preview1_dangling_fd.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{config, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_dangling_symlink.rs
+++ b/crates/test-programs/src/bin/preview1_dangling_symlink.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
+++ b/crates/test-programs/src/bin/preview1_dir_fd_op_failures.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_directory_seek.rs
+++ b/crates/test-programs/src/bin/preview1_directory_seek.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_fd_advise.rs
+++ b/crates/test-programs/src/bin/preview1_fd_advise.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_fd_filestat_get.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_get.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 unsafe fn test_fd_filestat_get() {
     let stat = wasip1::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
     assert_eq!(stat.size, 0, "stdio size should be 0");

--- a/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process, time::Duration};
 use test_programs::preview1::{
     assert_errno, assert_fs_time_eq, open_scratch_directory, TestConfig,

--- a/crates/test-programs/src/bin/preview1_fd_flags_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_flags_set.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_fd_readdir.rs
+++ b/crates/test-programs/src/bin/preview1_fd_readdir.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, mem, process, slice, str};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_allocate.rs
+++ b/crates/test-programs/src/bin/preview1_file_allocate.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
+++ b/crates/test-programs/src/bin/preview1_file_pread_pwrite.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_read_write.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_seek_tell.rs
+++ b/crates/test-programs/src/bin/preview1_file_seek_tell.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_file_truncation.rs
+++ b/crates/test-programs/src/bin/preview1_file_truncation.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_unbuffered_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_unbuffered_write.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_file_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_write.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_interesting_paths.rs
+++ b/crates/test-programs/src/bin/preview1_interesting_paths.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_nofollow_errors.rs
+++ b/crates/test-programs/src/bin/preview1_nofollow_errors.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_overwrite_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_overwrite_preopen.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_exists.rs
+++ b/crates/test-programs/src/bin/preview1_path_exists.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_filestat.rs
+++ b/crates/test-programs/src/bin/preview1_path_filestat.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process, time::Duration};
 use test_programs::preview1::{
     assert_errno, assert_fs_time_eq, open_scratch_directory, TestConfig,

--- a/crates/test-programs/src/bin/preview1_path_link.rs
+++ b/crates/test-programs/src/bin/preview1_path_link.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_open_create_existing.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_create_existing.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_open_dirfd_not_dir.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_dirfd_not_dir.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_open_lots.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_lots.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_open_missing.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_missing.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_open_nonblock.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_nonblock.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_path_open_preopen.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_preopen.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 const FIRST_PREOPEN: u32 = 3;
 
 unsafe fn path_open_preopen() {

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_path_rename.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory, TestConfig};
 

--- a/crates/test-programs/src/bin/preview1_path_rename_dir_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_path_rename_dir_trailing_slashes.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_path_symlink_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_path_symlink_trailing_slashes.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_poll_oneoff_files.rs
+++ b/crates/test-programs/src/bin/preview1_poll_oneoff_files.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, mem::MaybeUninit, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_poll_oneoff_stdio.rs
+++ b/crates/test-programs/src/bin/preview1_poll_oneoff_stdio.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use test_programs::preview1::{assert_errno, STDERR_FD, STDIN_FD, STDOUT_FD};

--- a/crates/test-programs/src/bin/preview1_readlink.rs
+++ b/crates/test-programs/src/bin/preview1_readlink.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_regular_file_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_regular_file_isatty.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_remove_directory.rs
+++ b/crates/test-programs/src/bin/preview1_remove_directory.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_remove_nonempty_directory.rs
+++ b/crates/test-programs/src/bin/preview1_remove_nonempty_directory.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_renumber.rs
+++ b/crates/test-programs/src/bin/preview1_renumber.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_sched_yield.rs
+++ b/crates/test-programs/src/bin/preview1_sched_yield.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 unsafe fn test_sched_yield() {
     wasip1::sched_yield().expect("sched_yield");
 }

--- a/crates/test-programs/src/bin/preview1_stdio.rs
+++ b/crates/test-programs/src/bin/preview1_stdio.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use test_programs::preview1::{STDERR_FD, STDIN_FD, STDOUT_FD};
 
 unsafe fn test_stdio() {

--- a/crates/test-programs/src/bin/preview1_stdio_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_stdio_isatty.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 unsafe fn test_stdio_isatty() {
     assert_eq!(libc::isatty(libc::STDIN_FILENO), 1, "stdin is a tty");
     assert_eq!(libc::isatty(libc::STDOUT_FILENO), 1, "stdout is a tty");

--- a/crates/test-programs/src/bin/preview1_stdio_not_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_stdio_not_isatty.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 unsafe fn test_stdio_not_isatty() {
     assert_eq!(libc::isatty(libc::STDIN_FILENO), 0, "stdin is not a tty");
     assert_eq!(libc::isatty(libc::STDOUT_FILENO), 0, "stdout is not a tty");

--- a/crates/test-programs/src/bin/preview1_symlink_create.rs
+++ b/crates/test-programs/src/bin/preview1_symlink_create.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::open_scratch_directory;
 

--- a/crates/test-programs/src/bin/preview1_symlink_filestat.rs
+++ b/crates/test-programs/src/bin/preview1_symlink_filestat.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process, time::Duration};
 use test_programs::preview1::{assert_fs_time_eq, open_scratch_directory, TestConfig};
 

--- a/crates/test-programs/src/bin/preview1_symlink_loop.rs
+++ b/crates/test-programs/src/bin/preview1_symlink_loop.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, config, open_scratch_directory};
 

--- a/crates/test-programs/src/bin/preview1_unlink_file_trailing_slashes.rs
+++ b/crates/test-programs/src/bin/preview1_unlink_file_trailing_slashes.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_op_in_unsafe_fn, reason = "old code, not worth updating yet")]
+
 use std::{env, process};
 use test_programs::preview1::{assert_errno, create_file, open_scratch_directory};
 

--- a/crates/test-programs/src/preview1.rs
+++ b/crates/test-programs/src/preview1.rs
@@ -41,10 +41,12 @@ pub fn open_scratch_directory(path: &str) -> Result<wasip1::Fd, String> {
 }
 
 pub unsafe fn create_file(dir_fd: wasip1::Fd, filename: &str) {
-    let file_fd = wasip1::path_open(dir_fd, 0, filename, wasip1::OFLAGS_CREAT, 0, 0, 0)
-        .expect("creating a file");
-    assert!(file_fd > STDERR_FD, "file descriptor range check",);
-    wasip1::fd_close(file_fd).expect("closing a file");
+    unsafe {
+        let file_fd = wasip1::path_open(dir_fd, 0, filename, wasip1::OFLAGS_CREAT, 0, 0, 0)
+            .expect("creating a file");
+        assert!(file_fd > STDERR_FD, "file descriptor range check",);
+        wasip1::fd_close(file_fd).expect("closing a file");
+    }
 }
 
 // Small workaround to get the crate's macros, through the

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -168,7 +168,7 @@ impl<T, E> TrappingUnwrap<T> for Result<T, E> {
 /// from WASI Preview 1 to Preview 2.  It will use this function to reserve
 /// descriptors for its own use, valid only for use with libc functions.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn adapter_open_badfd(fd: *mut u32) -> Errno {
+pub unsafe extern "C" fn adapter_open_badfd(fd: &mut u32) -> Errno {
     State::with(|state| {
         *fd = state.descriptors_mut().open(Descriptor::Bad)?;
         Ok(())
@@ -183,9 +183,11 @@ pub unsafe extern "C" fn adapter_close_badfd(fd: u32) -> Errno {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn reset_adapter_state() {
-    let state = get_state_ptr();
-    if !state.is_null() {
-        State::init(state)
+    unsafe {
+        let state = get_state_ptr();
+        if !state.is_null() {
+            State::init(state)
+        }
     }
 }
 
@@ -199,7 +201,7 @@ pub unsafe extern "C" fn cabi_import_realloc(
     let mut ptr = null_mut::<u8>();
     State::with(|state| {
         let mut alloc = state.import_alloc.replace(ImportAlloc::None);
-        ptr = alloc.alloc(old_ptr, old_size, align, new_size);
+        ptr = unsafe { alloc.alloc(old_ptr, old_size, align, new_size) };
         state.import_alloc.set(alloc);
         Ok(())
     });
@@ -378,30 +380,30 @@ impl ImportAlloc {
             return old_ptr;
         }
         match self {
-            ImportAlloc::OneAlloc(alloc) => {
+            ImportAlloc::OneAlloc(alloc) => unsafe {
                 let ret = alloc.alloc(align, size);
                 *self = ImportAlloc::None;
                 ret
-            }
-            ImportAlloc::SeparateStringsAndPointers { strings, pointers } => {
+            },
+            ImportAlloc::SeparateStringsAndPointers { strings, pointers } => unsafe {
                 if align == 1 {
                     strings.alloc(align, size + 1)
                 } else {
                     pointers.alloc(align, size)
                 }
-            }
+            },
             ImportAlloc::CountAndDiscardStrings {
                 strings_size,
                 alloc,
-            } => {
+            } => unsafe {
                 if align == 1 {
                     *strings_size += size;
                     alloc.clone().alloc(align, size)
                 } else {
                     alloc.alloc(align, size)
                 }
-            }
-            ImportAlloc::GetPreopenPath { cur, nth, alloc } => {
+            },
+            ImportAlloc::GetPreopenPath { cur, nth, alloc } => unsafe {
                 if align == 1 {
                     let real_alloc = *nth == *cur;
                     *cur += 1;
@@ -413,7 +415,7 @@ impl ImportAlloc {
                 } else {
                     alloc.alloc(align, size)
                 }
-            }
+            },
             ImportAlloc::None => {
                 unreachable!("no allocator configured")
             }
@@ -433,13 +435,15 @@ struct BumpAlloc {
 
 impl BumpAlloc {
     unsafe fn alloc(&mut self, align: usize, size: usize) -> *mut u8 {
-        self.align_to(align);
+        unsafe {
+            self.align_to(align);
+        }
         if size > self.len {
             unreachable!("allocation size is too large")
         }
         self.len -= size;
         let ret = self.base;
-        self.base = ret.add(size);
+        self.base = unsafe { ret.add(size) };
         ret
     }
 
@@ -452,7 +456,7 @@ impl BumpAlloc {
             unreachable!("failed to allocate")
         }
         self.len -= align_offset;
-        self.base = self.base.add(align_offset);
+        self.base = unsafe { self.base.add(align_offset) };
     }
 }
 
@@ -477,7 +481,7 @@ pub unsafe extern "C" fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errn
                     base: argv_buf,
                     len: usize::MAX,
                 },
-                pointers: state.temporary_alloc(),
+                pointers: unsafe { state.temporary_alloc() },
             };
             let (list, _) = state.with_import_alloc(alloc, || unsafe {
                 let mut list = WasmStrList {
@@ -491,10 +495,12 @@ pub unsafe extern "C" fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errn
             // Fill in `argv` by walking over the returned `list` and then
             // additionally apply the nul-termination for each argument itself
             // here.
-            for i in 0..list.len {
-                let s = list.base.add(i).read();
-                *argv.add(i) = s.ptr.cast_mut();
-                *s.ptr.add(s.len).cast_mut() = 0;
+            unsafe {
+                for i in 0..list.len {
+                    let s = list.base.add(i).read();
+                    *argv.add(i) = s.ptr.cast_mut();
+                    *s.ptr.add(s.len).cast_mut() = 0;
+                }
             }
         }
         Ok(())
@@ -503,7 +509,7 @@ pub unsafe extern "C" fn args_get(argv: *mut *mut u8, argv_buf: *mut u8) -> Errn
 
 /// Return command-line argument data sizes.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Size) -> Errno {
+pub unsafe extern "C" fn args_sizes_get(argc: &mut Size, argv_buf_size: &mut Size) -> Errno {
     State::with(|state| {
         #[cfg(feature = "proxy")]
         {
@@ -514,7 +520,7 @@ pub unsafe extern "C" fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Siz
         {
             let alloc = ImportAlloc::CountAndDiscardStrings {
                 strings_size: 0,
-                alloc: state.temporary_alloc(),
+                alloc: unsafe { state.temporary_alloc() },
             };
             let (len, alloc) = state.with_import_alloc(alloc, || unsafe {
                 let mut list = WasmStrList {
@@ -553,7 +559,7 @@ pub unsafe extern "C" fn environ_get(environ: *mut *const u8, environ_buf: *mut 
                     base: environ_buf,
                     len: usize::MAX,
                 },
-                pointers: state.temporary_alloc(),
+                pointers: unsafe { state.temporary_alloc() },
             };
             let (list, _) = state.with_import_alloc(alloc, || unsafe {
                 let mut list = StrTupleList {
@@ -568,11 +574,13 @@ pub unsafe extern "C" fn environ_get(environ: *mut *const u8, environ_buf: *mut 
             // are guaranteed to be allocated next to each other with one
             // extra byte at the end, so also insert the `=` between keys and
             // the `\0` at the end of the env var.
-            for i in 0..list.len {
-                let s = list.base.add(i).read();
-                *environ.add(i) = s.key.ptr;
-                *s.key.ptr.add(s.key.len).cast_mut() = b'=';
-                *s.value.ptr.add(s.value.len).cast_mut() = 0;
+            unsafe {
+                for i in 0..list.len {
+                    let s = list.base.add(i).read();
+                    *environ.add(i) = s.key.ptr;
+                    *s.key.ptr.add(s.key.len).cast_mut() = b'=';
+                    *s.value.ptr.add(s.value.len).cast_mut() = 0;
+                }
             }
         }
 
@@ -583,11 +591,11 @@ pub unsafe extern "C" fn environ_get(environ: *mut *const u8, environ_buf: *mut 
 /// Return environment variable data sizes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn environ_sizes_get(
-    environc: *mut Size,
-    environ_buf_size: *mut Size,
+    environc: &mut Size,
+    environ_buf_size: &mut Size,
 ) -> Errno {
     if !matches!(
-        get_allocation_state(),
+        unsafe { get_allocation_state() },
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         *environc = 0;
@@ -605,7 +613,7 @@ pub unsafe extern "C" fn environ_sizes_get(
         {
             let alloc = ImportAlloc::CountAndDiscardStrings {
                 strings_size: 0,
-                alloc: state.temporary_alloc(),
+                alloc: unsafe { state.temporary_alloc() },
             };
             let (len, alloc) = state.with_import_alloc(alloc, || unsafe {
                 let mut list = StrTupleList {
@@ -815,12 +823,14 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
                                 | wasi::RIGHTS_FD_FILESTAT_SET_TIMES
                                 | wasi::RIGHTS_POLL_FD_READWRITE;
 
-                            stat.write(Fdstat {
-                                fs_filetype: wasi::FILETYPE_DIRECTORY,
-                                fs_flags: 0,
-                                fs_rights_base,
-                                fs_rights_inheriting,
-                            });
+                            unsafe {
+                                stat.write(Fdstat {
+                                    fs_filetype: wasi::FILETYPE_DIRECTORY,
+                                    fs_flags: 0,
+                                    fs_rights_base,
+                                    fs_rights_inheriting,
+                                });
+                            }
                             Ok(())
                         }
                         _ => {
@@ -852,12 +862,14 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
                             }
                             let fs_rights_inheriting = fs_rights_base;
 
-                            stat.write(Fdstat {
-                                fs_filetype,
-                                fs_flags,
-                                fs_rights_base,
-                                fs_rights_inheriting,
-                            });
+                            unsafe {
+                                stat.write(Fdstat {
+                                    fs_filetype,
+                                    fs_flags,
+                                    fs_rights_base,
+                                    fs_rights_inheriting,
+                                });
+                            }
                             Ok(())
                         }
                     }
@@ -876,12 +888,14 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
                         fs_rights_base |= RIGHTS_FD_WRITE;
                     }
                     let fs_rights_inheriting = fs_rights_base;
-                    stat.write(Fdstat {
-                        fs_filetype: stdio.filetype(),
-                        fs_flags,
-                        fs_rights_base,
-                        fs_rights_inheriting,
-                    });
+                    unsafe {
+                        stat.write(Fdstat {
+                            fs_filetype: stdio.filetype(),
+                            fs_flags,
+                            fs_rights_base,
+                            fs_rights_inheriting,
+                        });
+                    }
                     Ok(())
                 }
                 Descriptor::Closed(_) | Descriptor::Bad => Err(ERRNO_BADF),
@@ -938,7 +952,7 @@ pub unsafe extern "C" fn fd_fdstat_set_rights(
 
 /// Return the attributes of an open file.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fd_filestat_get(fd: Fd, buf: *mut Filestat) -> Errno {
+pub unsafe extern "C" fn fd_filestat_get(fd: Fd, buf: &mut Filestat) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
             let ds = state.descriptors();
@@ -1052,22 +1066,23 @@ pub unsafe extern "C" fn fd_pread(
     mut iovs_ptr: *const Iovec,
     mut iovs_len: usize,
     offset: Filesize,
-    nread: *mut Size,
+    nread: &mut Size,
 ) -> Errno {
     cfg_filesystem_available! {
-        // Skip leading non-empty buffers.
-        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
-            iovs_ptr = iovs_ptr.add(1);
-            iovs_len -= 1;
-        }
-        if iovs_len == 0 {
-            *nread = 0;
-            return ERRNO_SUCCESS;
-        }
+        let (ptr, len) = unsafe {
+            // Skip leading non-empty buffers.
+            while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
+                iovs_ptr = iovs_ptr.add(1);
+                iovs_len -= 1;
+            }
+            if iovs_len == 0 {
+                *nread = 0;
+                return ERRNO_SUCCESS;
+            }
+            ((*iovs_ptr).buf, (*iovs_ptr).buf_len)
+        };
 
         State::with(|state| {
-            let ptr = (*iovs_ptr).buf;
-            let len = (*iovs_ptr).buf_len;
 
             let ds = state.descriptors();
             let file = ds.get_file(fd)?;
@@ -1092,7 +1107,7 @@ pub unsafe extern "C" fn fd_pread(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
     if !matches!(
-        get_allocation_state(),
+        unsafe { get_allocation_state() },
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         return ERRNO_BADF;
@@ -1116,14 +1131,16 @@ pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
                     }),
                     ..
                 }) => {
-                    buf.write(Prestat {
-                        tag: 0,
-                        u: PrestatU {
-                            dir: PrestatDir {
-                                pr_name_len: len.get(),
+                    unsafe {
+                        buf.write(Prestat {
+                            tag: 0,
+                            u: PrestatU {
+                                dir: PrestatDir {
+                                    pr_name_len: len.get(),
+                                },
                             },
-                        },
-                    });
+                        });
+                    }
 
                     Ok(())
                 }
@@ -1153,7 +1170,9 @@ pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_max_len
                 return Err(ERRNO_NAMETOOLONG)
             }
 
-            ds.get_preopen_path(state, fd, path, path_max_len);
+            unsafe {
+                ds.get_preopen_path(state, fd, path, path_max_len);
+            }
             Ok(())
         })
     }
@@ -1167,26 +1186,28 @@ pub unsafe extern "C" fn fd_pwrite(
     mut iovs_ptr: *const Ciovec,
     mut iovs_len: usize,
     offset: Filesize,
-    nwritten: *mut Size,
+    nwritten: &mut Size,
 ) -> Errno {
     cfg_filesystem_available! {
-        // Skip leading non-empty buffers.
-        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
-            iovs_ptr = iovs_ptr.add(1);
-            iovs_len -= 1;
-        }
-        if iovs_len == 0 {
-            *nwritten = 0;
-            return ERRNO_SUCCESS;
-        }
+        let bytes = unsafe {
+            // Skip leading non-empty buffers.
+            while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
+                iovs_ptr = iovs_ptr.add(1);
+                iovs_len -= 1;
+            }
+            if iovs_len == 0 {
+                *nwritten = 0;
+                return ERRNO_SUCCESS;
+            }
 
-        let ptr = (*iovs_ptr).buf;
-        let len = (*iovs_ptr).buf_len;
+            let ptr = (*iovs_ptr).buf;
+            let len = (*iovs_ptr).buf_len;
+            slice::from_raw_parts(ptr, len)
+        };
 
         State::with(|state| {
             let ds = state.descriptors();
             let file = ds.get_seekable_file(fd)?;
-            let bytes = slice::from_raw_parts(ptr, len);
             let bytes = if file.append {
                 match file.fd.append_via_stream()?.blocking_write_and_flush(bytes) {
                     Ok(()) => bytes.len(),
@@ -1211,20 +1232,21 @@ pub unsafe extern "C" fn fd_read(
     fd: Fd,
     mut iovs_ptr: *const Iovec,
     mut iovs_len: usize,
-    nread: *mut Size,
+    nread: &mut Size,
 ) -> Errno {
-    // Skip leading non-empty buffers.
-    while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
-        iovs_ptr = iovs_ptr.add(1);
-        iovs_len -= 1;
-    }
-    if iovs_len == 0 {
-        *nread = 0;
-        return ERRNO_SUCCESS;
-    }
+    let (ptr, len) = unsafe {
+        // Skip leading non-empty buffers.
+        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
+            iovs_ptr = iovs_ptr.add(1);
+            iovs_len -= 1;
+        }
+        if iovs_len == 0 {
+            *nread = 0;
+            return ERRNO_SUCCESS;
+        }
 
-    let ptr = (*iovs_ptr).buf;
-    let len = (*iovs_ptr).buf_len;
+        ((*iovs_ptr).buf, (*iovs_ptr).buf_len)
+    };
 
     State::with(|state| {
         let ds = state.descriptors();
@@ -1312,9 +1334,9 @@ pub unsafe extern "C" fn fd_readdir(
     buf: *mut u8,
     buf_len: Size,
     cookie: Dircookie,
-    bufused: *mut Size,
+    bufused: &mut Size,
 ) -> Errno {
-    let mut buf = slice::from_raw_parts_mut(buf, buf_len);
+    let mut buf = unsafe { slice::from_raw_parts_mut(buf, buf_len) };
     return State::with(|state| {
         // First determine if there's an entry in the dirent cache to use. This
         // is done to optimize the use case where a large directory is being
@@ -1391,10 +1413,12 @@ pub unsafe extern "C" fn fd_readdir(
 
             // Copy a `dirent` describing this entry into the destination `buf`,
             // truncating it if it doesn't fit entirely.
-            let bytes = slice::from_raw_parts(
-                (&dirent as *const wasi::Dirent).cast::<u8>(),
-                size_of::<Dirent>(),
-            );
+            let bytes = unsafe {
+                slice::from_raw_parts(
+                    (&dirent as *const wasi::Dirent).cast::<u8>(),
+                    size_of::<Dirent>(),
+                )
+            };
             let dirent_bytes_to_copy = buf.len().min(bytes.len());
             buf[..dirent_bytes_to_copy].copy_from_slice(&bytes[..dirent_bytes_to_copy]);
             buf = &mut buf[dirent_bytes_to_copy..];
@@ -1405,7 +1429,13 @@ pub unsafe extern "C" fn fd_readdir(
             // Note that this might be a 0-byte copy if the `dirent` was
             // truncated or fit entirely into the destination.
             let name_bytes_to_copy = buf.len().min(name.len());
-            ptr::copy_nonoverlapping(name.as_ptr().cast(), buf.as_mut_ptr(), name_bytes_to_copy);
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    name.as_ptr().cast(),
+                    buf.as_mut_ptr(),
+                    name_bytes_to_copy,
+                );
+            }
 
             buf = &mut buf[name_bytes_to_copy..];
 
@@ -1428,11 +1458,13 @@ pub unsafe extern "C" fn fd_readdir(
                 state.dirent_cache.for_fd.set(fd);
                 state.dirent_cache.cookie.set(cookie - 1);
                 state.dirent_cache.cached_dirent.set(dirent);
-                ptr::copy(
-                    name.as_ptr().cast::<u8>(),
-                    (*state.dirent_cache.path_data.get()).as_mut_ptr() as *mut u8,
-                    name.len(),
-                );
+                unsafe {
+                    ptr::copy(
+                        name.as_ptr().cast::<u8>(),
+                        (*state.dirent_cache.path_data.get()).as_mut_ptr() as *mut u8,
+                        name.len(),
+                    );
+                }
                 break;
             }
         }
@@ -1551,7 +1583,7 @@ pub unsafe extern "C" fn fd_seek(
     fd: Fd,
     offset: Filedelta,
     whence: Whence,
-    newoffset: *mut Filesize,
+    newoffset: &mut Filesize,
 ) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
@@ -1606,7 +1638,7 @@ pub unsafe extern "C" fn fd_sync(fd: Fd) -> Errno {
 /// Return the current offset of a file descriptor.
 /// Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fd_tell(fd: Fd, offset: *mut Filesize) -> Errno {
+pub unsafe extern "C" fn fd_tell(fd: Fd, offset: &mut Filesize) -> Errno {
     cfg_filesystem_available! {
         State::with(|state| {
             let ds = state.descriptors();
@@ -1624,29 +1656,30 @@ pub unsafe extern "C" fn fd_write(
     fd: Fd,
     mut iovs_ptr: *const Ciovec,
     mut iovs_len: usize,
-    nwritten: *mut Size,
+    nwritten: &mut Size,
 ) -> Errno {
     if !matches!(
-        get_allocation_state(),
+        unsafe { get_allocation_state() },
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         *nwritten = 0;
         return ERRNO_IO;
     }
 
-    // Skip leading empty buffers.
-    while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
-        iovs_ptr = iovs_ptr.add(1);
-        iovs_len -= 1;
-    }
-    if iovs_len == 0 {
-        *nwritten = 0;
-        return ERRNO_SUCCESS;
-    }
-
-    let ptr = (*iovs_ptr).buf;
-    let len = (*iovs_ptr).buf_len;
-    let bytes = slice::from_raw_parts(ptr, len);
+    let bytes = unsafe {
+        // Skip leading empty buffers.
+        while iovs_len > 1 && (*iovs_ptr).buf_len == 0 {
+            iovs_ptr = iovs_ptr.add(1);
+            iovs_len -= 1;
+        }
+        if iovs_len == 0 {
+            *nwritten = 0;
+            return ERRNO_SUCCESS;
+        }
+        let ptr = (*iovs_ptr).buf;
+        let len = (*iovs_ptr).buf_len;
+        slice::from_raw_parts(ptr, len)
+    };
 
     State::with(|state| {
         let ds = state.descriptors();
@@ -1699,7 +1732,7 @@ pub unsafe extern "C" fn path_create_directory(
     path_len: usize,
 ) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
 
         State::with(|state| {
             let ds = state.descriptors();
@@ -1718,10 +1751,10 @@ pub unsafe extern "C" fn path_filestat_get(
     flags: Lookupflags,
     path_ptr: *const u8,
     path_len: usize,
-    buf: *mut Filestat,
+    buf: &mut Filestat,
 ) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
         let at_flags = at_flags_from_lookupflags(flags);
 
         State::with(|state| {
@@ -1758,7 +1791,7 @@ pub unsafe extern "C" fn path_filestat_set_times(
     fst_flags: Fstflags,
 ) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
         let at_flags = at_flags_from_lookupflags(flags);
 
         State::with(|state| {
@@ -1794,8 +1827,8 @@ pub unsafe extern "C" fn path_link(
     new_path_len: usize,
 ) -> Errno {
     cfg_filesystem_available! {
-        let old_path = slice::from_raw_parts(old_path_ptr, old_path_len);
-        let new_path = slice::from_raw_parts(new_path_ptr, new_path_len);
+        let old_path = unsafe { slice::from_raw_parts(old_path_ptr, old_path_len) };
+        let new_path = unsafe { slice::from_raw_parts(new_path_ptr, new_path_len) };
         let at_flags = at_flags_from_lookupflags(old_flags);
 
         State::with(|state| {
@@ -1825,12 +1858,12 @@ pub unsafe extern "C" fn path_open(
     fs_rights_base: Rights,
     fs_rights_inheriting: Rights,
     fdflags: Fdflags,
-    opened_fd: *mut Fd,
+    opened_fd: &mut Fd,
 ) -> Errno {
     cfg_filesystem_available! {
         let _ = fs_rights_inheriting;
 
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
         let at_flags = at_flags_from_lookupflags(dirflags);
         let o_flags = o_flags_from_oflags(oflags);
         let flags = descriptor_flags_from_flags(fs_rights_base, fdflags);
@@ -1880,10 +1913,10 @@ pub unsafe extern "C" fn path_readlink(
     path_len: usize,
     buf: *mut u8,
     buf_len: Size,
-    bufused: *mut Size,
+    bufused: &mut Size,
 ) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
 
         State::with(|state| {
             // If the user gave us a buffer shorter than `PATH_MAX`, it may not be
@@ -1907,7 +1940,9 @@ pub unsafe extern "C" fn path_readlink(
                 // Preview1 follows POSIX in truncating the returned path if it
                 // doesn't fit.
                 let len = min(path.len(), buf_len);
-                ptr::copy_nonoverlapping(path.as_ptr().cast(), buf, len);
+                unsafe {
+                    ptr::copy_nonoverlapping(path.as_ptr().cast(), buf, len);
+                }
                 *bufused = len;
             } else {
                 *bufused = path.len();
@@ -1932,7 +1967,7 @@ pub unsafe extern "C" fn path_remove_directory(
     path_len: usize,
 ) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
 
         State::with(|state| {
             let ds = state.descriptors();
@@ -1955,8 +1990,8 @@ pub unsafe extern "C" fn path_rename(
     new_path_len: usize,
 ) -> Errno {
     cfg_filesystem_available! {
-        let old_path = slice::from_raw_parts(old_path_ptr, old_path_len);
-        let new_path = slice::from_raw_parts(new_path_ptr, new_path_len);
+        let old_path = unsafe { slice::from_raw_parts(old_path_ptr, old_path_len) };
+        let new_path = unsafe { slice::from_raw_parts(new_path_ptr, new_path_len) };
 
         State::with(|state| {
             let ds = state.descriptors();
@@ -1979,8 +2014,8 @@ pub unsafe extern "C" fn path_symlink(
     new_path_len: usize,
 ) -> Errno {
     cfg_filesystem_available! {
-        let old_path = slice::from_raw_parts(old_path_ptr, old_path_len);
-        let new_path = slice::from_raw_parts(new_path_ptr, new_path_len);
+        let old_path = unsafe { slice::from_raw_parts(old_path_ptr, old_path_len) };
+        let new_path = unsafe { slice::from_raw_parts(new_path_ptr, new_path_len) };
 
         State::with(|state| {
             let ds = state.descriptors();
@@ -1997,7 +2032,7 @@ pub unsafe extern "C" fn path_symlink(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn path_unlink_file(fd: Fd, path_ptr: *const u8, path_len: usize) -> Errno {
     cfg_filesystem_available! {
-        let path = slice::from_raw_parts(path_ptr, path_len);
+        let path = unsafe { slice::from_raw_parts(path_ptr, path_len) };
 
         State::with(|state| {
             let ds = state.descriptors();
@@ -2019,7 +2054,9 @@ impl Pollables {
         assert!(self.index < self.length);
         // Use `ptr::write` instead of `*... = pollable` because `ptr::write`
         // doesn't call drop on the old memory.
-        self.pointer.add(self.index).write(pollable);
+        unsafe {
+            self.pointer.add(self.index).write(pollable);
+        }
         self.index += 1;
     }
 }
@@ -2043,11 +2080,11 @@ pub unsafe extern "C" fn poll_oneoff(
     r#in: *const Subscription,
     out: *mut Event,
     nsubscriptions: Size,
-    nevents: *mut Size,
+    nevents: &mut Size,
 ) -> Errno {
     *nevents = 0;
 
-    let subscriptions = slice::from_raw_parts(r#in, nsubscriptions);
+    let subscriptions = unsafe { slice::from_raw_parts(r#in, nsubscriptions) };
 
     // We're going to split the `nevents` buffer into two non-overlapping
     // buffers: one to store the pollable handles, and the other to store
@@ -2073,7 +2110,7 @@ pub unsafe extern "C" fn poll_oneoff(
     // Store the pollable handles at the beginning, and the bool results at the
     // end, so that we don't clobber the bool results when writing the events.
     let pollables = out as *mut c_void as *mut Pollable;
-    let results = out.add(nsubscriptions).cast::<u32>().sub(nsubscriptions);
+    let results = unsafe { out.add(nsubscriptions).cast::<u32>().sub(nsubscriptions) };
 
     // Indefinite sleeping is not supported in preview1.
     if nsubscriptions == 0 {
@@ -2092,9 +2129,9 @@ pub unsafe extern "C" fn poll_oneoff(
         };
 
         for subscription in subscriptions {
-            pollables.push(match subscription.u.tag {
+            let pollable = match subscription.u.tag {
                 EVENTTYPE_CLOCK => {
-                    let clock = &subscription.u.u.clock;
+                    let clock = unsafe { &subscription.u.u.clock };
                     let absolute = (clock.flags & SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME)
                         == SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME;
                     match clock.id {
@@ -2144,16 +2181,19 @@ pub unsafe extern "C" fn poll_oneoff(
 
                 EVENTTYPE_FD_READ => state
                     .descriptors()
-                    .get_read_stream(subscription.u.u.fd_read.file_descriptor)
+                    .get_read_stream(unsafe { subscription.u.u.fd_read.file_descriptor })
                     .map(|stream| stream.subscribe())?,
 
                 EVENTTYPE_FD_WRITE => state
                     .descriptors()
-                    .get_write_stream(subscription.u.u.fd_write.file_descriptor)
+                    .get_write_stream(unsafe { subscription.u.u.fd_write.file_descriptor })
                     .map(|stream| stream.subscribe())?,
 
                 _ => return Err(ERRNO_INVAL),
-            });
+            };
+            unsafe {
+                pollables.push(pollable);
+            }
         }
 
         #[link(wasm_import_module = "wasi:io/poll@0.2.3")]
@@ -2171,7 +2211,7 @@ pub unsafe extern "C" fn poll_oneoff(
             nsubscriptions
                 .checked_mul(size_of::<u32>())
                 .trapping_unwrap(),
-            || {
+            || unsafe {
                 poll_import(
                     pollables.pointer,
                     pollables.length,
@@ -2185,12 +2225,12 @@ pub unsafe extern "C" fn poll_oneoff(
 
         drop(pollables);
 
-        let ready = std::slice::from_raw_parts(ready_list.base, ready_list.len);
+        let ready = unsafe { std::slice::from_raw_parts(ready_list.base, ready_list.len) };
 
         let mut count = 0;
 
         for subscription in ready {
-            let subscription = *subscriptions.as_ptr().add(*subscription as usize);
+            let subscription = unsafe { *subscriptions.as_ptr().add(*subscription as usize) };
 
             let type_;
 
@@ -2204,7 +2244,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     type_ = wasi::EVENTTYPE_FD_READ;
                     let ds = state.descriptors();
                     let desc = ds
-                        .get(subscription.u.u.fd_read.file_descriptor)
+                        .get(unsafe { subscription.u.u.fd_read.file_descriptor })
                         .trapping_unwrap();
                     match desc {
                         Descriptor::Streams(streams) => match &streams.type_ {
@@ -2233,7 +2273,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     type_ = wasi::EVENTTYPE_FD_WRITE;
                     let ds = state.descriptors();
                     let desc = ds
-                        .get(subscription.u.u.fd_write.file_descriptor)
+                        .get(unsafe { subscription.u.u.fd_write.file_descriptor })
                         .trapping_unwrap();
                     match desc {
                         Descriptor::Streams(streams) => match &streams.type_ {
@@ -2248,12 +2288,14 @@ pub unsafe extern "C" fn poll_oneoff(
                 _ => unreachable!(),
             };
 
-            *out.add(count) = Event {
-                userdata: subscription.userdata,
-                error,
-                type_,
-                fd_readwrite: EventFdReadwrite { nbytes, flags },
-            };
+            unsafe {
+                *out.add(count) = Event {
+                    userdata: subscription.userdata,
+                    error,
+                    type_,
+                    fd_readwrite: EventFdReadwrite { nbytes, flags },
+                };
+            }
 
             count += 1;
         }
@@ -2306,7 +2348,7 @@ pub unsafe extern "C" fn sched_yield() -> Errno {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn random_get(buf: *mut u8, buf_len: Size) -> Errno {
     if matches!(
-        get_allocation_state(),
+        unsafe { get_allocation_state() },
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         State::with(|state| {
@@ -2801,28 +2843,30 @@ impl State {
 
     #[cold]
     unsafe fn init(state: *mut State) {
-        state.write(State {
-            magic1: MAGIC,
-            magic2: MAGIC,
-            import_alloc: Cell::new(ImportAlloc::None),
-            descriptors: RefCell::new(None),
-            temporary_data: UnsafeCell::new(MaybeUninit::uninit()),
-            #[cfg(not(feature = "proxy"))]
-            dirent_cache: DirentCache {
-                stream: Cell::new(None),
-                for_fd: Cell::new(0),
-                cookie: Cell::new(wasi::DIRCOOKIE_START),
-                cached_dirent: Cell::new(wasi::Dirent {
-                    d_next: 0,
-                    d_ino: 0,
-                    d_type: FILETYPE_UNKNOWN,
-                    d_namlen: 0,
-                }),
-                path_data: UnsafeCell::new(MaybeUninit::uninit()),
-            },
-            #[cfg(not(feature = "proxy"))]
-            dotdot: [UnsafeCell::new(b'.'), UnsafeCell::new(b'.')],
-        });
+        unsafe {
+            state.write(State {
+                magic1: MAGIC,
+                magic2: MAGIC,
+                import_alloc: Cell::new(ImportAlloc::None),
+                descriptors: RefCell::new(None),
+                temporary_data: UnsafeCell::new(MaybeUninit::uninit()),
+                #[cfg(not(feature = "proxy"))]
+                dirent_cache: DirentCache {
+                    stream: Cell::new(None),
+                    for_fd: Cell::new(0),
+                    cookie: Cell::new(wasi::DIRCOOKIE_START),
+                    cached_dirent: Cell::new(wasi::Dirent {
+                        d_next: 0,
+                        d_ino: 0,
+                        d_type: FILETYPE_UNKNOWN,
+                        d_namlen: 0,
+                    }),
+                    path_data: UnsafeCell::new(MaybeUninit::uninit()),
+                },
+                #[cfg(not(feature = "proxy"))]
+                dotdot: [UnsafeCell::new(b'.'), UnsafeCell::new(b'.')],
+            });
+        }
     }
 
     /// Accessor for the descriptors member that ensures it is properly initialized

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -294,6 +294,7 @@
 #![cfg_attr(feature = "default", warn(rustdoc::broken_intra_doc_links))]
 #![no_std]
 #![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
+#![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]
 
 #[cfg(any(feature = "std", unix, windows))]
 #[macro_use]

--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -121,7 +121,7 @@ impl Mmap {
             let err = io::Error::last_os_error();
             CloseHandle(mapping);
             if ptr.is_null() {
-                return Err(err).context(format!("failed to create map view of {:#x} bytes", len));
+                return Err(err).context(format!("failed to create map view of {len:#x} bytes"));
             }
 
             let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), len);

--- a/crates/wasmtime/src/runtime/vm/sys/windows/unwind64.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/unwind64.rs
@@ -29,7 +29,7 @@ impl UnwindRegistration {
         assert!(unwind_len % unit_len == 0);
         if RtlAddFunctionTable(
             unwind_info as *mut Entry,
-            (unwind_len / unit_len) as u32,
+            (unwind_len / unit_len).try_into().unwrap(),
             base_address as _,
         ) == 0
         {

--- a/examples/min-platform/embedding/src/allocator.rs
+++ b/examples/min-platform/embedding/src/allocator.rs
@@ -35,31 +35,39 @@ struct MyAllocator;
 
 unsafe impl GlobalAlloc for MyGlobalDmalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        self.dlmalloc
-            .try_lock()
-            .unwrap()
-            .malloc(layout.size(), layout.align())
+        unsafe {
+            self.dlmalloc
+                .try_lock()
+                .unwrap()
+                .malloc(layout.size(), layout.align())
+        }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        self.dlmalloc
-            .try_lock()
-            .unwrap()
-            .calloc(layout.size(), layout.align())
+        unsafe {
+            self.dlmalloc
+                .try_lock()
+                .unwrap()
+                .calloc(layout.size(), layout.align())
+        }
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        self.dlmalloc
-            .try_lock()
-            .unwrap()
-            .realloc(ptr, layout.size(), layout.align(), new_size)
+        unsafe {
+            self.dlmalloc
+                .try_lock()
+                .unwrap()
+                .realloc(ptr, layout.size(), layout.align(), new_size)
+        }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        self.dlmalloc
-            .try_lock()
-            .unwrap()
-            .free(ptr, layout.size(), layout.align())
+        unsafe {
+            self.dlmalloc
+                .try_lock()
+                .unwrap()
+                .free(ptr, layout.size(), layout.align())
+        }
     }
 }
 

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -30,17 +30,20 @@ pub unsafe extern "C" fn run(
     simple_host_fn_module: *const u8,
     simple_host_fn_size: usize,
 ) -> usize {
-    let buf = core::slice::from_raw_parts_mut(error_buf, error_size);
-    let smoke = core::slice::from_raw_parts(smoke_module, smoke_size);
-    let simple_add = core::slice::from_raw_parts(simple_add_module, simple_add_size);
-    let simple_host_fn = core::slice::from_raw_parts(simple_host_fn_module, simple_host_fn_size);
-    match run_result(smoke, simple_add, simple_host_fn) {
-        Ok(()) => 0,
-        Err(e) => {
-            let msg = format!("{e:?}");
-            let len = buf.len().min(msg.len());
-            buf[..len].copy_from_slice(&msg.as_bytes()[..len]);
-            len
+    unsafe {
+        let buf = core::slice::from_raw_parts_mut(error_buf, error_size);
+        let smoke = core::slice::from_raw_parts(smoke_module, smoke_size);
+        let simple_add = core::slice::from_raw_parts(simple_add_module, simple_add_size);
+        let simple_host_fn =
+            core::slice::from_raw_parts(simple_host_fn_module, simple_host_fn_size);
+        match run_result(smoke, simple_add, simple_host_fn) {
+            Ok(()) => 0,
+            Err(e) => {
+                let msg = format!("{e:?}");
+                let len = buf.len().min(msg.len());
+                buf[..len].copy_from_slice(&msg.as_bytes()[..len]);
+                len
+            }
         }
     }
 }

--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -52,21 +52,23 @@ pub unsafe extern "C" fn run_wasi(
     wasi_component: *const u8,
     wasi_component_size: usize,
 ) -> usize {
-    let buf = core::slice::from_raw_parts_mut(out_buf, *out_size);
-    let wasi_component = core::slice::from_raw_parts(wasi_component, wasi_component_size);
-    match run(wasi_component) {
-        Ok(output) => {
-            let len = buf.len().min(output.len());
-            buf[..len].copy_from_slice(&output.as_bytes()[..len]);
-            *out_size = len;
-            return 0;
-        }
-        Err(e) => {
-            let msg = format!("{e:?}");
-            let len = buf.len().min(msg.len());
-            buf[..len].copy_from_slice(&msg.as_bytes()[..len]);
-            *out_size = len;
-            return 1;
+    unsafe {
+        let buf = core::slice::from_raw_parts_mut(out_buf, *out_size);
+        let wasi_component = core::slice::from_raw_parts(wasi_component, wasi_component_size);
+        match run(wasi_component) {
+            Ok(output) => {
+                let len = buf.len().min(output.len());
+                buf[..len].copy_from_slice(&output.as_bytes()[..len]);
+                *out_size = len;
+                return 0;
+            }
+            Err(e) => {
+                let msg = format!("{e:?}");
+                let len = buf.len().min(msg.len());
+                buf[..len].copy_from_slice(&msg.as_bytes()[..len]);
+                *out_size = len;
+                return 1;
+            }
         }
     }
 }

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -223,7 +223,7 @@ impl UnsafeBytecodeStream {
     /// that the address at `self._as_ptr() + offset` contains valid Pulley
     /// bytecode.
     pub unsafe fn offset(&self, offset: isize) -> Self {
-        UnsafeBytecodeStream(NonNull::new_unchecked(self.0.as_ptr().offset(offset)))
+        UnsafeBytecodeStream(unsafe { NonNull::new_unchecked(self.0.as_ptr().offset(offset)) })
     }
 
     /// Get this stream's underlying raw pointer.

--- a/pulley/src/opcode.rs
+++ b/pulley/src/opcode.rs
@@ -51,7 +51,7 @@ impl Opcode {
     /// It is unsafe to pass a `byte` that is not a valid opcode.
     pub unsafe fn unchecked_new(byte: u8) -> Self {
         debug_assert!(byte <= Self::MAX);
-        core::mem::transmute(byte)
+        unsafe { core::mem::transmute(byte) }
     }
 }
 
@@ -101,6 +101,6 @@ impl ExtendedOpcode {
     /// It is unsafe to pass `bytes` that is not a valid opcode.
     pub unsafe fn unchecked_new(byte: u16) -> Self {
         debug_assert!(byte <= Self::MAX);
-        core::mem::transmute(byte)
+        unsafe { core::mem::transmute(byte) }
     }
 }

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -51,7 +51,7 @@ macro_rules! impl_reg {
             const RANGE: Range<u8> = $range;
 
             unsafe fn new_unchecked(index: u8) -> Self {
-                core::mem::transmute(index)
+                unsafe { core::mem::transmute(index) }
             }
 
             fn to_u8(self) -> u8 {

--- a/pulley/tests/all/interp.rs
+++ b/pulley/tests/all/interp.rs
@@ -19,7 +19,7 @@ fn encoded(ops: &[Op]) -> Vec<u8> {
 unsafe fn run(vm: &mut Vm, ops: &[Op]) -> Result<(), NonNull<u8>> {
     let _ = env_logger::try_init();
     let ops = encoded(ops);
-    match vm.call(NonNull::from(&ops[..]).cast(), &[], []) {
+    match unsafe { vm.call(NonNull::from(&ops[..]).cast(), &[], []) } {
         DoneReason::ReturnToHost(_) => Ok(()),
         DoneReason::Trap { pc, .. } => Err(pc),
         DoneReason::CallIndirectHost { .. } => unimplemented!(),
@@ -54,7 +54,9 @@ unsafe fn assert_one<R0, R1, V>(
     eprintln!("op = {op:?}");
     let op = op.into();
 
-    run(&mut vm, &[op, Op::Ret(Ret {})]).expect("should not trap");
+    unsafe {
+        run(&mut vm, &[op, Op::Ret(Ret {})]).expect("should not trap");
+    }
 
     eprintln!("expected = {expected:#018x}");
 

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -217,17 +217,19 @@ fn guards_present_pooling(config: &mut Config) -> Result<()> {
     };
 
     unsafe fn assert_guards(store: &Store<()>, mem: &Memory) {
-        // guards before
-        println!("check pre-mem");
-        assert_faults(mem.data_ptr(&store).offset(-(GUARD_SIZE as isize)));
+        unsafe {
+            // guards before
+            println!("check pre-mem");
+            assert_faults(mem.data_ptr(&store).offset(-(GUARD_SIZE as isize)));
 
-        // unmapped just after memory
-        println!("check mem");
-        assert_faults(mem.data_ptr(&store).add(mem.data_size(&store)));
+            // unmapped just after memory
+            println!("check mem");
+            assert_faults(mem.data_ptr(&store).add(mem.data_size(&store)));
 
-        // guards after memory
-        println!("check post-mem");
-        assert_faults(mem.data_ptr(&store).add(1 << 20));
+            // guards after memory
+            println!("check post-mem");
+            assert_faults(mem.data_ptr(&store).add(1 << 20));
+        }
     }
     unsafe {
         assert_guards(&store, &mem1);
@@ -278,17 +280,19 @@ fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
     };
 
     unsafe fn assert_guards(store: &Store<()>, mem: &Memory) {
-        // guards before
-        println!("check pre-mem");
-        assert_faults(mem.data_ptr(&store).offset(-(GUARD_SIZE as isize)));
+        unsafe {
+            // guards before
+            println!("check pre-mem");
+            assert_faults(mem.data_ptr(&store).offset(-(GUARD_SIZE as isize)));
 
-        // unmapped just after memory
-        println!("check mem");
-        assert_faults(mem.data_ptr(&store).add(mem.data_size(&store)));
+            // unmapped just after memory
+            println!("check mem");
+            assert_faults(mem.data_ptr(&store).add(mem.data_size(&store)));
 
-        // guards after memory
-        println!("check post-mem");
-        assert_faults(mem.data_ptr(&store).add(1 << 20));
+            // guards after memory
+            println!("check post-mem");
+            assert_faults(mem.data_ptr(&store).add(1 << 20));
+        }
     }
     unsafe {
         assert_guards(&store, &mem1);
@@ -306,11 +310,12 @@ fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
 unsafe fn assert_faults(ptr: *mut u8) {
     use std::io::Error;
     #[cfg(unix)]
-    {
+    unsafe {
         // There's probably a faster way to do this here, but, uh, when in rome?
         match libc::fork() {
             0 => {
                 *ptr = 4;
+
                 std::process::exit(0);
             }
             -1 => panic!("failed to fork: {}", Error::last_os_error()),
@@ -326,7 +331,7 @@ unsafe fn assert_faults(ptr: *mut u8) {
         }
     }
     #[cfg(windows)]
-    {
+    unsafe {
         use windows_sys::Win32::System::Memory::*;
 
         let mut info = std::mem::MaybeUninit::uninit();

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -23,14 +23,18 @@ mod not_for_windows {
             // We rely on the Wasm page size being multiple of host page size.
             assert_eq!(size % page_size, 0);
 
-            let mem = mmap_anonymous(null_mut(), size, ProtFlags::empty(), MapFlags::PRIVATE)
-                .expect("mmap failed");
+            let mem = unsafe {
+                mmap_anonymous(null_mut(), size, ProtFlags::empty(), MapFlags::PRIVATE)
+                    .expect("mmap failed")
+            };
 
             // NOTE: mmap_anonymous returns zero initialized memory, which is relied upon by this
             // API.
 
-            mprotect(mem, minimum, MprotectFlags::READ | MprotectFlags::WRITE)
-                .expect("mprotect failed");
+            unsafe {
+                mprotect(mem, minimum, MprotectFlags::READ | MprotectFlags::WRITE)
+                    .expect("mprotect failed");
+            }
             *glob_counter.lock().unwrap() += minimum;
 
             Self {

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -8,7 +8,7 @@ fn serialize(engine: &Engine, wat: &str) -> Result<Vec<u8>> {
 }
 
 unsafe fn deserialize_and_instantiate(store: &mut Store<()>, buffer: &[u8]) -> Result<Instance> {
-    let module = Module::deserialize(store.engine(), buffer)?;
+    let module = unsafe { Module::deserialize(store.engine(), buffer)? };
     Ok(Instance::new(store, &module, &[])?)
 }
 


### PR DESCRIPTION
This commit enables the `unsafe-op-in-unsafe-fn` lint in rustc for the entire workspace. This lint will be warn-by-default in the 2024 edition so this is intended to smooth the future migration to the new edition.

Many `unsafe` blocks were added in places the lint warned about, with two major exceptions. The `wasmtime` and `wasmtime-c-api` crates simply expect this lint to fire and effectively disable the lint. They're too big at this time to do through this PR. My hope is that one day in the future they'll be migrated, but more realistically that probably won't happen so these crates just won't benefit from this lint.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
