### PR TITLE
Add context for failing to spawn dwarfdump

### DIFF
--- a/tests/all/debug/dump.rs
+++ b/tests/all/debug/dump.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::env;
 use std::process::Command;
 
@@ -18,7 +18,7 @@ pub fn get_dwarfdump(obj: &str, section: DwarfDumpSection) -> Result<String> {
     let output = Command::new(&dwarfdump)
         .args(&[section_flag, obj])
         .output()
-        .expect("success");
+        .context(format!("failed to spawn `{dwarfdump}`"))?;
     if !output.status.success() {
         bail!(
             "failed to execute {}: {}",


### PR DESCRIPTION
This always trips me up locally and so try to improve the error message from tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
