### PR TITLE
Drop pretty-env-logger from dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,10 +956,10 @@ dependencies = [
  "cranelift-native",
  "cranelift-object",
  "cranelift-reader",
+ "env_logger 0.11.5",
  "filecheck",
  "indicatif",
  "log",
- "pretty_env_logger",
  "pulley-interpreter",
  "rayon",
  "regalloc2",
@@ -2593,16 +2593,6 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger 0.10.0",
- "log",
-]
 
 [[package]]
 name = "prettyplease"
@@ -4290,10 +4280,10 @@ dependencies = [
  "anyhow",
  "base64",
  "directories-next",
+ "env_logger 0.11.5",
  "filetime",
  "log",
  "postcard",
- "pretty_env_logger",
  "rustix 1.0.3",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,6 @@ http-body-util = "0.1.0"
 bytes = { version = "1.4", default-features = false }
 futures = { version = "0.3.27", default-features = false }
 indexmap = { version = "2.0.0", default-features = false }
-pretty_env_logger = "0.5.0"
 syn = "2.0.25"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -38,7 +38,7 @@ filecheck = { workspace = true }
 log = { workspace = true }
 capstone = { workspace = true, optional = true }
 target-lexicon = { workspace = true, features = ["std"] }
-pretty_env_logger = { workspace = true }
+env_logger = { workspace = true }
 rayon = { version = "1", optional = true }
 indicatif = "0.13.0"
 thiserror = { workspace = true }

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -74,7 +74,7 @@ struct PassOptions {
 struct CompiledWithoutSupportOptions {}
 
 fn main() -> anyhow::Result<()> {
-    pretty_env_logger::init();
+    env_logger::init();
 
     match Commands::parse() {
         Commands::Cat(c) => cat::run(&c)?,

--- a/cranelift/tests/logged-filetests.rs
+++ b/cranelift/tests/logged-filetests.rs
@@ -9,7 +9,7 @@
 /// [#10529]: https://github.com/bytecodealliance/wasmtime/issues/10529
 #[test]
 fn logged_filetests() -> anyhow::Result<()> {
-    let _ = pretty_env_logger::formatted_builder()
+    env_logger::Builder::new()
         .filter_module(
             "cranelift_codegen::machinst::lower",
             log::LevelFilter::Trace,

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -35,5 +35,5 @@ rustix = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 filetime = "0.2.7"
-pretty_env_logger = { workspace = true }
+env_logger = { workspace = true }
 tempfile = "3"

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 // note: tempdir removes directory when being dropped, so we need to return it to the caller,
 //       so the paths are valid
 pub fn test_prolog() -> (TempDir, PathBuf, PathBuf) {
-    let _ = pretty_env_logger::try_init();
+    let _ = env_logger::try_init();
     let temp_dir = tempfile::tempdir().expect("Can't create temporary directory");
     let cache_dir = temp_dir.path().join("cache-dir");
     let config_path = temp_dir.path().join("cache-config.toml");


### PR DESCRIPTION
This dependency has been on an older version of `env_logger` for quite some time and hasn't been updated in a long time, so let's drop this as it's not necessarily critical for our use anyway.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
