### PR TITLE
Some fixes for try_call

### DIFF
--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -148,7 +148,7 @@ pub fn has_memory_fence_semantics(op: Opcode) -> bool {
         | Opcode::AtomicStore
         | Opcode::Fence
         | Opcode::Debugtrap => true,
-        Opcode::Call | Opcode::CallIndirect => true,
+        Opcode::Call | Opcode::CallIndirect | Opcode::TryCall | Opcode::TryCallIndirect => true,
         op if op.can_trap() => true,
         _ => false,
     }

--- a/cranelift/codegen/src/ir/exception_table.rs
+++ b/cranelift/codegen/src/ir/exception_table.rs
@@ -155,6 +155,12 @@ impl ExceptionTableData {
     pub fn signature(&self) -> SigRef {
         self.sig
     }
+
+    /// Clears all entries in this exception table, but leaves the function signature.
+    pub fn clear(&mut self) {
+        self.tags.clear();
+        self.targets.clear();
+    }
 }
 
 /// A wrapper for the context required to display a

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1127,7 +1127,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
     fn get_regs_clobbered_by_call(call_conv: isa::CallConv, is_exception: bool) -> PRegSet {
         match call_conv {
             isa::CallConv::Winch => WINCH_CLOBBERS,
-            _ if is_exception => ALL_CLOBBERS,
+            isa::CallConv::Tail if is_exception => ALL_CLOBBERS,
             _ => DEFAULT_AAPCS_CLOBBERS,
         }
     }

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -84,7 +84,7 @@ impl CallConv {
     /// Does this calling convention support exceptions?
     pub fn supports_exceptions(&self) -> bool {
         match self {
-            CallConv::Tail => true,
+            CallConv::Tail | CallConv::SystemV => true,
             _ => false,
         }
     }
@@ -92,7 +92,7 @@ impl CallConv {
     /// What types do the exception payload value(s) have?
     pub fn exception_payload_types(&self, pointer_ty: Type) -> &[Type] {
         match self {
-            CallConv::Tail => match pointer_ty {
+            CallConv::Tail | CallConv::SystemV => match pointer_ty {
                 types::I32 => &[types::I32, types::I32],
                 types::I64 => &[types::I64, types::I64],
                 _ => unreachable!(),

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -639,13 +639,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     }
 
     fn get_regs_clobbered_by_call(
-        _call_conv_of_callee: isa::CallConv,
+        call_conv_of_callee: isa::CallConv,
         is_exception: bool,
     ) -> PRegSet {
-        if is_exception {
-            ALL_CLOBBERS
-        } else {
-            DEFAULT_CLOBBERS
+        match call_conv_of_callee {
+            isa::CallConv::Tail if is_exception => ALL_CLOBBERS,
+            _ => DEFAULT_CLOBBERS,
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -907,7 +907,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         is_exception: bool,
     ) -> PRegSet {
         match call_conv_of_callee {
-            _ if is_exception => ALL_CLOBBERS,
+            isa::CallConv::Tail if is_exception => ALL_CLOBBERS,
             isa::CallConv::Tail => TAIL_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -914,7 +914,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         match call_conv_of_callee {
             CallConv::Winch => ALL_CLOBBERS,
             CallConv::WindowsFastcall => WINDOWS_CLOBBERS,
-            _ if is_exception => ALL_CLOBBERS,
+            CallConv::Tail if is_exception => ALL_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
     }

--- a/cranelift/filetests/filetests/egraph/try_call-mem-clobber.clif
+++ b/cranelift/filetests/filetests/egraph/try_call-mem-clobber.clif
@@ -1,0 +1,25 @@
+; Regression test for the alias analysis not considering try_call to be a memory fence
+
+test optimize
+set opt_level=speed_and_size
+target x86_64
+
+function u0:0(i64 sret, i64) system_v {
+    ss0 = explicit_slot 8
+    sig0 = (i64) system_v
+    fn0 = u0:1 sig0
+
+block0(v0: i64, v1: i64):
+    v20 = stack_addr.i64 ss0
+    ; check: v20 = stack_addr.i64 ss0
+    store v1, v20 ; store v1 to ss0
+    try_call fn0(v20), sig0, block1, []
+
+block1:
+    v21 = stack_addr.i64 ss0
+    v2 = load.i64 v21; load v2 from ss0 after the fn0 call potentially changed it
+    ; check: v2 = load.i64 v20
+    store v2, v0 ; v2 used to be incorrectly replaced by v1 in the egraph pass
+    ; nextln: store v2, v0
+    return
+}

--- a/cranelift/filetests/filetests/verifier/exceptions.clif
+++ b/cranelift/filetests/filetests/verifier/exceptions.clif
@@ -112,12 +112,12 @@ function %f4(i32) -> i32 {
 
 ;; Non-supported calling convention.
 function %f5(i32) -> i32 {
-    sig0 = (i32) -> f32 system_v
-    fn0 = %g(i32) -> f32 system_v
+    sig0 = (i32) -> f32 windows_fastcall
+    fn0 = %g(i32) -> f32 windows_fastcall
 
     block0(v1: i32):
         v2 = f64const 0x1.0
-        try_call fn0(v1), sig0, block1(ret0, v2), [ tag1: block2(), default: block3(v2) ] ; error: calling convention `system_v` of callee does not support exceptions
+        try_call fn0(v1), sig0, block1(ret0, v2), [ tag1: block2(), default: block3(v2) ] ; error: calling convention `windows_fastcall` of callee does not support exceptions
 
     block1(v3: f32, v4: f64):
         v5 = iconst.i32 1

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -151,8 +151,8 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
             ir::InstructionData::BranchTable { table, .. } => {
                 let pool = &self.builder.func.dfg.value_lists;
 
-                // Unlike all other jumps/branches, jump tables are
-                // capable of having the same successor appear
+                // Unlike most other jumps/branches and like try_call,
+                // jump tables are capable of having the same successor appear
                 // multiple times, so we must deduplicate.
                 let mut unique = EntitySet::<Block>::new();
                 for dest_block in self
@@ -179,7 +179,39 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                 }
             }
 
-            inst => debug_assert!(!inst.opcode().is_branch()),
+            ir::InstructionData::TryCall { exception, .. }
+            | ir::InstructionData::TryCallIndirect { exception, .. } => {
+                let pool = &self.builder.func.dfg.value_lists;
+
+                // Unlike most other jumps/branches and like br_table,
+                // exception tables are capable of having the same successor
+                // appear multiple times, so we must deduplicate.
+                let mut unique = EntitySet::<Block>::new();
+                for dest_block in self
+                    .builder
+                    .func
+                    .stencil
+                    .dfg
+                    .exception_tables
+                    .get(*exception)
+                    .expect("you are referencing an undeclared exception table")
+                    .all_branches()
+                {
+                    let block = dest_block.block(pool);
+                    if !unique.insert(block) {
+                        continue;
+                    }
+
+                    // Call `declare_block_predecessor` instead of `declare_successor` for
+                    // avoiding the borrow checker.
+                    self.builder
+                        .func_ctx
+                        .ssa
+                        .declare_block_predecessor(block, inst);
+                }
+            }
+
+            inst => assert!(!inst.opcode().is_branch()),
         }
 
         if data.opcode().is_terminator() {
@@ -1207,8 +1239,10 @@ mod tests {
     use alloc::string::ToString;
     use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::condcodes::IntCC;
-    use cranelift_codegen::ir::{types::*, UserFuncName};
-    use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, Value};
+    use cranelift_codegen::ir::{
+        types::*, AbiParam, BlockCall, ExceptionTableData, ExtFuncData, ExternalName, Function,
+        InstBuilder, MemFlags, Signature, UserExternalName, UserFuncName, Value,
+    };
     use cranelift_codegen::isa::{CallConv, TargetFrontendConfig, TargetIsa};
     use cranelift_codegen::settings;
     use cranelift_codegen::verifier::verify_function;
@@ -1969,6 +2003,96 @@ block0:
 block0:
     v0 = iconst.i32 -1
     return
+}",
+        );
+    }
+
+    #[test]
+    fn try_call() {
+        let mut sig = Signature::new(CallConv::SystemV);
+        sig.params.push(AbiParam::new(I8));
+        sig.returns.push(AbiParam::new(I32));
+        let mut fn_ctx = FunctionBuilderContext::new();
+        let mut func = Function::with_name_signature(UserFuncName::testcase("sample"), sig);
+
+        let sig0 = func.import_signature(Signature::new(CallConv::SystemV));
+        let name = func.declare_imported_user_function(UserExternalName::new(0, 0));
+        let fn0 = func.import_function(ExtFuncData {
+            name: ExternalName::User(name),
+            signature: sig0,
+            colocated: false,
+        });
+
+        let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
+
+        let block0 = builder.create_block();
+        let block1 = builder.create_block();
+        let block2 = builder.create_block();
+        let block3 = builder.create_block();
+
+        let my_var = Variable::from_u32(0);
+        builder.declare_var(my_var, I32);
+
+        builder.switch_to_block(block0);
+        let branch_val = builder.append_block_param(block0, I8);
+        builder.ins().brif(branch_val, block1, &[], block2, &[]);
+
+        builder.switch_to_block(block1);
+        let one = builder.ins().iconst(I32, 1);
+        builder.def_var(my_var, one);
+
+        let normal_return =
+            BlockCall::new(block3, [].into_iter(), &mut builder.func.dfg.value_lists);
+        let exception_table = builder
+            .func
+            .dfg
+            .exception_tables
+            .push(ExceptionTableData::new(sig0, normal_return, []));
+        builder.ins().try_call(fn0, &[], exception_table);
+
+        builder.switch_to_block(block2);
+        let two = builder.ins().iconst(I32, 2);
+        builder.def_var(my_var, two);
+
+        let normal_return =
+            BlockCall::new(block3, [].into_iter(), &mut builder.func.dfg.value_lists);
+        let exception_table = builder
+            .func
+            .dfg
+            .exception_tables
+            .push(ExceptionTableData::new(sig0, normal_return, []));
+        builder.ins().try_call(fn0, &[], exception_table);
+
+        builder.switch_to_block(block3);
+        let ret_val = builder.use_var(my_var);
+        builder.ins().return_(&[ret_val]);
+
+        builder.seal_all_blocks();
+        builder.finalize();
+
+        let flags = cranelift_codegen::settings::Flags::new(cranelift_codegen::settings::builder());
+        let ctx = cranelift_codegen::Context::for_function(func);
+        ctx.verify(&flags).expect("should be valid");
+
+        check(
+            &ctx.func,
+            "function %sample(i8) -> i32 system_v {
+    sig0 = () system_v
+    fn0 = u0:0 sig0
+
+block0(v0: i8):
+    brif v0, block1, block2
+
+block1:
+    v1 = iconst.i32 1
+    try_call fn0(), sig0, block3(v1), []  ; v1 = 1
+
+block2:
+    v2 = iconst.i32 2
+    try_call fn0(), sig0, block3(v2), []  ; v2 = 2
+
+block3(v3: i32):
+    return v3
 }",
         );
     }


### PR DESCRIPTION
Together with a change to allow the system_v call conv, this is enough to pass most of cg_clif's test suite (including panicking tests). In addition rustc's compiletest now works just fine in panic=unwind mode. Not all rustc tests pass yet, but the test failures seem to be caused by either cg_clif or bugs in the tests themself.

The second commit is not strictly necessary for correctness, but does make the optimizer work better with try_call.