### PR TITLE
asm: replace flag-using ALU instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2765,141 +2765,213 @@
 (rule (x64_xmm_load_const ty const)
       (x64_load ty (const_to_synthetic_amode const) (ExtKind.None)))
 
+
+;;;; Flag Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; These helpers are used to emit instructions that produce or consume flags.
+;; The operations used here are by no means the only ones possible; they are
+;; simply the ones currently used in Cranelift's lowerings.
+
+;; Some operations produce flags.
+(type ProduceFlagsOp (enum (Add) (Sub)))
+
+(decl x64_produce_flags (ProduceFlagsOp Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_produce_flags (ProduceFlagsOp.Add) ty src1 src2)
+      (x64_add_with_flags_paired ty src1 src2))
+(rule (x64_produce_flags (ProduceFlagsOp.Sub) ty src1 src2)
+      (x64_sub_with_flags_paired ty src1 src2))
+
+(decl asm_produce_flags (AssemblerOutputs) ProducesFlags)
+(rule (asm_produce_flags (AssemblerOutputs.RetGpr inst gpr))
+      (ProducesFlags.ProducesFlagsReturnsResultWithConsumer inst gpr))
+
+;; Other operations consume _and_ produce flags--"chaining".
+(type ChainFlagsOp (enum (Adc) (Sbb)))
+
+(decl x64_chain_flags (ChainFlagsOp Type Gpr Gpr) ConsumesAndProducesFlags)
+(rule (x64_chain_flags (ChainFlagsOp.Adc) ty src1 src2)
+      (x64_adc_chained ty src1 src2))
+(rule (x64_chain_flags (ChainFlagsOp.Sbb) ty src1 src2)
+      (x64_sbb_chained ty src1 src2))
+
+(decl asm_chain_flags (AssemblerOutputs) ConsumesAndProducesFlags)
+(rule (asm_chain_flags (AssemblerOutputs.RetGpr inst gpr))
+      (ConsumesAndProducesFlags.ReturnsReg inst gpr))
+
+;; Still others produce flags a part of a side-effect operation.
+
+(type ProduceFlagsSideEffectOp (enum (Or) (Sbb)))
+
+(decl x64_produce_flags_side_effect (ProduceFlagsSideEffectOp Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) (fits_in_64 ty) src1 src2)
+      (x64_or_with_flags_paired_side_effect ty src1 src2))
+(rule (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Sbb) (fits_in_64 ty) src1 src2)
+      (x64_sbb_paired_side_effect ty src1 src2))
+
+(decl asm_produce_flags_side_effect (AssemblerOutputs) ProducesFlags)
+(rule (asm_produce_flags_side_effect (AssemblerOutputs.RetGpr inst gpr))
+      (ProducesFlags.ProducesFlagsSideEffect inst))
+
+;; Other helpers for instruction emission.
+
+(decl asm_consume_flags (AssemblerOutputs) ConsumesFlags)
+(rule (asm_consume_flags (AssemblerOutputs.RetGpr inst gpr))
+      (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer inst gpr))
+
+
+
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; These constructors create SSA-style `MInst`s. It is their responsibility to
 ;; maintain the invariant that each temporary register they allocate and define
 ;; only gets defined the once.
 
-;; Helper for emitting `add` instructions.
-(decl x64_add (Type Gpr GprMemImm) Gpr)
+;; Helper for creating raw `add` instructions.
+(decl x64_add_raw (Type Gpr GprMemImm) AssemblerOutputs)
 
 ;; Match 8-bit immediates first; allows a smaller instruction encoding.
-(rule 3 (x64_add $I32 src1 (is_simm8 src2))   (x64_addl_mi_sxb src1 src2))
-(rule 3 (x64_add $I64 src1 (is_simm8 src2))   (x64_addq_mi_sxb src1 src2))
+(rule 2 (x64_add_raw $I32 src1 (is_simm8 src2))   (x64_addl_mi_sxb_raw src1 src2))
+(rule 2 (x64_add_raw $I64 src1 (is_simm8 src2))   (x64_addq_mi_sxb_raw src1 src2))
 
 ;; Match the remaining immediates.
-(rule 2 (x64_add $I8  src1 (is_imm8 src2))    (x64_addb_mi src1 src2))
-(rule 2 (x64_add $I16 src1 (is_imm16 src2))   (x64_addw_mi src1 src2))
-(rule 2 (x64_add $I32 src1 (is_imm32 src2))   (x64_addl_mi src1 src2))
-(rule 2 (x64_add $I64 src1 (is_simm32 src2))  (x64_addq_mi_sxl src1 src2))
-
-;; Use wider instructions than necessary for 8/16-bit register-to-register
-;; operations to avoid CPU false dependencies.
-(rule 1 (x64_add $I8  src1 (is_gpr src2))     (x64_addl_rm src1 src2))
-(rule 1 (x64_add $I16 src1 (is_gpr src2))     (x64_addl_rm src1 src2))
+(rule 1 (x64_add_raw $I8  src1 (is_imm8 src2))    (x64_addb_mi_raw src1 src2))
+(rule 1 (x64_add_raw $I16 src1 (is_imm16 src2))   (x64_addw_mi_raw src1 src2))
+(rule 1 (x64_add_raw $I32 src1 (is_imm32 src2))   (x64_addl_mi_raw src1 src2))
+(rule 1 (x64_add_raw $I64 src1 (is_simm32 src2))  (x64_addq_mi_sxl_raw src1 src2))
 
 ;; Match the operand size to the instruction width.
