### PR TITLE
Canonicalize NaN in cranelift-fuzzgen

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -254,6 +254,10 @@ where
         // into compilation anywhere, we leave it on unconditionally to make sure the generation doesn't panic.
         builder.enable("machine_code_cfg_info")?;
 
+        // Differential fuzzing between the interpreter and the host will only
+        // really work if NaN payloads are canonicalized, so enable this.
+        builder.enable("cranelift_nan_canonicalization")?;
+
         Ok(Flags::new(builder))
     }
 


### PR DESCRIPTION
Lacking this has happened to work fine up to now but Rust nightly is changing float implementations which is changing float payloads. As a result this is the only reliable method of ensuring that differential fuzzing between the interpreter and native backends remains reliable, in the same manner as this being enabled for core wasm as well.

Closes #10583

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
