### PR TITLE
Drop `shellexpand` from dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,16 +1115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,15 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
-dependencies = [
- "dirs-next",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4906,7 +4887,6 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "shellexpand",
  "syn 2.0.100",
  "witx",
 ]

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -130,7 +130,7 @@ macro_rules! define_wasi {
             wiggle::wasmtime_integration!({
                 // The wiggle code to integrate with lives here:
                 target: crate::snapshots::preview_1,
-                witx: ["$CARGO_MANIFEST_DIR/witx/preview1/wasi_snapshot_preview1.witx"],
+                witx: ["witx/preview1/wasi_snapshot_preview1.witx"],
                 errors: { errno => trappable Error },
                 $async_mode: *
             });
@@ -139,7 +139,7 @@ macro_rules! define_wasi {
             wiggle::wasmtime_integration!({
                 // The wiggle code to integrate with lives here:
                 target: crate::snapshots::preview_0,
-                witx: ["$CARGO_MANIFEST_DIR/witx/preview0/wasi_unstable.witx"],
+                witx: ["witx/preview0/wasi_unstable.witx"],
                 errors: { errno => trappable Error },
                 $async_mode: *
             });

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use wiggle::{GuestMemory, GuestPtr};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/witx/preview0/wasi_unstable.witx"],
+    witx: ["witx/preview0/wasi_unstable.witx"],
     errors: { errno => trappable Error },
     async: *,
     wasmtime: false,

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -26,7 +26,7 @@ use error::{Error, ErrorExt};
 pub(crate) const MAX_SHARED_BUFFER_SIZE: usize = 1 << 16;
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/witx/preview1/wasi_snapshot_preview1.witx"],
+    witx: ["witx/preview1/wasi_snapshot_preview1.witx"],
     errors: { errno => trappable Error },
     // Note: not every function actually needs to be async, however, nearly all of them do, and
     // keeping that set the same in this macro and the wasmtime_wiggle / lucet_wiggle macros is

--- a/crates/wasi-nn/build.rs
+++ b/crates/wasi-nn/build.rs
@@ -1,10 +1,8 @@
 //! This build script:
 //!  - has the configuration necessary for the Wiggle and WITX macros.
 fn main() {
-    // This is necessary for Wiggle/WITX macros.
     let cwd = std::env::current_dir().unwrap();
     let wasi_root = cwd.join("witx");
-    println!("cargo:rustc-env=WASI_ROOT={}", wasi_root.display());
 
     // Also automatically rebuild if the WITX files change
     for entry in walkdir::WalkDir::new(wasi_root) {

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -94,7 +94,7 @@ where
 mod generated {
     use super::*;
     wiggle::from_witx!({
-        witx: ["$WASI_ROOT/wasi-nn.witx"],
+        witx: ["witx/wasi-nn.witx"],
         errors: { nn_errno => WasiNnError }
     });
 

--- a/crates/wasi/src/preview0.rs
+++ b/crates/wasi/src/preview0.rs
@@ -24,7 +24,7 @@ pub fn add_to_linker_sync<T: Send>(
 }
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/witx/preview0/wasi_unstable.witx"],
+    witx: ["witx/preview0/wasi_unstable.witx"],
     async: {
         wasi_unstable::{
             fd_advise, fd_close, fd_datasync, fd_fdstat_get, fd_filestat_get, fd_filestat_set_size,
@@ -42,7 +42,7 @@ mod sync {
     use std::future::Future;
 
     wiggle::wasmtime_integration!({
-        witx: ["$CARGO_MANIFEST_DIR/witx/preview0/wasi_unstable.witx"],
+        witx: ["witx/preview0/wasi_unstable.witx"],
         target: super,
         block_on[in_tokio]: {
             wasi_unstable::{

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -825,7 +825,7 @@ pub fn add_to_linker_sync<T: Send>(
 // None of the generated modules, traits, or types should be used externally
 // to this module.
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/witx/preview1/wasi_snapshot_preview1.witx"],
+    witx: ["witx/preview1/wasi_snapshot_preview1.witx"],
     async: {
         wasi_snapshot_preview1::{
             fd_advise, fd_close, fd_datasync, fd_fdstat_get, fd_filestat_get, fd_filestat_set_size,
@@ -843,7 +843,7 @@ pub(crate) mod sync {
     use std::future::Future;
 
     wiggle::wasmtime_integration!({
-        witx: ["$CARGO_MANIFEST_DIR/witx/preview1/wasi_snapshot_preview1.witx"],
+        witx: ["witx/preview1/wasi_snapshot_preview1.witx"],
         target: super,
         block_on[in_tokio]: {
             wasi_snapshot_preview1::{

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -22,4 +22,3 @@ proc-macro2 = { workspace = true }
 heck = { workspace = true }
 anyhow = { workspace = true }
 syn = { workspace = true, features = ["full"] }
-shellexpand = "2.0"

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -252,11 +252,7 @@ impl Parse for Paths {
         let expanded_paths = path_lits
             .iter()
             .map(|lit| {
-                PathBuf::from(
-                    shellexpand::env(&lit.value())
-                        .expect("shell expansion")
-                        .as_ref(),
-                )
+                PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join(lit.value())
             })
             .collect::<Vec<PathBuf>>();
 

--- a/crates/wiggle/tests/atoms.rs
+++ b/crates/wiggle/tests/atoms.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -6,7 +6,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
     async: *,
 });
 

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/flags.witx"],
+    witx: ["tests/flags.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -5,7 +5,7 @@ use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 const FD_VAL: u32 = 123;
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/handles.witx"],
+    witx: ["tests/handles.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/ints.witx"],
+    witx: ["tests/ints.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/keywords.rs
+++ b/crates/wiggle/tests/keywords.rs
@@ -54,6 +54,6 @@ mod struct_test {
 /// Test that a union variant that conflicts with a Rust keyword can be compiled properly.
 mod union_test {
     wiggle::from_witx!({
-        witx: ["$CARGO_MANIFEST_DIR/tests/keywords_union.witx"],
+        witx: ["tests/keywords_union.witx"],
     });
 }

--- a/crates/wiggle/tests/lists.rs
+++ b/crates/wiggle/tests/lists.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/lists.witx"],
+    witx: ["tests/lists.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/pointers.witx"],
+    witx: ["tests/pointers.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/records.witx"],
+    witx: ["tests/records.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/strings.rs
+++ b/crates/wiggle/tests/strings.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr};
 use wiggle_test::{impl_errno, HostMemory, MemArea, MemAreas, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/strings.witx"],
+    witx: ["tests/strings.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/tracing.rs
+++ b/crates/wiggle/tests/tracing.rs
@@ -2,7 +2,7 @@
 // which isn't the default.
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
     async: {
         atoms::double_int_return_float,
     },

--- a/crates/wiggle/tests/variant.rs
+++ b/crates/wiggle/tests/variant.rs
@@ -3,7 +3,7 @@ use wiggle::{GuestMemory, GuestPtr, GuestType};
 use wiggle_test::{impl_errno, HostMemory, MemArea, WasiCtx};
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/variant.witx"],
+    witx: ["tests/variant.witx"],
 });
 
 impl_errno!(types::Errno);

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -7,7 +7,7 @@ use wiggle_test::WasiCtx;
 // witx is exposed with the type signatures that we expect.
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/wasi.witx"],
+    witx: ["tests/wasi.witx"],
 });
 
 // The only test in this file is to verify that the witx document provided by the

--- a/crates/wiggle/tests/wasmtime_async.rs
+++ b/crates/wiggle/tests/wasmtime_async.rs
@@ -2,7 +2,7 @@ use wasmtime::{Config, Engine, Linker, Module, Store, Val};
 use wiggle::GuestMemory;
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
     async: {
         atoms::{double_int_return_float}
     }

--- a/crates/wiggle/tests/wasmtime_integration.rs
+++ b/crates/wiggle/tests/wasmtime_integration.rs
@@ -3,7 +3,7 @@ use wiggle::GuestMemory;
 
 // from_witx invocation says the func is async. This context doesn't support async!
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
     async: {
         atoms::{double_int_return_float}
     }
@@ -13,7 +13,7 @@ pub mod integration {
     //  The integration invocation says the func is blocking, so it will still work.
     wiggle::wasmtime_integration!({
         target: crate,
-        witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+        witx: ["tests/atoms.witx"],
         block_on: {
             atoms::{double_int_return_float}
         }

--- a/crates/wiggle/tests/wasmtime_sync.rs
+++ b/crates/wiggle/tests/wasmtime_sync.rs
@@ -2,7 +2,7 @@ use wasmtime::{Engine, Linker, Module, Store, Val};
 use wiggle::GuestMemory;
 
 wiggle::from_witx!({
-    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    witx: ["tests/atoms.witx"],
     block_on: {
         atoms::double_int_return_float
     }


### PR DESCRIPTION
This is a historical dependency of `wiggle` which can be worked around in a different manner by making paths relative to `CARGO_MANIFEST_DIR` by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