-(rule 0 (x64_add $I8  src1 (is_gpr_mem src2)) (x64_addb_rm src1 src2))
-(rule 0 (x64_add $I16 src1 (is_gpr_mem src2)) (x64_addw_rm src1 src2))
-(rule 0 (x64_add $I32 src1 (is_gpr_mem src2)) (x64_addl_rm src1 src2))
-(rule 0 (x64_add $I64 src1 (is_gpr_mem src2)) (x64_addq_rm src1 src2))
+(rule 0 (x64_add_raw $I8  src1 (is_gpr_mem src2)) (x64_addb_rm_raw src1 src2))
+(rule 0 (x64_add_raw $I16 src1 (is_gpr_mem src2)) (x64_addw_rm_raw src1 src2))
+(rule 0 (x64_add_raw $I32 src1 (is_gpr_mem src2)) (x64_addl_rm_raw src1 src2))
+(rule 0 (x64_add_raw $I64 src1 (is_gpr_mem src2)) (x64_addq_rm_raw src1 src2))
 
-;; Helper for creating `add` instructions whose flags are also used.
+;; When the overflow flag is not considered, we can use wider instructions than
+;; necessary for 8/16-bit register-to-register operations to avoid CPU false
+;; dependencies.
+(decl x64_add_break_deps (Type Gpr GprMemImm) AssemblerOutputs)
+(rule 1 (x64_add_break_deps $I8  src1 (is_gpr src2)) (x64_addl_rm_raw src1 src2))
+(rule 1 (x64_add_break_deps $I16 src1 (is_gpr src2)) (x64_addl_rm_raw src1 src2))
+(rule 0 (x64_add_break_deps ty   src1 src2)          (x64_add_raw ty src1 src2))
+
+;; Normal use of `add` returns a `Gpr` register.
+(decl x64_add (Type Gpr GprMemImm) Gpr)
+(rule (x64_add ty src1 src2)
+      (emit_ret_gpr (x64_add_break_deps ty src1 src2)))
+
+;; When using `add` for its overflow flag (OF), we track that the flags are
+;; changed (and avoid the "dependency-breaking" rules that short-circuit
+;; overflow).
 (decl x64_add_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
 (rule (x64_add_with_flags_paired ty src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
-         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                        (AluRmiROpcode.Add)
-                        src1
-                        src2
-                        dst)
-         dst)))
+      (asm_produce_flags (x64_add_raw ty src1 src2)))
 
-(decl x64_alurmi_with_flags_paired (AluRmiROpcode Type Gpr GprMemImm) ProducesFlags)
-(rule (x64_alurmi_with_flags_paired opc (fits_in_64 ty) src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
-         (MInst.AluRmiR (raw_operand_size_of_type ty)
-                        opc
-                        src1
-                        src2
-                        dst)
-         dst)))
 
-(decl x64_alurmi_flags_side_effect (AluRmiROpcode Type Gpr GprMemImm) ProducesFlags)
-(rule (x64_alurmi_flags_side_effect opc (fits_in_64 ty) src1 src2)
-      (ProducesFlags.ProducesFlagsSideEffect
-       (MInst.AluRmiR (raw_operand_size_of_type ty)
-                      opc
-                      src1
-                      src2
-                      (temp_writable_gpr))))
 
-;; Should only be used for Adc and Sbb
-(decl x64_alurmi_with_flags_chained (AluRmiROpcode Type Gpr GprMemImm) ConsumesAndProducesFlags)
-(rule (x64_alurmi_with_flags_chained opc (fits_in_64 ty) src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ConsumesAndProducesFlags.ReturnsReg
-         (MInst.AluRmiR (raw_operand_size_of_type ty)
-                        opc
-                        src1
-                        src2
-                        dst)
-         dst)))
+;; Helper for creating raw `adc` instructions; Cranelift only uses the 64-bit
+;; variant of this instruction. As with `add`, we match 8-bit immediates first;
+;; this allows a smaller instruction encoding.
+(decl x64_adc_raw (Type Gpr GprMemImm) AssemblerOutputs)
+(rule 2 (x64_adc_raw $I64 src1 (is_simm8 src2))   (x64_adcq_mi_sxb_raw src1 src2))
+(rule 1 (x64_adc_raw $I64 src1 (is_simm32 src2))  (x64_adcq_mi_sxl_raw src1 src2))
+(rule 0 (x64_adc_raw $I64 src1 (is_gpr_mem src2)) (x64_adcq_rm_raw src1 src2))
 
-;; Helper for creating `adc` instructions.
+;; Normal use of the `adc` instruction consumes a previously-produced flag.
 (decl x64_adc_paired (Type Gpr GprMemImm) ConsumesFlags)
 (rule (x64_adc_paired ty src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
-         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                        (AluRmiROpcode.Adc)
-                        src1
-                        src2
-                        dst)
-         dst)))
+      (asm_consume_flags (x64_adc_raw ty src1 src2)))
+
+;; We also use `adc` to modify flags that are used later.
+(decl x64_adc_chained (Type Gpr GprMemImm) ConsumesAndProducesFlags)
+(rule (x64_adc_chained ty src1 src2)
+      (asm_chain_flags (x64_adc_raw ty src1 src2)))
 
 
 
