### PR TITLE
Move C++ `MemoryType` to its own header

### DIFF
--- a/crates/c-api/include/wasmtime.hh
+++ b/crates/c-api/include/wasmtime.hh
@@ -49,6 +49,7 @@
 
 #include <wasmtime.h>
 #include <wasmtime/error.hh>
+#include <wasmtime/types.hh>
 
 namespace wasmtime {
 
@@ -740,103 +741,6 @@ public:
   ValType(ValType &&other) = default;
   /// Moves the memory owned by another value type into this one.
   ValType &operator=(ValType &&other) = default;
-
-  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
-  /// this instance.
-  Ref *operator->() { return &ref; }
-  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
-  /// this instance.
-  Ref *operator*() { return &ref; }
-};
-
-/**
- * \brief Type information about a WebAssembly linear memory
- */
-class MemoryType {
-  friend class Memory;
-
-  struct deleter {
-    void operator()(wasm_memorytype_t *p) const { wasm_memorytype_delete(p); }
-  };
-
-  std::unique_ptr<wasm_memorytype_t, deleter> ptr;
-
-public:
-  /// \brief Non-owning reference to a `MemoryType`, must not be used after the
-  /// original owner has been deleted.
-  class Ref {
-    friend class MemoryType;
-
-    const wasm_memorytype_t *ptr;
-
-  public:
-    /// Creates a reference from the raw C API representation.
-    Ref(const wasm_memorytype_t *ptr) : ptr(ptr) {}
-    /// Creates a reference from an original `MemoryType`.
-    Ref(const MemoryType &ty) : Ref(ty.ptr.get()) {}
-
-    /// Returns the minimum size, in WebAssembly pages, of this memory.
-    uint64_t min() const { return wasmtime_memorytype_minimum(ptr); }
-
-    /// Returns the maximum size, in WebAssembly pages, of this memory, if
-    /// specified.
-    std::optional<uint64_t> max() const {
-      uint64_t max = 0;
-      auto present = wasmtime_memorytype_maximum(ptr, &max);
-      if (present) {
-        return max;
-      }
-      return std::nullopt;
-    }
-
-    /// Returns whether or not this is a 64-bit memory type.
-    bool is_64() const { return wasmtime_memorytype_is64(ptr); }
-
-    /// Returns whether or not this is a shared memory type.
-    bool is_shared() const { return wasmtime_memorytype_isshared(ptr); }
-  };
-
-private:
-  Ref ref;
-  MemoryType(wasm_memorytype_t *ptr) : ptr(ptr), ref(ptr) {}
-
-public:
-  /// Creates a new 32-bit wasm memory type with the specified minimum number of
-  /// pages for the minimum size. The created type will have no maximum memory
-  /// size.
-  explicit MemoryType(uint32_t min)
-      : MemoryType(wasmtime_memorytype_new(min, false, 0, false, false)) {}
-  /// Creates a new 32-bit wasm memory type with the specified minimum number of
-  /// pages for the minimum size, and maximum number of pages for the max size.
-  MemoryType(uint32_t min, uint32_t max)
-      : MemoryType(wasmtime_memorytype_new(min, true, max, false, false)) {}
-
-  /// Same as the `MemoryType` constructor, except creates a 64-bit memory.
-  static MemoryType New64(uint64_t min) {
-    return MemoryType(wasmtime_memorytype_new(min, false, 0, true, false));
-  }
-
-  /// Same as the `MemoryType` constructor, except creates a 64-bit memory.
-  static MemoryType New64(uint64_t min, uint64_t max) {
-    return MemoryType(wasmtime_memorytype_new(min, true, max, true, false));
-  }
-
-  /// Creates a new wasm memory type from the specified ref, making a fresh
-  /// owned value.
-  MemoryType(Ref other) : MemoryType(wasm_memorytype_copy(other.ptr)) {}
-  /// Copies the provided type into a new type.
-  MemoryType(const MemoryType &other)
-      : MemoryType(wasm_memorytype_copy(other.ptr.get())) {}
-  /// Copies the provided type into a new type.
-  MemoryType &operator=(const MemoryType &other) {
-    ptr.reset(wasm_memorytype_copy(other.ptr.get()));
-    return *this;
-  }
-  ~MemoryType() = default;
-  /// Moves the type information from another type into this one.
-  MemoryType(MemoryType &&other) = default;
-  /// Moves the type information from another type into this one.
-  MemoryType &operator=(MemoryType &&other) = default;
 
   /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
   /// this instance.

--- a/crates/c-api/include/wasmtime/types.hh
+++ b/crates/c-api/include/wasmtime/types.hh
@@ -1,0 +1,6 @@
+#ifndef WASMTIME_TYPES_HH
+#define WASMTIME_TYPES_HH
+
+#include <wasmtime/types/memory.hh>
+
+#endif // WASMTIME_TYPES_HH

--- a/crates/c-api/include/wasmtime/types/memory.hh
+++ b/crates/c-api/include/wasmtime/types/memory.hh
@@ -1,0 +1,157 @@
+/**
+ * \file wasmtime/types/memory.hh
+ */
+
+#ifndef WASMTIME_TYPES_MEMORY_HH
+#define WASMTIME_TYPES_MEMORY_HH
+
+#include <memory>
+#include <optional>
+#include <wasm.h>
+#include <wasmtime/memory.h>
+
+namespace wasmtime {
+
+/**
+ * \brief Type information about a WebAssembly linear memory
+ */
+class MemoryType {
+  friend class Memory;
+
+  struct deleter {
+    void operator()(wasm_memorytype_t *p) const { wasm_memorytype_delete(p); }
+  };
+
+  std::unique_ptr<wasm_memorytype_t, deleter> ptr;
+
+public:
+  /// \brief Non-owning reference to a `MemoryType`, must not be used after the
+  /// original owner has been deleted.
+  class Ref {
+    friend class MemoryType;
+
+    const wasm_memorytype_t *ptr;
+
+  public:
+    /// Creates a reference from the raw C API representation.
+    Ref(const wasm_memorytype_t *ptr) : ptr(ptr) {}
+    /// Creates a reference from an original `MemoryType`.
+    Ref(const MemoryType &ty) : Ref(ty.ptr.get()) {}
+
+    /// Returns the minimum size, in WebAssembly pages, of this memory.
+    uint64_t min() const { return wasmtime_memorytype_minimum(ptr); }
+
+    /// Returns the maximum size, in WebAssembly pages, of this memory, if
+    /// specified.
+    std::optional<uint64_t> max() const {
+      uint64_t max = 0;
+      auto present = wasmtime_memorytype_maximum(ptr, &max);
+      if (present) {
+        return max;
+      }
+      return std::nullopt;
+    }
+
+    /// Returns whether or not this is a 64-bit memory type.
+    bool is_64() const { return wasmtime_memorytype_is64(ptr); }
+
+    /// Returns whether or not this is a shared memory type.
+    bool is_shared() const { return wasmtime_memorytype_isshared(ptr); }
+  };
+
+private:
+  Ref ref;
+  MemoryType(wasm_memorytype_t *ptr) : ptr(ptr), ref(ptr) {}
+
+public:
+  /// Creates a new 32-bit wasm memory type with the specified minimum number of
+  /// pages for the minimum size. The created type will have no maximum memory
+  /// size.
+  explicit MemoryType(uint32_t min)
+      : MemoryType(wasmtime_memorytype_new(min, false, 0, false, false)) {}
+  /// Creates a new 32-bit wasm memory type with the specified minimum number of
+  /// pages for the minimum size, and maximum number of pages for the max size.
+  MemoryType(uint32_t min, uint32_t max)
+      : MemoryType(wasmtime_memorytype_new(min, true, max, false, false)) {}
+
+  /// Same as the `MemoryType` constructor, except creates a 64-bit memory.
+  static MemoryType New64(uint64_t min) {
+    return MemoryType(wasmtime_memorytype_new(min, false, 0, true, false));
+  }
+
+  /// Same as the `MemoryType` constructor, except creates a 64-bit memory.
+  static MemoryType New64(uint64_t min, uint64_t max) {
+    return MemoryType(wasmtime_memorytype_new(min, true, max, true, false));
+  }
+
+  /// Creates a new wasm memory type from the specified ref, making a fresh
+  /// owned value.
+  MemoryType(Ref other) : MemoryType(wasm_memorytype_copy(other.ptr)) {}
+  /// Copies the provided type into a new type.
+  MemoryType(const MemoryType &other)
+      : MemoryType(wasm_memorytype_copy(other.ptr.get())) {}
+  /// Copies the provided type into a new type.
+  MemoryType &operator=(const MemoryType &other) {
+    ptr.reset(wasm_memorytype_copy(other.ptr.get()));
+    return *this;
+  }
+  ~MemoryType() = default;
+  /// Moves the type information from another type into this one.
+  MemoryType(MemoryType &&other) = default;
+  /// Moves the type information from another type into this one.
+  MemoryType &operator=(MemoryType &&other) = default;
+
+  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
+  /// this instance.
+  Ref *operator->() { return &ref; }
+  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
+  /// this instance.
+  Ref *operator*() { return &ref; }
+
+  /// \brief Helper class to build a `MemoryType`.
+  class Builder {
+    uint64_t _min;
+    std::optional<uint64_t> _max;
+    bool _memory64;
+    bool _shared;
+
+  public:
+    /// \brief Default constructor for a memory type with 0 initial size.
+    Builder() : _min(0), _memory64(false), _shared(false) {}
+
+    /// \brief Configure the minimum size, in pages, of linear memory.
+    Builder& min(uint64_t min) {
+      _min = min;
+      return *this;
+    }
+
+    /// \brief Configure the maximal size, in pages, of linear memory.
+    Builder& max(std::optional<uint64_t> max) {
+      _max = max;
+      return *this;
+    }
+
+    /// \brief Configure whether this is a 64-bit linear memory.
+    Builder& memory64(bool enable) {
+      _memory64 = enable;
+      return *this;
+    }
+
+    /// \brief Configure whether this is a shared linear memory.
+    Builder& shared(bool enable) {
+      _shared = enable;
+      return *this;
+    }
+
+    /// \brief Construct the final `MemoryType` value.
+    MemoryType build() const {
+      return MemoryType(wasmtime_memorytype_new(
+            _min, _max.has_value(), _max.has_value() ? *_max : 0,
+            _memory64, _shared));
+    }
+  };
+};
+
+}; // namespace wasmtime
+
+#endif // WASMTIME_TYPES_MEMORY_HH

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_capi_test(types FILES types.cc)
 add_capi_test(func FILES func.cc)
 add_capi_test(component-instantiate FILES component/instantiate.cc)
 add_capi_test(error FILES error.cc)
+add_capi_test(memory_type FILES memory_type.cc)
 
 # Add a custom test where two files include `wasmtime.hh` and are compiled into
 # the same executable (basically makes sure any defined functions in the header

--- a/crates/c-api/tests/memory_type.cc
+++ b/crates/c-api/tests/memory_type.cc
@@ -1,0 +1,55 @@
+#include <wasmtime/types/memory.hh>
+#include <gtest/gtest.h>
+
+using namespace wasmtime;
+
+TEST(MemoryType, Simple) {
+  MemoryType ty(1);
+  EXPECT_EQ(ty->min(), 1);
+  EXPECT_EQ(ty->max(), std::nullopt);
+  EXPECT_FALSE(ty->is_64());
+  EXPECT_FALSE(ty->is_shared());
+}
+
+TEST(MemoryType, WithMax) {
+  MemoryType ty(1, 2);
+  EXPECT_EQ(ty->min(), 1);
+  EXPECT_EQ(ty->max(), 2);
+  EXPECT_FALSE(ty->is_64());
+  EXPECT_FALSE(ty->is_shared());
+}
+
+TEST(MemoryType, Mem64) {
+  MemoryType ty = MemoryType::New64(1);
+  EXPECT_EQ(ty->min(), 1);
+  EXPECT_EQ(ty->max(), std::nullopt);
+  EXPECT_TRUE(ty->is_64());
+  EXPECT_FALSE(ty->is_shared());
+
+  ty = MemoryType::New64(1, 2);
+  EXPECT_EQ(ty->min(), 1);
+  EXPECT_EQ(ty->max(), 2);
+  EXPECT_TRUE(ty->is_64());
+  EXPECT_FALSE(ty->is_shared());
+}
+
+TEST(MemoryType, Builder) {
+  MemoryType ty = MemoryType::Builder().build();
+  EXPECT_EQ(ty->min(), 0);
+  EXPECT_EQ(ty->max(), std::nullopt);
+  EXPECT_FALSE(ty->is_64());
+  EXPECT_FALSE(ty->is_shared());
+
+  ty = MemoryType::Builder().max(4).shared(true).memory64(true).build();
+  EXPECT_EQ(ty->min(), 0);
+  EXPECT_EQ(ty->max(), 4);
+  EXPECT_TRUE(ty->is_64());
+  EXPECT_TRUE(ty->is_shared());
+
+  ty = MemoryType::Builder().min(5).max(500).shared(true).memory64(false).build();
+  EXPECT_EQ(ty->min(), 5);
+  EXPECT_EQ(ty->max(), 500);
+  EXPECT_FALSE(ty->is_64());
+  EXPECT_TRUE(ty->is_shared());
+
+}


### PR DESCRIPTION
While here fill out its API a bit with a builder type and some tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
