### PR TITLE
Update wasmi to version 0.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,9 +4084,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60160ffa66a3f95ae969aaf9cac28591b919a677d68faf29810c4989d5b0cad8"
+checksum = "3cd93c135ccbe88cfd00992c9c49778d364417bdb5cfb360eac60fe2d4d34676"
 dependencies = [
  "arrayvec",
  "multi-stash",
@@ -4100,18 +4100,18 @@ dependencies = [
 
 [[package]]
 name = "wasmi_collections"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38a962e32f510cd9732dc24308658bccbfe636df813bf53e798073c16c5ab8d"
+checksum = "55e817a9a96149aa3ddb84c44c6fe37ed608d53136d794d4d3cd8019de11fb42"
 dependencies = [
  "string-interner",
 ]
 
 [[package]]
 name = "wasmi_core"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae83f6d1e9344c25ab2defb563a65c3bcfad6fbd910c342367a15222b9e9525"
+checksum = "24f5adb8c394f8fb66653ce0a00e3a109fed285f3351a4b5854c1300ac8d3b20"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -4119,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi_ir"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9306bd1b4aa21dbfa9e4fc472d51cd40548c34add184e5ac38c3adf4214c356"
+checksum = "6e532ea88ccdbe2889ed3c00a8733971e1160c9a73a4dcee2fdec47fb3ee8ba4"
 dependencies = [
  "wasmi_core",
 ]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -30,7 +30,7 @@ wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
 wasm-mutate = { workspace = true }
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
-wasmi = { version = "0.43.0", default-features = false, features = ["std", "simd"] }
+wasmi = { version = "0.43.1", default-features = false, features = ["std", "simd"] }
 futures = { workspace = true }
 wasmtime-test-util = { workspace = true, features = ['wast', 'component-fuzz', 'component'] }
 


### PR DESCRIPTION
Contains https://github.com/wasmi-labs/wasmi/pull/1444 which fixes a bug that was reported during fuzzing.

The fuzzbug range points to https://github.com/bytecodealliance/wasmtime/compare/7e5a7e521ae121e239a8ad9e927653b26e474ac0...c68dbc2fd82bb6e5271dc425ee171628e7ffce4b

cc @Robbepop 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
