### PR TITLE
Increase discovery timeout for C++ tests

### DIFF
--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -13,7 +13,10 @@ function(add_capi_test name)
   cmake_parse_arguments(PARSE_ARGV 1 arg "" "" "FILES")
   add_executable(test-${name} ${arg_FILES})
   target_link_libraries(test-${name} PRIVATE wasmtime-cpp gtest_main)
-  gtest_discover_tests(test-${name})
+  gtest_discover_tests(test-${name}
+    # GitHub Actions on Windows is pretty slow, let's give it lots more time
+    # than the default 5 seconds.
+    DISCOVERY_TIMEOUT 60)
 endfunction()
 
 add_capi_test(simple FILES simple.cc)


### PR DESCRIPTION
I think we're hitting this on CI occasionally on Windows, so increase the timeout in the hopes that this'll make such a spurious error go away.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
