### PR TITLE
wasmtime: remove Any-typing from the vm's representation of resource types table

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -486,10 +486,7 @@ impl InstanceData {
     // though it should be guaranteed that the single owning reference currently
     // lives within the `ComponentInstance` that's being built.
     fn resource_types_mut(&mut self) -> &mut ImportedResources {
-        Arc::get_mut(self.state.resource_types_mut())
-            .unwrap()
-            .downcast_mut()
-            .unwrap()
+        Arc::get_mut(self.state.resource_types_mut()).unwrap()
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -6,7 +6,6 @@ use crate::types::matching;
 use crate::Module;
 use crate::{prelude::*, Engine};
 use alloc::sync::Arc;
-use core::any::Any;
 use wasmtime_environ::component::{
     ComponentTypes, NameMap, ResourceIndex, TypeComponentInstance, TypeDef, TypeFuncIndex,
     TypeModule, TypeResourceTableIndex,
@@ -188,7 +187,7 @@ impl<'a> InstanceType<'a> {
     pub fn new(instance: &'a ComponentInstance) -> InstanceType<'a> {
         InstanceType {
             types: instance.component_types(),
-            resources: downcast_arc_ref(instance.resource_types()),
+            resources: instance.resource_types(),
         }
     }
 
@@ -199,18 +198,4 @@ impl<'a> InstanceType<'a> {
             .copied()
             .unwrap_or_else(|| ResourceType::uninstantiated(&self.types, index))
     }
-}
-
-/// Small helper method to downcast an `Arc` borrow into a borrow of a concrete
-/// type within the `Arc`.
-///
-/// Note that this is different than `downcast_ref` which projects out `&T`
-/// where here we want `&Arc<T>`.
-fn downcast_arc_ref<T: 'static>(arc: &Arc<dyn Any + Send + Sync>) -> &Arc<T> {
-    // First assert that the payload of the `Any` is indeed a `T`
-    let _ = arc.downcast_ref::<T>();
-
-    // Next do an unsafe pointer cast to convert the `Any` into `T` which should
-    // be safe given the above check.
-    unsafe { &*(arc as *const Arc<dyn Any + Send + Sync> as *const Arc<T>) }
 }


### PR DESCRIPTION
Nonfunctional change.

This any-typing is a left over escape hatch from the wasmtime / wasmtime-runtime divide, but now that the types all live in the same crate we can eliminate the Any and just use the concrete type everywhere.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
