### PR TITLE
Fix the new `logged-filetests.rs` test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -433,17 +433,18 @@ jobs:
     - uses: ./.github/actions/cancel-on-failure
       if: failure()
 
-  fiber_tests:
-    name: wasmtime-fiber tests
+  special_tests:
+    name: One-off special tests
     runs-on: ubuntu-latest
-    env:
-      CARGO_NDK_VERSION: 2.12.2
+    needs: determine
+    if: needs.determine.outputs.run-full
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
     - run: cargo test -p wasmtime-fiber --no-default-features
+    - run: cargo test -p cranelift-tools --test logged-filetests
 
     # common logic to cancel the entire run if this job fails
     - uses: ./.github/actions/cancel-on-failure
@@ -1200,7 +1201,7 @@ jobs:
       - cargo_vet
       - doc
       - micro_checks
-      - fiber_tests
+      - special_tests
       - clippy
       - monolith_checks
       - platform_checks

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -1036,7 +1036,8 @@ impl S390xMachineDeps {
         // (but after restoring FPRs, which might clobber %r1).
         let temp_dest = match dest {
             CallInstDest::Indirect { reg }
-                if is_reg_saved_in_prologue(call_conv, reg.to_real_reg().unwrap()) =>
+                if reg.to_real_reg().is_some()
+                    && is_reg_saved_in_prologue(call_conv, reg.to_real_reg().unwrap()) =>
             {
                 insts.push(Inst::Mov64 {
                     rd: writable_gpr(1),


### PR DESCRIPTION
This test unfortunately didn't actually have any effect in CI. Locally setting `RUST_LOG` and running `cargo run test filetests` showed a panic in the s390x backend that this test was not uncovering. The reason that this test wasn't actually doing anything on CI is that it's tested adjacently with the `wasmtime-cli` crate. Both crates are tested with `--all-features` which enables the CLI's `disable-logging` feature which meant that all logging statements, including the ones we want to test, were compiled out.

This commit fixes the s390x panic and then additionally adds a special CI job (repurposing an existing one) for testing just this test in isolation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
