### PR TITLE
Update to wasm-tools 229

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,7 +3998,8 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ba1d491ecacb085a2552025c10a675a6fddcbd03b1fc9b36c536010ce265d2"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.229.0",
@@ -4026,7 +4027,8 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78fdb7d29a79191ab363dc90c1ddd3a1e880ffd5348d92d48482393a9e6c5f4d"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
@@ -4037,7 +4039,8 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b8030bb9e10d1e050d1d8796af5e454e6082a5302ce68948f41debd0ea2a8e"
 dependencies = [
  "egg",
  "log",
@@ -4050,7 +4053,8 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0227a2ef527946ab58f9eefcb232576d89126db8c96b266c04e4a934cf24c92"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4069,7 +4073,8 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd33c30a68c41ff354d7b3741f5d2d3dfbf8eb52033176bb01364cbdf016c17c"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
@@ -4136,7 +4141,8 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3b1f053f5d41aa55640a1fa9b6d1b8a9e4418d118ce308d20e24ff3575a8c"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4148,7 +4154,8 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25dac01892684a99b8fbfaf670eb6b56edea8a096438c75392daeb83156ae2e"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -4824,7 +4831,8 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "229.0.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63fcaff613c12225696bb163f79ca38ffb40e9300eff0ff4b8aa8b2f7eadf0d9"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -4836,7 +4844,8 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189bad08b70455a9e9e67dc126d2dcf91fac143a80f1046747a5dde6d4c33e0"
 dependencies = [
  "wast 229.0.0",
 ]
@@ -5283,7 +5292,8 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f550067740e223bfe6c4878998e81cdbe2529dd9a793dc49248dd6613394e8b"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5319,7 +5329,8 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.229.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459c6ba62bf511d6b5f2a845a2a736822e38059c1cfa0b644b467bbbfae4efa6"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,7 +3407,7 @@ dependencies = [
  "cargo_metadata",
  "heck 0.5.0",
  "wasmtime",
- "wit-component 0.228.0",
+ "wit-component 0.229.0",
 ]
 
 [[package]]
@@ -3825,7 +3825,7 @@ name = "verify-component-adapter"
 version = "33.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wat",
 ]
 
@@ -3926,7 +3926,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.229.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3997,12 +3997,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
@@ -4026,40 +4025,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc79a7e49646e1591d26649eac7ad2b09488aa02c086f3d076705830eae61031"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde9925ed128fec1fb2a92e3544f5045d2915804f2bb74b1afcdbbb75d6a0111"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "egg",
  "log",
  "rand",
  "thiserror 1.0.65",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8906f0848b81bd33103f0db54396c52db4c46518eb55bebf28eae45a442b47f1"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.229.0",
 ]
 
 [[package]]
@@ -4072,14 +4068,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0372abe423e894392241cefbd65739714051448086dbcc50e4e32f879c4970"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
  "thiserror 1.0.65",
- "wit-parser 0.228.0",
+ "wit-parser 0.229.0",
 ]
 
 [[package]]
@@ -4140,9 +4135,8 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4153,13 +4147,12 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]
@@ -4206,9 +4199,9 @@ dependencies = [
  "tempfile",
  "trait-variant",
  "wasi-common",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.229.0",
  "wasm-wave",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -4352,8 +4345,8 @@ dependencies = [
  "trait-variant",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -4371,10 +4364,10 @@ dependencies = [
  "wasmtime-wasi-threads",
  "wasmtime-wasi-tls",
  "wasmtime-wast",
- "wast 228.0.0",
+ "wast 229.0.0",
  "wat",
  "windows-sys 0.59.0",
- "wit-component 0.228.0",
+ "wit-component 0.229.0",
 ]
 
 [[package]]
@@ -4409,7 +4402,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.228.0",
+ "wit-parser 0.229.0",
 ]
 
 [[package]]
@@ -4435,7 +4428,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
@@ -4461,8 +4454,8 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
+ "wasm-encoder 0.229.0",
+ "wasmparser 0.229.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wat",
@@ -4475,7 +4468,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4534,7 +4527,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-test-util",
@@ -4554,12 +4547,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.229.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4787,7 +4780,7 @@ dependencies = [
  "log",
  "tokio",
  "wasmtime",
- "wast 228.0.0",
+ "wast 229.0.0",
 ]
 
 [[package]]
@@ -4799,7 +4792,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -4812,7 +4805,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
- "wit-parser 0.228.0",
+ "wit-parser 0.229.0",
 ]
 
 [[package]]