-;; Helper for emitting `sub` instructions.
-(decl x64_sub (Type Gpr GprMemImm) Gpr)
+;; Helper for emitting raw `sub` instructions.
+(decl x64_sub_raw (Type Gpr GprMemImm) AssemblerOutputs)
 
 ;; Match 8-bit immediates first; allows a smaller instruction encoding.
-(rule 3 (x64_sub $I32 src1 (is_simm8 src2))   (x64_subl_mi_sxb src1 src2))
-(rule 3 (x64_sub $I64 src1 (is_simm8 src2))   (x64_subq_mi_sxb src1 src2))
+(rule 3 (x64_sub_raw $I32 src1 (is_simm8 src2))   (x64_subl_mi_sxb_raw src1 src2))
+(rule 3 (x64_sub_raw $I64 src1 (is_simm8 src2))   (x64_subq_mi_sxb_raw src1 src2))
 
 ;; Match the remaining immediates.
-(rule 2 (x64_sub $I8  src1 (is_imm8 src2))    (x64_subb_mi src1 src2))
-(rule 2 (x64_sub $I16 src1 (is_imm16 src2))   (x64_subw_mi src1 src2))
-(rule 2 (x64_sub $I32 src1 (is_imm32 src2))   (x64_subl_mi src1 src2))
-(rule 2 (x64_sub $I64 src1 (is_simm32 src2))  (x64_subq_mi_sxl src1 src2))
-
-;; Use wider instructions than necessary for 8/16-bit register-to-register
-;; operations to avoid CPU false dependencies.
-(rule 1 (x64_sub $I8  src1 (is_gpr src2))     (x64_subl_rm src1 src2))
-(rule 1 (x64_sub $I16 src1 (is_gpr src2))     (x64_subl_rm src1 src2))
+(rule 2 (x64_sub_raw $I8  src1 (is_imm8 src2))    (x64_subb_mi_raw src1 src2))
+(rule 2 (x64_sub_raw $I16 src1 (is_imm16 src2))   (x64_subw_mi_raw src1 src2))
+(rule 2 (x64_sub_raw $I32 src1 (is_imm32 src2))   (x64_subl_mi_raw src1 src2))
+(rule 2 (x64_sub_raw $I64 src1 (is_simm32 src2))  (x64_subq_mi_sxl_raw src1 src2))
 
 ;; Match the operand size to the instruction width.
-(rule 0 (x64_sub $I8  src1 (is_gpr_mem src2)) (x64_subb_rm src1 src2))
-(rule 0 (x64_sub $I16 src1 (is_gpr_mem src2)) (x64_subw_rm src1 src2))
-(rule 0 (x64_sub $I32 src1 (is_gpr_mem src2)) (x64_subl_rm src1 src2))
-(rule 0 (x64_sub $I64 src1 (is_gpr_mem src2)) (x64_subq_rm src1 src2))
+(rule 0 (x64_sub_raw $I8  src1 (is_gpr_mem src2)) (x64_subb_rm_raw src1 src2))
+(rule 0 (x64_sub_raw $I16 src1 (is_gpr_mem src2)) (x64_subw_rm_raw src1 src2))
+(rule 0 (x64_sub_raw $I32 src1 (is_gpr_mem src2)) (x64_subl_rm_raw src1 src2))
+(rule 0 (x64_sub_raw $I64 src1 (is_gpr_mem src2)) (x64_subq_rm_raw src1 src2))
 
-;; Helper for creating `sub` instructions whose flags are also used.
+;; When the overflow flag is not considered, we can use wider instructions than
+;; necessary for 8/16-bit register-to-register operations to avoid CPU false
+;; dependencies.
+(decl x64_sub_break_deps (Type Gpr GprMemImm) AssemblerOutputs)
+(rule 1 (x64_sub_break_deps $I8  src1 (is_gpr src2)) (x64_subl_rm_raw src1 src2))
+(rule 1 (x64_sub_break_deps $I16 src1 (is_gpr src2)) (x64_subl_rm_raw src1 src2))
+(rule 0 (x64_sub_break_deps ty   src1 src2)          (x64_sub_raw ty src1 src2))
+
+;; Normal use of `sub` returns a `Gpr` register.
+(decl x64_sub (Type Gpr GprMemImm) Gpr)
+(rule (x64_sub ty src1 src2)
+      (emit_ret_gpr (x64_sub_break_deps ty src1 src2)))
+
+;; When using `sub` for its flags (OF, CF, SF), we track that the flags are
+;; changed.
 (decl x64_sub_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
 (rule (x64_sub_with_flags_paired ty src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
-         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                        (AluRmiROpcode.Sub)
-                        src1
-                        src2
-                        dst)
-         dst)))
+      (asm_produce_flags (x64_sub_raw ty src1 src2)))
 
