### PR TITLE
Minor doc updates for C++ API inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Languages supported by the Bytecode Alliance:
 
 * **[Rust]** - the [`wasmtime` crate]
 * **[C]** - the [`wasm.h`, `wasi.h`, and `wasmtime.h` headers][c-headers], [CMake](crates/c-api/CMakeLists.txt) or [`wasmtime` Conan package]
-* **C++** - the [`wasmtime-cpp` repository][wasmtime-cpp] or use [`wasmtime-cpp` Conan package]
+* **C++** - the [`wasmtime.hh` header][c-headers] or the [`wasmtime-cpp` Conan package]
 * **[Python]** - the [`wasmtime` PyPI package]
 * **[.NET]** - the [`Wasmtime` NuGet package]
 * **[Go]** - the [`wasmtime-go` repository]
@@ -145,7 +145,6 @@ Languages supported by the community:
 [`Wasmtime` NuGet package]: https://www.nuget.org/packages/Wasmtime
 [Go]: https://bytecodealliance.github.io/wasmtime/lang-go.html
 [`wasmtime-go` repository]: https://pkg.go.dev/github.com/bytecodealliance/wasmtime-go
-[wasmtime-cpp]: https://github.com/bytecodealliance/wasmtime-cpp
 [`wasmtime` Conan package]: https://conan.io/center/wasmtime
 [`wasmtime-cpp` Conan package]: https://conan.io/center/wasmtime-cpp
 [Ruby]: https://bytecodealliance.github.io/wasmtime/lang-ruby.html

--- a/crates/c-api/README.md
+++ b/crates/c-api/README.md
@@ -1,11 +1,11 @@
-# Wasmtime's C API
+# Wasmtime's C/C++ API
 
 ## API Documentation
 
 [The API documentation for the Wasmtime C library is hosted
 here.](https://bytecodealliance.github.io/wasmtime/c-api/).
 
-## Using in a C Project
+## Using in a C/C++ Project
 
 ### Using a Pre-Built Static or Dynamic Library
 
@@ -14,7 +14,7 @@ page](https://github.com/bytecodealliance/wasmtime/releases) has pre-built
 binaries for both static and dynamic libraries for a variety of architectures
 and operating systems attached, as well as header files you can include.
 
-### Building Wasmtime's C API from Source
+### Building Wasmtime's C/C++ API from Source
 
 To use Wasmtime from a C or C++ project, you must have
 [CMake](https://cmake.org/) and [a Rust
@@ -36,11 +36,13 @@ These commands will produce the following files:
 * `artifacts/lib/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime library. Exact
   extension depends on your operating system.
 
-* `artifacts/include/**.h`: Header files for working with Wasmtime.
+* `artifacts/include/**.{h,hh}`: Header files for working with Wasmtime.
 
 ## Using in a C++ Project
 
-A header only C++ API is also offered as `wasmtime.hh`, which is built on top of the C API. Its located next to the C headers when you download a pre-built library, or when building from source. C++17 is required.
+A header only C++ API is also offered as `wasmtime.hh`, which is built on top
+of the C API. Its located next to the C headers when you download a pre-built
+library, or when building from source. C++17 is required.
 
 ## Using in a Rust Project
 

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -1,12 +1,16 @@
 /**
- * \mainpage Wasmtime C API
+ * \mainpage Wasmtime C/C++ API
  *
- * This documentation is an overview and API reference for the C API of
+ * This documentation is an overview and API reference for the C and C++ API of
  * Wasmtime. The C API is spread between three different header files:
  *
  * * \ref wasmtime.h
  * * \ref wasi.h
  * * \ref wasm.h
+ *
+ * The C++ API builds on the C API and thus is represented in just header files:
+ *
+ * * \ref wasmtime.hh
  *
  * The \ref wasmtime.h header file includes all the other header files and is
  * the main header file you'll likely be using. The \ref wasm.h header file


### PR DESCRIPTION
Minor updates to a few locations to clarify that the C++ API now lives in this repository.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
