### PR TITLE
Component and Instance have corresponding get_export, get_export_index

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -282,15 +282,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/chars")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -300,14 +300,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/chars")
+                            .get_export_index(&mut store, None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -298,15 +298,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/chars")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -316,14 +316,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/chars")
+                            .get_export_index(&mut store, None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -375,15 +375,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/chars")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -393,14 +393,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/chars")
+                            .get_export_index(&mut store, None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -327,15 +327,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/chars")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -345,14 +345,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/chars")
+                            .get_export_index(&mut store, None, "foo:foo/chars")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -502,15 +502,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/conventions")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -520,14 +520,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .get_export_index(&mut store, None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -538,15 +538,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/conventions")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -556,14 +556,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .get_export_index(&mut store, None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -987,15 +987,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/conventions")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1005,14 +1005,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .get_export_index(&mut store, None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -698,15 +698,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/conventions")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -716,14 +716,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/conventions")
+                            .get_export_index(&mut store, None, "foo:foo/conventions")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -629,15 +629,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/flegs")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -647,14 +647,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .get_export_index(&mut store, None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -655,15 +655,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/flegs")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -673,14 +673,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .get_export_index(&mut store, None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -929,15 +929,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/flegs")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -947,14 +947,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .get_export_index(&mut store, None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -767,15 +767,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/flegs")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -785,14 +785,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/flegs")
+                            .get_export_index(&mut store, None, "foo:foo/flegs")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -303,15 +303,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/floats")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -321,14 +321,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/floats")
+                            .get_export_index(&mut store, None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -323,15 +323,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/floats")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -341,14 +341,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/floats")
+                            .get_export_index(&mut store, None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -476,15 +476,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/floats")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -494,14 +494,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/floats")
+                            .get_export_index(&mut store, None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -381,15 +381,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/floats")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -399,14 +399,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/floats")
+                            .get_export_index(&mut store, None, "foo:foo/floats")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/function-new.rs
+++ b/crates/component-macro/tests/expanded/function-new.rs
@@ -110,9 +110,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let new = _component
-                .export_index(None, "new")
-                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
-                .1;
+                .get_export_index(None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -128,7 +127,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let new = _instance
-                .get_export(&mut store, None, "new")
+                .get_export_index(&mut store, None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }

--- a/crates/component-macro/tests/expanded/function-new_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_async.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let new = _component
-                .export_index(None, "new")
-                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
-                .1;
+                .get_export_index(None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let new = _instance
-                .get_export(&mut store, None, "new")
+                .get_export_index(&mut store, None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let new = _component
-                .export_index(None, "new")
-                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
-                .1;
+                .get_export_index(None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let new = _instance
-                .get_export(&mut store, None, "new")
+                .get_export_index(&mut store, None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }

--- a/crates/component-macro/tests/expanded/function-new_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/function-new_tracing_async.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let new = _component
-                .export_index(None, "new")
-                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?
-                .1;
+                .get_export_index(None, "new")
+                .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let new = _instance
-                .get_export(&mut store, None, "new")
+                .get_export_index(&mut store, None, "new")
                 .ok_or_else(|| anyhow::anyhow!("no function export `new` found"))?;
             Ok(FooIndices { new })
         }

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -541,15 +541,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/integers")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -559,14 +559,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/integers")
+                            .get_export_index(&mut store, None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -590,15 +590,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/integers")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -608,14 +608,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/integers")
+                            .get_export_index(&mut store, None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -1268,15 +1268,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/integers")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1286,14 +1286,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/integers")
+                            .get_export_index(&mut store, None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -855,15 +855,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/integers")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -873,14 +873,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/integers")
+                            .get_export_index(&mut store, None, "foo:foo/integers")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -1241,15 +1241,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1259,14 +1259,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/lists")
+                            .get_export_index(&mut store, None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -1351,15 +1351,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1369,14 +1369,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/lists")
+                            .get_export_index(&mut store, None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -2449,15 +2449,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -2467,14 +2467,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/lists")
+                            .get_export_index(&mut store, None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -1782,15 +1782,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1800,14 +1800,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/lists")
+                            .get_export_index(&mut store, None, "foo:foo/lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -553,15 +553,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/manyarg")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -571,14 +571,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .get_export_index(&mut store, None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -571,15 +571,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/manyarg")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -589,14 +589,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .get_export_index(&mut store, None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -642,15 +642,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/manyarg")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -660,14 +660,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .get_export_index(&mut store, None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -614,15 +614,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/manyarg")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -632,14 +632,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/manyarg")
+                            .get_export_index(&mut store, None, "foo:foo/manyarg")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -334,15 +334,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.1.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -352,14 +352,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -437,15 +438,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.2.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -455,14 +456,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -355,15 +355,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.1.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -373,14 +373,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -458,15 +459,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.2.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -476,14 +477,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -432,15 +432,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.1.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -450,14 +450,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -536,15 +537,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.2.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -554,14 +555,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -381,15 +381,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.1.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -399,14 +399,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.1.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -495,15 +496,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "my:dep/a@0.2.0")
+                        let instance = component
+                            .get_export_index(None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -513,14 +514,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "my:dep/a@0.2.0")
+                            .get_export_index(&mut store, None, "my:dep/a@0.2.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -758,15 +758,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/records")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -776,14 +776,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/records")
+                            .get_export_index(&mut store, None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -792,15 +792,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/records")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -810,14 +810,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/records")
+                            .get_export_index(&mut store, None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -1212,15 +1212,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/records")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1230,14 +1230,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/records")
+                            .get_export_index(&mut store, None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -953,15 +953,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/records")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -971,14 +971,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/records")
+                            .get_export_index(&mut store, None, "foo:foo/records")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -342,15 +342,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-export")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -360,14 +360,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .get_export_index(&mut store, None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -517,15 +518,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-import")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -535,14 +536,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-import",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -695,15 +701,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export1")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -713,14 +719,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export1",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -811,15 +822,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export2")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -829,14 +840,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export2",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -358,15 +358,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-export")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -376,14 +376,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .get_export_index(&mut store, None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -539,15 +540,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-import")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -557,14 +558,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-import",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -723,15 +729,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export1")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -741,14 +747,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export1",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -841,15 +852,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export2")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -859,14 +870,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export2",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -353,15 +353,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-export")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -371,14 +371,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .get_export_index(&mut store, None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -533,15 +534,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-import")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -551,14 +552,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-import",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -720,15 +726,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export1")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -738,14 +744,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export1",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -839,15 +850,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export2")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -857,14 +868,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export2",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -358,15 +358,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-export")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -376,14 +376,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-export")
+                            .get_export_index(&mut store, None, "foo:foo/simple-export")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -566,15 +567,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-import")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-import")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -584,14 +585,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-import")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-import",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -779,15 +785,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export1")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export1")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -797,14 +803,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export1")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export1",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(
@@ -906,15 +917,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/export-using-export2")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/export-using-export2")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -924,14 +935,19 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/export-using-export2")
+                            .get_export_index(
+                                &mut store,
+                                None,
+                                "foo:foo/export-using-export2",
+                            )
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -163,11 +163,10 @@ const _: () = {
                 _component,
             )?;
             let some_world_func2 = _component
