### PR TITLE
component::__internal::InstanceType now owns its contents

### DIFF
--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -410,7 +410,7 @@ fn expand_record_for_component_type(
             #[inline]
             fn typecheck(
                 ty: &#internal::InterfaceType,
-                types: &#internal::InstanceType<'_>,
+                types: &#internal::InstanceType,
             ) -> #internal::anyhow::Result<()> {
                 #internal::#typecheck(ty, types, &[#typecheck_argument])
             }
@@ -1019,7 +1019,7 @@ impl Expander for ComponentTypeExpander {
                 #[inline]
                 fn typecheck(
                     ty: &#internal::InterfaceType,
-                    types: &#internal::InstanceType<'_>,
+                    types: &#internal::InstanceType,
                 ) -> #internal::anyhow::Result<()> {
                     #internal::typecheck_variant(ty, types, &[#case_names_and_checks])
                 }
@@ -1080,7 +1080,7 @@ impl Expander for ComponentTypeExpander {
                 #[inline]
                 fn typecheck(
                     ty: &#internal::InterfaceType,
-                    types: &#internal::InstanceType<'_>,
+                    types: &#internal::InstanceType,
                 ) -> #internal::anyhow::Result<()> {
                     #internal::typecheck_enum(ty, types, &[#case_names])
                 }

