### PR TITLE
Cranelift: update to regalloc2 0.12.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4c3c15aa088eccea44550bffea9e9a5d0b14a264635323d23c6e6351acca98"
+checksum = "7f8901022fb3dd7d9fc8e925df91df33e889705a1e3c76901fe5abef917788dc"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.11.3"
+regalloc2 = "0.12.0"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -627,17 +627,20 @@ block0(v0: i128, v1: i64):
 ;   mv fp,sp
 ;   addi sp,sp,-32
 ;   sd s1,24(sp)
+;   sd s3,16(sp)
 ; block0:
 ;   sd a1,0(sp)
 ;   load_sym s1,%f14+0
 ;   mv a5,a1
 ;   mv a6,a2
 ;   mv a7,a0
+;   mv s3,a1
 ;   mv a2,a7
 ;   mv a3,a5
 ;   mv a4,a7
 ;   callind s1
 ;   ld s1,24(sp)
+;   ld s3,16(sp)
 ;   addi sp,sp,32
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -652,7 +655,8 @@ block0(v0: i128, v1: i64):
 ;   mv s0, sp
 ;   addi sp, sp, -0x20
 ;   sd s1, 0x18(sp)
-; block1: ; offset 0x18
+;   sd s3, 0x10(sp)
+; block1: ; offset 0x1c
 ;   sd a1, 0(sp)
 ;   auipc s1, 0
 ;   ld s1, 0xc(s1)
@@ -662,11 +666,13 @@ block0(v0: i128, v1: i64):
 ;   mv a5, a1
 ;   mv a6, a2
 ;   mv a7, a0
+;   mv s3, a1
 ;   mv a2, a7
 ;   mv a3, a5
 ;   mv a4, a7
 ;   jalr s1
 ;   ld s1, 0x18(sp)
+;   ld s3, 0x10(sp)
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -720,17 +726,20 @@ block0(v0: i128, v1: i64):
 ;   mv fp,sp
 ;   addi sp,sp,-32
 ;   sd s1,24(sp)
+;   sd s3,16(sp)
 ; block0:
 ;   sd a1,0(sp)
 ;   load_sym s1,%f15+0
 ;   mv a5,a1
 ;   mv a6,a2
 ;   mv a7,a0
+;   mv s3,a1
 ;   mv a2,a7
 ;   mv a3,a5
 ;   mv a4,a7
 ;   callind s1
 ;   ld s1,24(sp)
+;   ld s3,16(sp)
 ;   addi sp,sp,32
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -745,7 +754,8 @@ block0(v0: i128, v1: i64):
 ;   mv s0, sp
 ;   addi sp, sp, -0x20
 ;   sd s1, 0x18(sp)
-; block1: ; offset 0x18
+;   sd s3, 0x10(sp)
+; block1: ; offset 0x1c
 ;   sd a1, 0(sp)
 ;   auipc s1, 0
 ;   ld s1, 0xc(s1)
@@ -755,11 +765,13 @@ block0(v0: i128, v1: i64):
 ;   mv a5, a1
 ;   mv a6, a2
 ;   mv a7, a0
+;   mv s3, a1
 ;   mv a2, a7
 ;   mv a3, a5
 ;   mv a4, a7
 ;   jalr s1
 ;   ld s1, 0x18(sp)
+;   ld s3, 0x10(sp)
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -74,19 +74,19 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movdqu  rsp(0 + virtual offset), %xmm4
 ;   movdqu  %xmm0, rsp(80 + virtual offset)
 ;   pshufd  $1, %xmm4, %xmm0
-;   movdqu  rsp(16 + virtual offset), %xmm2
-;   pshufd  $1, %xmm2, %xmm1
-;   movdqu  rsp(32 + virtual offset), %xmm5
-;   pshufd  $1, %xmm5, %xmm2
+;   movdqu  rsp(16 + virtual offset), %xmm1
+;   pshufd  $1, %xmm1, %xmm1
+;   movdqu  rsp(32 + virtual offset), %xmm2
+;   pshufd  $1, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r9
 ;   call    *%r9
 ;   movdqu  rsp(0 + virtual offset), %xmm4
 ;   movdqu  %xmm0, rsp(48 + virtual offset)
 ;   pshufd  $2, %xmm4, %xmm0
-;   movdqu  rsp(16 + virtual offset), %xmm7
-;   pshufd  $2, %xmm7, %xmm1
-;   movdqu  rsp(32 + virtual offset), %xmm3
-;   pshufd  $2, %xmm3, %xmm2
+;   movdqu  rsp(16 + virtual offset), %xmm1
+;   pshufd  $2, %xmm1, %xmm1
+;   movdqu  rsp(32 + virtual offset), %xmm2
+;   pshufd  $2, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r10
 ;   call    *%r10
 ;   movdqu  rsp(0 + virtual offset), %xmm4
@@ -125,19 +125,19 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movdqu (%rsp), %xmm4
 ;   movdqu %xmm0, 0x50(%rsp)
 ;   pshufd $1, %xmm4, %xmm0
-;   movdqu 0x10(%rsp), %xmm2
-;   pshufd $1, %xmm2, %xmm1
-;   movdqu 0x20(%rsp), %xmm5
-;   pshufd $1, %xmm5, %xmm2
+;   movdqu 0x10(%rsp), %xmm1
+;   pshufd $1, %xmm1, %xmm1
+;   movdqu 0x20(%rsp), %xmm2
+;   pshufd $1, %xmm2, %xmm2
 ;   movabsq $0, %r9 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r9
 ;   movdqu (%rsp), %xmm4
 ;   movdqu %xmm0, 0x30(%rsp)
 ;   pshufd $2, %xmm4, %xmm0
-;   movdqu 0x10(%rsp), %xmm7
-;   pshufd $2, %xmm7, %xmm1
-;   movdqu 0x20(%rsp), %xmm3
-;   pshufd $2, %xmm3, %xmm2
+;   movdqu 0x10(%rsp), %xmm1
+;   pshufd $2, %xmm1, %xmm1
+;   movdqu 0x20(%rsp), %xmm2
+;   pshufd $2, %xmm2, %xmm2
 ;   movabsq $0, %r10 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r10
 ;   movdqu (%rsp), %xmm4

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -933,8 +933,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.11.3"
-when = "2025-04-07"
+version = "0.12.0"
+when = "2025-04-11"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"

--- a/tests/disas/pulley/epoch-simple.wat
+++ b/tests/disas/pulley/epoch-simple.wat
@@ -14,5 +14,5 @@
 ;;       br_if_xulteq64 x7, x6, 0x9    // target = 0x26
 ;;   24: pop_frame
 ;;       ret
-;;   26: call 0x8a    // target = 0xb0
+;;   26: call 0x8d    // target = 0xb3
 ;;   2b: jump -0x7    // target = 0x24


### PR DESCRIPTION
This pulls in bytecodealliance/regalloc2#220, a fix to an infinite loop in register allocation.

Fixes #10562.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
