### PR TITLE
Cranelift: move exception-handler metadata into callsites.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -2942,14 +2942,11 @@ impl MachInstEmit for Inst {
                     let offset = sink.cur_offset();
                     sink.push_user_stack_map(state, offset, s);
                 }
-                sink.add_call_site();
 
-                // Add exception info, if any, at this point (which will
-                // be the return address on stack).
                 if let Some(try_call) = info.try_call_info.as_ref() {
-                    for &(tag, label) in &try_call.exception_dests {
-                        sink.add_exception_handler(tag, label);
-                    }
+                    sink.add_call_site(&try_call.exception_dests);
+                } else {
+                    sink.add_call_site(&[]);
                 }
 
                 if info.callee_pop_size > 0 {
@@ -2989,14 +2986,11 @@ impl MachInstEmit for Inst {
                     let offset = sink.cur_offset();
                     sink.push_user_stack_map(state, offset, s);
                 }
-                sink.add_call_site();
 
-                // Add exception info, if any, at this point (which will
-                // be the return address on stack).
                 if let Some(try_call) = info.try_call_info.as_ref() {
-                    for &(tag, label) in &try_call.exception_dests {
-                        sink.add_exception_handler(tag, label);
-                    }
+                    sink.add_call_site(&try_call.exception_dests);
+                } else {
+                    sink.add_call_site(&[]);
                 }
 
                 if info.callee_pop_size > 0 {
@@ -3035,7 +3029,7 @@ impl MachInstEmit for Inst {
                 // for the target, but rather a function relocation.
                 sink.add_reloc(Reloc::Arm64Call, &info.dest, 0);
                 sink.put4(enc_jump26(0b000101, 0));
-                sink.add_call_site();
+                sink.add_call_site(&[]);
 
                 // `emit_return_call_common_sequence` emits an island if
                 // necessary, so we can safely disable the worst-case-size check
@@ -3050,7 +3044,7 @@ impl MachInstEmit for Inst {
                     targets: vec![],
                 }
                 .emit(sink, emit_info, state);
-                sink.add_call_site();
+                sink.add_call_site(&[]);
 
                 // `emit_return_call_common_sequence` emits an island if
                 // necessary, so we can safely disable the worst-case-size check

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -182,14 +182,11 @@ fn pulley_emit<P>(
                 let offset = sink.cur_offset();
                 sink.push_user_stack_map(state, offset, s);
             }
-            sink.add_call_site();
 
-            // Add exception info, if any, at this point (which will
-            // be the return address on stack).
             if let Some(try_call) = info.try_call_info.as_ref() {
-                for &(tag, label) in &try_call.exception_dests {
-                    sink.add_exception_handler(tag, label);
-                }
+                sink.add_call_site(&try_call.exception_dests);
+            } else {
+                sink.add_call_site(&[]);
             }
 
             let adjust = -i32::try_from(info.callee_pop_size).unwrap();
@@ -226,14 +223,10 @@ fn pulley_emit<P>(
                 sink.push_user_stack_map(state, offset, s);
             }
 
-            sink.add_call_site();
-
-            // Add exception info, if any, at this point (which will
-            // be the return address on stack).
             if let Some(try_call) = info.try_call_info.as_ref() {
-                for &(tag, label) in &try_call.exception_dests {
-                    sink.add_exception_handler(tag, label);
-                }
+                sink.add_call_site(&try_call.exception_dests);
+            } else {
+                sink.add_call_site(&[]);
             }
 
             let adjust = -i32::try_from(info.callee_pop_size).unwrap();
@@ -295,7 +288,7 @@ fn pulley_emit<P>(
                 let offset = sink.cur_offset();
                 sink.push_user_stack_map(state, offset, s);
             }
-            sink.add_call_site();
+            sink.add_call_site(&[]);
 
             // If a callee pop is happening here that means that something has
             // messed up, these are expected to be "very simple" signatures.

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3216,14 +3216,11 @@ impl Inst {
                     sink.push_user_stack_map(state, offset, s);
                 }
                 put(sink, enc);
-                sink.add_call_site();
 
-                // Add exception info, if any, at this point (which will
-                // be the return address on stack).
                 if let Some(try_call) = info.try_call_info.as_ref() {
-                    for &(tag, label) in &try_call.exception_dests {
-                        sink.add_exception_handler(tag, label);
-                    }
+                    sink.add_call_site(&try_call.exception_dests);
+                } else {
+                    sink.add_call_site(&[]);
                 }
 
                 state.nominal_sp_offset -= info.callee_pop_size;
@@ -3264,7 +3261,7 @@ impl Inst {
                     }
                 };
                 put(sink, enc);
-                sink.add_call_site();
+                sink.add_call_site(&[]);
             }
             &Inst::ElfTlsGetOffset { ref symbol, .. } => {
                 let opcode = 0xc05; // BRASL
@@ -3281,7 +3278,7 @@ impl Inst {
                 }
 
                 put(sink, &enc_ril_b(opcode, gpr(14), 0));
-                sink.add_call_site();
+                sink.add_call_site(&[]);
             }
             &Inst::Args { .. } => {}
             &Inst::Rets { .. } => {}

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1611,14 +1611,11 @@ pub(crate) fn emit(
             // beginning of the immediate field.
             emit_reloc(sink, Reloc::X86CallPCRel4, &call_info.dest, -4);
             sink.put4(0);
-            sink.add_call_site();
 
-            // Add exception info, if any, at this point (which will
-            // be the return address on stack).
             if let Some(try_call) = call_info.try_call_info.as_ref() {
-                for &(tag, label) in &try_call.exception_dests {
-                    sink.add_exception_handler(tag, label);
-                }
+                sink.add_call_site(&try_call.exception_dests);
+            } else {
+                sink.add_call_site(&[]);
             }
 
             // Reclaim the outgoing argument area that was released by the callee, to ensure that
@@ -1663,7 +1660,7 @@ pub(crate) fn emit(
             // beginning of the immediate field.
             emit_reloc(sink, Reloc::X86CallPCRel4, &call_info.dest, -4);
             sink.put4(0);
-            sink.add_call_site();
+            sink.add_call_site(&[]);
         }
 
         Inst::ReturnCallUnknown { info: call_info } => {
@@ -1675,7 +1672,7 @@ pub(crate) fn emit(
                 target: RegMem::reg(callee),
             }
             .emit(sink, info, state);
-            sink.add_call_site();
+            sink.add_call_site(&[]);
         }
 
         Inst::CallUnknown {
@@ -1717,14 +1714,10 @@ pub(crate) fn emit(
                 sink.push_user_stack_map(state, offset, s);
             }
 
-            sink.add_call_site();
-
-            // Add exception info, if any, at this point (which will
-            // be the return address on stack).
             if let Some(try_call) = call_info.try_call_info.as_ref() {
-                for &(tag, label) in &try_call.exception_dests {
-                    sink.add_exception_handler(tag, label);
-                }
+                sink.add_call_site(&try_call.exception_dests);
+            } else {
+                sink.add_call_site(&[]);
             }
 
             // Reclaim the outgoing argument area that was released by the callee, to ensure that


### PR DESCRIPTION
This PR starts with a cherry-pick of @bjorn3's work at [1], which switches exception-handler metadata from a separate list of records (of callsite offset, tag, handler offset tuples) to per-callsite (tag, handler) tuples. This is cleaner for both the native-code use-case and for our planned Wasmtime use-case: in both cases one knows the specific callsite in each frame and wants to look at handlers only for that callsite. The old representation was designed for fast emission and flat storage, but we can get flat storage with this semantic structure as well...

... with the second commit, in which I've updated @bjorn3's implementation to keep a separate vector of handler tuples in the `MachBuffer`, and refer to ranges in this vector in the callsite metadata. It also provides an iterator that yields per-callsite information in a safe way.

No functional change in-tree (because Cranelift and Wasmtime both do not use this metadata yet) but should enable `cg_clif` to use our exception support for native unwind.

Co-authored-by: `bjorn3 <17426603+bjorn3@users.noreply.github.com>`

[1]: https://github.com/bjorn3/wasmtime/commit/72c68f2c68ee3fe3159e203c6277d5322844ad37#diff-f9524bac9108c13ddfe351160d287ab858d4e815181a867e56fa5382e5bd564e