### PR TITLE
wasmtime serve: when handle_request fails, give a 500 response

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,10 @@ Unreleased.
   ComponentExportIndex)` and `ComponentExportIndex`, respectively.
   [#10597](https://github.com/bytecodealliance/wasmtime/pull/10597)
 
+* On failure, `wasmtime serve` gives an internal server error response, rather
+  than closing the connection.
+  [#10645](https://github.com/bytecodealliance/wasmtime/pull/10645)
+
 --------------------------------------------------------------------------------
 
 Release notes for previous releases of Wasmtime can be found on the respective

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2092,8 +2092,9 @@ after empty
                         .body(String::new())
                         .context("failed to make request")?,
                 )
-                .await;
-            assert!(res.is_err());
+                .await
+                .expect("got response from wasmtime");
+            assert_eq!(res.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
         }
 
         let (stdout, stderr) = server.finish()?;


### PR DESCRIPTION
Without this 500 response, hyper closes the connection without sending a response. Sending a 500 is better http hygiene.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
