### PR TITLE
Cranelift: update to regalloc2 0.12.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8901022fb3dd7d9fc8e925df91df33e889705a1e3c76901fe5abef917788dc"
+checksum = "987b16639ffa003f99fe9c183ce633c6ba2578f6383b2f04fe9dc669f9aac55a"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.12.0"
+regalloc2 = "0.12.1"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/cranelift/filetests/filetests/isa/x64/exceptions-regalloc-verifier.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions-regalloc-verifier.clif
@@ -1,0 +1,14 @@
+test compile
+set regalloc_checker=1
+target x86_64
+
+function u0:0() -> i32 tail {
+    sig0 = () -> i32 tail
+    fn0 = u0:1 sig0
+
+block0:
+    try_call fn0(), sig0, block1(ret0), []
+
+block1(v0: i32):
+    return v0
+}

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -933,8 +933,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.12.0"
-when = "2025-04-11"
+version = "0.12.1"
+when = "2025-04-15"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"


### PR DESCRIPTION
Pulls in bytecodealliance/regalloc2#224 which fixes the regalloc checker for try-call instructions.

This PR also includes the test from #10585. Fixes #10585.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
