### PR TITLE
wit-bindgen: InterfaceGenerator::extract_typed_function: NFC rewrite in functional style

### DIFF
--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -3159,23 +3159,11 @@ impl<'a> InterfaceGenerator<'a> {
     }
 
     fn extract_typed_function(&mut self, func: &Function) -> (String, String) {
-        let prev = mem::take(&mut self.src);
         let snake = func_field_name(self.resolve, func);
-        uwrite!(self.src, "*_instance.get_typed_func::<(");
-        for (_, ty) in func.params.iter() {
-            self.print_ty(ty, TypeMode::AllBorrowed("'_"));
-            self.push_str(", ");
-        }
-        self.src.push_str("), (");
-        if let Some(ty) = func.result {
-            self.print_ty(&ty, TypeMode::Owned);
-            self.push_str(", ");
-        }
-        uwriteln!(self.src, ")>(&mut store, &self.{snake})?.func()");
-
-        let ret = (snake, mem::take(&mut self.src).to_string());
-        self.src = prev;
-        ret
+        let sig = self.typedfunc_sig(func, TypeMode::AllBorrowed("'_"));
+        let extract =
+            format!("*_instance.get_typed_func::<{sig}>(&mut store, &self.{snake})?.func()");
+        (snake, extract)
     }
 
     fn define_rust_guest_export(


### PR DESCRIPTION
Nonfunctional change. Now that typedfunc_sig exists, no need for this nonsense.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
