### PR TITLE
winch(aarch64): Fix cmov implementation

### DIFF
--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -69,7 +69,7 @@
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
 ;;       cmp     w1, w3, uxtx
-;;       csel    x2, x4, x4, hs
+;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
 ;;       b.ne    #0xe0
@@ -137,7 +137,7 @@
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
 ;;       cmp     w1, w3, uxtx
-;;       csel    x2, x4, x4, hs
+;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
 ;;       b.ne    #0x200

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -66,7 +66,7 @@
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
 ;;       cmp     w1, w3, uxtx
-;;       csel    x2, x4, x4, hs
+;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
 ;;       b.ne    #0xfc

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -43,7 +43,7 @@
 ;;       mov     x16, #0
 ;;       mov     x4, x16
 ;;       cmp     x2, x1, uxtx
-;;       csel    x3, x4, x4, hi
+;;       csel    x3, x4, x3, hi
 ;;       ldur    w0, [x3]
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x58]
@@ -58,7 +58,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x4, x5, x5, hi
+;;       csel    x4, x5, x4, hi
 ;;       ldur    w1, [x4]
 ;;       ldur    w2, [x28, #0xc]
 ;;       ldur    x3, [x9, #0x58]
@@ -76,7 +76,7 @@
 ;;       mov     x16, #0
 ;;       mov     x6, x16
 ;;       cmp     x4, x3, uxtx
-;;       csel    x5, x6, x6, hi
+;;       csel    x5, x6, x5, hi
 ;;       ldur    w2, [x5]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -46,7 +46,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x4, x5, x5, hi
+;;       csel    x4, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28, #4]
 ;;       ldur    w1, [x28, #0xc]
@@ -62,7 +62,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x4, x5, x5, hi
+;;       csel    x4, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #0xc]
@@ -81,7 +81,7 @@
 ;;       mov     x16, #0
 ;;       mov     x5, x16
 ;;       cmp     x3, x2, uxtx
-;;       csel    x4, x5, x5, hi
+;;       csel    x4, x5, x4, hi
 ;;       stur    w0, [x4]
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -842,13 +842,13 @@ impl Assembler {
         });
     }
 
-    // If the condition is true, Conditional Select writes rm to rd. If the condition is false,
-    // it writes rn to rd
-    pub fn csel(&mut self, rm: Reg, rn: Reg, rd: WritableReg, cond: Cond) {
+    /// If the condition is true, `csel` writes rn to rd. If the
+    /// condition is false, it writes rm to rd
+    pub fn csel(&mut self, rn: Reg, rm: Reg, rd: WritableReg, cond: Cond) {
         self.emit(Inst::CSel {
             rd: rd.map(Into::into),
-            rm: rm.into(),
             rn: rn.into(),
+            rm: rm.into(),
             cond,
         });
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -394,7 +394,7 @@ impl Masm for MacroAssembler {
         cc: IntCmpKind,
         _size: OperandSize,
     ) -> Result<()> {
-        self.asm.csel(src, src, dst, Cond::from(cc));
+        self.asm.csel(src, dst.to_reg(), dst, Cond::from(cc));
         Ok(())
     }
 


### PR DESCRIPTION
This commit fixes conditional move implementation in aarch64. Prior to this commit, the implementation would emit

    csel dst, src, src

resuting in an unconditional move.

This was surfaced as a bug in the `call_indirect` implemenation

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
