### PR TITLE
remove compiler cfg on configured target

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2167,7 +2167,6 @@ impl Config {
     /// Returns the configured compiler target for this `Config`.
     pub(crate) fn compiler_target(&self) -> target_lexicon::Triple {
         // If a target is explicitly configured, always use that.
-        #[cfg(any(feature = "cranelift", feature = "winch"))]
         if let Some(target) = self.target.clone() {
             return target;
         }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

New changes from stale PR: https://github.com/bytecodealliance/wasmtime/pull/10197

Pulley can now be used without a compiler, but this line prevents the configured target (`pulley64`, etc) from actually being used.