@@ -4830,24 +4823,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "228.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+version = "229.0.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.229.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec29c89a8d055df988de7236483bf569988ac3d6905899f6af5ef920f9385ad"
+version = "1.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
- "wast 228.0.0",
+ "wast 229.0.0",
 ]
 
 [[package]]
@@ -4977,7 +4968,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -5291,9 +5282,8 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb53295365b9500e17bc41c40229337183244f0d6185a5b028c587837c3370f"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5302,10 +5292,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.228.0",
- "wasm-metadata 0.228.0",
- "wasmparser 0.228.0",
- "wit-parser 0.228.0",
+ "wasm-encoder 0.229.0",
+ "wasm-metadata 0.229.0",
+ "wasmparser 0.229.0",
+ "wit-parser 0.229.0",
 ]
 
 [[package]]
@@ -5328,9 +5318,8 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399ce56e28d79fd3abfa03fdc7ceb89ffec4d4b2674fe3a92056b7d845653c38"
+version = "0.229.0"
+source = "git+https://github.com/bytecodealliance/wasm-tools?branch=ci%2Frelease-1.229.0#04db6480afc7fcfb667c5ed3d023875925cc5d14"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -5341,7 +5330,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.228.0",
+ "wasmparser 0.229.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,16 +307,16 @@ wit-bindgen = { version = "0.41.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.41.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.228.0", default-features = false, features = ['simd'] }
-wat = "1.228.0"
-wast = "228.0.0"
-wasmprinter = "0.228.0"
-wasm-encoder = "0.228.0"
-wasm-smith = "0.228.0"
-wasm-mutate = "0.228.0"
-wit-parser = "0.228.0"
-wit-component = "0.228.0"
-wasm-wave = "0.228.0"
+wasmparser = { version = "0.229.0", default-features = false, features = ['simd'] }
+wat = "1.229.0"
+wast = "229.0.0"
+wasmprinter = "0.229.0"
+wasm-encoder = "0.229.0"
+wasm-smith = "0.229.0"
+wasm-mutate = "0.229.0"
+wit-parser = "0.229.0"
+wit-component = "0.229.0"
+wasm-wave = "0.229.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
@@ -590,3 +590,14 @@ inherits = "release"
 codegen-units = 1
 lto = true
 
+[patch.crates-io]
+wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
+wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -589,15 +589,3 @@ opt-level = 's'
 inherits = "release"
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wat = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wast = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }
-wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools', branch = 'ci/release-1.229.0' }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -525,7 +525,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
             }
 
             Payload::CodeSectionStart { count, range, .. } => {
-                self.validator.code_section_start(count, &range)?;
+                self.validator.code_section_start(&range)?;
                 let cnt = usize::try_from(count).unwrap();
                 self.result.function_body_inputs.reserve_exact(cnt);
                 self.result.debuginfo.wasm_file.code_section_offset = range.start as u64;

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -812,6 +812,8 @@ impl<'a, 'data> Translator<'a, 'data> {
                         }
                         wasmparser::CanonicalFunction::ContextGet(..)
                         | wasmparser::CanonicalFunction::ContextSet(..)
+                        | wasmparser::CanonicalFunction::TaskCancel
+                        | wasmparser::CanonicalFunction::SubtaskCancel { .. }
                         | wasmparser::CanonicalFunction::ThreadSpawnRef { .. }
                         | wasmparser::CanonicalFunction::ThreadSpawnIndirect { .. }
                         | wasmparser::CanonicalFunction::ThreadAvailableParallelism => {

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -205,6 +205,7 @@ struct WasmFeatures {
     component_model_async: bool,
     component_model_async_builtins: bool,
     component_model_async_stackful: bool,
+    component_model_error_context: bool,
     gc_types: bool,
     wide_arithmetic: bool,
     stack_switching: bool,
@@ -236,6 +237,7 @@ impl Metadata<'_> {
             cm_async_stackful,
             cm_nested_names,
             cm_values,
+            cm_error_context,
             legacy_exceptions,
             gc_types,
             stack_switching,
@@ -284,6 +286,7 @@ impl Metadata<'_> {
                 component_model_async: cm_async,
                 component_model_async_builtins: cm_async_builtins,
                 component_model_async_stackful: cm_async_stackful,
+                component_model_error_context: cm_error_context,
             },
         }
     }
