### PR TITLE
asm: change how regalloc interacts with operands

### DIFF
--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -147,32 +147,3 @@ impl AsReg for u8 {
         *self
     }
 }
-
-/// Describe a visitor for the register operands of an instruction.
-///
-/// Due to how Cranelift's register allocation works, we allow the visitor to
-/// modify the register operands in place. This allows Cranelift to convert
-/// virtual registers (`[128..N)`) to physical registers (`[0..16)`) without
-/// re-allocating the entire instruction object.
-pub trait RegisterVisitor<R: Registers> {
-    /// Visit a read-only register.
-    fn read(&mut self, reg: &mut R::ReadGpr);
-    /// Visit a read-write register.
-    fn read_write(&mut self, reg: &mut R::ReadWriteGpr);
-    /// Visit a read-only fixed register; for safety, this register cannot be
-    /// modified in-place.
-    fn fixed_read(&mut self, reg: &R::ReadGpr);
-    /// Visit a read-write fixed register; for safety, this register cannot be
-    /// modified in-place.
-    fn fixed_read_write(&mut self, reg: &R::ReadWriteGpr);
-    /// Visit a read-only SSE register.
-    fn read_xmm(&mut self, reg: &mut R::ReadXmm);
-    /// Visit a read-write SSE register.
-    fn read_write_xmm(&mut self, reg: &mut R::ReadWriteXmm);
-    /// Visit a read-only fixed SSE register; for safety, this register cannot
-    /// be modified in-place.
-    fn fixed_read_xmm(&mut self, reg: &R::ReadXmm);
-    /// Visit a read-write fixed SSE register; for safety, this register cannot
-    /// be modified in-place.
-    fn fixed_read_write_xmm(&mut self, reg: &R::ReadWriteXmm);
-}

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -198,6 +198,13 @@ impl AsReg for FuzzReg {
     }
 }
 
+impl From<u8> for FuzzReg {
+    fn from(reg: u8) -> Self {
+        // assert!(reg < 16, "invalid register: {reg}");
+        Self(reg)
+    }
+}
+
 impl Arbitrary<'_> for AmodeOffsetPlusKnownOffset {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<Self> {
         // For now, we don't generate offsets (TODO).
@@ -223,14 +230,14 @@ impl<R: AsReg> Arbitrary<'_> for NonRspGpr<R> {
         Ok(Self::new(R::new(*gpr)))
     }
 }
-impl<'a, R: AsReg> Arbitrary<'a> for Gpr<R> {
+impl<'a, R: AsReg + Arbitrary<'a>> Arbitrary<'a> for Gpr<R> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Ok(Self(R::new(u.int_in_range(0..=15)?)))
+        Ok(Self(u.arbitrary()?))
     }
 }
-impl<'a, R: AsReg> Arbitrary<'a> for Xmm<R> {
+impl<'a, R: AsReg + Arbitrary<'a>> Arbitrary<'a> for Xmm<R> {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        Ok(Self(R::new(u.int_in_range(0..=15)?)))
+        Ok(Self(u.arbitrary()?))
     }
 }
 

--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -17,18 +17,6 @@ impl<R: AsReg> Gpr<R> {
         Self(reg)
     }
 
