### PR TITLE
Update spec test suite

### DIFF
--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -1742,6 +1742,8 @@ pub enum ConstOp {
         array_type_index: TypeIndex,
         array_size: u32,
     },
+    ExternConvertAny,
+    AnyConvertExtern,
 }
 
 impl ConstOp {
@@ -1783,6 +1785,8 @@ impl ConstOp {
                 array_type_index: TypeIndex::from_u32(array_type_index),
                 array_size,
             },
+            O::ExternConvertAny => Self::ExternConvertAny,
+            O::AnyConvertExtern => Self::AnyConvertExtern,
             op => {
                 return Err(wasm_unsupported!(
                     "unsupported opcode in const expression at offset {offset:#x}: {op:?}",


### PR DESCRIPTION
Now that wasm-tools is updated it's possible to run the latest version again. This notably required implementing the `extern.convert_any` and `any.convert_extern` instructions in a const-expression context.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
