### PR TITLE
asm: use `Formatter::add_block` for more generated code

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate.rs
+++ b/cranelift/assembler-x64/meta/src/generate.rs
@@ -36,15 +36,13 @@ fn generate_inst_enum(f: &mut Formatter, insts: &[dsl::Inst]) {
     fmtln!(f, "#[doc(hidden)]");
     generate_derive(f);
     generate_derive_arbitrary_bounds(f);
-    fmtln!(f, "pub enum Inst<R: Registers> {{");
-    f.indent_push();
-    for inst in insts {
-        let variant_name = inst.name();
-        let struct_name = inst.struct_name_with_generic();
-        fmtln!(f, "{variant_name}({struct_name}),");
-    }
-    f.indent_pop();
-    fmtln!(f, "}}");
+    f.add_block("pub enum Inst<R: Registers>", |f| {
+        for inst in insts {
+            let variant_name = inst.name();
+            let struct_name = inst.struct_name_with_generic();
+            fmtln!(f, "{variant_name}({struct_name}),");
+        }
+    });
 }
 
 /// `#[derive(...)]`
@@ -64,42 +62,30 @@ fn generate_derive_arbitrary_bounds(f: &mut Formatter) {
 
 /// `impl std::fmt::Display for Inst { ... }`
 fn generate_inst_display_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
-    fmtln!(f, "impl<R: Registers> std::fmt::Display for Inst<R> {{");
-    f.indent(|f| {
-        fmtln!(f, "fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{");
-        f.indent(|f| {
-            fmtln!(f, "match self {{");
-            f.indent_push();
-            for inst in insts {
-                let variant_name = inst.name();
-                fmtln!(f, "Self::{variant_name}(i) => write!(f, \"{{i}}\"),");
-            }
-            f.indent_pop();
-            fmtln!(f, "}}");
+    f.add_block("impl<R: Registers> std::fmt::Display for Inst<R>", |f| {
+        f.add_block("fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result", |f| {
+            f.add_block("match self", |f| {
+                for inst in insts {
+                    let variant_name = inst.name();
+                    fmtln!(f, "Self::{variant_name}(i) => write!(f, \"{{i}}\"),");
+                }
+            });
         });
-        fmtln!(f, "}}");
     });
-    fmtln!(f, "}}");
 }
 
 /// `impl Inst { fn encode... }`
 fn generate_inst_encode_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
-    fmtln!(f, "impl<R: Registers> Inst<R> {{");
-    f.indent(|f| {
-        fmtln!(f, "pub fn encode(&self, b: &mut impl CodeSink, o: &impl KnownOffsetTable) {{");
-        f.indent(|f| {
-            fmtln!(f, "match self {{");
-            f.indent_push();
-            for inst in insts {
-                let variant_name = inst.name();
-                fmtln!(f, "Self::{variant_name}(i) => i.encode(b, o),");
-            }
-            f.indent_pop();
-            fmtln!(f, "}}");
+    f.add_block("impl<R: Registers> Inst<R>", |f| {
+        f.add_block("pub fn encode(&self, b: &mut impl CodeSink, o: &impl KnownOffsetTable)", |f| {
+            f.add_block("match self", |f| {
+                for inst in insts {
+                    let variant_name = inst.name();
+                    fmtln!(f, "Self::{variant_name}(i) => i.encode(b, o),");
+                }
+            });
         });
-        fmtln!(f, "}}");
     });
-    fmtln!(f, "}}");
 }
 
 /// `impl Inst { fn visit... }`
@@ -124,21 +110,14 @@ fn generate_inst_visit_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
 
 /// `impl Inst { fn features... }`
 fn generate_inst_features_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
-    fmtln!(f, "impl<R: Registers> Inst<R> {{");
-    f.indent(|f| {
-        fmtln!(f, "#[must_use]");
-        fmtln!(f, "pub fn features(&self) -> Vec<Feature> {{");
-        f.indent(|f| {
-            fmtln!(f, "match self {{");
-            f.indent_push();
-            for inst in insts {
-                let variant_name = inst.name();
-                fmtln!(f, "Self::{variant_name}(i) => i.features(),");
-            }
-            f.indent_pop();
-            fmtln!(f, "}}");
+    f.add_block("impl<R: Registers> Inst<R>", |f| {
+        f.add_block("pub fn features(&self) -> Vec<Feature>", |f| {
+            f.add_block("match self", |f| {
+                for inst in insts {
+                    let variant_name = inst.name();
+                    fmtln!(f, "Self::{variant_name}(i) => i.features(),");
+                }
+            });
         });
-        fmtln!(f, "}}");
     });
-    fmtln!(f, "}}");
 }


### PR DESCRIPTION
This propagates a helpful pattern from #10348 in more places; `Formatter::add_block` is a bit more clear and prevents some classes of generation mistakes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