@@ -495,6 +498,7 @@ impl Metadata<'_> {
             component_model_async,
             component_model_async_builtins,
             component_model_async_stackful,
+            component_model_error_context,
             gc_types,
             wide_arithmetic,
             stack_switching,
@@ -596,6 +600,11 @@ impl Metadata<'_> {
             component_model_async_stackful,
             other.contains(F::CM_ASYNC_STACKFUL),
             "WebAssembly component model support for async stackful",
+        )?;
+        Self::check_bool(
+            component_model_error_context,
+            other.contains(F::CM_ERROR_CONTEXT),
+            "WebAssembly component model support for error-context",
         )?;
         Self::check_cfg_bool(
             cfg!(feature = "gc"),

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1238,8 +1238,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-encoder]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1250,14 +1250,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-metadata]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-wave]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1268,14 +1268,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmparser]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmprinter]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1436,14 +1436,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wast]]
-version = "228.0.0"
-when = "2025-04-01"
+version = "229.0.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wat]]
-version = "1.228.0"
-when = "2025-04-01"
+version = "1.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1710,8 +1710,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-component]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1722,8 +1722,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-parser]]
-version = "0.228.0"
-when = "2025-04-01"
+version = "0.229.0"
+when = "2025-04-17"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/tests/misc_testsuite/no-panic-on-invalid.wast
+++ b/tests/misc_testsuite/no-panic-on-invalid.wast
@@ -1,0 +1,35 @@
+
+(assert_malformed
+  (module binary
+    "\00asm\01\00\00\00" ;; version header
+
+    "\01\06"          ;; type section, 6 bytes
+    "\01"             ;; 1 type
+    "\60\01\7f\01\7f" ;; function type, 1 i32 parameter, 1 i32 result
+
+
+    "\03\02"          ;; function section, 2 bytes
+    "\01\00"          ;; 1 function, type 0
+
+    "\0a\14"          ;; code section, 20 bytes
+    "\01"             ;; 1 function
+    "\12"             ;; 18-byte function
+    "\00"             ;; no locals
+    "\41\00"          ;; i32.const 0
+    "\41\00"          ;; i32.const 0
+    "\0d\00"          ;; br_if 0
+    "\41\00"          ;; i32.const 0
+    "\0f"             ;; return
+    "\0b"             ;; end
+
+    ;; operator-wise this function is now done, but the invalid part of this
+    ;; continues going and adds more instructions
+    "\02\40"          ;; block
+    "\41\00"          ;; i32.const 0
+    "\0f"             ;; return
+    "\0b"             ;; end
+
+    ;; pretend this is the actual function end
+    "\0b"             ;; end
+  )
+  "hello")

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -126,7 +126,7 @@ impl TargetIsa for Aarch64 {
         let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 
         let mut body_codegen = codegen.emit_prologue()?;
-        body_codegen.emit(&mut body, validator)?;
+        body_codegen.emit(body, validator)?;
         let names = body_codegen.env.take_name_map();
         let base = body_codegen.source_location.base;
         Ok(CompiledFunction::new(

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -138,7 +138,7 @@ impl TargetIsa for X64 {
 
         let mut body_codegen = codegen.emit_prologue()?;
 
-        body_codegen.emit(&mut body, validator)?;
+        body_codegen.emit(body, validator)?;
         let base = body_codegen.source_location.base;
 
         let names = body_codegen.env.take_name_map();


### PR DESCRIPTION
A number of changes here:

* New component model intrinsics (ignored for now, they're async-related)
* Updated interface for reading binary operators, fixing a longstanding panic in Wasmtime.
* Plumbing for error-context being a gated feature now in the component model.



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
