### PR TITLE
c-api: Compile a component

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -59,5 +59,6 @@ winch = ['wasmtime/winch']
 debug-builtins = ['wasmtime/debug-builtins']
 wat = ['dep:wat', 'wasmtime/wat']
 pooling-allocator = ["wasmtime/pooling-allocator"]
+component-model = ["wasmtime/component-model"]
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/artifact/Cargo.toml
+++ b/crates/c-api/artifact/Cargo.toml
@@ -40,6 +40,7 @@ default = [
   'winch',
   'debug-builtins',
   'pooling-allocator',
+  'component-model',
   # ... if you add a line above this be sure to change the other locations
   # marked WASMTIME_FEATURE_LIST
 ]
@@ -62,5 +63,6 @@ cranelift = ["wasmtime-c-api/cranelift"]
 winch = ["wasmtime-c-api/winch"]
 debug-builtins = ["wasmtime-c-api/debug-builtins"]
 pooling-allocator = ["wasmtime-c-api/pooling-allocator"]
+component-model = ["wasmtime-c-api/component-model"]
 # ... if you add a line above this be sure to read the comment at the end of
 # `default`

--- a/crates/c-api/build.rs
+++ b/crates/c-api/build.rs
@@ -22,6 +22,7 @@ const FEATURES: &[&str] = &[
     "DEBUG_BUILTINS",
     "WAT",
     "POOLING_ALLOCATOR",
+    "COMPONENT_MODEL",
 ];
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/cmake/features.cmake
+++ b/crates/c-api/cmake/features.cmake
@@ -45,5 +45,6 @@ feature(cranelift ON)
 feature(winch ON)
 feature(debug-builtins ON)
 feature(pooling-allocator ON)
+feature(component-model ON)
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -200,6 +200,7 @@
 #include <wasmtime/trap.h>
 #include <wasmtime/val.h>
 #include <wasmtime/async.h>
+#include <wasmtime/component.h>
 // IWYU pragma: end_exports
 // clang-format on
 

--- a/crates/c-api/include/wasmtime/component.h
+++ b/crates/c-api/include/wasmtime/component.h
@@ -1,0 +1,6 @@
+#ifndef WASMTIME_COMPONENT_H
+#define WASMTIME_COMPONENT_H
+
+#include <wasmtime/component/component.h>
+
+#endif // WASMTIME_COMPONENT_H

--- a/crates/c-api/include/wasmtime/component/component.h
+++ b/crates/c-api/include/wasmtime/component/component.h
@@ -1,0 +1,116 @@
+#ifndef WASMTIME_COMPONENT_COMPONENT_H
+#define WASMTIME_COMPONENT_COMPONENT_H
+
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+#include <wasm.h>
+#include <wasmtime/error.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Representation of a component in the component model.
+typedef struct wasmtime_component_t wasmtime_component_t;
+
+#ifdef WASMTIME_FEATURE_COMPILER
+
+/**
+ * \brief Compiles a WebAssembly binary into a #wasmtime_component_t
+ *
+ * This function will compile a WebAssembly binary into an owned
+ #wasmtime_component_t.
+ *
+ * It requires a component binary, such as what is produced by Rust `cargo
+ component` tooling.
+ *
+ * This function does not take ownership of any of its arguments, but the
+ * returned error and component are owned by the caller.
+
+ * \param engine the #wasm_engine_t that will create the component
+ * \param buf the address of the buffer containing the WebAssembly binary
+ * \param len the length of the buffer containing the WebAssembly binary
+ * \param component_out on success, contains the address of the created
+ *        component
+ *
+ * \return NULL on success, else a #wasmtime_error_t describing the error
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_new(const wasm_engine_t *engine, const uint8_t *buf,
+                       size_t len, wasmtime_component_t **component_out);
+
+/**
+ * \brief This function serializes compiled component artifacts as blob data.
+ *
+ * \param component the component
+ * \param ret if the conversion is successful, this byte vector is filled in
+ * with the serialized compiled component.
+ *
+ * \return a non-null error if parsing fails, or returns `NULL`. If parsing
+ * fails then `ret` isn't touched.
+ *
+ * This function does not take ownership of `component`, and the caller is
+ * expected to deallocate the returned #wasmtime_error_t and #wasm_byte_vec_t.
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_serialize(const wasmtime_component_t *component,
+                             wasm_byte_vec_t *ret);
+
+#endif // WASMTIME_FEATURE_COMPILER
+
+/**
+ * \brief Build a component from serialized data.
+ *
+ * This function does not take ownership of any of its arguments, but the
+ * returned error and component are owned by the caller.
+ *
+ * This function is not safe to receive arbitrary user input. See the Rust
+ * documentation for more information on what inputs are safe to pass in here
+ * (e.g. only that of `wasmtime_component_serialize`)
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_deserialize(const wasm_engine_t *engine, const uint8_t *buf,
+                               size_t len,
+                               wasmtime_component_t **component_out);
+
+/**
+ * \brief Deserialize a component from an on-disk file.
+ *
+ * This function is the same as #wasmtime_component_deserialize except that it
+ * reads the data for the serialized component from the path on disk. This can
+ * be faster than the alternative which may require copying the data around.
+ *
+ * This function does not take ownership of any of its arguments, but the
+ * returned error and component are owned by the caller.
+ *
+ * This function is not safe to receive arbitrary user input. See the Rust
+ * documentation for more information on what inputs are safe to pass in here
+ * (e.g. only that of `wasmtime_component_serialize`)
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_deserialize_file(const wasm_engine_t *engine,
+                                    const char *path,
+                                    wasmtime_component_t **component_out);
+
+/**
+ * \brief Creates a shallow clone of the specified component, increasing the
+ * internal reference count.
+ */
+WASM_API_EXTERN wasmtime_component_t *
+wasmtime_component_clone(const wasmtime_component_t *component);
+
+/**
+ * \brief Deletes a #wasmtime_component_t created by
+ * #wasmtime_component_from_binary
+ *
+ * \param component the component to delete
+ */
+WASM_API_EXTERN void wasmtime_component_delete(wasmtime_component_t *component);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
+
+#endif // WASMTIME_COMPONENT_COMPONENT_H

