### PR TITLE
doc: fixup `Pollable` example

### DIFF
--- a/crates/wasi-io/src/poll.rs
+++ b/crates/wasi-io/src/poll.rs
@@ -39,8 +39,7 @@ pub struct DynPollable {
 ///
 /// ```
 /// # // stub out so we don't need a dep to build the doctests:
-/// # mod tokio { pub mod time { pub use std::time::{Duration, Instant}; pub async fn sleep_until(_:
-/// Instant) {} } }
+/// # mod tokio { pub mod time { pub use std::time::{Duration, Instant}; pub async fn sleep_until(_: Instant) {} } }
 /// use tokio::time::{self, Duration, Instant};
 /// use wasmtime_wasi_io::{IoView, poll::{Pollable, subscribe, DynPollable}, async_trait};
 /// use wasmtime::component::Resource;


### PR DESCRIPTION
[Usage example for `wasmtime_wasi::Pollable` in v31.0.0](https://docs.rs/wasmtime-wasi/31.0.0/wasmtime_wasi/trait.Pollable.html#example) is displayed as:
```rust
Instant) {} } }
use tokio::time::{self, Duration, Instant};
use wasmtime_wasi_io::{IoView, poll::{Pollable, subscribe, DynPollable}, async_trait};
use wasmtime::component::Resource;
use wasmtime::Result;

fn sleep(cx: &mut dyn IoView, dur: Duration) -> Result<Resource<DynPollable>> {
    let end = Instant::now() + dur;
    let sleep = MySleep { end };
    let sleep_resource = cx.table().push(sleep)?;
    subscribe(cx.table(), sleep_resource)
}

struct MySleep {
    end: Instant,
}

#[async_trait]
impl Pollable for MySleep {
    async fn ready(&mut self) {
        tokio::time::sleep_until(self.end).await;
    }
}
```

which would not compile, if it were duplicated.

Note, that the doctests do not catch this issue, since the Rust code *in the source* is valid, however the displayed one is not due to `#` only hiding part of the implementation