-                .export_index(None, "some-world-func2")
+                .get_export_index(None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
-                })?
-                .1;
+                })?;
             Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
@@ -190,7 +189,7 @@ const _: () = {
                 _instance,
             )?;
             let some_world_func2 = _instance
-                .get_export(&mut store, None, "some-world-func2")
+                .get_export_index(&mut store, None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?;
@@ -1158,15 +1157,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/uses-resource-transitively")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1176,7 +1175,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "foo:foo/uses-resource-transitively",
@@ -1187,7 +1186,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -168,11 +168,10 @@ const _: () = {
                 _component,
             )?;
             let some_world_func2 = _component
-                .export_index(None, "some-world-func2")
+                .get_export_index(None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
-                })?
-                .1;
+                })?;
             Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
@@ -195,7 +194,7 @@ const _: () = {
                 _instance,
             )?;
             let some_world_func2 = _instance
-                .get_export(&mut store, None, "some-world-func2")
+                .get_export_index(&mut store, None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?;
@@ -1283,15 +1282,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/uses-resource-transitively")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1301,7 +1300,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "foo:foo/uses-resource-transitively",
@@ -1312,7 +1311,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -240,11 +240,10 @@ const _: () = {
                 _component,
             )?;
             let some_world_func2 = _component
-                .export_index(None, "some-world-func2")
+                .get_export_index(None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
-                })?
-                .1;
+                })?;
             Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
@@ -267,7 +266,7 @@ const _: () = {
                 _instance,
             )?;
             let some_world_func2 = _instance
