### PR TITLE
wasmtime component: get InstancePre from Instance

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -1,8 +1,8 @@
 use crate::component::func::HostFunc;
 use crate::component::matching::InstanceType;
 use crate::component::{
-    types::ComponentItem, Component, ComponentExportIndex, ComponentNamedList, Func, Lift, Lower,
-    ResourceType, TypedFunc,
+    types::Component as ComponentType, types::ComponentItem, Component, ComponentExportIndex,
+    ComponentNamedList, Func, Lift, Lower, ResourceType, TypedFunc,
 };
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
@@ -814,6 +814,7 @@ impl<'a> Instantiator<'a> {
 /// method.
 pub struct InstancePre<T> {
     component: Component,
+    component_type: ComponentType,
     imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
     _marker: marker::PhantomData<fn() -> T>,
 }
@@ -823,6 +824,7 @@ impl<T> Clone for InstancePre<T> {
     fn clone(&self) -> Self {
         Self {
             component: self.component.clone(),
+            component_type: self.component_type.clone(),
             imports: self.imports.clone(),
             _marker: self._marker,
         }
@@ -838,10 +840,12 @@ impl<T> InstancePre<T> {
     /// satisfy the imports of the `component` provided.
     pub(crate) unsafe fn new_unchecked(
         component: Component,
+        component_type: ComponentType,
         imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,
     ) -> InstancePre<T> {
         InstancePre {
             component,
+            component_type,
             imports: Arc::new(imports),
             _marker: marker::PhantomData,
         }
@@ -850,6 +854,14 @@ impl<T> InstancePre<T> {
     /// Returns the underlying component that will be instantiated.
     pub fn component(&self) -> &Component {
         &self.component
+    }
+
+    /// Returns the type at which the underlying component will be
+    /// instantiated. This contains the instantiated type information which
+    /// was determined by the Linker. This type is a refinement of the one
+    /// given by `self.component().component_type()`.
+    pub fn component_type(&self) -> &ComponentType {
+        &self.component_type
     }
 
     /// Returns the underlying engine.

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -213,15 +213,9 @@ impl<T> Linker<T> {
         let cx = self.typecheck(&component)?;
 
         // A successful typecheck resolves all of the imported resources used by
-        // this InstancePre. We keep track of those in types::Component
-        // representation, because we can't keep an interior InstanceType.
-        let component_type = types::Component::from(
-            component.ty(),
-            &InstanceType {
-                types: cx.types,
-                resources: &cx.imported_resources,
-            },
-        );
+        // this InstancePre. We keep a clone of this table in the InstancePre
+        // so that we can construct an InstanceType for typechecking.
+        let imported_resources = cx.imported_resources.clone();
 
         // Now that all imports are known to be defined and satisfied by this
         // linker a list of "flat" import items (aka no instances) is created
@@ -259,7 +253,7 @@ impl<T> Linker<T> {
             assert_eq!(i, idx);
         }
         Ok(unsafe {
-            InstancePre::new_unchecked(component.clone(), component_type, Arc::new(imports))
+            InstancePre::new_unchecked(component.clone(), Arc::new(imports), imported_resources)
         })
     }
 

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -258,7 +258,9 @@ impl<T> Linker<T> {
             let i = imports.push(import);
             assert_eq!(i, idx);
         }
-        Ok(unsafe { InstancePre::new_unchecked(component.clone(), component_type, imports) })
+        Ok(unsafe {
+            InstancePre::new_unchecked(component.clone(), component_type, Arc::new(imports))
+        })
     }
 
     /// Instantiates the [`Component`] provided into the `store` specified.

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -816,6 +816,14 @@ impl Component {
             )
         })
     }
+
+    #[doc(hidden)]
+    pub fn instance_type(&self) -> InstanceType<'_> {
+        InstanceType {
+            types: &self.0.types,
+            resources: &self.0.resources,
+        }
+    }
 }
 
 /// Component instance type


### PR DESCRIPTION
* `wasmtime::component::InstancePre` gets a new field to hold an arc to the imported resources table `resource_types: Arc<PrimaryMap<ResourceIndex, ResourceType>>`. This information is available at the two spots where an `InstancePre` is constructed (one of which is new, below), so theres no additional computation required here, just a clone of the arc.
* `InstancePre` gets a new method `instance_type(&self) -> InstanceType<'_>`. The `InstanceType` is used for typechecking. The whole purpose of this PR is so that typechecking can occur from either an Instance or InstancePre, and without taking a borrow into a Store, for the sake of #10610.
* `wasmtime::component::Instance` gets a new method `instance_pre<T>(&self, store: &impl AsContext<Data = T>) -> InstancePre<T>`. All of the information required to construct the `InstancePre` is already found in the Store at the Instances's index.
