### PR TITLE
Don't discard errors in `default_value` helpers

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1141,9 +1141,9 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
                 .into()
             }
             other_ty => match other_ty.default_value(&mut store) {
-                Some(item) => item,
-                None => {
-                    log::warn!("couldn't create import for {import:?}");
+                Ok(item) => item,
+                Err(e) => {
+                    log::warn!("couldn't create import for {import:?}: {e:?}");
                     return;
                 }
             },

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -282,9 +282,17 @@ impl<T> Linker<T> {
         for import in module.imports() {
             if let Err(import_err) = self._get_by_import(&import) {
                 let default_extern =
-                    import_err.ty().default_value(&mut *store).ok_or_else(|| {
-                        anyhow!("no default value exists for type `{:?}`", import_err.ty())
-                    })?;
+                    import_err
+                        .ty()
+                        .default_value(&mut *store)
+                        .with_context(|| {
+                            anyhow!(
+                                "no default value exists for `{}::{}` with type `{:?}`",
+                                import.module(),
+                                import.name(),
+                                import_err.ty(),
+                            )
+                        })?;
                 self.define(
                     store.as_context(),
                     import.module(),


### PR DESCRIPTION
This commit updates the `default_value` helpers added recently to return a `Result` instead of returning an `Option<T>` and throwing away error information. This fixes a fuzz bug showing up recently which happened because the error in question was one we've flagged to ignore, but because the error was discarded we didn't know to ignore it so it ended up causing a fuzz failure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
