### PR TITLE
wasmtime-wit-bindgen: nonfunctional changes to internals

### DIFF
--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -3272,23 +3272,18 @@ impl<'a> InterfaceGenerator<'a> {
         }
 
         self.src.push_str("let callee = unsafe {\n");
-        uwrite!(self.src, "{wt}::component::TypedFunc::<(");
-        for (_, ty) in func.params.iter() {
-            self.print_ty(ty, param_mode);
-            self.push_str(", ");
-        }
-        self.src.push_str("), (");
-        if let Some(ty) = func.result {
-            self.print_ty(&ty, TypeMode::Owned);
-            self.push_str(", ");
-        }
+        uwrite!(
+            self.src,
+            "{wt}::component::TypedFunc::<{}>",
+            self.typedfunc_sig(func, param_mode)
+        );
         let projection_to_func = match &func.kind {
             FunctionKind::Freestanding => "",
             _ => ".funcs",
         };
         uwriteln!(
             self.src,
-            ")>::new_unchecked(self{projection_to_func}.{})",
+            "::new_unchecked(self{projection_to_func}.{})",
             func_field_name(self.resolve, func),
         );
         self.src.push_str("};\n");

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -49,7 +49,7 @@ pub trait RustGenerator<'a> {
             Type::String => match mode {
                 TypeMode::AllBorrowed(lt) => {
                     if lt != "'_" {
-                        format!("&{} str", lt)
+                        format!("&{lt} str")
                     } else {
                         format!("&str")
                     }
@@ -90,7 +90,7 @@ pub trait RustGenerator<'a> {
             if info.has_list && lt.is_none() {
                 if let TypeMode::AllBorrowed(lt) = mode {
                     if lt != "'_" {
-                        out.push_str(&format!("&{} ", lt))
+                        out.push_str(&format!("&{lt} "))
                     } else {
                         out.push_str("&")
                     }
@@ -215,14 +215,14 @@ pub trait RustGenerator<'a> {
         match mode {
             TypeMode::AllBorrowed(lt) => {
                 if lt != "'_" {
-                    format!("&{} [{}]", lt, ty)
+                    format!("&{lt} [{ty}]")
                 } else {
-                    format!("&[{}]", ty)
+                    format!("&[{ty}]")
                 }
             }
             TypeMode::Owned => {
                 let wt = self.wasmtime_path();
-                format!("{wt}::component::__internal::Vec<{}>", ty)
+                format!("{wt}::component::__internal::Vec<{ty}>")
             }
         }
     }
@@ -294,7 +294,7 @@ pub trait RustGenerator<'a> {
     }
     fn generics(&self, lifetime: Option<&str>) -> String {
         if let Some(lt) = lifetime {
-            format!("<{},>", lt)
+            format!("<{lt},>")
         } else {
             String::new()
         }

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -391,6 +391,21 @@ pub trait RustGenerator<'a> {
             None
         }
     }
+
+    fn typedfunc_sig(&self, func: &Function, param_mode: TypeMode) -> String {
+        let mut out = "(".to_string();
+        for (_, ty) in func.params.iter() {
+            out.push_str(&self.ty(ty, param_mode));
+            out.push_str(", ");
+        }
+        out.push_str("), (");
+        if let Some(ty) = func.result {
+            out.push_str(&self.ty(&ty, TypeMode::Owned));
+            out.push_str(", ");
+        }
+        out.push_str(")");
+        out
+    }
 }
 
 /// Translate `name` to a Rust `snake_case` identifier.


### PR DESCRIPTION
These changes to wasmtime-wit-bindgen make more functional versions of some of the imperative internal apis for printing datatypes and function types. This PR creates variants of a bunch of these internal functions that drops their `print_` prefix and has them return String instead of append to self.src. This is probably worse for performance, but I assume it just doesn't matter for a code generator inside a proc macro.

The existing imperative apis (those starting with `print_`) still exist, except in the cases where they were dead code- that is, they were only used by other imperative code that was translated to the functional style.