### PR TITLE
Add a "profiling" cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,6 +584,10 @@ debug-assertions = false
 overflow-checks = false
 opt-level = 's'
 
+[profile.profiling]
+inherits = "bench"
+debug-info = "line-tables-only"
+
 [profile.fastest-runtime]
 inherits = "release"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -586,7 +586,7 @@ opt-level = 's'
 
 [profile.profiling]
 inherits = "bench"
-debug-info = "line-tables-only"
+debug = "line-tables-only"
 
 [profile.fastest-runtime]
 inherits = "release"


### PR DESCRIPTION
This allows us to get basic debug info for profiling our micro benchmarks.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
