### PR TITLE
Allow GC heap OOMs in `wasmtime_fuzzing::oracles::unwrap_instance`

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -409,9 +409,15 @@ fn unwrap_instance(
         return None;
     }
 
-    // Allow traps which can happen normally with `unreachable` or a
-    // timeout or such
-    if e.is::<Trap>() {
+    // Allow traps which can happen normally with `unreachable` or a timeout or
+    // such.
+    if e.is::<Trap>()
+        // Also allow failures to instantiate as a result of hitting pooling
+        // limits.
+        || e.is::<wasmtime::PoolConcurrencyLimitError>()
+        // And GC heap OOMs.
+        || e.is::<wasmtime::GcHeapOutOfMemory<()>>()
+    {
         return None;
     }
 
@@ -421,11 +427,6 @@ fn unwrap_instance(
     // every single module under the sun due to using name-based resolution
     // rather than positional-based resolution
     if string.contains("incompatible import type") {
-        return None;
-    }
-
-    // Also allow failures to instantiate as a result of hitting pooling limits.
-    if e.is::<wasmtime::PoolConcurrencyLimitError>() {
         return None;
     }
 


### PR DESCRIPTION
These errors are expected to crop up for some fuzz inputs and are not evidence of a bug in Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