--- a/crates/test-util/src/component.rs
+++ b/crates/test-util/src/component.rs
@@ -87,7 +87,7 @@ macro_rules! forward_impls {
             const ABI: CanonicalAbiInfo = <$b as ComponentType>::ABI;
 
             #[inline]
-            fn typecheck(ty: &InterfaceType, types: &InstanceType<'_>) -> Result<()> {
+            fn typecheck(ty: &InterfaceType, types: &InstanceType) -> Result<()> {
                 <$b as ComponentType>::typecheck(ty, types)
             }
         }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -382,11 +382,11 @@ impl Component {
         self.with_uninstantiated_instance_type(|ty| types::Component::from(self.inner.ty, ty))
     }
 
-    fn with_uninstantiated_instance_type<R>(&self, f: impl FnOnce(&InstanceType<'_>) -> R) -> R {
+    fn with_uninstantiated_instance_type<R>(&self, f: impl FnOnce(&InstanceType) -> R) -> R {
         let resources = Arc::new(PrimaryMap::new());
         f(&InstanceType {
-            types: self.types(),
-            resources: &resources,
+            types: self.types().clone(),
+            resources,
         })
     }
 

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -19,7 +19,7 @@ use wasmtime_environ::component::{
 
 pub struct HostFunc {
     entrypoint: VMLoweringCallee,
-    typecheck: Box<dyn (Fn(TypeFuncIndex, &InstanceType<'_>) -> Result<()>) + Send + Sync>,
+    typecheck: Box<dyn (Fn(TypeFuncIndex, &InstanceType) -> Result<()>) + Send + Sync>,
     func: Box<dyn Any + Send + Sync>,
 }
 
@@ -96,7 +96,7 @@ impl HostFunc {
         })
     }
 
-    pub fn typecheck(&self, ty: TypeFuncIndex, types: &InstanceType<'_>) -> Result<()> {
+    pub fn typecheck(&self, ty: TypeFuncIndex, types: &InstanceType) -> Result<()> {
         (self.typecheck)(ty, types)
     }
 
@@ -109,7 +109,7 @@ impl HostFunc {
     }
 }
 
-fn typecheck<P, R>(ty: TypeFuncIndex, types: &InstanceType<'_>) -> Result<()>
+fn typecheck<P, R>(ty: TypeFuncIndex, types: &InstanceType) -> Result<()>
 where
     P: ComponentNamedList + Lift,
     R: ComponentNamedList + Lower,

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -355,7 +355,7 @@ impl<'a, T> LowerContext<'a, T> {
 
     /// Returns the instance type information corresponding to the instance that
     /// this context is lowering into.
-    pub fn instance_type(&self) -> InstanceType<'_> {
+    pub fn instance_type(&self) -> InstanceType {
         // Note that the unsafety here should be valid given the contract of
         // `LowerContext::new`.
         InstanceType::new(unsafe { &*self.instance })
@@ -520,7 +520,7 @@ impl<'a> LiftContext<'a> {
 
     /// Returns instance type information for the component instance that is
     /// being lifted from.
-    pub fn instance_type(&self) -> InstanceType<'_> {
+    pub fn instance_type(&self) -> InstanceType {
         // Note that the unsafety here should be valid given the contract of
         // `LiftContext::new`.
         InstanceType::new(unsafe { &*self.instance })

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -476,7 +476,7 @@ impl InstanceData {
     }
 
     #[inline]
-    pub fn ty(&self) -> InstanceType<'_> {
+    pub fn ty(&self) -> InstanceType {
         InstanceType::new(self.instance())
     }
 

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -161,8 +161,8 @@ impl<T> Linker<T> {
     fn typecheck<'a>(&'a self, component: &'a Component) -> Result<TypeChecker<'a>> {
         let mut cx = TypeChecker {
             engine: &self.engine,
-            types: component.types(),
             strings: &self.strings,
+            types: &component.types(),
             imported_resources: Default::default(),
         };
 
@@ -185,8 +185,8 @@ impl<T> Linker<T> {
         Ok(types::Component::from(
             component.ty(),
             &InstanceType {
-                types: cx.types,
-                resources: &cx.imported_resources,
+                types: cx.types.clone(),
+                resources: cx.imported_resources.clone(),
             },
         ))
     }

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -19,11 +19,11 @@ pub struct TypeChecker<'a> {
     pub imported_resources: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[doc(hidden)]
-pub struct InstanceType<'a> {
-    pub types: &'a Arc<ComponentTypes>,
-    pub resources: &'a Arc<PrimaryMap<ResourceIndex, ResourceType>>,
+pub struct InstanceType {
+    pub types: Arc<ComponentTypes>,
+    pub resources: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
 }
 
 impl TypeChecker<'_> {
@@ -164,11 +164,13 @@ impl TypeChecker<'_> {
     }
 
     fn func(&self, expected: TypeFuncIndex, actual: &HostFunc) -> Result<()> {
-        let instance_type = InstanceType {
-            types: self.types,
-            resources: &self.imported_resources,
-        };
-        actual.typecheck(expected, &instance_type)
+        actual.typecheck(
+            expected,
+            &InstanceType {
+                types: self.types.clone(),
+                resources: self.imported_resources.clone(),
+            },
+        )
     }
 }
 
@@ -183,11 +185,11 @@ impl Definition {
     }
 }
 
-impl<'a> InstanceType<'a> {
-    pub fn new(instance: &'a ComponentInstance) -> InstanceType<'a> {
+impl InstanceType {
+    pub fn new(instance: &ComponentInstance) -> InstanceType {
         InstanceType {
-            types: instance.component_types(),
-            resources: instance.resource_types(),
+            types: instance.component_types().clone(),
+            resources: instance.resource_types().clone(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -821,7 +821,7 @@ unsafe impl<T: 'static> ComponentType for Resource<T> {
 
     type Lower = <u32 as ComponentType>::Lower;
 
-    fn typecheck(ty: &InterfaceType, types: &InstanceType<'_>) -> Result<()> {
+    fn typecheck(ty: &InterfaceType, types: &InstanceType) -> Result<()> {
         let resource = match ty {
             InterfaceType::Own(t) | InterfaceType::Borrow(t) => *t,
             other => bail!("expected `own` or `borrow`, found `{}`", desc(other)),
@@ -1108,7 +1108,7 @@ unsafe impl ComponentType for ResourceAny {
 
     type Lower = <u32 as ComponentType>::Lower;
 
-    fn typecheck(ty: &InterfaceType, _types: &InstanceType<'_>) -> Result<()> {
+    fn typecheck(ty: &InterfaceType, _types: &InstanceType) -> Result<()> {
         match ty {
             InterfaceType::Own(_) | InterfaceType::Borrow(_) => Ok(()),
             other => bail!("expected `own` or `borrow`, found `{}`", desc(other)),

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -41,7 +41,7 @@ struct Handle<T> {
 }
 
 impl<T> Handle<T> {
-    fn new(index: T, ty: &InstanceType<'_>) -> Handle<T> {
+    fn new(index: T, ty: &InstanceType) -> Handle<T> {
         Handle {
             index,
             types: ty.types.clone(),
@@ -49,10 +49,10 @@ impl<T> Handle<T> {
         }
     }
 
-    fn instance(&self) -> InstanceType<'_> {
+    fn instance(&self) -> InstanceType {
         InstanceType {
-            types: &self.types,
-            resources: &self.resources,
+            types: self.types.clone(),
+            resources: self.resources.clone(),
         }
     }
 
@@ -262,7 +262,7 @@ impl PartialEq for List {
 impl Eq for List {}
 
 impl List {
-    pub(crate) fn from(index: TypeListIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeListIndex, ty: &InstanceType) -> Self {
         List(Handle::new(index, ty))
     }
 
@@ -286,7 +286,7 @@ pub struct Field<'a> {
 pub struct Record(Handle<TypeRecordIndex>);
 
 impl Record {
-    pub(crate) fn from(index: TypeRecordIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeRecordIndex, ty: &InstanceType) -> Self {
         Record(Handle::new(index, ty))
     }
 
@@ -312,7 +312,7 @@ impl Eq for Record {}
 pub struct Tuple(Handle<TypeTupleIndex>);
 
 impl Tuple {
-    pub(crate) fn from(index: TypeTupleIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeTupleIndex, ty: &InstanceType) -> Self {
         Tuple(Handle::new(index, ty))
     }
 
@@ -346,7 +346,7 @@ pub struct Case<'a> {
 pub struct Variant(Handle<TypeVariantIndex>);
 
 impl Variant {
-    pub(crate) fn from(index: TypeVariantIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeVariantIndex, ty: &InstanceType) -> Self {
         Variant(Handle::new(index, ty))
     }
 
@@ -375,7 +375,7 @@ impl Eq for Variant {}
 pub struct Enum(Handle<TypeEnumIndex>);
 
 impl Enum {
-    pub(crate) fn from(index: TypeEnumIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeEnumIndex, ty: &InstanceType) -> Self {
         Enum(Handle::new(index, ty))
     }
 
@@ -401,7 +401,7 @@ impl Eq for Enum {}
 pub struct OptionType(Handle<TypeOptionIndex>);
 
 impl OptionType {
-    pub(crate) fn from(index: TypeOptionIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeOptionIndex, ty: &InstanceType) -> Self {
         OptionType(Handle::new(index, ty))
     }
 
@@ -424,7 +424,7 @@ impl Eq for OptionType {}
 pub struct ResultType(Handle<TypeResultIndex>);
 
 impl ResultType {
-    pub(crate) fn from(index: TypeResultIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeResultIndex, ty: &InstanceType) -> Self {
         ResultType(Handle::new(index, ty))
     }
 
@@ -458,7 +458,7 @@ impl Eq for ResultType {}
 pub struct Flags(Handle<TypeFlagsIndex>);
 
 impl Flags {
-    pub(crate) fn from(index: TypeFlagsIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeFlagsIndex, ty: &InstanceType) -> Self {
         Flags(Handle::new(index, ty))
     }
 
@@ -638,7 +638,7 @@ impl Type {
     }
 
     /// Convert the specified `InterfaceType` to a `Type`.
-    pub(crate) fn from(ty: &InterfaceType, instance: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(ty: &InterfaceType, instance: &InstanceType) -> Self {
         match ty {
             InterfaceType::Bool => Type::Bool,
             InterfaceType::S8 => Type::S8,
@@ -703,7 +703,7 @@ impl Type {
 pub struct ComponentFunc(Handle<TypeFuncIndex>);
 
 impl ComponentFunc {
-    pub(crate) fn from(index: TypeFuncIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeFuncIndex, ty: &InstanceType) -> Self {
         Self(Handle::new(index, ty))
     }
 
@@ -732,7 +732,7 @@ impl ComponentFunc {
 pub struct Module(Handle<TypeModuleIndex>);
 
 impl Module {
-    pub(crate) fn from(index: TypeModuleIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeModuleIndex, ty: &InstanceType) -> Self {
         Self(Handle::new(index, ty))
     }
 
@@ -771,7 +771,7 @@ impl Module {
 pub struct Component(Handle<TypeComponentIndex>);
 
 impl Component {
-    pub(crate) fn from(index: TypeComponentIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeComponentIndex, ty: &InstanceType) -> Self {
         Self(Handle::new(index, ty))
     }
 
@@ -823,7 +823,7 @@ impl Component {
 pub struct ComponentInstance(Handle<TypeComponentInstanceIndex>);
 
 impl ComponentInstance {
-    pub(crate) fn from(index: TypeComponentInstanceIndex, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(index: TypeComponentInstanceIndex, ty: &InstanceType) -> Self {
         Self(Handle::new(index, ty))
     }
 
@@ -869,7 +869,7 @@ pub enum ComponentItem {
 }
 
 impl ComponentItem {
-    pub(crate) fn from(engine: &Engine, def: &TypeDef, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from(engine: &Engine, def: &TypeDef, ty: &InstanceType) -> Self {
         match def {
             TypeDef::Component(idx) => Self::Component(Component::from(*idx, ty)),
             TypeDef::ComponentInstance(idx) => {
@@ -901,7 +901,7 @@ impl ComponentItem {
             }
         }
     }
-    pub(crate) fn from_export(engine: &Engine, export: &Export, ty: &InstanceType<'_>) -> Self {
+    pub(crate) fn from_export(engine: &Engine, export: &Export, ty: &InstanceType) -> Self {
         match export {
             Export::Instance { ty: idx, .. } => {
                 Self::ComponentInstance(ComponentInstance::from(*idx, ty))


### PR DESCRIPTION
Having refs to a pair of arcs made it less expensive to create an InstanceType, but tied its to a borrow of the ComponentInstance (transitively the Store) which makes some new typechecking operations which have an AsContextMut impossible.

This has no direct benefit in this PR, but it split out of #10610 because it is more easily reviewed in isolation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
