### PR TITLE
asm: move assembler operand matchers

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1899,6 +1899,31 @@
 (extractor (is_multi_register_gpr_type ty)
            (and (type_register_class (RegisterClass.Gpr false)) ty))
 
+;;;; Helpers for matching operands ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; These are mainly used for matching operands for the external assembler.
+
+(decl is_imm8 (u8) GprMemImm)
+(extern extractor is_imm8 is_imm8)
+(decl is_simm8 (i8) GprMemImm)
+(extern extractor is_simm8 is_simm8)
+(decl is_imm16 (u16) GprMemImm)
+(extern extractor is_imm16 is_imm16)
+(decl is_simm16 (i16) GprMemImm)
+(extern extractor is_simm16 is_simm16)
+(decl is_imm32 (u32) GprMemImm)
+(extern extractor is_imm32 is_imm32)
+(decl is_simm32 (i32) GprMemImm)
+(extern extractor is_simm32 is_simm32)
+(decl is_gpr (Gpr) GprMemImm)
+(extern extractor is_gpr is_gpr)
+(decl is_gpr_mem (GprMem) GprMemImm)
+(extern extractor is_gpr_mem is_gpr_mem)
+(decl is_xmm_mem (XmmMem) XmmMem)
+(extern extractor is_xmm_mem is_xmm_mem)
+(decl is_xmm (Xmm) XmmMem)
+(extern extractor is_xmm is_xmm)
+
 ;;;; Helpers for Querying Enabled ISA Extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl pure use_avx512vl () bool)
@@ -2946,27 +2971,7 @@
                  (MInst.Mul size signed src1 src2 dst_lo dst_hi)
                  dst_lo)))
 
-;; Helpers for matching operands, extracting them into their assembler types.
-(decl is_imm8 (u8) GprMemImm)
-(extern extractor is_imm8 is_imm8)
-(decl is_simm8 (i8) GprMemImm)
-(extern extractor is_simm8 is_simm8)
-(decl is_imm16 (u16) GprMemImm)
-(extern extractor is_imm16 is_imm16)
-(decl is_simm16 (i16) GprMemImm)
-(extern extractor is_simm16 is_simm16)
-(decl is_imm32 (u32) GprMemImm)
-(extern extractor is_imm32 is_imm32)
-(decl is_simm32 (i32) GprMemImm)
-(extern extractor is_simm32 is_simm32)
-(decl is_gpr (Gpr) GprMemImm)
-(extern extractor is_gpr is_gpr)
-(decl is_gpr_mem (GprMem) GprMemImm)
-(extern extractor is_gpr_mem is_gpr_mem)
-(decl is_xmm_mem (XmmMem) XmmMem)
-(extern extractor is_xmm_mem is_xmm_mem)
-(decl is_xmm (Xmm) XmmMem)
-(extern extractor is_xmm is_xmm)
+
 
 ;; Helper for emitting `and` instructions.
 (decl x64_and (Type Gpr GprMemImm) Gpr)


### PR DESCRIPTION
This change only moves the match helpers for the external assembler into a more appropriate location; no functional changes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
