### PR TITLE
Log module "DNA" during fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,9 @@ name = "flagset"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "flate2"
@@ -4041,7 +4044,10 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
+ "serde",
+ "serde_derive",
  "wasm-encoder 0.229.0",
+ "wat",
 ]
 
 [[package]]
@@ -4533,6 +4539,7 @@ dependencies = [
  "log",
  "rand",
  "rayon",
+ "serde_json",
  "target-lexicon",
  "tempfile",
  "v8",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -27,12 +27,13 @@ wasmprinter = { workspace = true }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
 wasmtime = { workspace = true, features = ['default', 'winch'] }
 wasm-encoder = { workspace = true }
-wasm-smith = { workspace = true }
+wasm-smith = { workspace = true, features = ['serde'] }
 wasm-mutate = { workspace = true }
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
 wasmi = { version = "0.43.1", default-features = false, features = ["std", "simd"] }
 futures = { workspace = true }
 wasmtime-test-util = { workspace = true, features = ['wast', 'component-fuzz', 'component'] }
+serde_json = { workspace = true }
 
 [dependencies.wasmtime-cli-flags]
 workspace = true


### PR DESCRIPTION
This commit updates the fuzzing infrastructure of the `wasmtime-fuzzing` crate to record the "DNA string" of a module used to generate a module in a `*.dna` file. This is accompanied with a `*.json` file to pass to `wasm-tools smith --config`. The end result is that it should be possible now to more easily reproduce a module generation outside of Wasmtime itself when reproducing bugs and such.

Creation of these files is gated on the debug log level in a similar manner to creation of normal wasm files is gated on the debug log level too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