-                .get_export(&mut store, None, "some-world-func2")
+                .get_export_index(&mut store, None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?;
@@ -2292,15 +2291,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/uses-resource-transitively")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -2310,7 +2309,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "foo:foo/uses-resource-transitively",
@@ -2321,7 +2320,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -168,11 +168,10 @@ const _: () = {
                 _component,
             )?;
             let some_world_func2 = _component
-                .export_index(None, "some-world-func2")
+                .get_export_index(None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
-                })?
-                .1;
+                })?;
             Ok(TheWorldIndices {
                 interface1,
                 some_world_func2,
@@ -195,7 +194,7 @@ const _: () = {
                 _instance,
             )?;
             let some_world_func2 = _instance
-                .get_export(&mut store, None, "some-world-func2")
+                .get_export_index(&mut store, None, "some-world-func2")
                 .ok_or_else(|| {
                     anyhow::anyhow!("no function export `some-world-func2` found")
                 })?;
@@ -1687,15 +1686,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/uses-resource-transitively")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/uses-resource-transitively")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1705,7 +1704,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "foo:foo/uses-resource-transitively",
@@ -1716,7 +1715,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -354,14 +354,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "http-handler")
+                let instance = component
+                    .get_export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -370,12 +368,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "http-handler")
+                    .get_export_index(&mut store, None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -376,14 +376,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "http-handler")
+                let instance = component
+                    .get_export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -392,12 +390,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "http-handler")
+                    .get_export_index(&mut store, None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -415,14 +415,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "http-handler")
+                let instance = component
+                    .get_export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -431,12 +429,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "http-handler")
+                    .get_export_index(&mut store, None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -392,14 +392,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "http-handler")
+                let instance = component
+                    .get_export_index(None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -408,12 +406,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "http-handler")
+                    .get_export_index(&mut store, None, "http-handler")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `http-handler`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -337,15 +337,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -355,14 +355,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple")
+                            .get_export_index(&mut store, None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -361,15 +361,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -379,14 +379,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple")
+                            .get_export_index(&mut store, None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -596,15 +596,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -614,14 +614,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple")
+                            .get_export_index(&mut store, None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -449,15 +449,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -467,14 +467,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple")
+                            .get_export_index(&mut store, None, "foo:foo/simple")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -360,15 +360,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -378,14 +378,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .get_export_index(&mut store, None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -384,15 +384,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -402,14 +402,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .get_export_index(&mut store, None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -551,15 +551,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -569,14 +569,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .get_export_index(&mut store, None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -445,15 +445,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/simple-lists")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -463,14 +463,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/simple-lists")
+                            .get_export_index(&mut store, None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -365,13 +365,13 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/anon")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -381,12 +381,13 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/anon")
+                            .get_export_index(&mut store, None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -379,13 +379,13 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/anon")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -395,12 +395,13 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/anon")
+                            .get_export_index(&mut store, None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -433,13 +433,13 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/anon")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -449,12 +449,13 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/anon")
+                            .get_export_index(&mut store, None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -392,13 +392,13 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/anon")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -408,12 +408,13 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/anon")
+                            .get_export_index(&mut store, None, "foo:foo/anon")
                             .ok_or_else(|| {
                                 anyhow::anyhow!("no exported instance named `foo:foo/anon`")
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/smoke-default.rs
+++ b/crates/component-macro/tests/expanded/smoke-default.rs
@@ -110,9 +110,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let y = _component
-                .export_index(None, "y")
-                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
-                .1;
+                .get_export_index(None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }
         /// Creates a new instance of [`TheWorldIndices`] from an
@@ -128,7 +127,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let y = _instance
-                .get_export(&mut store, None, "y")
+                .get_export_index(&mut store, None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }

--- a/crates/component-macro/tests/expanded/smoke-default_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_async.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let y = _component
-                .export_index(None, "y")
-                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
-                .1;
+                .get_export_index(None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }
         /// Creates a new instance of [`TheWorldIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let y = _instance
-                .get_export(&mut store, None, "y")
+                .get_export_index(&mut store, None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let y = _component
-                .export_index(None, "y")
-                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
-                .1;
+                .get_export_index(None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }
         /// Creates a new instance of [`TheWorldIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let y = _instance
-                .get_export(&mut store, None, "y")
+                .get_export_index(&mut store, None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }

--- a/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_tracing_async.rs
@@ -113,9 +113,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let y = _component
-                .export_index(None, "y")
-                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?
-                .1;
+                .get_export_index(None, "y")
+                .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }
         /// Creates a new instance of [`TheWorldIndices`] from an
@@ -131,7 +130,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let y = _instance
-                .get_export(&mut store, None, "y")
+                .get_export_index(&mut store, None, "y")
                 .ok_or_else(|| anyhow::anyhow!("no function export `y` found"))?;
             Ok(TheWorldIndices { y })
         }

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -192,14 +192,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "the-name")
+                let instance = component
+                    .get_export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -208,12 +206,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "the-name")
+                    .get_export_index(&mut store, None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -198,14 +198,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "the-name")
+                let instance = component
+                    .get_export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -214,12 +212,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "the-name")
+                    .get_export_index(&mut store, None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -198,14 +198,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "the-name")
+                let instance = component
+                    .get_export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -214,12 +212,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "the-name")
+                    .get_export_index(&mut store, None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
@@ -198,14 +198,12 @@ pub mod exports {
             pub fn new(
                 component: &wasmtime::component::Component,
             ) -> wasmtime::Result<GuestIndices> {
-                let (_, instance) = component
-                    .export_index(None, "the-name")
+                let instance = component
+                    .get_export_index(None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
-                Self::_new(|name| {
-                    component.export_index(Some(&instance), name).map(|p| p.1)
-                })
+                Self::_new(|name| component.get_export_index(Some(&instance), name))
             }
             /// This constructor is similar to [`GuestIndices::new`] except that it
             /// performs string lookups after instantiation time.
@@ -214,12 +212,12 @@ pub mod exports {
                 instance: &wasmtime::component::Instance,
             ) -> wasmtime::Result<GuestIndices> {
                 let instance_export = instance
-                    .get_export(&mut store, None, "the-name")
+                    .get_export_index(&mut store, None, "the-name")
                     .ok_or_else(|| {
                         anyhow::anyhow!("no exported instance named `the-name`")
                     })?;
                 Self::_new(|name| {
-                    instance.get_export(&mut store, Some(&instance_export), name)
+                    instance.get_export_index(&mut store, Some(&instance_export), name)
                 })
             }
             fn _new(

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -309,15 +309,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/strings")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -327,14 +327,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/strings")
+                            .get_export_index(&mut store, None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -327,15 +327,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/strings")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -345,14 +345,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/strings")
+                            .get_export_index(&mut store, None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -445,15 +445,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/strings")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -463,14 +463,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/strings")
+                            .get_export_index(&mut store, None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -372,15 +372,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/strings")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -390,14 +390,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/strings")
+                            .get_export_index(&mut store, None, "foo:foo/strings")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -1308,15 +1308,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/variants")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1326,14 +1326,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/variants")
+                            .get_export_index(&mut store, None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -1363,15 +1363,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/variants")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1381,14 +1381,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/variants")
+                            .get_export_index(&mut store, None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -2173,15 +2173,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/variants")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -2191,14 +2191,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/variants")
+                            .get_export_index(&mut store, None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -1661,15 +1661,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "foo:foo/variants")
+                        let instance = component
+                            .get_export_index(None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -1679,14 +1679,15 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(&mut store, None, "foo:foo/variants")
+                            .get_export_index(&mut store, None, "foo:foo/variants")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -198,15 +198,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "same:name/this-name-is-duplicated")
+                        let instance = component
+                            .get_export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -216,7 +216,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "same:name/this-name-is-duplicated",
@@ -227,7 +227,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -204,15 +204,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "same:name/this-name-is-duplicated")
+                        let instance = component
+                            .get_export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -222,7 +222,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "same:name/this-name-is-duplicated",
@@ -233,7 +233,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/wat_concurrent.rs
+++ b/crates/component-macro/tests/expanded/wat_concurrent.rs
@@ -204,15 +204,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "same:name/this-name-is-duplicated")
+                        let instance = component
+                            .get_export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -222,7 +222,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "same:name/this-name-is-duplicated",
@@ -233,7 +233,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/wat_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/wat_tracing_async.rs
@@ -204,15 +204,15 @@ pub mod exports {
                     pub fn new(
                         component: &wasmtime::component::Component,
                     ) -> wasmtime::Result<GuestIndices> {
-                        let (_, instance) = component
-                            .export_index(None, "same:name/this-name-is-duplicated")
+                        let instance = component
+                            .get_export_index(None, "same:name/this-name-is-duplicated")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
                         Self::_new(|name| {
-                            component.export_index(Some(&instance), name).map(|p| p.1)
+                            component.get_export_index(Some(&instance), name)
                         })
                     }
                     /// This constructor is similar to [`GuestIndices::new`] except that it
@@ -222,7 +222,7 @@ pub mod exports {
                         instance: &wasmtime::component::Instance,
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance_export = instance
-                            .get_export(
+                            .get_export_index(
                                 &mut store,
                                 None,
                                 "same:name/this-name-is-duplicated",
@@ -233,7 +233,8 @@ pub mod exports {
                                 )
                             })?;
                         Self::_new(|name| {
-                            instance.get_export(&mut store, Some(&instance_export), name)
+                            instance
+                                .get_export_index(&mut store, Some(&instance_export), name)
                         })
                     }
                     fn _new(

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -135,9 +135,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let f = _component
-                .export_index(None, "f")
-                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
-                .1;
+                .get_export_index(None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -153,7 +152,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let f = _instance
-                .get_export(&mut store, None, "f")
+                .get_export_index(&mut store, None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -138,9 +138,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let f = _component
-                .export_index(None, "f")
-                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
-                .1;
+                .get_export_index(None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -156,7 +155,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let f = _instance
-                .get_export(&mut store, None, "f")
+                .get_export_index(&mut store, None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -138,9 +138,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let f = _component
-                .export_index(None, "f")
-                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
-                .1;
+                .get_export_index(None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -156,7 +155,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let f = _instance
-                .get_export(&mut store, None, "f")
+                .get_export_index(&mut store, None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -138,9 +138,8 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = component;
             let f = _component
-                .export_index(None, "f")
-                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?
-                .1;
+                .get_export_index(None, "f")
+                .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }
         /// Creates a new instance of [`FooIndices`] from an
@@ -156,7 +155,7 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _instance = instance;
             let f = _instance
-                .get_export(&mut store, None, "f")
+                .get_export_index(&mut store, None, "f")
                 .ok_or_else(|| anyhow::anyhow!("no function export `f` found"))?;
             Ok(FooIndices { f })
         }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -674,6 +674,37 @@ impl Component {
     /// Looks up a specific export of this component by `name` optionally nested
     /// within the `instance` provided.
     ///
+    /// See related method [`Self::get_export`] for additional docs and
+    /// examples.
+    ///
+    /// This method is primarily used to acquire a [`ComponentExportIndex`]
+    /// which can be used with [`Instance`](crate::component::Instance) when
+    /// looking up exports. Export lookup with [`ComponentExportIndex`] can
+    /// skip string lookups at runtime and instead use a more efficient
+    /// index-based lookup.
+    ///
+    /// This method only returns the [`ComponentExportIndex`]. If you need the
+    /// corresponding [`types::ComponentItem`], use the related function
+    /// [`Self::get_export`].
+    ///
+    ///
+    /// [`Instance`](crate::component::Instance) has a corresponding method
+    /// [`Instance::get_export_index`](crate::component::Instance::get_export_index).
+    pub fn get_export_index(
+        &self,
+        instance: Option<&ComponentExportIndex>,
+        name: &str,
+    ) -> Option<ComponentExportIndex> {
+        let index = self.lookup_export_index(instance, name)?;
+        Some(ComponentExportIndex {
+            id: self.inner.id,
+            index,
+        })
+    }
+
+    /// Looks up a specific export of this component by `name` optionally nested
+    /// within the `instance` provided.
+    ///
     /// This method is primarily used to acquire a [`ComponentExportIndex`]
     /// which can be used with [`Instance`](crate::component::Instance) when
     /// looking up exports. Export lookup with [`ComponentExportIndex`] can
@@ -696,6 +727,14 @@ impl Component {
     /// implements the [`InstanceExportLookup`] trait which enables using it
     /// with [`Instance::get_func`](crate::component::Instance::get_func) for
     /// example.
+    ///
+    /// The returned [`types::ComponentItem`] is more expensive to calculate
+    /// than the [`ComponentExportIndex`]. If you only consume the
+    /// [`ComponentExportIndex`], use the related method
+    /// [`Self::get_export_index`] instead.
+    ///
+    /// [`Instance`](crate::component::Instance) has a corresponding method
+    /// [`Instance::get_export`](crate::component::Instance::get_export).
     ///
     /// # Examples
     ///
@@ -721,7 +760,7 @@ impl Component {
     /// )?;
     ///
     /// // Perform a lookup of the function "f" before instantiaton.
-    /// let (ty, export) = component.export_index(None, "f").unwrap();
+    /// let (ty, export) = component.get_export(None, "f").unwrap();
     /// assert!(matches!(ty, ComponentItem::ComponentFunc(_)));
     ///
     /// // After instantiation use `export` to lookup the function in question
@@ -733,7 +772,7 @@ impl Component {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn export_index(
+    pub fn get_export(
         &self,
         instance: Option<&ComponentExportIndex>,
         name: &str,
@@ -793,7 +832,7 @@ impl Component {
 
 /// A value which represents a known export of a component.
 ///
-/// This is the return value of [`Component::export_index`] and implements the
+/// This is the return value of [`Component::get_export`] and implements the
 /// [`InstanceExportLookup`] trait to work with lookups like
 /// [`Instance::get_func`](crate::component::Instance::get_func).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use wasmtime_environ::component::{
     AllCallFunc, CompiledComponentInfo, ComponentArtifacts, ComponentTypes, Export, ExportIndex,
     GlobalInitializer, InstantiateModule, NameMapNoIntern, StaticModuleIndex, TrampolineIndex,
-    TypeComponentIndex, TypeDef, VMComponentOffsets,
+    TypeComponentIndex, VMComponentOffsets,
 };
 use wasmtime_environ::TypeTrace;
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
@@ -779,16 +779,12 @@ impl Component {
     ) -> Option<(types::ComponentItem, ComponentExportIndex)> {
         let info = self.env_component();
         let index = self.lookup_export_index(instance, name)?;
-        let ty = match info.export_items[index] {
-            Export::Instance { ty, .. } => TypeDef::ComponentInstance(ty),
-            Export::LiftedFunction { ty, .. } => TypeDef::ComponentFunc(ty),
-            Export::ModuleStatic { ty, .. } | Export::ModuleImport { ty, .. } => {
-                TypeDef::Module(ty)
-            }
-            Export::Type(ty) => ty,
-        };
         let item = self.with_uninstantiated_instance_type(|instance| {
-            types::ComponentItem::from(&self.inner.engine, &ty, instance)
+            types::ComponentItem::from_export(
+                &self.inner.engine,
+                &info.export_items[index],
+                instance,
+            )
         });
         Some((
             item,

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -308,15 +308,11 @@ impl Instance {
     ) -> Option<(ComponentItem, ComponentExportIndex)> {
         let data = store[self.0].as_ref().unwrap();
         let index = data.component.lookup_export_index(instance, name)?;
-        let ty = match data.component.env_component().export_items[index] {
-            Export::Instance { ty, .. } => TypeDef::ComponentInstance(ty),
-            Export::LiftedFunction { ty, .. } => TypeDef::ComponentFunc(ty),
-            Export::ModuleStatic { ty, .. } | Export::ModuleImport { ty, .. } => {
-                TypeDef::Module(ty)
-            }
-            Export::Type(ty) => ty,
-        };
-        let item = ComponentItem::from(&store.engine(), &ty, &data.ty());
+        let item = ComponentItem::from_export(
+            &store.engine(),
+            &data.component.env_component().export_items[index],
+            &data.ty(),
+        );
         Some((
             item,
             ComponentExportIndex {

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -6,10 +6,10 @@ use alloc::sync::Arc;
 use core::fmt;
 use core::ops::Deref;
 use wasmtime_environ::component::{
-    ComponentTypes, InterfaceType, ResourceIndex, TypeComponentIndex, TypeComponentInstanceIndex,
-    TypeDef, TypeEnumIndex, TypeFlagsIndex, TypeFuncIndex, TypeListIndex, TypeModuleIndex,
-    TypeOptionIndex, TypeRecordIndex, TypeResourceTableIndex, TypeResultIndex, TypeTupleIndex,
-    TypeVariantIndex,
+    ComponentTypes, Export, InterfaceType, ResourceIndex, TypeComponentIndex,
+    TypeComponentInstanceIndex, TypeDef, TypeEnumIndex, TypeFlagsIndex, TypeFuncIndex,
+    TypeListIndex, TypeModuleIndex, TypeOptionIndex, TypeRecordIndex, TypeResourceTableIndex,
+    TypeResultIndex, TypeTupleIndex, TypeVariantIndex,
 };
 use wasmtime_environ::PrimaryMap;
 
@@ -899,6 +899,20 @@ impl ComponentItem {
                 };
                 Self::Resource(ty)
             }
+        }
+    }
+    pub(crate) fn from_export(engine: &Engine, export: &Export, ty: &InstanceType<'_>) -> Self {
+        match export {
+            Export::Instance { ty: idx, .. } => {
+                Self::ComponentInstance(ComponentInstance::from(*idx, ty))
+            }
+            Export::LiftedFunction { ty: idx, .. } => {
+                Self::ComponentFunc(ComponentFunc::from(*idx, ty))
+            }
+            Export::ModuleStatic { ty: idx, .. } | Export::ModuleImport { ty: idx, .. } => {
+                Self::Module(Module::from(*idx, ty))
+            }
+            Export::Type(idx) => Self::from(engine, idx, ty),
         }
     }
 }

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -626,12 +626,12 @@ impl Wasmtime {
                 field = func_field_name(resolve, func);
                 ty = format!("{wt}::component::Func");
                 get_index_from_component = format!(
-                    "_component.export_index(None, \"{}\")
-                        .ok_or_else(|| anyhow::anyhow!(\"no function export `{0}` found\"))?.1",
+                    "_component.get_export_index(None, \"{}\")
+                        .ok_or_else(|| anyhow::anyhow!(\"no function export `{0}` found\"))?",
                     func.name
                 );
                 get_index_from_instance = format!(
-                    "_instance.get_export(&mut store, None, \"{}\")
+                    "_instance.get_export_index(&mut store, None, \"{}\")
                         .ok_or_else(|| anyhow::anyhow!(\"no function export `{0}` found\"))?",
                     func.name
                 );
@@ -686,12 +686,9 @@ impl Wasmtime {
 pub fn new(
     component: &{wt}::component::Component,
 ) -> {wt}::Result<{struct_name}Indices> {{
-    let (_, instance) = component.export_index(None, \"{instance_name}\")
+    let instance = component.get_export_index(None, \"{instance_name}\")
         .ok_or_else(|| anyhow::anyhow!(\"no exported instance named `{instance_name}`\"))?;
-    Self::_new(|name| {{
-        component.export_index(Some(&instance), name)
-            .map(|p| p.1)
-    }})
+    Self::_new(|name| component.get_export_index(Some(&instance), name))
 }}
 
 /// This constructor is similar to [`{struct_name}Indices::new`] except that it
@@ -700,11 +697,9 @@ pub fn new_instance(
     mut store: impl {wt}::AsContextMut,
     instance: &{wt}::component::Instance,
 ) -> {wt}::Result<{struct_name}Indices> {{
-    let instance_export = instance.get_export(&mut store, None, \"{instance_name}\")
+    let instance_export = instance.get_export_index(&mut store, None, \"{instance_name}\")
         .ok_or_else(|| anyhow::anyhow!(\"no exported instance named `{instance_name}`\"))?;
-    Self::_new(|name| {{
-        instance.get_export(&mut store, Some(&instance_export), name)
-    }})
+    Self::_new(|name| instance.get_export_index(&mut store, Some(&instance_export), name))
 }}
 
 fn _new(

--- a/examples/wasip2/main.rs
+++ b/examples/wasip2/main.rs
@@ -67,12 +67,12 @@ fn main() -> Result<()> {
     let instance = linker.instantiate(&mut store, &component)?;
     // Get the index for the exported interface
     let interface_idx = instance
-        .get_export(&mut store, None, "wasi:cli/run@0.2.0")
+        .get_export_index(&mut store, None, "wasi:cli/run@0.2.0")
         .expect("Cannot get `wasi:cli/run@0.2.0` interface");
     // Get the index for the exported function in the exported interface
     let parent_export_idx = Some(&interface_idx);
     let func_idx = instance
-        .get_export(&mut store, parent_export_idx, "run")
+        .get_export_index(&mut store, parent_export_idx, "run")
         .expect("Cannot get `run` function in `wasi:cli/run@0.2.0` interface");
     let func = instance
         .get_func(&mut store, func_idx)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -566,8 +566,8 @@ impl RunCommand {
                 })?;
                 let mut export = None;
                 for name in names {
-                    let (_item, ix) = component
-                        .get_export(export.as_ref(), name)
+                    let ix = component
+                        .get_export_index(export.as_ref(), name)
                         .expect("export exists");
                     export = Some(ix);
                 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -567,7 +567,7 @@ impl RunCommand {
                 let mut export = None;
                 for name in names {
                     let (_item, ix) = component
-                        .export_index(export.as_ref(), name)
+                        .get_export(export.as_ref(), name)
                         .expect("export exists");
                     export = Some(ix);
                 }

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -219,9 +219,9 @@ fn functions_in_instances() -> Result<()> {
 
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
-    let (_, instance_index) = component.export_index(None, "test:test/foo").unwrap();
-    let (_, func_index) = component
-        .export_index(Some(&instance_index), "call")
+    let instance_index = component.get_export_index(None, "test:test/foo").unwrap();
+    let func_index = component
+        .get_export_index(Some(&instance_index), "call")
         .unwrap();
     let mut store = Store::new(&engine, None);
     assert!(store.data().is_none());

--- a/tests/all/component_model/instance.rs
+++ b/tests/all/component_model/instance.rs
@@ -38,17 +38,23 @@ fn instance_exports() -> Result<()> {
     assert!(instance
         .get_export(&mut store, None, "not an instance")
         .is_none());
-    let i = instance.get_export(&mut store, None, "r").unwrap();
+    let i = instance.get_export_index(&mut store, None, "r").unwrap();
     assert!(instance.get_export(&mut store, Some(&i), "x").is_none());
     instance.get_export(&mut store, None, "i").unwrap();
-    let i2 = instance.get_export(&mut store, None, "r2").unwrap();
-    let m = instance.get_export(&mut store, Some(&i2), "m").unwrap();
+    let i2 = instance.get_export_index(&mut store, None, "r2").unwrap();
+    let m = instance
+        .get_export_index(&mut store, Some(&i2), "m")
+        .unwrap();
     assert!(instance.get_func(&mut store, &m).is_none());
     assert!(instance.get_module(&mut store, &m).is_some());
 
-    let i = instance.get_export(&mut store, None, "i").unwrap();
-    let i = instance.get_export(&mut store, Some(&i), "i").unwrap();
-    let m = instance.get_export(&mut store, Some(&i), "m").unwrap();
+    let i = instance.get_export_index(&mut store, None, "i").unwrap();
+    let i = instance
+        .get_export_index(&mut store, Some(&i), "i")
+        .unwrap();
+    let m = instance
+        .get_export_index(&mut store, Some(&i), "m")
+        .unwrap();
     instance.get_module(&mut store, &m).unwrap();
 
     Ok(())
@@ -69,7 +75,7 @@ fn export_old_get_new() -> Result<()> {
 
     let component = Component::new(&engine, component)?;
     component.get_export(None, "a:b/m@1.0.1").unwrap();
-    let (_, i) = component.get_export(None, "a:b/i@1.0.1").unwrap();
+    let i = component.get_export_index(None, "a:b/i@1.0.1").unwrap();
     component.get_export(Some(&i), "m").unwrap();
 
     let mut store = Store::new(&engine, ());
@@ -82,7 +88,7 @@ fn export_old_get_new() -> Result<()> {
         .unwrap();
 
     let i = instance
-        .get_export(&mut store, None, "a:b/i@1.0.1")
+        .get_export_index(&mut store, None, "a:b/i@1.0.1")
         .unwrap();
     instance.get_export(&mut store, Some(&i), "m").unwrap();
 
@@ -104,7 +110,7 @@ fn export_new_get_old() -> Result<()> {
 
     let component = Component::new(&engine, component)?;
     component.get_export(None, "a:b/m@1.0.0").unwrap();
-    let (_, i) = component.get_export(None, "a:b/i@1.0.0").unwrap();
+    let i = component.get_export_index(None, "a:b/i@1.0.0").unwrap();
     component.get_export(Some(&i), "m").unwrap();
 
     let mut store = Store::new(&engine, ());
@@ -117,7 +123,7 @@ fn export_new_get_old() -> Result<()> {
         .unwrap();
 
     let i = instance
-        .get_export(&mut store, None, "a:b/i@1.0.0")
+        .get_export_index(&mut store, None, "a:b/i@1.0.0")
         .unwrap();
     instance.get_export(&mut store, Some(&i), "m").unwrap();
 
@@ -158,14 +164,14 @@ fn export_missing_get_max() -> Result<()> {
 
     for (name, test_fn) in tests {
         println!("test {name}");
-        let (_, m) = component.get_export(None, name).unwrap();
+        let m = component.get_export_index(None, name).unwrap();
         let m = instance.get_module(&mut store, &m).unwrap();
         test_fn(&m);
 
         let m = instance.get_module(&mut store, name).unwrap();
         test_fn(&m);
 
-        let m = instance.get_export(&mut store, None, name).unwrap();
+        let m = instance.get_export_index(&mut store, None, name).unwrap();
         let m = instance.get_module(&mut store, &m).unwrap();
         test_fn(&m);
     }

--- a/tests/all/component_model/instance.rs
+++ b/tests/all/component_model/instance.rs
@@ -68,9 +68,9 @@ fn export_old_get_new() -> Result<()> {
     "#;
 
     let component = Component::new(&engine, component)?;
-    component.export_index(None, "a:b/m@1.0.1").unwrap();
-    let (_, i) = component.export_index(None, "a:b/i@1.0.1").unwrap();
-    component.export_index(Some(&i), "m").unwrap();
+    component.get_export(None, "a:b/m@1.0.1").unwrap();
+    let (_, i) = component.get_export(None, "a:b/i@1.0.1").unwrap();
+    component.get_export(Some(&i), "m").unwrap();
 
     let mut store = Store::new(&engine, ());
     let linker = Linker::new(&engine);
@@ -103,9 +103,9 @@ fn export_new_get_old() -> Result<()> {
     "#;
 
     let component = Component::new(&engine, component)?;
-    component.export_index(None, "a:b/m@1.0.0").unwrap();
-    let (_, i) = component.export_index(None, "a:b/i@1.0.0").unwrap();
-    component.export_index(Some(&i), "m").unwrap();
+    component.get_export(None, "a:b/m@1.0.0").unwrap();
+    let (_, i) = component.get_export(None, "a:b/i@1.0.0").unwrap();
+    component.get_export(Some(&i), "m").unwrap();
 
     let mut store = Store::new(&engine, ());
     let linker = Linker::new(&engine);
@@ -158,7 +158,7 @@ fn export_missing_get_max() -> Result<()> {
 
     for (name, test_fn) in tests {
         println!("test {name}");
-        let (_, m) = component.export_index(None, name).unwrap();
+        let (_, m) = component.get_export(None, name).unwrap();
         let m = instance.get_module(&mut store, &m).unwrap();
         test_fn(&m);
 


### PR DESCRIPTION
Prior to this PR, there was `Component::export_index` which looked up `(ComponentItem, ComponentExportIndex)` and `Instance::get_export` which looked up `ComponentExportIndex`.

Now each of these structures has a `get_export` which looks up the `(ComponentItem, ComponentExportIndex)` and `get_export_index` which looks up just the `ComponentExportIndex`. The docs point to the sister methods, and mention that creating the ComponentItem is comparatively expensive so use the cheaper `get_export_index` if you don't need it.

This will be a breaking change to users, but the hope is that most users are only using these by way of wasmtime-wit-bindgen, so hopefully its not a big deal.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