-    /// Return the register's hardware encoding; the underlying type `R` _must_
-    /// be a real register at this point.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the register is not a valid x64 register.
-    pub fn enc(&self) -> u8 {
-        let enc = self.0.enc();
-        assert!(enc < 16, "invalid register: {enc}");
-        enc
-    }
-
     /// Return the register name at the given `size`.
     pub fn to_string(&self, size: Size) -> String {
         self.0.to_string(Some(size))
@@ -38,6 +26,24 @@ impl<R: AsReg> Gpr<R> {
     /// code.
     pub(crate) fn always_emit_if_8bit_needed(&self, rex: &mut RexFlags) {
         rex.always_emit_if_8bit_needed(self.enc());
+    }
+}
+
+impl<R: AsReg> AsReg for Gpr<R> {
+    fn new(reg: u8) -> Self {
+        Self(R::new(reg))
+    }
+
+    /// Return the register's hardware encoding; the underlying type `R` _must_
+    /// be a real register at this point.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the register is not a valid x64 register.
+    fn enc(&self) -> u8 {
+        let enc = self.0.enc();
+        assert!(enc < 16, "invalid register: {enc}");
+        enc
     }
 }
 

--- a/cranelift/assembler-x64/src/inst.rs
+++ b/cranelift/assembler-x64/src/inst.rs
@@ -3,10 +3,11 @@
 //!
 //! See also: [`Inst`], an `enum` containing all these instructions.
 
-use crate::api::{AsReg, CodeSink, KnownOffsetTable, RegisterVisitor, Registers};
+use crate::api::{AsReg, CodeSink, KnownOffsetTable, Registers};
 use crate::gpr::{self, Gpr, Size};
 use crate::imm::{Extension, Imm16, Imm32, Imm8, Simm32, Simm8};
 use crate::mem::{emit_modrm_sib_disp, Amode, GprMem, XmmMem};
+use crate::op::Operand;
 use crate::rex::{self, RexFlags};
 use crate::xmm::Xmm;
 use crate::Fixed;

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -50,6 +50,7 @@ pub mod gpr;
 mod imm;
 pub mod inst;
 mod mem;
+mod op;
 mod rex;
 pub mod xmm;
 
@@ -75,8 +76,7 @@ pub use inst::Inst;
 pub use inst::Feature;
 
 pub use api::{
-    AsReg, CodeSink, Constant, KnownOffset, KnownOffsetTable, Label, RegisterVisitor, Registers,
-    TrapCode,
+    AsReg, CodeSink, Constant, KnownOffset, KnownOffsetTable, Label, Registers, TrapCode,
 };
 pub use fixed::Fixed;
 pub use gpr::{Gpr, NonRspGpr, Size};
@@ -84,6 +84,7 @@ pub use imm::{Extension, Imm16, Imm32, Imm8, Simm16, Simm32, Simm8};
 pub use mem::{
     Amode, AmodeOffset, AmodeOffsetPlusKnownOffset, DeferredTarget, GprMem, Scale, XmmMem,
 };
+pub use op::Operand;
 pub use rex::RexFlags;
 pub use xmm::Xmm;
 

--- a/cranelift/assembler-x64/src/op.rs
+++ b/cranelift/assembler-x64/src/op.rs
@@ -1,0 +1,116 @@
+//! Materialize mutable instruction operands, e.g., for register allocation.
+
+use crate::{
+    Amode, Fixed, Gpr, GprMem, Imm16, Imm32, Imm8, Registers, Simm16, Simm32, Simm8, Xmm, XmmMem,
+};
+
+/// An instruction operand.
+///
+/// This is useful for iterating over the operands of an [`Inst`][crate::Inst].
+///
+/// ```
+/// # use cranelift_assembler_x64::{Fixed, Imm8, inst, Inst, Operand, Registers};
+/// pub struct Regs;
+/// impl Registers for Regs {
+///     type ReadGpr = u8;
+///     type ReadWriteGpr = u8;
+///     type ReadXmm = u8;
+///     type ReadWriteXmm = u8;
+/// }
+///
+/// let rax = 0;
+/// let mut inst: Inst<Regs> = inst::addb_i::new(Fixed(rax), Imm8::new(0x42)).into();
+/// let operands = inst.operands();
+/// assert_eq!(operands.len(), 2);
+/// assert!(matches!(operands[0], Operand::ReadWriteGpr { fixed: Some(0), .. }));
+/// assert!(matches!(operands[1], Operand::Imm8(_)));
+/// ```
+
+/// TODO
+#[derive(Debug)]
+pub enum Operand<'a, R: Registers> {
+    // Memory operands.
+    Amode(&'a mut Amode<R::ReadGpr>),
+
+    // Register operands.
+    ReadGpr {
+        gpr: &'a mut R::ReadGpr,
+        fixed: Option<u8>,
+    },
+    ReadWriteGpr {
+        gpr: &'a mut R::ReadWriteGpr,
+        fixed: Option<u8>,
+    },
+    ReadXmm {
+        xmm: &'a mut R::ReadXmm,
+        fixed: Option<u8>,
+    },
+    ReadWriteXmm {
+        xmm: &'a mut R::ReadWriteXmm,
+        fixed: Option<u8>,
+    },
+
+    // Immediate operands.
+    Imm8(&'a mut Imm8),
+    Imm16(&'a mut Imm16),
+    Imm32(&'a mut Imm32),
+    Simm8(&'a mut Simm8),
+    Simm16(&'a mut Simm16),
+    Simm32(&'a mut Simm32),
+}
+
+impl<'a, R: Registers> Operand<'a, R> {
+    pub fn from_read_gpr(gpr: &'a mut Gpr<R::ReadGpr>) -> Self {
+        let gpr = &mut gpr.0;
+        Operand::ReadGpr { gpr, fixed: None }
+    }
+    pub fn from_read_write_gpr(gpr: &'a mut Gpr<R::ReadWriteGpr>) -> Self {
+        let gpr = &mut gpr.0;
+        Operand::ReadWriteGpr { gpr, fixed: None }
+    }
+    pub fn from_read_fixed_gpr<const E: u8>(gpr: &'a mut Fixed<R::ReadGpr, E>) -> Self {
+        let gpr = &mut gpr.0;
+        let fixed = Some(E);
+        Operand::ReadGpr { gpr, fixed }
+    }
+    pub fn from_read_write_fixed_gpr<const E: u8>(gpr: &'a mut Fixed<R::ReadWriteGpr, E>) -> Self {
+        let gpr = &mut gpr.0;
+        let fixed = Some(E);
+        Operand::ReadWriteGpr { gpr, fixed }
+    }
+    pub fn from_read_xmm(xmm: &'a mut Xmm<R::ReadXmm>) -> Self {
+        let xmm = &mut xmm.0;
+        Operand::ReadXmm { xmm, fixed: None }
+    }
+    pub fn from_read_write_xmm(xmm: &'a mut Xmm<R::ReadWriteXmm>) -> Self {
+        let xmm = &mut xmm.0;
+        Operand::ReadWriteXmm { xmm, fixed: None }
+    }
+    pub fn from_read_gpr_mem(gpr_mem: &'a mut GprMem<R::ReadGpr, R::ReadGpr>) -> Self {
+        match gpr_mem {
+            GprMem::Gpr(gpr) => Operand::ReadGpr { gpr, fixed: None },
+            GprMem::Mem(amode) => Operand::Amode(amode),
+        }
+    }
+    pub fn from_read_write_gpr_mem(gpr_mem: &'a mut GprMem<R::ReadWriteGpr, R::ReadGpr>) -> Self {
+        match gpr_mem {
+            GprMem::Gpr(gpr) => Operand::ReadWriteGpr { gpr, fixed: None },
+            GprMem::Mem(amode) => Operand::Amode(amode),
+        }
+    }
+    pub fn from_read_xmm_mem(xmm_mem: &'a mut XmmMem<R::ReadXmm, R::ReadGpr>) -> Self {
+        match xmm_mem {
+            XmmMem::Xmm(xmm) => Operand::ReadXmm { xmm, fixed: None },
+            XmmMem::Mem(amode) => Operand::Amode(amode),
+        }
+    }
+    pub fn from_read_write_xmm_mem(xmm_mem: &'a mut XmmMem<R::ReadWriteXmm, R::ReadGpr>) -> Self {
+        match xmm_mem {
+            XmmMem::Xmm(xmm) => Operand::ReadWriteXmm { xmm, fixed: None },
+            XmmMem::Mem(amode) => Operand::Amode(amode),
+        }
+    }
+    pub fn from_amode(amode: &'a mut Amode<R::ReadGpr>) -> Self {
+        Operand::Amode(amode)
+    }
+}

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -1,8 +1,8 @@
 //! Interface with the external assembler crate.
 
 use super::{
-    regs, Amode, Gpr, Inst, LabelUse, MachBuffer, MachLabel, OperandVisitor, OperandVisitorImpl,
-    SyntheticAmode, VCodeConstant, WritableGpr, WritableXmm, Xmm,
+    regs, Amode, Gpr, Inst, LabelUse, MachBuffer, MachLabel, SyntheticAmode, VCodeConstant,
+    WritableGpr, WritableXmm, Xmm,
 };
 use crate::ir::TrapCode;
 use cranelift_assembler_x64 as asm;
@@ -142,54 +142,6 @@ fn enc_xmm(xmm: &Xmm) -> u8 {
         real.hw_enc()
     } else {
         unreachable!()
-    }
-}
-
-/// A wrapper to implement the `cranelift-assembler-x64` register allocation trait,
-/// `RegallocVisitor`, in terms of the trait used in Cranelift,
-/// `OperandVisitor`.
-pub(crate) struct RegallocVisitor<'a, T>
-where
-    T: OperandVisitorImpl,
-{
-    pub collector: &'a mut T,
-}
-
-impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for RegallocVisitor<'a, T> {
-    fn read(&mut self, reg: &mut Gpr) {
-        self.collector.reg_use(reg);
-    }
-
-    fn read_write(&mut self, reg: &mut PairedGpr) {
-        let PairedGpr { read, write } = reg;
-        self.collector.reg_use(read);
-        self.collector.reg_reuse_def(write, 0);
-    }
-
-    fn fixed_read(&mut self, _reg: &Gpr) {
-        todo!()
-    }
-
-    fn fixed_read_write(&mut self, _reg: &PairedGpr) {
-        todo!()
-    }
-
-    fn read_xmm(&mut self, reg: &mut Xmm) {
-        self.collector.reg_use(reg);
-    }
-
-    fn read_write_xmm(&mut self, reg: &mut PairedXmm) {
-        let PairedXmm { read, write } = reg;
-        self.collector.reg_use(read);
-        self.collector.reg_reuse_def(write, 0);
-    }
-
-    fn fixed_read_xmm(&mut self, _reg: &Xmm) {
-        todo!()
-    }
-
-    fn fixed_read_write_xmm(&mut self, _reg: &PairedXmm) {
-        todo!()
     }
 }
 


### PR DESCRIPTION
This PR changes the paradigm for how a user (like `regalloc2`) will interact with the operands of an assembler instruction. Instead of using a visitor pattern, calling functions for each of the operands, this approach builds up a list of operands that expose `&mut` references to the underlying operands of the instruction.

While this does have the advantage of being a bit more straightforward, the motivation for this is more subtle: some instructions have special register constraints that the visitor pattern does not handle. E.g., when switching `AluConstOp` to use the new assembler, I noticed that the calls it makes to the register allocator are quite different than the visitor expects: `AluConstOp` boils down to `xor %r*, %r*` and expects us a completely different call to `regalloc2`: a single `reg_def()`. We would need to build a completely different visitor implementation for this.

Also, this refactoring makes it possible for users of the assembler to examine and modify any operands to any instruction. This should be useful regardless of the `AluConstOp` motivation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
