### PR TITLE
Update linkage of `libm` for nightly Rust

### DIFF
--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -112,10 +112,10 @@ impl TestFileCompiler {
         #[cfg(unix)]
         {
             unsafe extern "C" {
-                safe fn ceilf(f: f32) -> f32;
+                safe fn cosf(f: f32) -> f32;
             }
             let f = 1.2_f32;
-            assert_eq!(f.ceil(), ceilf(f));
+            assert_eq!(f.cos(), cosf(f));
         }
 
         let module = JITModule::new(builder);


### PR DESCRIPTION
Upstream rustc has changed meaning that the `ceil` function is now defined in bcompiler-builtins, so link a different symbol to force pulling in `libm` to get `dlsym` working for its symbols in Cranelift tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
