### PR TITLE
Winch: Free dst register if computing heap address fails

### DIFF
--- a/tests/disas/winch/x64/v128_ops/load_lane/zero_max_memory.wat
+++ b/tests/disas/winch/x64/v128_ops/load_lane/zero_max_memory.wat
@@ -1,0 +1,53 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (memory 0 0)
+  (func (result f32)
+    i32.const 0
+    if
+      unreachable
+    end
+    i32.const 0
+    v128.const i64x2 0 0
+    v128.load64_lane align=1 0
+    drop
+    f32.const 0
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x5e
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movl    $0, %eax
+;;       testl   %eax, %eax
+;;       je      0x3b
+;;   39: ud2
+;;       movdqu  0x1d(%rip), %xmm0
+;;       movl    $0, %eax
+;;       movq    8(%r14), %rcx
+;;       movq    (%rcx), %r11
+;;       addq    $1, %r11
+;;       movq    %r11, (%rcx)
+;;       ud2
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   5e: ud2
+;;   60: addb    %al, (%rax)
+;;   62: addb    %al, (%rax)
+;;   64: addb    %al, (%rax)
+;;   66: addb    %al, (%rax)
+;;   68: addb    %al, (%rax)
+;;   6a: addb    %al, (%rax)
+;;   6c: addb    %al, (%rax)
+;;   6e: addb    %al, (%rax)

--- a/tests/misc_testsuite/winch/v128_load_lane_invalid_address.wast
+++ b/tests/misc_testsuite/winch/v128_load_lane_invalid_address.wast
@@ -1,0 +1,18 @@
+;;! simd = true
+
+(module
+  (memory 0 0)
+  (func (export "test") (result f32)
+    i32.const 0
+    if
+      unreachable
+    end
+    i32.const 0
+    v128.const i64x2 0 0
+    v128.load64_lane align=1 0
+    drop
+    f32.const 0
+  )
+)
+
+(assert_trap (invoke "test") "out of bounds memory access")

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -908,12 +908,19 @@ where
             Ok(())
         };
 
+        // Ensure that the destination register is not allocated if
+        // `emit_compute_heap_address` does not return an address.
         match kind {
             LoadKind::VectorLane(_) => {
+                // Destination vector register is at the top of the stack and
+                // `emit_compute_heap_address` expects an integer register
+                // containing the address to load to be at the top of the stack.
                 let dst = self.context.pop_to_reg(self.masm, None)?;
                 let addr = self.emit_compute_heap_address(&arg, kind.derive_operand_size())?;
                 if let Some(addr) = addr {
                     emit_load(self, dst.reg, addr, kind)?;
+                } else {
+                    self.context.free_reg(dst);
                 }
             }
             _ => {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fixes a bug where a destination register is allocated and not freed when performing a vector load lane from a memory address that is invalid at compilation time. Not freeing the destination register causes an internal compiler error later when emitting code for any result value that uses that register.