--- a/crates/c-api/include/wasmtime/conf.h.in
+++ b/crates/c-api/include/wasmtime/conf.h.in
@@ -27,6 +27,7 @@
 #cmakedefine WASMTIME_FEATURE_WINCH
 #cmakedefine WASMTIME_FEATURE_DEBUG_BUILTINS
 #cmakedefine WASMTIME_FEATURE_POOLING_ALLOCATOR
+#cmakedefine WASMTIME_FEATURE_COMPONENT_MODEL
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST
 

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -766,6 +766,13 @@ WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
 
+/**
+ * \brief Configures whether the WebAssembly component-model proposal will be
+ * enabled for compilation.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model.
+ */
 WASMTIME_CONFIG_PROP(void, component_model, bool)
 
 #endif // WASMTIME_FEATURE_COMPONENT_MODEL

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -764,6 +764,12 @@ WASM_API_EXTERN void wasmtime_pooling_allocation_strategy_set(
 
 #endif // WASMTIME_FEATURE_POOLING_ALLOCATOR
 
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+WASMTIME_CONFIG_PROP(void, component_model, bool)
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -1,0 +1,87 @@
+use std::ffi::{c_char, CStr};
+
+use anyhow::Context;
+use wasmtime::component::Component;
+
+use crate::{wasm_byte_vec_t, wasm_config_t, wasm_engine_t, wasmtime_error_t};
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_config_component_model_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_component_model(enable);
+}
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct wasmtime_component_t {
+    pub(crate) component: Component,
+}
+
+#[unsafe(no_mangle)]
+#[cfg(any(feature = "cranelift", feature = "winch"))]
+pub unsafe extern "C" fn wasmtime_component_new(
+    engine: &wasm_engine_t,
+    buf: *const u8,
+    len: usize,
+    component_out: &mut *mut wasmtime_component_t,
+) -> Option<Box<wasmtime_error_t>> {
+    let binary = unsafe { crate::slice_from_raw_parts(buf, len) };
+    crate::handle_result(
+        Component::from_binary(&engine.engine, binary),
+        |component| {
+            *component_out = Box::into_raw(Box::new(wasmtime_component_t { component }));
+        },
+    )
+}
+
+#[unsafe(no_mangle)]
+#[cfg(any(feature = "cranelift", feature = "winch"))]
+pub unsafe extern "C" fn wasmtime_component_serialize(
+    component: &wasmtime_component_t,
+    ret: &mut wasm_byte_vec_t,
+) -> Option<Box<wasmtime_error_t>> {
+    crate::handle_result(component.component.serialize(), |buffer| {
+        ret.set_buffer(buffer);
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_deserialize(
+    engine: &wasm_engine_t,
+    buf: *const u8,
+    len: usize,
+    component_out: &mut *mut wasmtime_component_t,
+) -> Option<Box<wasmtime_error_t>> {
+    let binary = unsafe { crate::slice_from_raw_parts(buf, len) };
+    crate::handle_result(
+        unsafe { Component::deserialize(&engine.engine, binary) },
+        |component| {
+            *component_out = Box::into_raw(Box::new(wasmtime_component_t { component }));
+        },
+    )
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_deserialize_file(
+    engine: &wasm_engine_t,
+    path: *const c_char,
+    component_out: &mut *mut wasmtime_component_t,
+) -> Option<Box<wasmtime_error_t>> {
+    let path = unsafe { CStr::from_ptr(path) };
+    let result = path
+        .to_str()
+        .context("input path is not valid utf-8")
+        .and_then(|path| unsafe { Component::deserialize_file(&engine.engine, path) });
+    crate::handle_result(result, |component| {
+        *component_out = Box::into_raw(Box::new(wasmtime_component_t { component }));
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_clone(
+    component: &wasmtime_component_t,
+) -> Box<wasmtime_component_t> {
+    Box::new(component.clone())
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_delete(_component: Box<wasmtime_component_t>) {}

--- a/crates/c-api/src/component/mod.rs
+++ b/crates/c-api/src/component/mod.rs
@@ -1,0 +1,3 @@
+mod component;
+
+pub use component::*;

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -71,6 +71,11 @@ mod wat2wasm;
 #[cfg(feature = "wat")]
 pub use crate::wat2wasm::*;
 
+#[cfg(feature = "component-model")]
+mod component;
+#[cfg(feature = "component-model")]
+pub use crate::component::*;
+
 /// Initialize a `MaybeUninit<T>`
 ///
 /// TODO: Replace calls to this function with


### PR DESCRIPTION
First little bit of #9812, ["compile a component"](https://github.com/bytecodealliance/wasmtime/pull/9812#pullrequestreview-2503060369), with some changes suggested in the original pr:
- [No longer depends on cranelift](https://github.com/bytecodealliance/wasmtime/pull/9812#discussion_r1884430669), feature gated compile function on `WASMTIME_FEATURE_COMPILER`.
- [Moved config switch to config.h](https://github.com/bytecodealliance/wasmtime/pull/9812#discussion_r1884432876).
- [Prepared the file structure for multiple header files](https://github.com/bytecodealliance/wasmtime/pull/9812#discussion_r1884460573), should the same be done for the rust side?

Based on the efforts of @lanfeust69 and @rockwotj.