### PR TITLE
Correct some fast-execution documentation

### DIFF
--- a/docs/examples-fast-execution.md
+++ b/docs/examples-fast-execution.md
@@ -63,7 +63,7 @@ architecture that will run the pre-compiled Wasm programs can have a large
 impact for certain Wasm programs, particularly those using SIMD instructions.
 
 See the API docs for
-[`wasmtime::Config::detect_host_feature`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.detect_host_feature)
+[`wasmtime::Config::cranelift_flag_enable`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.cranelift_flag_enable)
 for more details.
 
 ## Putting It All Together

--- a/examples/fast_execution.rs
+++ b/examples/fast_execution.rs
@@ -31,16 +31,10 @@ fn main() -> Result<()> {
                 );
                 return Ok(());
             }
-            config.detect_host_feature(|feature| {
-                match feature {
-                    // A few example x86_64 features you can configure.
-                    "sse4.1" => Some(true),
-                    "avx" => Some(true),
-                    "avx2" => Some(true),
-                    "lzcnt" => Some(true),
-                    _ => None,
-                }
-            });
+            config.cranelift_flag_enable("has_sse41");
+            config.cranelift_flag_enable("has_avx");
+            config.cranelift_flag_enable("has_avx2");
+            config.cranelift_flag_enable("has_lzcnt");
         }
     }
 


### PR DESCRIPTION
The `Config::detect_host_feature` API is used for detecting whether the host has a feature, not whether the compilation artifacts should have it enabled. Switch to using `cranelift_flag_enable` instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