-;; Helper for creating `sbb` instructions.
+
+
+;; Helper for creating raw `sbb` instructions; Cranelift only uses the 64-bit
+;; variant of this instruction.
+(decl x64_sbb_raw (Type Gpr GprMemImm) AssemblerOutputs)
+
+;; Match 8-bit immediates first; allows a smaller instruction encoding.
+(rule 2 (x64_sbb_raw $I32 src1 (is_simm8 src2))   (x64_sbbl_mi_sxb_raw src1 src2))
+(rule 2 (x64_sbb_raw $I64 src1 (is_simm8 src2))   (x64_sbbq_mi_sxb_raw src1 src2))
+
+;; Match the remaining immediates.
+(rule 1 (x64_sbb_raw $I8  src1 (is_imm8 src2))    (x64_sbbb_mi_raw src1 src2))
+(rule 1 (x64_sbb_raw $I16 src1 (is_imm16 src2))   (x64_sbbw_mi_raw src1 src2))
+(rule 1 (x64_sbb_raw $I32 src1 (is_imm32 src2))   (x64_sbbl_mi_raw src1 src2))
+(rule 1 (x64_sbb_raw $I64 src1 (is_simm32 src2))  (x64_sbbq_mi_sxl_raw src1 src2))
+
+;; Match the operand size to the instruction width.
+(rule 0 (x64_sbb_raw $I8  src1 (is_gpr_mem src2)) (x64_sbbb_rm_raw src1 src2))
+(rule 0 (x64_sbb_raw $I16 src1 (is_gpr_mem src2)) (x64_sbbw_rm_raw src1 src2))
+(rule 0 (x64_sbb_raw $I32 src1 (is_gpr_mem src2)) (x64_sbbl_rm_raw src1 src2))
+(rule 0 (x64_sbb_raw $I64 src1 (is_gpr_mem src2)) (x64_sbbq_rm_raw src1 src2))
+
+;; When the overflow flag is not considered, we can use wider instructions than
+;; necessary for 8/16-bit register-to-register operations to avoid CPU false
+;; dependencies.
+(decl x64_sbb_break_deps (Type Gpr GprMemImm) AssemblerOutputs)
+(rule 1 (x64_sbb_break_deps $I8  src1 (is_gpr src2)) (x64_sbbl_rm_raw src1 src2))
+(rule 1 (x64_sbb_break_deps $I16 src1 (is_gpr src2)) (x64_sbbl_rm_raw src1 src2))
+(rule 0 (x64_sbb_break_deps ty   src1 src2)          (x64_sbb_raw ty src1 src2))
+
+;; Normal use of the `sbb` instruction consumes previously-produced flags (OF,
+;; CF, SF).
 (decl x64_sbb_paired (Type Gpr GprMemImm) ConsumesFlags)
 (rule (x64_sbb_paired ty src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-        (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer
-         (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                        (AluRmiROpcode.Sbb)
-                        src1
-                        src2
-                        dst)
-         dst)))
+      (asm_consume_flags (x64_sbb_break_deps ty src1 src2)))
+
+;; We also use `sbb` to modify flags that all later used.
+(decl x64_sbb_chained (Type Gpr GprMemImm) ConsumesAndProducesFlags)
+(rule (x64_sbb_chained ty src1 src2)
+      (asm_chain_flags (x64_sbb_raw ty src1 src2)))
+
+;; We also use `sbb` in side-effecting operations.
+(decl x64_sbb_paired_side_effect (Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_sbb_paired_side_effect  ty src1 src2)
+      (asm_produce_flags_side_effect (x64_sbb_raw ty src1 src2)))
+
+
 
 ;; Helper for creating `mul` instructions or `imul` instructions (depending
 ;; on `signed`)
@@ -3009,29 +3081,42 @@
 
 
 
-;; Helper for emitting `or` instructions.
-(decl x64_or (Type Gpr GprMemImm) Gpr)
+;; Helper for emitting raw `or` instructions.
+(decl x64_or_raw (Type Gpr GprMemImm) AssemblerOutputs)
 
 ;; Match 8-bit immediates first; allows a smaller instruction encoding.
-(rule 3 (x64_or $I32 src1 (is_simm8 src2))   (x64_orl_mi_sxb src1 src2))
-(rule 3 (x64_or $I64 src1 (is_simm8 src2))   (x64_orq_mi_sxb src1 src2))
+(rule 2 (x64_or_raw $I32 src1 (is_simm8 src2))   (x64_orl_mi_sxb_raw src1 src2))
+(rule 2 (x64_or_raw $I64 src1 (is_simm8 src2))   (x64_orq_mi_sxb_raw src1 src2))
 
 ;; Match the remaining immediates.
