### PR TITLE
Automatically trigger GC in `{Array,Extern,Struct}Ref` allocation functions

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -307,11 +307,6 @@ impl ArrayRef {
         elem: &Val,
         len: u32,
     ) -> Result<Rooted<ArrayRef>> {
-        assert!(
-            !store.async_support(),
-            " use `ArrayRef::new_async` with asynchronous stores"
-        );
-
         store.retry_after_gc((), |store, ()| {
             Self::new_from_iter(store, allocator, RepeatN(elem, len))
         })
@@ -366,11 +361,6 @@ impl ArrayRef {
         elem: &Val,
         len: u32,
     ) -> Result<Rooted<ArrayRef>> {
-        assert!(
-            store.async_support(),
-            "use `ArrayRef::new` with synchronous stores"
-        );
-
         store
             .retry_after_gc_async((), |store, ()| {
                 Self::new_from_iter(store, allocator, RepeatN(elem, len))
@@ -493,11 +483,6 @@ impl ArrayRef {
         allocator: &ArrayRefPre,
         elems: &[Val],
     ) -> Result<Rooted<ArrayRef>> {
-        assert!(
-            !store.async_support(),
-            "use `ArrayRef::new_fixed_async` with asynchronous stores"
-        );
-
         store.retry_after_gc((), |store, ()| {
             Self::new_from_iter(store, allocator, elems.iter())
         })
@@ -553,11 +538,6 @@ impl ArrayRef {
         allocator: &ArrayRefPre,
         elems: &[Val],
     ) -> Result<Rooted<ArrayRef>> {
-        assert!(
-            store.async_support(),
-            "use `ArrayRef::new_fixed` with synchronous stores"
-        );
-
         store
             .retry_after_gc_async((), |store, ()| {
                 Self::new_from_iter(store, allocator, elems.iter())
@@ -568,7 +548,7 @@ impl ArrayRef {
     /// Like `ArrayRef::new_fixed[_async]` but it is the caller's responsibility
     /// to ensure that when async is enabled, this is only called from on a
     /// fiber stack.
-    pub(crate) unsafe fn _new_fixed_maybe_async(
+    pub(crate) unsafe fn new_fixed_maybe_async(
         store: &mut StoreOpaque,
         allocator: &ArrayRefPre,
         elems: &[Val],

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -228,6 +228,36 @@ impl ManuallyRooted<ArrayRef> {
     }
 }
 
+/// An iterator for elements in `ArrayRef::new[_async].
+///
+/// NB: We can't use `iter::repeat(elem).take(len)` because that doesn't
+/// implement `ExactSizeIterator`.
+struct RepeatN<'a>(&'a Val, u32);
+
+impl<'a> Iterator for RepeatN<'a> {
+    type Item = &'a Val;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.1 == 0 {
+            None
+        } else {
+            self.1 -= 1;
+            Some(self.0)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for RepeatN<'_> {
+    fn len(&self) -> usize {
+        usize::try_from(self.1).unwrap()
+    }
+}
+
 impl ArrayRef {
     /// Allocate a new `array` of the given length, with every element
     /// initialized to `elem`.
@@ -237,17 +267,27 @@ impl ArrayRef {
     ///
     /// This is similar to the `array.new` instruction.
     ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new array, then this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
+    ///
     /// # Errors
     ///
     /// If the given `elem` value's type does not match the `allocator`'s array
     /// type's element type, an error is returned.
     ///
     /// If the allocation cannot be satisfied because the GC heap is currently
-    /// out of memory, but performing a garbage collection might free up space
-    /// such that retrying the allocation afterwards might succeed, then a
-    /// [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory] error is returned.
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
     ///
     /// # Panics
+    ///
+    /// Panics if the `store` is configured for async; use
+    /// [`ArrayRef::new_async`][crate::ArrayRef::new_async] to perform
+    /// asynchronous allocation instead.
     ///
     /// Panics if either the allocator or the `elem` value is not associated
     /// with the given store.
@@ -271,40 +311,88 @@ impl ArrayRef {
             allocator.store_id,
             "attempted to use a `ArrayRefPre` with the wrong store"
         );
+        assert!(
+            !store.async_support(),
+            " use `ArrayRef::new_async` with asynchronous stores"
+        );
 
         // Type check the initial element value against the element type.
         elem.ensure_matches_ty(store, allocator.ty.element_type().unpack())
             .context("element type mismatch")?;
 
-        return Self::_new_unchecked(store, allocator, RepeatN(elem, len));
+        store.retry_after_gc((), |store, ()| {
+            Self::_new_unchecked(store, allocator, RepeatN(elem, len))
+        })
+    }
 
-        // NB: Can't use `iter::repeat(elem).take(len)` above because that
-        // doesn't implement `ExactSizeIterator`.
-        struct RepeatN<'a>(&'a Val, u32);
+    /// Asynchronously allocate a new `array` of the given length, with every
+    /// element initialized to `elem`.
+    ///
+    /// For example, `ArrayRef::new(ctx, pre, &Val::I64(9), 3)` allocates the
+    /// array `[9, 9, 9]`.
+    ///
+    /// This is similar to the `array.new` instruction.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new array, then this method will automatically trigger a asynchronous
+    /// collection in an attempt to free up space in the GC heap.
+    ///
+    /// # Errors
+    ///
+    /// If the given `elem` value's type does not match the `allocator`'s array
+    /// type's element type, an error is returned.
+    ///
+    /// If the allocation cannot be satisfied because the GC heap is currently
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if your engine is not configured for async; use
+    /// [`ArrayRef::new_async`][crate::ArrayRef::new_async] to perform
+    /// synchronous allocation instead.
+    ///
+    /// Panics if either the allocator or the `elem` value is not associated
+    /// with the given store.
+    #[cfg(feature = "async")]
+    pub async fn new_async(
+        mut store: impl AsContextMut,
+        allocator: &ArrayRefPre,
+        elem: &Val,
+        len: u32,
+    ) -> Result<Rooted<ArrayRef>> {
+        Self::_new_async(store.as_context_mut().0, allocator, elem, len).await
+    }
 
-        impl<'a> Iterator for RepeatN<'a> {
-            type Item = &'a Val;
+    #[cfg(feature = "async")]
+    pub(crate) async fn _new_async(
+        store: &mut StoreOpaque,
+        allocator: &ArrayRefPre,
+        elem: &Val,
+        len: u32,
+    ) -> Result<Rooted<ArrayRef>> {
+        assert_eq!(
+            store.id(),
+            allocator.store_id,
+            "attempted to use a `ArrayRefPre` with the wrong store"
+        );
+        assert!(
+            store.async_support(),
+            "use `ArrayRef::new` with synchronous stores"
+        );
 
-            fn next(&mut self) -> Option<Self::Item> {
-                if self.1 == 0 {
-                    None
-                } else {
-                    self.1 -= 1;
-                    Some(self.0)
-                }
-            }
+        // Type check the initial element value against the element type.
+        elem.ensure_matches_ty(store, allocator.ty.element_type().unpack())
+            .context("element type mismatch")?;
 
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                let len = self.len();
-                (len, Some(len))
-            }
-        }
-
-        impl ExactSizeIterator for RepeatN<'_> {
-            fn len(&self) -> usize {
-                usize::try_from(self.1).unwrap()
-            }
-        }
+        store
+            .retry_after_gc_async((), |store, ()| {
+                Self::_new_unchecked(store, allocator, RepeatN(elem, len))
+            })
+            .await
     }
 
     /// Allocate a new array of the given elements, without checking that the
@@ -346,12 +434,18 @@ impl ArrayRef {
         }
     }
 
-    /// Allocate a new `array` containing the given elements.
+    /// Synchronously allocate a new `array` containing the given elements.
     ///
     /// For example, `ArrayRef::new_fixed(ctx, pre, &[Val::I64(4), Val::I64(5),
     /// Val::I64(6)])` allocates the array `[4, 5, 6]`.
     ///
     /// This is similar to the `array.new_fixed` instruction.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new array, then this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
     ///
     /// # Errors
     ///
@@ -359,11 +453,15 @@ impl ArrayRef {
     /// array type's element type, an error is returned.
     ///
     /// If the allocation cannot be satisfied because the GC heap is currently
-    /// out of memory, but performing a garbage collection might free up space
-    /// such that retrying the allocation afterwards might succeed, then a
-    /// [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory] error is returned.
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
     ///
     /// # Panics
+    ///
+    /// Panics if the `store` is configured for async; use
+    /// [`ArrayRef::new_fixed_async`][crate::ArrayRef::new_fixed_async] to
+    /// perform asynchronous allocation instead.
     ///
     /// Panics if the allocator or any of the `elems` values are not associated
     /// with the given store.
@@ -385,6 +483,10 @@ impl ArrayRef {
             allocator.store_id,
             "attempted to use a `ArrayRefPre` with the wrong store"
         );
+        assert!(
+            !store.async_support(),
+            "use `ArrayRef::new_fixed_async` with asynchronous stores"
+        );
 
         // Type check the elements against the element type.
         for elem in elems {
@@ -392,7 +494,82 @@ impl ArrayRef {
                 .context("element type mismatch")?;
         }
 
-        return Self::_new_unchecked(store, allocator, elems.iter());
+        store.retry_after_gc((), |store, ()| {
+            Self::_new_unchecked(store, allocator, elems.iter())
+        })
+    }
+
+    /// Asynchronously allocate a new `array` containing the given elements.
+    ///
+    /// For example, `ArrayRef::new_fixed_async(ctx, pre, &[Val::I64(4),
+    /// Val::I64(5), Val::I64(6)])` allocates the array `[4, 5, 6]`.
+    ///
+    /// This is similar to the `array.new_fixed` instruction.
+    ///
+    /// If your engine is not configured for async, use
+    /// [`ArrayRef::new_fixed`][crate::ArrayRef::new_fixed] to perform
+    /// synchronous allocation.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new array, then this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
+    ///
+    /// # Errors
+    ///
+    /// If any of the `elems` values' type does not match the `allocator`'s
+    /// array type's element type, an error is returned.
+    ///
+    /// If the allocation cannot be satisfied because the GC heap is currently
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `store` is not configured for async; use
+    /// [`ArrayRef::new_fixed`][crate::ArrayRef::new_fixed] to perform
+    /// synchronous allocation instead.
+    ///
+    /// Panics if the allocator or any of the `elems` values are not associated
+    /// with the given store.
+    #[cfg(feature = "async")]
+    pub async fn new_fixed_async(
+        mut store: impl AsContextMut,
+        allocator: &ArrayRefPre,
+        elems: &[Val],
+    ) -> Result<Rooted<ArrayRef>> {
+        Self::_new_fixed_async(store.as_context_mut().0, allocator, elems).await
+    }
+
+    #[cfg(feature = "async")]
+    pub(crate) async fn _new_fixed_async(
+        store: &mut StoreOpaque,
+        allocator: &ArrayRefPre,
+        elems: &[Val],
+    ) -> Result<Rooted<ArrayRef>> {
+        assert_eq!(
+            store.id(),
+            allocator.store_id,
+            "attempted to use a `ArrayRefPre` with the wrong store"
+        );
+        assert!(
+            store.async_support(),
+            "use `ArrayRef::new_fixed` with synchronous stores"
+        );
+
+        // Type check the elements against the element type.
+        for elem in elems {
+            elem.ensure_matches_ty(store, allocator.ty.element_type().unpack())
+                .context("element type mismatch")?;
+        }
+
+        store
+            .retry_after_gc_async((), |store, ()| {
+                Self::_new_unchecked(store, allocator, elems.iter())
+            })
+            .await
     }
 
     #[inline]
@@ -478,7 +655,7 @@ impl ArrayRef {
 
     /// Get the values of this array's elements.
     ///
-    /// Note that `i8` and `i16` field values are zero-extended into
+    /// Note that `i8` and `i16` element values are zero-extended into
     /// `Val::I32(_)`s.
     ///
     /// # Errors

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -221,7 +221,10 @@ impl ExternRef {
     where
         T: 'static + Any + Send + Sync,
     {
-        assert!(!store.async_support(), "use `ExternRef::new_async` with asynchronous stores");
+        assert!(
+            !store.async_support(),
+            "use `ExternRef::new_async` with asynchronous stores"
+        );
         let value: Box<dyn Any + Send + Sync> = Box::new(value);
         let gc_ref = store.retry_after_gc(value, |store, value| {
             store
@@ -326,7 +329,10 @@ impl ExternRef {
     where
         T: 'static + Any + Send + Sync,
     {
-        assert!(store.async_support(), "use `ExternRef::new` with synchronous stores");
+        assert!(
+            store.async_support(),
+            "use `ExternRef::new` with synchronous stores"
+        );
         let value: Box<dyn Any + Send + Sync> = Box::new(value);
         let gc_ref = store
             .retry_after_gc_async(value, |store, value| {

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -137,28 +137,33 @@ unsafe impl GcRefImpl for ExternRef {
 }
 
 impl ExternRef {
-    /// Creates a new instance of `ExternRef` wrapping the given value.
+    /// Synchronously allocates a new `ExternRef` wrapping the given value.
     ///
     /// The resulting value is automatically unrooted when the given `context`'s
-    /// scope is exited. See [`Rooted<T>`][crate::Rooted]'s documentation for
-    /// more details.
+    /// scope is exited. If you need to hold the reference past the `context`'s
+    /// scope, convert the result into a
+    /// [`ManuallyRooted<T>`][crate::ManuallyRooted]. See the documentation for
+    /// [`Rooted<T>`][crate::Rooted] and
+    /// [`ManuallyRooted<T>`][crate::ManuallyRooted] for more details.
     ///
-    /// This method will *not* automatically trigger a GC to free up space in
-    /// the GC heap; instead it will return an error. This gives you more
-    /// precise control over when collections happen and allows you to choose
-    /// between performing synchronous and asynchronous collections.
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating a new
+    /// `externref`, this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
     ///
     /// # Errors
     ///
     /// If the allocation cannot be satisfied because the GC heap is currently
-    /// out of memory, but performing a garbage collection might free up space
-    /// such that retrying the allocation afterwards might succeed, then a
-    /// `GcHeapOutOfMemory<T>` error is returned.
+    /// out of memory, then a [`GcHeapOutOfMemory<T>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
     ///
-    /// The `GcHeapOutOfMemory<T>` error contains the host value that the
-    /// `externref` would have wrapped. You can extract that value from this
-    /// error and reuse it when attempting to allocate an `externref` again
-    /// after GC or otherwise do with it whatever you see fit.
+    /// The [`GcHeapOutOfMemory<T>`][crate::GcHeapOutOfMemory] error contains
+    /// the host value that the `externref` would have wrapped. You can extract
+    /// that value from the error and reuse it when attempting to allocate an
+    /// `externref` again after dropping rooted GC references and then
+    /// performing a collection or otherwise do with it whatever you see fit.
     ///
     /// # Example
     ///
@@ -170,26 +175,25 @@ impl ExternRef {
     /// {
     ///     let mut scope = RootScope::new(&mut store);
     ///
-    ///     // Create an `externref` wrapping a `str`.
-    ///     let externref = match ExternRef::new(&mut scope, "hello!") {
+    ///     // Allocate an `externref` wrapping a `String`.
+    ///     let externref = match ExternRef::new(&mut scope, "hello!".to_string()) {
+    ///         // The allocation succeeded.
     ///         Ok(x) => x,
-    ///         // If the heap is out of memory, then do a GC and try again.
-    ///         Err(e) if e.is::<GcHeapOutOfMemory<&'static str>>() => {
-    ///             // Do a GC! Note: in an async context, you'd want to do
-    ///             // `scope.as_context_mut().gc_async().await`.
-    ///             scope.as_context_mut().gc();
-    ///
-    ///             // Extract the original host value from the error.
-    ///             let host_value = e
-    ///                 .downcast::<GcHeapOutOfMemory<&'static str>>()
-    ///                 .unwrap()
-    ///                 .into_inner();
-    ///
-    ///             // Try to allocate the `externref` again, now that the GC
-    ///             // has hopefully freed up some space.
-    ///             ExternRef::new(&mut scope, host_value)?
-    ///         }
-    ///         Err(e) => return Err(e),
+    ///         // The allocation failed.
+    ///         Err(e) => match e.downcast::<GcHeapOutOfMemory<String>>() {
+    ///             // The allocation failed because the GC heap does not have
+    ///             // capacity for this allocation.
+    ///             Ok(oom) => {
+    ///                 // Take back ownership of our `String`.
+    ///                 let s = oom.into_inner();
+    ///                 // Drop other rooted GC refs to make room for this
+    ///                 // allocation, and try again, passing the string back
+    ///                 // into the second allocation attempt. Alternatively,
+    ///                 // propagate the error up to callers...
+    /// #               return Ok(());
+    ///             }
+    ///             Err(e) => return Err(e),
+    ///         },
     ///     };
     ///
     ///     // Use the `externref`, pass it to Wasm, etc...
@@ -199,21 +203,143 @@ impl ExternRef {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `context` is configured for async; use
+    /// [`ExternRef::new_async`][crate::ExternRef::new_async] to perform
+    /// asynchronous allocation instead.
     pub fn new<T>(mut context: impl AsContextMut, value: T) -> Result<Rooted<ExternRef>>
     where
         T: 'static + Any + Send + Sync,
     {
         let ctx = context.as_context_mut().0;
+        Self::_new(ctx, value)
+    }
 
+    pub(crate) fn _new<T>(store: &mut StoreOpaque, value: T) -> Result<Rooted<ExternRef>>
+    where
+        T: 'static + Any + Send + Sync,
+    {
+        assert!(!store.async_support(), "use `ExternRef::new_async` with asynchronous stores");
         let value: Box<dyn Any + Send + Sync> = Box::new(value);
-        let gc_ref = ctx
-            .gc_store_mut()?
-            .alloc_externref(value)
-            .context("unrecoverable error when allocating new `externref`")?
-            .map_err(|x| GcHeapOutOfMemory::<T>::new(*x.downcast().unwrap()))
-            .context("failed to allocate `externref`")?;
+        let gc_ref = store.retry_after_gc(value, |store, value| {
+            store
+                .gc_store_mut()?
+                .alloc_externref(value)
+                .context("unrecoverable error when allocating new `externref`")?
+                .map_err(|x| GcHeapOutOfMemory::<T>::new(*x.downcast().unwrap()))
+                .context("failed to allocate `externref`")
+        })?;
 
-        let mut ctx = AutoAssertNoGc::new(ctx);
+        let mut ctx = AutoAssertNoGc::new(store);
+        Ok(Self::from_cloned_gc_ref(&mut ctx, gc_ref.into()))
+    }
+
+    /// Asynchronously allocates a new `ExternRef` wrapping the given value.
+    ///
+    /// The resulting value is automatically unrooted when the given `context`'s
+    /// scope is exited. If you need to hold the reference past the `context`'s
+    /// scope, convert the result into a
+    /// [`ManuallyRooted<T>`][crate::ManuallyRooted]. See the documentation for
+    /// [`Rooted<T>`][crate::Rooted] and
+    /// [`ManuallyRooted<T>`][crate::ManuallyRooted] for more details.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating a new
+    /// `externref`, this method will automatically trigger an asynchronous
+    /// collection in an attempt to free up space in the GC heap.
+    ///
+    /// # Errors
+    ///
+    /// If the allocation cannot be satisfied because the GC heap is currently
+    /// out of memory, then a [`GcHeapOutOfMemory<T>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
+    ///
+    /// The [`GcHeapOutOfMemory<T>`][crate::GcHeapOutOfMemory] error contains
+    /// the host value that the `externref` would have wrapped. You can extract
+    /// that value from the error and reuse it when attempting to allocate an
+    /// `externref` again after dropping rooted GC references and then
+    /// performing a collection or otherwise do with it whatever you see fit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use wasmtime::*;
+    ///
+    /// # async fn _foo() -> Result<()> {
+    /// let mut store = Store::<()>::default();
+    ///
+    /// {
+    ///     let mut scope = RootScope::new(&mut store);
+    ///
+    ///     // Create an `externref` wrapping a `String`.
+    ///     let externref = match ExternRef::new_async(&mut scope, "hello!".to_string()).await {
+    ///         // The allocation succeeded.
+    ///         Ok(x) => x,
+    ///         // The allocation failed.
+    ///         Err(e) => match e.downcast::<GcHeapOutOfMemory<String>>() {
+    ///             // The allocation failed because the GC heap does not have
+    ///             // capacity for this allocation.
+    ///             Ok(oom) => {
+    ///                 // Take back ownership of our `String`.
+    ///                 let s = oom.into_inner();
+    ///                 // Drop other rooted GC refs to make room for this
+    ///                 // allocation, and try again, passing the string back
+    ///                 // into the second allocation attempt. Alternatively,
+    ///                 // propagate the error up to callers...
+    /// #               return Ok(());
+    ///             }
+    ///             Err(e) => return Err(e),
+    ///         },
+    ///     };
+    ///
+    ///     // Use the `externref`, pass it to Wasm, etc...
+    /// }
+    ///
+    /// // The `externref` is automatically unrooted when we exit the scope.
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `context` is not configured for async; use
+    /// [`ExternRef::new`][crate::ExternRef::new] to perform synchronous
+    /// allocation instead.
+    #[cfg(feature = "async")]
+    pub async fn new_async<T>(mut context: impl AsContextMut, value: T) -> Result<Rooted<ExternRef>>
+    where
+        T: 'static + Any + Send + Sync,
+    {
+        let ctx = context.as_context_mut().0;
+        Self::_new_async(ctx, value).await
+    }
+
+    #[cfg(feature = "async")]
+    pub(crate) async fn _new_async<T>(
+        store: &mut StoreOpaque,
+        value: T,
+    ) -> Result<Rooted<ExternRef>>
+    where
+        T: 'static + Any + Send + Sync,
+    {
+        assert!(store.async_support(), "use `ExternRef::new` with synchronous stores");
+        let value: Box<dyn Any + Send + Sync> = Box::new(value);
+        let gc_ref = store
+            .retry_after_gc_async(value, |store, value| {
+                store
+                    .gc_store_mut()?
+                    .alloc_externref(value)
+                    .context("unrecoverable error when allocating new `externref`")?
+                    .map_err(|x| GcHeapOutOfMemory::<T>::new(*x.downcast().unwrap()))
+                    .context("failed to allocate `externref`")
+            })
+            .await?;
+
+        let mut ctx = AutoAssertNoGc::new(store);
         Ok(Self::from_cloned_gc_ref(&mut ctx, gc_ref.into()))
     }
 
@@ -272,58 +398,6 @@ impl ExternRef {
     ) -> Result<Rooted<ExternRef>> {
         let gc_ref = anyref.try_clone_gc_ref(store)?;
         Ok(Self::from_cloned_gc_ref(store, gc_ref))
-    }
-
-    /// Creates a new, manually-rooted instance of `ExternRef` wrapping the
-    /// given value.
-    ///
-    /// The resulting value must be manually unrooted, or else it will leak for
-    /// the entire duration of the store's lifetime. See
-    /// [`ManuallyRooted<T>`][crate::ManuallyRooted]'s documentation for more
-    /// details.
-    ///
-    /// # Errors
-    ///
-    /// This function returns the same errors in the same scenarios as
-    /// [`ExternRef::new`][crate::ExternRef::new].
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use wasmtime::*;
-    /// # fn _foo() -> Result<()> {
-    /// let mut store = Store::<()>::default();
-    ///
-    /// // Create a manually-rooted `externref` wrapping a `str`.
-    /// let externref = ExternRef::new_manually_rooted(&mut store, "hello!")?;
-    ///
-    /// // Use `externref` a bunch, pass it to Wasm, etc...
-    ///
-    /// // Don't forget to explicitly unroot the `externref` when you're done
-    /// // using it!
-    /// externref.unroot(&mut store);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn new_manually_rooted<T>(
-        mut store: impl AsContextMut,
-        value: T,
-    ) -> Result<ManuallyRooted<ExternRef>>
-    where
-        T: 'static + Any + Send + Sync,
-    {
-        let ctx = store.as_context_mut().0;
-
-        let value: Box<dyn Any + Send + Sync> = Box::new(value);
-        let gc_ref = ctx
-            .gc_store_mut()?
-            .alloc_externref(value)
-            .context("unrecoverable error when allocating new `externref`")?
-            .map_err(|x| GcHeapOutOfMemory::<T>::new(*x.downcast().unwrap()))
-            .context("failed to allocate `externref`")?;
-
-        let mut ctx = AutoAssertNoGc::new(ctx);
-        Ok(ManuallyRooted::new(&mut ctx, gc_ref.into()))
     }
 
     /// Create a new `Rooted<ExternRef>` from the given GC reference.

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -221,10 +221,6 @@ impl ExternRef {
     where
         T: 'static + Any + Send + Sync,
     {
-        assert!(
-            !store.async_support(),
-            "use `ExternRef::new_async` with asynchronous stores"
-        );
         let value: Box<dyn Any + Send + Sync> = Box::new(value);
         let gc_ref = store.retry_after_gc(value, |store, value| {
             store
@@ -329,10 +325,6 @@ impl ExternRef {
     where
         T: 'static + Any + Send + Sync,
     {
-        assert!(
-            store.async_support(),
-            "use `ExternRef::new` with synchronous stores"
-        );
         let value: Box<dyn Any + Send + Sync> = Box::new(value);
         let gc_ref = store
             .retry_after_gc_async(value, |store, value| {

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1666,27 +1666,32 @@ where
     /// # fn foo() -> Result<()> {
     /// let mut store = Store::<()>::default();
     ///
-    /// let a = ExternRef::new_manually_rooted(&mut store, "hello")?;
-    /// let b = a.clone(&mut store);
-    ///
-    /// // `a` and `b` are rooting the same object.
-    /// assert!(ManuallyRooted::ref_eq(&store, &a, &b)?);
+    /// let a;
+    /// let b;
+    /// let x;
     ///
     /// {
     ///     let mut scope = RootScope::new(&mut store);
+    ///
+    ///     a = ExternRef::new(&mut scope, "hello")?.to_manually_rooted(&mut scope)?;
+    ///     b = a.clone(&mut scope);
+    ///
+    ///     // `a` and `b` are rooting the same object.
+    ///     assert!(ManuallyRooted::ref_eq(&scope, &a, &b)?);
     ///
     ///     // `c` is a different GC root, is in a different scope, and is a
     ///     // `Rooted<T>` instead of a `ManuallyRooted<T>`, but is still rooting
     ///     // the same object.
     ///     let c = a.to_rooted(&mut scope);
     ///     assert!(ManuallyRooted::ref_eq(&scope, &a, &c)?);
+    ///
+    ///     x = ExternRef::new(&mut scope, "goodbye")?.to_manually_rooted(&mut scope)?;
+    ///
+    ///     // `a` and `x` are rooting different objects.
+    ///     assert!(!ManuallyRooted::ref_eq(&scope, &a, &x)?);
     /// }
     ///
-    /// let x = ExternRef::new_manually_rooted(&mut store, "goodbye")?;
-    ///
-    /// // `a` and `x` are rooting different objects.
-    /// assert!(!ManuallyRooted::ref_eq(&store, &a, &x)?);
-    ///
+    /// // Unroot our manually-rooted GC references.
     /// a.unroot(&mut store);
     /// b.unroot(&mut store);
     /// x.unroot(&mut store);

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -133,18 +133,7 @@ impl StructRefPre {
 ///     let mut scope = RootScope::new(&mut store);
 ///
 ///     // Allocate an instance of the struct type.
-///     let my_struct = match StructRef::new(&mut scope, &allocator, &[Val::I32(42)]) {
-///         Ok(s) => s,
-///         // If the heap is out of memory, then do a GC and try again.
-///         Err(e) if e.is::<GcHeapOutOfMemory<()>>() => {
-///             // Do a GC! Note: in an async context, you'd want to do
-///             // `scope.as_context_mut().gc_async().await`.
-///             scope.as_context_mut().gc();
-///
-///             StructRef::new(&mut scope, &allocator, &[Val::I32(42)])?
-///         }
-///         Err(e) => return Err(e),
-///     };
+///     let my_struct = StructRef::new(&mut scope, &allocator, &[Val::I32(42)])?;
 ///
 ///     // That instance's field should have the expected value.
 ///     let val = my_struct.field(&mut scope, 0)?.unwrap_i32();
@@ -212,7 +201,13 @@ impl ManuallyRooted<StructRef> {
 }
 
 impl StructRef {
-    /// Allocate a new `struct` and get a reference to it.
+    /// Synchronously allocate a new `struct` and get a reference to it.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new struct, then this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
     ///
     /// # Errors
     ///
@@ -220,11 +215,15 @@ impl StructRef {
     /// `allocator`'s struct type, an error is returned.
     ///
     /// If the allocation cannot be satisfied because the GC heap is currently
-    /// out of memory, but performing a garbage collection might free up space
-    /// such that retrying the allocation afterwards might succeed, then a
-    /// [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory] error is returned.
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
     ///
     /// # Panics
+    ///
+    /// Panics if your engine is configured for async; use
+    /// [`StructRef::new_async`][crate::StructRef::new_async] to perform
+    /// synchronous allocation instead.
     ///
     /// Panics if the allocator, or any of the field values, is not associated
     /// with the given store.
@@ -246,8 +245,80 @@ impl StructRef {
             allocator.store_id,
             "attempted to use a `StructRefPre` with the wrong store"
         );
+        assert!(
+            !store.async_support(),
+            "use `StructRef::new_async` with asynchronous stores"
+        );
+        Self::type_check_fields(store, allocator, fields)?;
+        store.retry_after_gc((), |store, ()| {
+            Self::new_unchecked(store, allocator, fields)
+        })
+    }
 
-        // Type check the given values against the field types.
+    /// Asynchronously allocate a new `struct` and get a reference to it.
+    ///
+    /// # Automatic Garbage Collection
+    ///
+    /// If the GC heap is at capacity, and there isn't room for allocating this
+    /// new struct, then this method will automatically trigger a synchronous
+    /// collection in an attempt to free up space in the GC heap.
+    ///
+    /// # Errors
+    ///
+    /// If the given `fields` values' types do not match the field types of the
+    /// `allocator`'s struct type, an error is returned.
+    ///
+    /// If the allocation cannot be satisfied because the GC heap is currently
+    /// out of memory, then a [`GcHeapOutOfMemory<()>`][crate::GcHeapOutOfMemory]
+    /// error is returned. The allocation might succeed on a second attempt if
+    /// you drop some rooted GC references and try again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if your engine is not configured for async; use
+    /// [`StructRef::new`][crate::StructRef::new] to perform synchronous
+    /// allocation instead.
+    ///
+    /// Panics if the allocator, or any of the field values, is not associated
+    /// with the given store.
+    #[cfg(feature = "async")]
+    pub async fn new_async(
+        mut store: impl AsContextMut,
+        allocator: &StructRefPre,
+        fields: &[Val],
+    ) -> Result<Rooted<StructRef>> {
+        Self::_new_async(store.as_context_mut().0, allocator, fields).await
+    }
+
+    #[cfg(feature = "async")]
+    pub(crate) async fn _new_async(
+        store: &mut StoreOpaque,
+        allocator: &StructRefPre,
+        fields: &[Val],
+    ) -> Result<Rooted<StructRef>> {
+        assert_eq!(
+            store.id(),
+            allocator.store_id,
+            "attempted to use a `StructRefPre` with the wrong store"
+        );
+        assert!(
+            store.async_support(),
+            "use `StructRef::new` with synchronous stores"
+        );
+        Self::type_check_fields(store, allocator, fields)?;
+        store
+            .retry_after_gc_async((), |store, ()| {
+                Self::new_unchecked(store, allocator, fields)
+            })
+            .await
+    }
+
+    /// Type check the field values before allocating a new struct.
+    fn type_check_fields(
+        store: &mut StoreOpaque,
+        allocator: &StructRefPre,
+        fields: &[Val],
+    ) -> Result<(), Error> {
         let expected_len = allocator.ty.fields().len();
         let actual_len = fields.len();
         ensure!(
@@ -263,7 +334,18 @@ impl StructRef {
             val.ensure_matches_ty(store, ty)
                 .context("field type mismatch")?;
         }
+        Ok(())
+    }
 
+    /// Given that the field values have already been type checked, allocate a
+    /// new struct.
+    ///
+    /// Does not attempt GC+retry on OOM, that is the caller's responsibility.
+    fn new_unchecked(
+        store: &mut StoreOpaque,
+        allocator: &StructRefPre,
+        fields: &[Val],
+    ) -> Result<Rooted<StructRef>> {
         // Allocate the struct and write each field value into the appropriate
         // offset.
         let structref = store

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -310,10 +310,6 @@ impl StructRef {
         allocator: &StructRefPre,
         fields: &[Val],
     ) -> Result<Rooted<StructRef>> {
-        assert!(
-            store.async_support(),
-            "use `StructRef::new` with synchronous stores"
-        );
         Self::type_check_fields(store, allocator, fields)?;
         unsafe {
             store.retry_after_gc_maybe_async((), |store, ()| {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1529,7 +1529,10 @@ impl StoreOpaque {
     where
         T: Send + Sync + 'static,
     {
-        debug_assert!(!self.async_support());
+        assert!(
+            !self.async_support(),
+            "use the `*_async` versions of methods when async is configured"
+        );
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1569,6 +1569,7 @@ impl StoreOpaque {
 
     /// Like `gc` but must be called from a fiber stack if this is an async
     /// store.
+    #[cfg(feature = "gc")]
     unsafe fn maybe_async_gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>> {
         let mut scope = crate::OpaqueRootScope::new(self);
         let store_id = scope.id();

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -517,7 +517,10 @@ impl StoreOpaque {
     where
         T: Send + Sync + 'static,
     {
-        debug_assert!(self.async_support());
+        assert!(
+            self.async_support(),
+            "you must configure async to use the `*_async` versions of methods"
+        );
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -200,7 +200,7 @@ pub unsafe trait VMStore {
     ///
     /// If the async GC was cancelled, returns an error. This should be raised
     /// as a trap to clean up Wasm execution.
-    fn maybe_async_gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>>;
+    unsafe fn maybe_async_gc(&mut self, root: Option<VMGcRef>) -> Result<Option<VMGcRef>>;
 
     /// Metadata required for resources for the component model.
     #[cfg(feature = "component-model")]

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -73,7 +73,7 @@ impl<'a> ConstEvalContext<'a> {
             .collect::<Vec<_>>();
 
         let allocator = StructRefPre::_new(store, struct_ty);
-        let struct_ref = StructRef::_new(store, &allocator, &fields)?;
+        let struct_ref = unsafe { StructRef::new_maybe_async(store, &allocator, &fields)? };
         let raw = struct_ref.to_anyref()._to_raw(store)?;
         Ok(ValRaw::anyref(raw))
     }
@@ -141,6 +141,9 @@ impl ConstExprEvaluator {
     /// global values of the expected types. This evaluator operates directly on
     /// untyped `ValRaw`s and does not and cannot check that its operands are of
     /// the correct type.
+    ///
+    /// If given async store, then this must be called from on an async fiber
+    /// stack.
     pub unsafe fn eval(
         &mut self,
         store: &mut StoreOpaque,
@@ -269,7 +272,7 @@ impl ConstExprEvaluator {
                     let elem = Val::_from_raw(&mut store, self.pop()?, ty.element_type().unpack());
 
                     let pre = ArrayRefPre::_new(&mut store, ty);
-                    let array = ArrayRef::_new(&mut store, &pre, &elem, len)?;
+                    let array = unsafe { ArrayRef::new_maybe_async(&mut store, &pre, &elem, len)? };
 
                     self.stack
                         .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));
@@ -288,7 +291,7 @@ impl ConstExprEvaluator {
                         .expect("type should have a default value");
 
                     let pre = ArrayRefPre::_new(&mut store, ty);
-                    let array = ArrayRef::_new(&mut store, &pre, &elem, len)?;
+                    let array = unsafe { ArrayRef::new_maybe_async(&mut store, &pre, &elem, len)? };
 
                     self.stack
                         .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));
@@ -323,7 +326,8 @@ impl ConstExprEvaluator {
                         .collect::<SmallVec<[_; 8]>>();
 
                     let pre = ArrayRefPre::_new(&mut store, ty);
-                    let array = ArrayRef::_new_fixed(&mut store, &pre, &elems)?;
+                    let array =
+                        unsafe { ArrayRef::_new_fixed_maybe_async(&mut store, &pre, &elems)? };
 
                     self.stack
                         .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -327,7 +327,7 @@ impl ConstExprEvaluator {
 
                     let pre = ArrayRefPre::_new(&mut store, ty);
                     let array =
-                        unsafe { ArrayRef::_new_fixed_maybe_async(&mut store, &pre, &elems)? };
+                        unsafe { ArrayRef::new_fixed_maybe_async(&mut store, &pre, &elems)? };
 
                     self.stack
                         .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -827,7 +827,7 @@ unsafe fn array_new_elem(
             }
         }
 
-        let array = unsafe { ArrayRef::_new_fixed_maybe_async(store, &pre, &vals)? };
+        let array = unsafe { ArrayRef::new_fixed_maybe_async(store, &pre, &vals)? };
 
         let mut store = AutoAssertNoGc::new(store);
         let gc_ref = array.try_clone_gc_ref(&mut store)?;

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -772,7 +772,7 @@ unsafe fn array_new_elem(
     use crate::{
         store::AutoAssertNoGc,
         vm::const_expr::{ConstEvalContext, ConstExprEvaluator},
-        ArrayRef, ArrayRefPre, ArrayType, Func, GcHeapOutOfMemory, RootSet, RootedGcRefImpl, Val,
+        ArrayRef, ArrayRefPre, ArrayType, Func, RootSet, RootedGcRefImpl, Val,
     };
     use wasmtime_environ::{ModuleInternedTypeIndex, TableSegmentElements};
 
@@ -827,16 +827,7 @@ unsafe fn array_new_elem(
             }
         }
 
-        let array = match ArrayRef::_new_fixed(store, &pre, &vals) {
-            Ok(a) => a,
-            Err(e) if e.is::<GcHeapOutOfMemory<()>>() => {
-                // Collect garbage to hopefully free up space, then try the
-                // allocation again.
-                store.maybe_async_gc(None)?;
-                ArrayRef::_new_fixed(store, &pre, &vals)?
-            }
-            Err(e) => return Err(e),
-        };
+        let array = unsafe { ArrayRef::_new_fixed_maybe_async(store, &pre, &vals)? };
 
         let mut store = AutoAssertNoGc::new(store);
         let gc_ref = array.try_clone_gc_ref(&mut store)?;

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -22,8 +22,8 @@ pub struct WastContext<T> {
     modules: HashMap<String, ModuleKind>,
     #[cfg(feature = "component-model")]
     component_linker: component::Linker<T>,
-    store: Store<T>,
-    async_runtime: Option<tokio::runtime::Runtime>,
+    pub(crate) store: Store<T>,
+    pub(crate) async_runtime: Option<tokio::runtime::Runtime>,
 }
 
 enum Outcome<T = Results> {
@@ -215,7 +215,7 @@ where
                     .args
                     .iter()
                     .map(|v| match v {
-                        WastArg::Core(v) => core::val(&mut self.store, v),
+                        WastArg::Core(v) => core::val(self, v),
                         _ => bail!("expected core function, found other other argument {v:?}"),
                     })
                     .collect::<Result<Vec<_>>>()?;

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -755,7 +755,10 @@ fn manually_rooted_gets_collected_after_unrooting() -> Result<()> {
     let mut store = Store::<()>::default();
     let flag = Arc::new(AtomicBool::new(false));
 
-    let externref = ExternRef::new_manually_rooted(&mut store, SetFlagOnDrop(flag.clone()))?;
+    let externref = {
+        let mut scope = RootScope::new(&mut store);
+        ExternRef::new(&mut scope, SetFlagOnDrop(flag.clone()))?.to_manually_rooted(&mut scope)?
+    };
 
     store.gc();
     assert!(!flag.load(SeqCst), "not dropped when still rooted");


### PR DESCRIPTION
Rather than forcing all callers to check for `GcHeapOutOfMemory`, trigger a GC, and then try again. This does force us to define `*_async` variations for when async is enabled, however; it's ultimately worth it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
