### PR TITLE
asm: plumb fixed registers through operand visitor

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -127,53 +127,34 @@ impl dsl::Inst {
             &format!("pub fn visit{extra_generic_bound}(&mut self, visitor: &mut impl RegisterVisitor<R>)"),
             |f| {
                 for o in &self.format.operands {
+                    let mutability = o.mutability.generate_snake_case();
+                    let reg = o.location.generate_register_class();
                     match o.location.kind() {
                         Imm(_) => {
                             // Immediates do not need register allocation.
                         }
-                        FixedReg(reg) => {
-                            let call = o.mutability.generate_regalloc_call();
-                            fmtln!(f, "let enc = self.{reg}.expected_enc();");
-                            fmtln!(f, "visitor.fixed_{call}(&mut self.{reg}.0, enc);");
+                        FixedReg(loc) => {
+                            let reg_lower = reg.unwrap().to_lowercase();
+                            fmtln!(f, "let enc = self.{loc}.expected_enc();");
+                            fmtln!(f, "visitor.fixed_{mutability}_{reg_lower}(&mut self.{loc}.0, enc);");
                         }
-                        Reg(reg) => {
-                            match reg.bits() {
-                                128 => {
-                                    let call = o.mutability.generate_xmm_regalloc_call();
-                                    fmtln!(f, "visitor.{call}(self.{reg}.as_mut());");
-                                }
-                                _ => {
-                                    let call = o.mutability.generate_regalloc_call();
-                                    fmtln!(f, "visitor.{call}(self.{reg}.as_mut());");
-                                }
-                            };
+                        Reg(loc) => {
+                            let reg_lower = reg.unwrap().to_lowercase();
+                            fmtln!(f, "visitor.{mutability}_{reg_lower}(self.{loc}.as_mut());");
                         }
-                        RegMem(rm) => {
-                            match rm.bits() {
-                                128 => {
-                                    let call = o.mutability.generate_xmm_regalloc_call();
-                                    f.add_block(&format!("match &mut self.{rm}"), |f| {
-                                        fmtln!(f, "XmmMem::Xmm(r) => visitor.{call}(r),");
-                                        fmtln!(
-                                        f,
-                                        "XmmMem::Mem(m) => m.registers_mut().iter_mut().for_each(|r| visitor.read(r)),"
-                                    );
-                                    });
-                                }
-                                _ => {
-                                    let call = o.mutability.generate_regalloc_call();
-                                    f.add_block(&format!("match &mut self.{rm}"), |f| {
-                                        fmtln!(f, "GprMem::Gpr(r) => visitor.{call}(r),");
-                                        fmtln!(
-                                        f,
-                                        "GprMem::Mem(m) => m.registers_mut().iter_mut().for_each(|r| visitor.read(r)),"
-                                    );
-                                    });
-                                }
-                            };
+                        RegMem(loc) => {
+                            let reg = reg.unwrap();
+                            let reg_lower = reg.to_lowercase();
+                            f.add_block(&format!("match &mut self.{loc}"), |f| {
+                                fmtln!(f, "{reg}Mem::{reg}(r) => visitor.{mutability}_{reg_lower}(r),");
+                                fmtln!(
+                                    f,
+                                    "{reg}Mem::Mem(m) => m.registers_mut().iter_mut().for_each(|r| visitor.read_gpr(r)),"
+                                );
+                            });
                         }
-                        Mem(m) => {
-                            fmtln!(f, "self.{m}.registers_mut().iter_mut().for_each(|r| visitor.read(r));");
+                        Mem(loc) => {
+                            fmtln!(f, "self.{loc}.registers_mut().iter_mut().for_each(|r| visitor.read_gpr(r));");
                         }
                     }
                 }

--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -131,13 +131,10 @@ impl dsl::Inst {
                         Imm(_) => {
                             // Immediates do not need register allocation.
                         }
-                        FixedReg(_) => {
+                        FixedReg(reg) => {
                             let call = o.mutability.generate_regalloc_call();
-                            let ty = o.mutability.generate_type();
-                            let Some(fixed) = o.location.generate_fixed_reg() else {
-                                unreachable!()
-                            };
-                            fmtln!(f, "visitor.fixed_{call}(&R::{ty}Gpr::new({fixed}));");
+                            fmtln!(f, "let enc = self.{reg}.expected_enc();");
+                            fmtln!(f, "visitor.fixed_{call}(&mut self.{reg}.0, enc);");
                         }
                         Reg(reg) => {
                             match reg.bits() {

--- a/cranelift/assembler-x64/meta/src/generate/operand.rs
+++ b/cranelift/assembler-x64/meta/src/generate/operand.rs
@@ -19,18 +19,31 @@ impl dsl::Operand {
                     cl => "{ gpr::enc::RCX }",
                     _ => unreachable!(),
                 };
-                format!("Fixed<R::{}Gpr, {enc}>", self.mutability.generate_type())
+                format!("Fixed<R::{}Gpr, {enc}>", self.mutability.generate_camel_case())
             }
-            r8 | r16 | r32 | r64 => format!("Gpr<R::{}Gpr>", self.mutability.generate_type()),
-            rm8 | rm16 | rm32 | rm64 => format!("GprMem<R::{}Gpr, R::ReadGpr>", self.mutability.generate_type()),
-            xmm => format!("Xmm<R::{}Xmm>", self.mutability.generate_type()),
-            rm128 => format!("XmmMem<R::{}Xmm, R::ReadGpr>", self.mutability.generate_type()),
+            r8 | r16 | r32 | r64 => format!("Gpr<R::{}Gpr>", self.mutability.generate_camel_case()),
+            rm8 | rm16 | rm32 | rm64 => format!("GprMem<R::{}Gpr, R::ReadGpr>", self.mutability.generate_camel_case()),
+            xmm => format!("Xmm<R::{}Xmm>", self.mutability.generate_camel_case()),
+            rm128 => format!("XmmMem<R::{}Xmm, R::ReadGpr>", self.mutability.generate_camel_case()),
             m8 | m16 | m32 | m64 => format!("Amode<R::ReadGpr>"),
         }
     }
 }
 
 impl dsl::Location {
+    /// `Xmm|Gpr`
+    #[must_use]
+    pub fn generate_register_class(&self) -> Option<&str> {
+        use dsl::Location::*;
+        match self {
+            al | ax | eax | rax | cl | r8 | r16 | r32 | r64 | rm8 | rm16 | rm32 | rm64 => Some("Gpr"),
+            xmm | rm128 => Some("Xmm"),
+            // Do not generate a register class for memory-only access or
+            // immediates.
+            imm8 | imm16 | imm32 | m8 | m16 | m32 | m64 => None,
+        }
+    }
+
     /// `self.<operand>.to_string(...)`
     #[must_use]
     pub fn generate_to_string(&self, extension: dsl::Extension) -> String {
@@ -75,31 +88,11 @@ impl dsl::Location {
             }
         }
     }
-
-    /// `Gpr(regs::...)`
-    #[must_use]
-    pub fn generate_fixed_reg(&self) -> Option<&str> {
-        use dsl::Location::*;
-        match self {
-            al | ax | eax | rax => Some("gpr::enc::RAX"),
-            cl => Some("gpr::enc::RCX"),
-            imm8 | imm16 | imm32 | r8 | r16 | r32 | r64 | xmm | rm8 | rm16 | rm32 | rm64 | rm128 | m8 | m16 | m32
-            | m64 => None,
-        }
-    }
 }
 
 impl dsl::Mutability {
     #[must_use]
-    pub fn generate_regalloc_call(&self) -> &str {
-        match self {
-            dsl::Mutability::Read => "read",
-            dsl::Mutability::ReadWrite => "read_write",
-        }
-    }
-
-    #[must_use]
-    pub fn generate_type(&self) -> &str {
+    pub fn generate_camel_case(&self) -> &str {
         match self {
             dsl::Mutability::Read => "Read",
             dsl::Mutability::ReadWrite => "ReadWrite",
@@ -107,10 +100,10 @@ impl dsl::Mutability {
     }
 
     #[must_use]
-    pub fn generate_xmm_regalloc_call(&self) -> &str {
+    pub fn generate_snake_case(&self) -> &str {
         match self {
-            dsl::Mutability::Read => "read_xmm",
-            dsl::Mutability::ReadWrite => "read_write_xmm",
+            dsl::Mutability::Read => "read",
+            dsl::Mutability::ReadWrite => "read_write",
         }
     }
 }

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -159,20 +159,20 @@ pub trait RegisterVisitor<R: Registers> {
     fn read(&mut self, reg: &mut R::ReadGpr);
     /// Visit a read-write register.
     fn read_write(&mut self, reg: &mut R::ReadWriteGpr);
-    /// Visit a read-only fixed register; for safety, this register cannot be
-    /// modified in-place.
-    fn fixed_read(&mut self, reg: &R::ReadGpr);
-    /// Visit a read-write fixed register; for safety, this register cannot be
-    /// modified in-place.
-    fn fixed_read_write(&mut self, reg: &R::ReadWriteGpr);
+    /// Visit a read-only fixed register; this register can be modified in-place
+    /// but must emit as the hardware encoding `enc`.
+    fn fixed_read(&mut self, reg: &mut R::ReadGpr, enc: u8);
+    /// Visit a read-write fixed register; this register can be modified
+    /// in-place but must emit as the hardware encoding `enc`.
+    fn fixed_read_write(&mut self, reg: &mut R::ReadWriteGpr, enc: u8);
     /// Visit a read-only SSE register.
     fn read_xmm(&mut self, reg: &mut R::ReadXmm);
     /// Visit a read-write SSE register.
     fn read_write_xmm(&mut self, reg: &mut R::ReadWriteXmm);
-    /// Visit a read-only fixed SSE register; for safety, this register cannot
-    /// be modified in-place.
-    fn fixed_read_xmm(&mut self, reg: &R::ReadXmm);
-    /// Visit a read-write fixed SSE register; for safety, this register cannot
-    /// be modified in-place.
-    fn fixed_read_write_xmm(&mut self, reg: &R::ReadWriteXmm);
+    /// Visit a read-only fixed SSE register; this register can be modified
+    /// in-place but must emit as the hardware encoding `enc`.
+    fn fixed_read_xmm(&mut self, reg: &mut R::ReadXmm, enc: u8);
+    /// Visit a read-write fixed SSE register; this register can be modified
+    /// in-place but must emit as the hardware encoding `enc`.
+    fn fixed_read_write_xmm(&mut self, reg: &mut R::ReadWriteXmm, enc: u8);
 }

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -156,15 +156,15 @@ impl AsReg for u8 {
 /// re-allocating the entire instruction object.
 pub trait RegisterVisitor<R: Registers> {
     /// Visit a read-only register.
-    fn read(&mut self, reg: &mut R::ReadGpr);
+    fn read_gpr(&mut self, reg: &mut R::ReadGpr);
     /// Visit a read-write register.
-    fn read_write(&mut self, reg: &mut R::ReadWriteGpr);
+    fn read_write_gpr(&mut self, reg: &mut R::ReadWriteGpr);
     /// Visit a read-only fixed register; this register can be modified in-place
     /// but must emit as the hardware encoding `enc`.
-    fn fixed_read(&mut self, reg: &mut R::ReadGpr, enc: u8);
+    fn fixed_read_gpr(&mut self, reg: &mut R::ReadGpr, enc: u8);
     /// Visit a read-write fixed register; this register can be modified
     /// in-place but must emit as the hardware encoding `enc`.
-    fn fixed_read_write(&mut self, reg: &mut R::ReadWriteGpr, enc: u8);
+    fn fixed_read_write_gpr(&mut self, reg: &mut R::ReadWriteGpr, enc: u8);
     /// Visit a read-only SSE register.
     fn read_xmm(&mut self, reg: &mut R::ReadXmm);
     /// Visit a read-write SSE register.

--- a/cranelift/assembler-x64/src/fixed.rs
+++ b/cranelift/assembler-x64/src/fixed.rs
@@ -25,6 +25,16 @@ use crate::AsReg;
 #[derive(Clone, Debug)]
 pub struct Fixed<R, const E: u8>(pub R);
 
+impl<R, const E: u8> Fixed<R, E> {
+    /// Return the fixed register encoding.
+    ///
+    /// Regardless of what `R` is (e.g., pre-register allocation), we want to be
+    /// able to know what this register should encode as.
+    pub fn expected_enc(&self) -> u8 {
+        E
+    }
+}
+
 impl<R: AsReg, const E: u8> AsReg for Fixed<R, E> {
     fn new(reg: u8) -> Self {
         assert!(reg == E);

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -157,22 +157,22 @@ where
 }
 
 impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for RegallocVisitor<'a, T> {
-    fn read(&mut self, reg: &mut Gpr) {
+    fn read_gpr(&mut self, reg: &mut Gpr) {
         self.collector.reg_use(reg);
     }
 
-    fn read_write(&mut self, reg: &mut PairedGpr) {
+    fn read_write_gpr(&mut self, reg: &mut PairedGpr) {
         let PairedGpr { read, write } = reg;
         self.collector.reg_use(read);
         self.collector.reg_reuse_def(write, 0);
     }
 
-    fn fixed_read(&mut self, reg: &mut Gpr, enc: u8) {
+    fn fixed_read_gpr(&mut self, reg: &mut Gpr, enc: u8) {
         self.collector
             .reg_fixed_use(reg, fixed_reg(enc, RegClass::Int));
     }
 
-    fn fixed_read_write(&mut self, reg: &mut PairedGpr, enc: u8) {
+    fn fixed_read_write_gpr(&mut self, reg: &mut PairedGpr, enc: u8) {
         let PairedGpr { read, write } = reg;
         self.collector
             .reg_fixed_use(read, fixed_reg(enc, RegClass::Int));

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -4,8 +4,9 @@ use super::{
     regs, Amode, Gpr, Inst, LabelUse, MachBuffer, MachLabel, OperandVisitor, OperandVisitorImpl,
     SyntheticAmode, VCodeConstant, WritableGpr, WritableXmm, Xmm,
 };
-use crate::ir::TrapCode;
+use crate::{ir::TrapCode, Reg};
 use cranelift_assembler_x64 as asm;
+use regalloc2::{PReg, RegClass};
 use std::string::String;
 
 /// Define the types of registers Cranelift will use.
@@ -166,12 +167,17 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
         self.collector.reg_reuse_def(write, 0);
     }
 
-    fn fixed_read(&mut self, _reg: &Gpr) {
-        todo!()
+    fn fixed_read(&mut self, reg: &mut Gpr, enc: u8) {
+        self.collector
+            .reg_fixed_use(reg, fixed_reg(enc, RegClass::Int));
     }
 
-    fn fixed_read_write(&mut self, _reg: &PairedGpr) {
-        todo!()
+    fn fixed_read_write(&mut self, reg: &mut PairedGpr, enc: u8) {
+        let PairedGpr { read, write } = reg;
+        self.collector
+            .reg_fixed_use(read, fixed_reg(enc, RegClass::Int));
+        self.collector
+            .reg_fixed_def(write, fixed_reg(enc, RegClass::Int));
     }
 
     fn read_xmm(&mut self, reg: &mut Xmm) {
@@ -184,13 +190,24 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
         self.collector.reg_reuse_def(write, 0);
     }
 
-    fn fixed_read_xmm(&mut self, _reg: &Xmm) {
-        todo!()
+    fn fixed_read_xmm(&mut self, reg: &mut Xmm, enc: u8) {
+        self.collector
+            .reg_fixed_use(reg, fixed_reg(enc, RegClass::Float));
     }
 
-    fn fixed_read_write_xmm(&mut self, _reg: &PairedXmm) {
-        todo!()
+    fn fixed_read_write_xmm(&mut self, reg: &mut PairedXmm, enc: u8) {
+        let PairedXmm { read, write } = reg;
+        self.collector
+            .reg_fixed_use(read, fixed_reg(enc, RegClass::Float));
+        self.collector
+            .reg_fixed_def(write, fixed_reg(enc, RegClass::Float));
     }
+}
+
+/// A helper for building a fixed register from its hardware encoding.
+fn fixed_reg(enc: u8, class: RegClass) -> Reg {
+    let preg = PReg::new(usize::from(enc), class);
+    Reg::from_real_reg(preg)
 }
 
 impl Into<asm::Amode<Gpr>> for SyntheticAmode {


### PR DESCRIPTION
This finishes plumbing out fixed registers using the visitor pattern in
`cranelift-codegen`. This was skipped initially in [#10629] because
[#10632] offered a different approach; while we discuss whether and how
that should proceed, this change at least fixes up the current state of
things.

[#10629]: https://github.com/bytecodealliance/wasmtime/pull/10629
[#10632]: https://github.com/bytecodealliance/wasmtime/pull/10632