### PR TITLE
wasmtime-slab: add PartialOrd and Ord to Ids.

### DIFF
--- a/crates/slab/src/lib.rs
+++ b/crates/slab/src/lib.rs
@@ -131,7 +131,7 @@ use core::fmt;
 use core::num::NonZeroU32;
 
 /// An identifier for an allocated value inside a `slab`.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Id(EntryIndex);
 
@@ -193,7 +193,7 @@ enum Entry<T> {
     },
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 struct EntryIndex(NonZeroU32);
 


### PR DESCRIPTION
This became necessary in a use-case where I am using slab IDs as keys in a BTreeMap (as a member of a tuple key type). The actual ordering doesn't carry a fundamental meaning, but overall I do need ordering as the first elements of the tuple have significant ordering and I need to process in order (namely: timer deadlines). The slab ID ordering is at least stable (since the Ids are integers under the hood), and this is useful for anyone who needs to build an ordered key type. The alternative is to use `.into_raw()` and manually write an `Ord` impl or use the raw `u32` in a key, which is much worse.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