-(rule 2 (x64_or $I8  src1 (is_imm8 src2))    (x64_orb_mi src1 src2))
-(rule 2 (x64_or $I16 src1 (is_imm16 src2))   (x64_orw_mi src1 src2))
-(rule 2 (x64_or $I32 src1 (is_imm32 src2))   (x64_orl_mi src1 src2))
-(rule 2 (x64_or $I64 src1 (is_simm32 src2))  (x64_orq_mi_sxl src1 src2))
-
-;; Use wider instructions than necessary for 8/16-bit register-to-register
-;; operations to avoid CPU false dependencies.
-(rule 1 (x64_or $I8  src1 (is_gpr src2))     (x64_orl_rm src1 src2))
-(rule 1 (x64_or $I16 src1 (is_gpr src2))     (x64_orl_rm src1 src2))
+(rule 1 (x64_or_raw $I8  src1 (is_imm8 src2))    (x64_orb_mi_raw src1 src2))
+(rule 1 (x64_or_raw $I16 src1 (is_imm16 src2))   (x64_orw_mi_raw src1 src2))
+(rule 1 (x64_or_raw $I32 src1 (is_imm32 src2))   (x64_orl_mi_raw src1 src2))
+(rule 1 (x64_or_raw $I64 src1 (is_simm32 src2))  (x64_orq_mi_sxl_raw src1 src2))
 
 ;; Match the operand size to the instruction width.
-(rule 0 (x64_or $I8  src1 (is_gpr_mem src2)) (x64_orb_rm src1 src2))
-(rule 0 (x64_or $I16 src1 (is_gpr_mem src2)) (x64_orw_rm src1 src2))
-(rule 0 (x64_or $I32 src1 (is_gpr_mem src2)) (x64_orl_rm src1 src2))
-(rule 0 (x64_or $I64 src1 (is_gpr_mem src2)) (x64_orq_rm src1 src2))
+(rule 0 (x64_or_raw $I8  src1 (is_gpr_mem src2)) (x64_orb_rm_raw src1 src2))
+(rule 0 (x64_or_raw $I16 src1 (is_gpr_mem src2)) (x64_orw_rm_raw src1 src2))
+(rule 0 (x64_or_raw $I32 src1 (is_gpr_mem src2)) (x64_orl_rm_raw src1 src2))
+(rule 0 (x64_or_raw $I64 src1 (is_gpr_mem src2)) (x64_orq_rm_raw src1 src2))
+
+;; When flags are not considered, we can use wider instructions than necessary
+;; for 8/16-bit register-to-register operations to avoid CPU false dependencies.
+(decl x64_or_break_deps (Type Gpr GprMemImm) AssemblerOutputs)
+(rule 1 (x64_or_break_deps $I8  src1 (is_gpr src2)) (x64_orl_rm_raw src1 src2))
+(rule 1 (x64_or_break_deps $I16 src1 (is_gpr src2)) (x64_orl_rm_raw src1 src2))
+(rule 0 (x64_or_break_deps ty   src1 src2)          (x64_or_raw ty src1 src2))
+
+;; Normal use of `or` returns a `Gpr` register.
+(decl x64_or (Type Gpr GprMemImm) Gpr)
+(rule (x64_or ty src1 src2)
+      (emit_ret_gpr (x64_or_break_deps ty src1 src2)))
+
+;; When using `or` for its flags (SF, ZF, PF), we track that the flags are
+;; changed. Note t
+(decl x64_or_with_flags_paired_side_effect (Type Gpr GprMemImm) ProducesFlags)
+(rule (x64_or_with_flags_paired_side_effect ty src1 src2)
+      (asm_produce_flags_side_effect (x64_or_raw ty src1 src2)))
 
 
 
@@ -5306,7 +5391,7 @@
         (let ((same_lo Reg (x64_xor $I64 a_lo b_lo))
               (same_hi Reg (x64_xor $I64 a_hi b_hi)))
           (icmp_cond_result
-            (x64_alurmi_flags_side_effect (AluRmiROpcode.Or) $I64 same_lo same_hi)
+            (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) $I64 same_lo same_hi)
             cc)))
 
 ;; The only cases left are L/NL/B/NB which we can implement with a sub/sbb
@@ -5316,7 +5401,7 @@
         (icmp_cond_result
           (produces_flags_concat
             (x64_cmp (OperandSize.Size64) a_lo b_lo)
-            (x64_alurmi_flags_side_effect (AluRmiROpcode.Sbb) $I64 a_hi b_hi))
+            (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Sbb) $I64 a_hi b_hi))
           cc))
 
 (type FcmpCondResult

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2781,6 +2781,8 @@
 (rule (x64_produce_flags (ProduceFlagsOp.Sub) ty src1 src2)
       (x64_sub_with_flags_paired ty src1 src2))
 
+;; This should only be use for instructions that _do_ produce flags that can be
+;; consumed later. It is semantically "unsafe" and must be used correctly.
 (decl asm_produce_flags (AssemblerOutputs) ProducesFlags)
 (rule (asm_produce_flags (AssemblerOutputs.RetGpr inst gpr))
       (ProducesFlags.ProducesFlagsReturnsResultWithConsumer inst gpr))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -146,15 +146,15 @@
         (output_pair (value_regs_get results 0)
                      (value_regs_get results 1))))
 
-(decl construct_overflow_op_alu (Type CC AluRmiROpcode Gpr GprMemImm) InstOutput)
-(rule (construct_overflow_op_alu ty cc alu_op src1 src2)
-      (construct_overflow_op cc (x64_alurmi_with_flags_paired alu_op ty src1 src2)))
+(decl construct_overflow_op_alu (Type CC ProduceFlagsOp Gpr GprMemImm) InstOutput)
+(rule (construct_overflow_op_alu ty cc op src1 src2)
+      (construct_overflow_op cc (x64_produce_flags op ty src1 src2)))
 
 ;; This essentially creates
 ;; alu_<op1> x_lo, y_lo
 ;; alu_<op2> x_hi, y_hi
 ;; set<cc> r8
