### PR TITLE
winch(docs): Update missing tier 2 requirements

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -104,7 +104,7 @@ For explanations of what each tier means see below.
 | Target               | `x86_64-unknown-illumos`          | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-linux-musl` [^4]  | CI testing, full-time maintainer |
 | Target               | `x86_64-unknown-none` [^5]        | CI testing, full-time maintainer |
-| Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals (`simd`, `relaxed-simd`, `tail-call`, `reference-types`, `threads`)     |
+| Compiler Backend     | Winch on x86\_64                  | WebAssembly proposals ([`relaxed-simd`], [`tail-call`], [`reference-types`])     |
 | Compiler Backend     | Winch on aarch64                  | Complete implementation     |
 | WebAssembly Proposal | [`gc`]                            | Complete implementation     |
 | WASI Proposal        | [`wasi-nn`]                       | More expansive CI testing   |


### PR DESCRIPTION
Updates Tier 2 requirements to match the implementation status of the WebAsembly proposals on x86-64

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