-(decl construct_overflow_op_alu_128 (CC AluRmiROpcode AluRmiROpcode Value Value) InstOutput)
+(decl construct_overflow_op_alu_128 (CC ProduceFlagsOp ChainFlagsOp Value Value) InstOutput)
 (rule (construct_overflow_op_alu_128 cc op1 op2 x y)
       ;; Get the high/low registers for `x`.
       (let ((x_regs ValueRegs x)
@@ -164,8 +164,8 @@
         (let ((y_regs ValueRegs y)
               (y_lo Gpr (value_regs_get_gpr y_regs 0))
               (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-          (let    ((lo_inst ProducesFlags (x64_alurmi_with_flags_paired op1 $I64 x_lo y_lo))
-                   (hi_inst ConsumesAndProducesFlags (x64_alurmi_with_flags_chained op2 $I64 x_hi y_hi))
+          (let    ((lo_inst ProducesFlags (x64_produce_flags op1 $I64 x_lo y_lo))
+                   (hi_inst ConsumesAndProducesFlags (x64_chain_flags op2 $I64 x_hi y_hi))
                    (of_inst ConsumesFlags (x64_setcc_paired cc))
 
                    (result MultiReg (with_flags_chained lo_inst hi_inst of_inst)))
@@ -174,35 +174,35 @@
 ;;;; Rules for `uadd_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (uadd_overflow x y @ (value_type (fits_in_64 ty))))
-      (construct_overflow_op_alu ty (CC.B) (AluRmiROpcode.Add) x y))
+      (construct_overflow_op_alu ty (CC.B) (ProduceFlagsOp.Add) x y))
 
 ;; i128 gets lowered into adc and add
 (rule 0 (lower (uadd_overflow x y @ (value_type $I128)))
-        (construct_overflow_op_alu_128 (CC.B) (AluRmiROpcode.Add) (AluRmiROpcode.Adc) x y))
+        (construct_overflow_op_alu_128 (CC.B) (ProduceFlagsOp.Add) (ChainFlagsOp.Adc) x y))
 
 ;;;; Rules for `sadd_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (sadd_overflow x y @ (value_type (fits_in_64 ty))))
-      (construct_overflow_op_alu ty (CC.O) (AluRmiROpcode.Add) x y))
+      (construct_overflow_op_alu ty (CC.O) (ProduceFlagsOp.Add) x y))
 
 (rule 0 (lower (sadd_overflow x y @ (value_type $I128)))
-        (construct_overflow_op_alu_128 (CC.O) (AluRmiROpcode.Add) (AluRmiROpcode.Adc) x y))
+        (construct_overflow_op_alu_128 (CC.O) (ProduceFlagsOp.Add) (ChainFlagsOp.Adc) x y))
 
 ;;;; Rules for `usub_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (usub_overflow x y @ (value_type (fits_in_64 ty))))
-      (construct_overflow_op_alu ty (CC.B) (AluRmiROpcode.Sub) x y))
+      (construct_overflow_op_alu ty (CC.B) (ProduceFlagsOp.Sub) x y))
 
 (rule 0 (lower (usub_overflow x y @ (value_type $I128)))
-        (construct_overflow_op_alu_128 (CC.B) (AluRmiROpcode.Sub) (AluRmiROpcode.Sbb) x y))
+        (construct_overflow_op_alu_128 (CC.B) (ProduceFlagsOp.Sub) (ChainFlagsOp.Sbb) x y))
 
 ;;;; Rules for `ssub_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 1 (lower (ssub_overflow x y @ (value_type (fits_in_64 ty))))
-      (construct_overflow_op_alu ty (CC.O) (AluRmiROpcode.Sub) x y))
+      (construct_overflow_op_alu ty (CC.O) (ProduceFlagsOp.Sub) x y))
 
 (rule 0 (lower (ssub_overflow x y @ (value_type $I128)))
-        (construct_overflow_op_alu_128 (CC.O) (AluRmiROpcode.Sub) (AluRmiROpcode.Sbb) x y))
+        (construct_overflow_op_alu_128 (CC.O) (ProduceFlagsOp.Sub) (ChainFlagsOp.Sbb) x y))
 
 ;;;; Rules for `umul_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3565,7 +3565,7 @@
       (let ((lo Gpr (value_regs_get_gpr val 0))
             (hi Gpr (value_regs_get_gpr val 1)))
           (icmp_cond_result
-            (x64_alurmi_flags_side_effect (AluRmiROpcode.Or) $I64 lo hi)
+            (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) $I64 lo hi)
             (cc_invert cc))))
 
 

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
-;   sbbq    %rax, %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -47,7 +47,7 @@ block0(v0: i64):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -78,7 +78,7 @@ block0(v0: i64):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -109,7 +109,7 @@ block0(v0: i64):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -140,7 +140,7 @@ block0(v0: i32):
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
-;   sbbq    %rax, %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -171,7 +171,7 @@ block0(v0: i32):
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -202,7 +202,7 @@ block0(v0: i32):
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -233,7 +233,7 @@ block0(v0: i32):
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -264,7 +264,7 @@ block0(v0: i16):
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
-;   sbbq    %rax, %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -295,7 +295,7 @@ block0(v0: i16):
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -326,7 +326,7 @@ block0(v0: i16):
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -357,7 +357,7 @@ block0(v0: i16):
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -388,7 +388,7 @@ block0(v0: i8):
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
-;   sbbq    %rax, %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -419,7 +419,7 @@ block0(v0: i8):
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -450,7 +450,7 @@ block0(v0: i8):
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -481,7 +481,7 @@ block0(v0: i8):
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -513,7 +513,7 @@ block0(v0: i128):
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rdx
-;   sbbq    %rdx, %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -548,7 +548,7 @@ block0(v0: i128):
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
-;   sbbq    %rax, %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -581,7 +581,7 @@ block0(v0: i128):
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -614,7 +614,7 @@ block0(v0: i128):
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -647,7 +647,7 @@ block0(v0: i128):
 ;   movq    %rdi, %r8
 ;   negq    %r8, %r8
 ;   movq    %rdi, %rax
-;   sbbl    %eax, %edi, %eax
+;   sbbl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -679,7 +679,7 @@ block0(v0: i64):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rdx
-;   sbbq    %rdx, %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -712,7 +712,7 @@ block0(v0: i32):
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rdx
-;   sbbq    %rdx, %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -745,7 +745,7 @@ block0(v0: i16):
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rdx
-;   sbbq    %rdx, %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -778,7 +778,7 @@ block0(v0: i8):
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rdx
-;   sbbq    %rdx, %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -813,7 +813,7 @@ block0(v0: i32, v1: i32):
 ;   setnle  %al
 ;   movq    %rax, %r8
 ;   negb    %r8b, %r8b
-;   sbbl    %eax, %eax, %eax
+;   sbbl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -14,9 +14,9 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addq    %rax, %rdx, %rax
+;   addq %rdx, %rax
 ;   movq    %rsi, %rdx
-;   adcq    %rdx, %rcx, %rdx
+;   adcq %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -45,9 +45,9 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   subq    %rax, %rdx, %rax
+;   subq %rdx, %rax
 ;   movq    %rsi, %rdx
-;   sbbq    %rdx, %rcx, %rdx
+;   sbbq %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -328,44 +328,44 @@ block0(v0: i128, v1: i128):
 ;   xorq %rdx, %rax
 ;   movq    %rsi, %r8
 ;   xorq %rcx, %r8
-;   orq     %rax, %r8, %rax
+;   orq %r8, %rax
 ;   setz    %al
 ;   movq    %rdi, %r8
 ;   xorq %rdx, %r8
 ;   movq    %rsi, %r9
 ;   xorq %rcx, %r9
-;   orq     %r8, %r9, %r8
+;   orq %r9, %r8
 ;   setnz   %r9b
 ;   cmpq    %rdx, %rdi
 ;   movq    %rsi, %r8
-;   sbbq    %r8, %rcx, %r8
+;   sbbq %rcx, %r8
 ;   setl    %r8b
 ;   cmpq    %rdi, %rdx
 ;   movq    %rcx, %r10
-;   sbbq    %r10, %rsi, %r10
+;   sbbq %rsi, %r10
 ;   setnl   %r11b
 ;   cmpq    %rdi, %rdx
 ;   movq    %rcx, %r10
-;   sbbq    %r10, %rsi, %r10
+;   sbbq %rsi, %r10
 ;   setl    %r10b
 ;   cmpq    %rdx, %rdi
 ;   movq    %rsi, %rbx
-;   sbbq    %rbx, %rcx, %rbx
+;   sbbq %rcx, %rbx
 ;   setnl   %r14b
 ;   cmpq    %rdx, %rdi
 ;   movq    %rsi, %r12
-;   sbbq    %r12, %rcx, %r12
+;   sbbq %rcx, %r12
 ;   setb    %r13b
 ;   cmpq    %rdi, %rdx
 ;   movq    %rcx, %r15
-;   sbbq    %r15, %rsi, %r15
+;   sbbq %rsi, %r15
 ;   setnb   %bl
 ;   cmpq    %rdi, %rdx
 ;   movq    %rcx, %r15
-;   sbbq    %r15, %rsi, %r15
+;   sbbq %rsi, %r15
 ;   setb    %r15b
 ;   cmpq    %rdx, %rdi
-;   sbbq    %rsi, %rcx, %rsi
+;   sbbq %rcx, %rsi
 ;   setnb   %dil
 ;   andl %r9d, %eax
 ;   andl %r11d, %r8d
@@ -476,7 +476,7 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   jnz     label2; j label1
 ; block1:
 ;   movl    $1, %eax
@@ -524,7 +524,7 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   orq     %rdi, %rsi, %rdi
+;   orq %rsi, %rdi
 ;   jnz     label2; j label1
 ; block1:
 ;   movl    $2, %eax
@@ -1115,14 +1115,14 @@ block2(v8: i128):
 ;   testb   %dl, %dl
 ;   jnz     label2; j label1
 ; block1:
-;   addq    %rax, $2, %rax
+;   addq $0x2, %rax
 ;   setb    %dil
 ;   movzbq  %dil, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   addq    %rax, $1, %rax
+;   addq $0x1, %rax
 ;   setb    %cl
 ;   movzbq  %cl, %rdx
 ;   movq    %rbp, %rsp
@@ -1179,17 +1179,17 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq    rbp(stack args max - 32), %rdx
 ;   movq    rbp(stack args max - 24), %r11
 ;   movq    rbp(stack args max - 16), %r10
-;   addq    %rdi, %r15, %rdi
+;   addq %r15, %rdi
 ;   movq    %r13, %r14
-;   adcq    %rsi, %r14, %rsi
-;   addq    %r9, %r8, %r9
-;   adcq    %rcx, $0, %rcx
-;   addq    %rax, %r11, %rax
-;   adcq    %rdx, %r10, %rdx
-;   addq    %rdi, %r9, %rdi
-;   adcq    %rsi, %rcx, %rsi
-;   addq    %rax, %rdi, %rax
-;   adcq    %rdx, %rsi, %rdx
+;   adcq %r14, %rsi
+;   addq %r8, %r9
+;   adcq $0x0, %rcx
+;   addq %r11, %rax
+;   adcq %r10, %rdx
+;   addq %r9, %rdi
+;   adcq %rcx, %rsi
+;   addq %rdi, %rax
+;   adcq %rsi, %rdx
 ;   movq    0(%rsp), %r13
 ;   movq    8(%rsp), %r14
 ;   movq    16(%rsp), %r15
@@ -1855,7 +1855,7 @@ block0(v0: i128):
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rsi, %rdx
-;   adcq    %rdx, %r8, %rdx
+;   adcq %r8, %rdx
 ;   negq    %rdx, %rdx
 ;   cmovsq  %rdi, %rax, %rax
 ;   cmovsq  %rsi, %rdx, %rdx
@@ -1924,8 +1924,8 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rdi, %rax
-;   addq    %rax, %rsi, %rax
-;   adcq    %rdx, $0, %rdx
+;   addq %rsi, %rax
+;   adcq $0x0, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -2015,8 +2015,8 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rdi, %rax
-;   subq    %rax, %rsi, %rax
-;   sbbq    %rdx, $0, %rdx
+;   subq %rsi, %rax
+;   sbbq $0x0, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -2049,7 +2049,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
-;   addq    %rax, 0(%rdi), %rax
+;   addq (%rdi), %rax
 ;   setb    %r8b
 ;   movzbq  %r8b, %rdx
 ;   movq    %rbp, %rsp
@@ -2086,8 +2086,8 @@ block0(v0: i64, v1: i64):
 ;   movq    0(%rdi), %r9
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rsi, %rax
-;   addq    %rax, %r9, %rax
-;   adcq    %rdx, 8(%rdi), %rdx
+;   addq %r9, %rax
+;   adcq 8(%rdi), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -2123,8 +2123,8 @@ block0(v0: i64, v1: i64):
 ;   movq    0(%rdi), %r9
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rsi, %rax
-;   subq    %rax, %r9, %rax
-;   sbbq    %rdx, 8(%rdi), %rdx
+;   subq %r9, %rax
+;   sbbq 8(%rdi), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -2158,7 +2158,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   movl    $200, %eax
 ;   cmpq    %rdx, %rdi
-;   sbbq    %rsi, %rcx, %rsi
+;   sbbq %rcx, %rsi
 ;   cmovbl  const(0), %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -2196,7 +2196,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addq    %rax, %rsi, %rax
+;   addq %rsi, %rax
 ;   setb    %r8b
 ;   movzbq  %r8b, %rdx
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -30,7 +30,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   addq    %rdi, %rsi, %rdi
+;   addq %rsi, %rdi
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
@@ -13,7 +13,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addl    %eax, $127, %eax
+;   addl $0x7f, %eax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -44,7 +44,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addl    %eax, $127, %eax
+;   addl $0x7f, %eax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -74,7 +74,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addl    %eax, %esi, %eax
+;   addl %esi, %eax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -105,7 +105,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addq    %rax, $127, %rax
+;   addq $0x7f, %rax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -136,7 +136,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addq    %rax, $127, %rax
+;   addq $0x7f, %rax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -166,7 +166,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   addq    %rax, %rsi, %rax
+;   addq %rsi, %rax
 ;   jb #trap=user1
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
This change replaces ISLE lowerings for the `ProducesFlags` and `ConsumesFlags` wrappers with instructions from the new assembler. This is a necessary step towards fully using the new assembler for ALU instructions (`AluRmiR` is only used for zeroing registers now).

A couple items of note:
- there are a few places where `lower.isle` wants to abstract over some subset of ALU operations to avoid repetition; this change retains that via some `x64_*_flags` helpers that take a new type (`ChainFlagsOp`, e.g.) that restricts which operations the helper can use. This is not a major refactor but it does show that we use these flag-producing instructions in quite limited ways.
- we previously decided to keep rules that used wider versions of registers for i8/i16 operations to avoid CPU dependencies; this is problematic for instructions that rely on overflow, though, so this change extracts those "wider register" rules into `x64_*_break_deps` helpers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
