### PR TITLE
asm: clear GPR with `xor <tmp>, <tmp>`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -794,6 +794,9 @@
        ;; knowledge about semantics and initial-value independence anyway.
        (XmmUninitializedValue (dst WritableXmm))
 
+       ;; See `XmmUninitializedValue` above.
+       (GprUninitializedValue (dst WritableGpr))
+
        ;; A call to the `ElfTlsGetAddr` libcall. Returns address of TLS symbol
        ;; `dst`, which is constrained to `rax`.
        (ElfTlsGetAddr (symbol ExternalName)
@@ -2061,6 +2064,13 @@
 (rule (xmm_uninit_value)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmUninitializedValue dst))))
+        dst))
+
+;; Helper for creating GprUninitializedValue instructions.
+(decl gpr_uninit_value () Gpr)
+(rule (gpr_uninit_value)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.GprUninitializedValue dst))))
         dst))
 
 ;; Helper for constructing a LoadExtName instruction.

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3208,10 +3208,8 @@
 
 ;; Special case for integer zero immediates: turn them into an `xor r, r`.
 (rule 1 (imm (fits_in_64 ty) (u64_zero))
-      (let ((wgpr WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (_ Unit (emit (MInst.AluConstOp (AluRmiROpcode.Xor) size wgpr))))
-        (gpr_to_reg wgpr)))
+      (let ((tmp Gpr (gpr_uninit_value)))
+        (x64_xor ty tmp tmp)))
 
 ;; Special case for zero immediates with vector types, they turn into an xor
 ;; specific to the vector type.
@@ -5836,6 +5834,7 @@
 (convert WritableGpr WritableReg writable_gpr_to_reg)
 (convert WritableGpr Reg writable_gpr_to_r_reg)
 (convert WritableGpr GprMem writable_gpr_to_gpr_mem)
+(convert WritableGpr GprMemImm writable_gpr_to_gpr_mem_imm)
 (convert WritableGpr ValueRegs writable_gpr_to_value_regs)
 
 (convert Xmm InstOutput output_xmm)
@@ -5906,6 +5905,9 @@
 (decl writable_gpr_to_gpr_mem (WritableGpr) GprMem)
 (rule (writable_gpr_to_gpr_mem w_gpr)
       (gpr_to_gpr_mem w_gpr))
+(decl writable_gpr_to_gpr_mem_imm (WritableGpr) GprMemImm)
+(rule (writable_gpr_to_gpr_mem_imm w_gpr)
+      (gpr_to_gpr_mem_imm w_gpr))
 (decl writable_gpr_to_value_regs (WritableGpr) ValueRegs)
 (rule (writable_gpr_to_value_regs w_gpr)
       (value_reg w_gpr))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -3350,7 +3350,10 @@ pub(crate) fn emit(
 
         Inst::XmmUninitializedValue { .. } | Inst::GprUninitializedValue { .. } => {
             // These instruction formats only exist to declare a register as a
-            // `def`; no code is emitted.
+            // `def`; no code is emitted. This is always immediately followed by
+            // an instruction, such as `xor <tmp>, <tmp>`, that semantically
+            // reads this undefined value but arithmetically produces the same
+            // result regardless of its value.
         }
 
         Inst::XmmMovRM { op, src, dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -3348,9 +3348,9 @@ pub(crate) fn emit(
             sink.put1(*imm);
         }
 
-        Inst::XmmUninitializedValue { .. } => {
-            // This instruction format only exists to declare a register as a `def`; no code is
-            // emitted.
+        Inst::XmmUninitializedValue { .. } | Inst::GprUninitializedValue { .. } => {
+            // These instruction formats only exist to declare a register as a
+            // `def`; no code is emitted.
         }
 
         Inst::XmmMovRM { op, src, dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -137,6 +137,7 @@ impl Inst {
             | Inst::XmmCmpRmR { .. }
             | Inst::XmmMinMaxSeq { .. }
             | Inst::XmmUninitializedValue { .. }
+            | Inst::GprUninitializedValue { .. }
             | Inst::ElfTlsGetAddr { .. }
             | Inst::MachOTlsGetAddr { .. }
             | Inst::CoffTlsGetAddr { .. }
@@ -1235,6 +1236,12 @@ impl PrettyPrint for Inst {
                 format!("{op} {dst}")
             }
 
+            Inst::GprUninitializedValue { dst } => {
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                let op = ljustify("uninit".into());
+                format!("{op} {dst}")
+            }
+
             Inst::XmmToGpr {
                 op,
                 src,
@@ -2268,6 +2275,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             src2.get_operands(collector);
         }
         Inst::XmmUninitializedValue { dst } => collector.reg_def(dst),
+        Inst::GprUninitializedValue { dst } => collector.reg_def(dst),
         Inst::XmmMinMaxSeq { lhs, rhs, dst, .. } => {
             collector.reg_use(rhs);
             collector.reg_use(lhs);

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -957,6 +957,10 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
         }
 
+        Inst::GprUninitializedValue { dst } => {
+            ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
+        }
+
         Inst::ElfTlsGetAddr { dst, .. } | Inst::MachOTlsGetAddr { dst, .. } => {
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
         }

--- a/cranelift/filetests/filetests/isa/x64/atomic-128.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-128.clif
@@ -14,10 +14,14 @@ block0(v0: i64):
 ;   subq    %rsp, $16, %rsp
 ;   movq    %rbx, 0(%rsp)
 ; block0:
-;   xorq    %rax, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
-;   xorq    %rbx, %rbx, %rbx
-;   xorq    %rcx, %rcx, %rcx
+;   uninit  %rax
+;   xorq %rax, %rax
+;   uninit  %rdx
+;   xorq %rdx, %rdx
+;   uninit  %rbx
+;   xorq %rbx, %rbx
+;   uninit  %rcx
+;   xorq %rcx, %rcx
 ;   lock cmpxchg16b 0(%rdi), replacement=%rcx:%rbx, expected=%rdx:%rax, dst_old=%rdx:%rax
 ;   movq    0(%rsp), %rbx
 ;   addq    %rsp, $16, %rsp

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -222,7 +222,8 @@ block2:
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -270,7 +271,8 @@ block2:
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -311,17 +313,18 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $2, %r9d
-;   movl    %edi, %r10d
-;   cmpl    %r9d, %r10d
-;   cmovbl  %r10d, %r9d, %r9d
-;   br_table %r9, %rax, %rcx
+;   movl    $2, %r10d
+;   movl    %edi, %r11d
+;   cmpl    %r10d, %r11d
+;   cmovbl  %r11d, %r10d, %r10d
+;   br_table %r10, %rcx, %rdx
 ; block1:
 ;   jmp     label4
 ; block2:
 ;   jmp     label4
 ; block3:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -336,14 +339,14 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movl $2, %r9d
-;   movl %edi, %r10d
-;   cmpl %r9d, %r10d
-;   cmovbl %r10d, %r9d
-;   leaq 9(%rip), %rax
-;   movslq (%rax, %r9, 4), %rcx
-;   addq %rcx, %rax
-;   jmpq *%rax
+;   movl $2, %r10d
+;   movl %edi, %r11d
+;   cmpl %r10d, %r11d
+;   cmovbl %r11d, %r10d
+;   leaq 9(%rip), %rcx
+;   movslq (%rcx, %r10, 4), %rdx
+;   addq %rdx, %rcx
+;   jmpq *%rcx
 ;   sbbb %al, (%rax)
 ;   addb %al, (%rax)
 ;   adcl %eax, (%rax)
@@ -383,7 +386,8 @@ block2:
 ;   testq   %rdi, %rdi
 ;   jl      label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -431,7 +435,8 @@ block2:
 ;   testl   %edi, %edi
 ;   jl      label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -479,7 +484,8 @@ block2:
 ;   testq   %rdi, %rdi
 ;   jz      label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -527,7 +533,8 @@ block2:
 ;   testl   %edi, %edi
 ;   jz      label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -575,7 +582,8 @@ block2:
 ;   testq   %rdi, %rdi
 ;   jnle    label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   uninit  %rax
+;   xorl %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -18,7 +18,8 @@ block0(v0: i128):
 ;   addq $0x40, %rax
 ;   cmpq    $64, %rcx
 ;   cmovnzq %rcx, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -27,7 +27,8 @@ block0(v0: i128):
 ;   addq $0x40, %rax
 ;   cmpq    $64, %rdi
 ;   cmovnzq %rdi, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -18,7 +18,8 @@ block0(v0: i128):
 ;   addq $0x40, %r9
 ;   cmpq    $64, %rax
 ;   cmovzq  %r9, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -22,7 +22,8 @@ block0(v0: i128):
 ;   addq $0x40, %rdx
 ;   cmpq    $64, %rax
 ;   cmovzq  %rdx, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -565,7 +565,8 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -651,7 +652,8 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -728,7 +730,8 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -793,7 +796,8 @@ block0(v0: i128):
 ;   imulq   %rdi, %rcx, %rdi
 ;   shrq    $56, %rdi, %rdi
 ;   addq %rdi, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1111,13 +1115,14 @@ block2(v8: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testb   %dl, %dl
 ;   jnz     label2; j label1
 ; block1:
 ;   addq $0x2, %rax
-;   setb    %dil
-;   movzbq  %dil, %rdx
+;   setb    %cl
+;   movzbq  %cl, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1139,8 +1144,8 @@ block2(v8: i128):
 ;   jne 0x20
 ; block2: ; offset 0xf
 ;   addq $2, %rax
-;   setb %dil
-;   movzbq %dil, %rdx
+;   setb %cl
+;   movzbq %cl, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1349,7 +1354,8 @@ block0(v0: i128):
 ;   addq $0x40, %rax
 ;   cmpq    $64, %rdi
 ;   cmovnzq %rdi, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1397,7 +1403,8 @@ block0(v0: i128):
 ;   addq $0x40, %rdx
 ;   cmpq    $64, %rax
 ;   cmovzq  %rdx, %rax, %rax
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1463,16 +1470,17 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r10
+;   movq    %rdx, %r11
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r10
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r10, %r8
+;   movq    %r11, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -1489,13 +1497,13 @@ block0(v0: i128, v1: i128):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r10
+;   movq %rdx, %r11
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r10
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r10, %r8
+;   movq %r11, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax
@@ -1529,7 +1537,8 @@ block0(v0: i128, v1: i128):
 ;   movq    %r11, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
@@ -1578,23 +1587,24 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   movq    %rdx, %rax
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r11
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   sarq    %cl, %r10, %r10
-;   movq    %rcx, %r11
+;   movq    %rcx, %rax
 ;   movl    $64, %ecx
-;   movq    %r11, %rax
-;   subq %rax, %rcx
-;   movq    %rsi, %r9
-;   shlq    %cl, %r9, %r9
-;   xorq    %r11, %r11, %r11
-;   testq   $127, %rax
-;   cmovzq  %r11, %r9, %r9
-;   orq %r9, %rdi
+;   movq    %rax, %rdx
+;   subq %rdx, %rcx
+;   movq    %rsi, %r11
+;   shlq    %cl, %r11, %r11
+;   uninit  %rax
+;   xorq %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r11, %r11
+;   orq %r11, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %rax
+;   testq   $64, %rdx
 ;   movq    %r10, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq    %rsi, %rdx
@@ -1608,23 +1618,23 @@ block0(v0: i128, v1: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   movq %rdx, %rax
 ;   movq %rdx, %rcx
-;   movq %rdx, %r11
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   sarq %cl, %r10
-;   movq %rcx, %r11
+;   movq %rcx, %rax
 ;   movl $0x40, %ecx
-;   movq %r11, %rax
-;   subq %rax, %rcx
-;   movq %rsi, %r9
-;   shlq %cl, %r9
-;   xorq %r11, %r11
-;   testq $0x7f, %rax
-;   cmoveq %r11, %r9
-;   orq %r9, %rdi
+;   movq %rax, %rdx
+;   subq %rdx, %rcx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   xorq %rax, %rax
+;   testq $0x7f, %rdx
+;   cmoveq %rax, %r11
+;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
-;   testq $0x40, %rax
+;   testq $0x40, %rdx
 ;   movq %r10, %rax
 ;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
@@ -1644,45 +1654,45 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r8
+;   movq    %rdx, %r9
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rcx, %r8
-;   movq    %rsi, %r11
-;   shlq    %cl, %r11, %r11
+;   movq    %rcx, %r9
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
 ;   movl    $64, %ecx
-;   movq    %r8, %rax
-;   subq %rax, %rcx
-;   movq    %rdi, %r10
-;   shrq    %cl, %r10, %r10
-;   xorq    %rax, %rax, %rax
-;   movq    %r8, %rcx
+;   movq    %r9, %r8
+;   subq %r8, %rcx
+;   movq    %rdi, %r11
+;   shrq    %cl, %r11, %r11
+;   uninit  %rax
+;   xorq %rax, %rax
+;   movq    %r9, %rcx
 ;   testq   $127, %rcx
-;   cmovzq  %rax, %r10, %r10
-;   orq %r11, %r10
+;   cmovzq  %rax, %r11, %r11
+;   orq %r10, %r11
 ;   testq   $64, %rcx
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmovzq  %r11, %rdx, %rdx
 ;   movl    $128, %ecx
-;   movq    %r8, %r10
-;   subq %r10, %rcx
+;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r9
-;   shrq    %cl, %r9, %r9
-;   movq    %rcx, %r8
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r8, %r10
 ;   subq %r10, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %r8, %r8, %r8
+;   uninit  %r8
+;   xorq %r8, %r8
 ;   testq   $127, %r10
 ;   cmovzq  %r8, %rsi, %rsi
 ;   orq %rdi, %rsi
 ;   testq   $64, %r10
-;   movq    %r9, %r10
-;   cmovzq  %rsi, %r10, %r10
-;   cmovzq  %r9, %r8, %r8
-;   orq %r10, %rax
+;   movq    %r11, %rdi
+;   cmovzq  %rsi, %rdi, %rdi
+;   cmovzq  %r11, %r8, %r8
+;   orq %rdi, %rax
 ;   orq %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1694,34 +1704,32 @@ block0(v0: i128, v1: i128):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r8
+;   movq %rdx, %r9
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rcx, %r8
-;   movq %rsi, %r11
-;   shlq %cl, %r11
+;   movq %rcx, %r9
+;   movq %rsi, %r10
+;   shlq %cl, %r10
 ;   movl $0x40, %ecx
-;   movq %r8, %rax
-;   subq %rax, %rcx
-;   movq %rdi, %r10
-;   shrq %cl, %r10
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   movq %rdi, %r11
+;   shrq %cl, %r11
 ;   xorq %rax, %rax
-;   movq %r8, %rcx
+;   movq %r9, %rcx
 ;   testq $0x7f, %rcx
-;   cmoveq %rax, %r10
-;   orq %r11, %r10
+;   cmoveq %rax, %r11
+;   orq %r10, %r11
 ;   testq $0x40, %rcx
 ;   cmoveq %rdx, %rax
-;   cmoveq %r10, %rdx
+;   cmoveq %r11, %rdx
 ;   movl $0x80, %ecx
-;   movq %r8, %r10
-;   subq %r10, %rcx
+;   subq %r8, %rcx
 ;   shrq %cl, %rdi
-;   movq %rsi, %r9
-;   shrq %cl, %r9
-;   movq %rcx, %r8
+;   movq %rsi, %r11
+;   shrq %cl, %r11
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r8, %r10
 ;   subq %r10, %rcx
 ;   shlq %cl, %rsi
 ;   xorq %r8, %r8
@@ -1729,10 +1737,10 @@ block0(v0: i128, v1: i128):
 ;   cmoveq %r8, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %r10
-;   movq %r9, %r10
-;   cmoveq %rsi, %r10
-;   cmoveq %r9, %r8
-;   orq %r10, %rax
+;   movq %r11, %rdi
+;   cmoveq %rsi, %rdi
+;   cmoveq %r11, %r8
+;   orq %rdi, %rax
 ;   orq %r8, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1756,11 +1764,12 @@ block0(v0: i128, v1: i128):
 ;   movq    %rsi, %r10
 ;   shrq    %cl, %r10, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %rax
-;   subq %rax, %rcx
+;   movq    %r9, %rdx
+;   subq %rdx, %rcx
 ;   movq    %rsi, %r11
 ;   shlq    %cl, %r11, %r11
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %r9, %rcx
 ;   testq   $127, %rcx
 ;   cmovzq  %rdx, %r11, %r11
@@ -1770,24 +1779,25 @@ block0(v0: i128, v1: i128):
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movl    $128, %ecx
-;   movq    %r9, %r10
-;   subq %r10, %rcx
-;   movq    %rdi, %r8
-;   shlq    %cl, %r8, %r8
+;   movq    %r9, %r8
+;   subq %r8, %rcx
+;   movq    %rdi, %r10
+;   shlq    %cl, %r10, %r10
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   subq %r9, %rcx
+;   subq %r11, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %r11, %r11, %r11
-;   testq   $127, %r9
-;   cmovzq  %r11, %rdi, %rdi
+;   uninit  %r8
+;   xorq %r8, %r8
+;   testq   $127, %r11
+;   cmovzq  %r8, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r9
-;   cmovzq  %r8, %r11, %r11
-;   cmovzq  %rdi, %r8, %r8
-;   orq %r11, %rax
-;   orq %r8, %rdx
+;   testq   $64, %r11
+;   cmovzq  %r10, %r8, %r8
+;   cmovzq  %rdi, %r10, %r10
+;   orq %r8, %rax
+;   orq %r10, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1805,8 +1815,8 @@ block0(v0: i128, v1: i128):
 ;   movq %rsi, %r10
 ;   shrq %cl, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %rax
-;   subq %rax, %rcx
+;   movq %r9, %rdx
+;   subq %rdx, %rcx
 ;   movq %rsi, %r11
 ;   shlq %cl, %r11
 ;   xorq %rdx, %rdx
@@ -1819,24 +1829,24 @@ block0(v0: i128, v1: i128):
 ;   cmoveq %r11, %rax
 ;   cmoveq %r10, %rdx
 ;   movl $0x80, %ecx
-;   movq %r9, %r10
-;   subq %r10, %rcx
-;   movq %rdi, %r8
-;   shlq %cl, %r8
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   movq %rdi, %r10
+;   shlq %cl, %r10
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   subq %r9, %rcx
+;   subq %r11, %rcx
 ;   shrq %cl, %rdi
-;   xorq %r11, %r11
-;   testq $0x7f, %r9
-;   cmoveq %r11, %rdi
+;   xorq %r8, %r8
+;   testq $0x7f, %r11
+;   cmoveq %r8, %rdi
 ;   orq %rsi, %rdi
-;   testq $0x40, %r9
-;   cmoveq %r8, %r11
-;   cmoveq %rdi, %r8
-;   orq %r11, %rax
-;   orq %r8, %rdx
+;   testq $0x40, %r11
+;   cmoveq %r10, %r8
+;   cmoveq %rdi, %r10
+;   orq %r8, %rax
+;   orq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1851,7 +1861,8 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %r8, %r8, %r8
+;   uninit  %r8
+;   xorq %r8, %r8
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rsi, %rdx
@@ -1922,7 +1933,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   addq %rsi, %rax
 ;   adcq $0x0, %rdx
@@ -2013,7 +2025,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   subq %rsi, %rax
 ;   sbbq $0x0, %rdx
@@ -2083,10 +2096,11 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    0(%rdi), %r9
-;   xorq    %rdx, %rdx, %rdx
+;   movq    0(%rdi), %r10
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rsi, %rax
-;   addq %r9, %rax
+;   addq %r10, %rax
 ;   adcq 8(%rdi), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -2097,10 +2111,10 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq (%rdi), %r9 ; trap: heap_oob
+;   movq (%rdi), %r10 ; trap: heap_oob
 ;   xorq %rdx, %rdx
 ;   movq %rsi, %rax
-;   addq %r9, %rax
+;   addq %r10, %rax
 ;   adcq 8(%rdi), %rdx ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -2120,10 +2134,11 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    0(%rdi), %r9
-;   xorq    %rdx, %rdx, %rdx
+;   movq    0(%rdi), %r10
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rsi, %rax
-;   subq %r9, %rax
+;   subq %r10, %rax
 ;   sbbq 8(%rdi), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -2134,10 +2149,10 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq (%rdi), %r9 ; trap: heap_oob
+;   movq (%rdi), %r10 ; trap: heap_oob
 ;   xorq %rdx, %rdx
 ;   movq %rsi, %rax
-;   subq %r9, %rax
+;   subq %r10, %rax
 ;   sbbq 8(%rdi), %rdx ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -22,12 +22,13 @@ block0(v0: i128, v1: i8):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %r8
+;   movq    %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -47,9 +48,9 @@ block0(v0: i128, v1: i8):
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %r8
+;   movq %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax
@@ -74,16 +75,17 @@ block0(v0: i128, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r9
+;   movq    %rdx, %r10
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %r8
+;   movq    %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -100,13 +102,13 @@ block0(v0: i128, v1: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r9
+;   movq %rdx, %r10
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %r8
+;   movq %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax
@@ -131,16 +133,17 @@ block0(v0: i128, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r9
+;   movq    %rdx, %r10
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %r8
+;   movq    %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -157,13 +160,13 @@ block0(v0: i128, v1: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r9
+;   movq %rdx, %r10
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %r8
+;   movq %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax
@@ -188,16 +191,17 @@ block0(v0: i128, v1: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r9
+;   movq    %rdx, %r10
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %r8
+;   movq    %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -214,13 +218,13 @@ block0(v0: i128, v1: i16):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r9
+;   movq %rdx, %r10
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %r8
+;   movq %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax
@@ -245,16 +249,17 @@ block0(v0: i128, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r9
+;   movq    %rdx, %r10
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r9, %r8
+;   movq    %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %rax, %rax, %rax
+;   uninit  %rax
+;   xorq %rax, %rax
 ;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
@@ -271,13 +276,13 @@ block0(v0: i128, v1: i8):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r9
+;   movq %rdx, %r10
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
 ;   shlq %cl, %rsi
-;   movq %rcx, %r9
+;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r9, %r8
+;   movq %r10, %r8
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
 ;   xorq %rax, %rax

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -23,16 +23,17 @@ block0(v0: i128, v1: i8):
 ;   sarq    %cl, %r10, %r10
 ;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r11, %rax
-;   subq %rax, %rcx
-;   movq    %rsi, %r9
-;   shlq    %cl, %r9, %r9
-;   xorq    %r11, %r11, %r11
-;   testq   $127, %rax
-;   cmovzq  %r11, %r9, %r9
-;   orq %r9, %rdi
+;   movq    %r11, %rdx
+;   subq %rdx, %rcx
+;   movq    %rsi, %r11
+;   shlq    %cl, %r11, %r11
+;   uninit  %rax
+;   xorq %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r11, %r11
+;   orq %r11, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %rax
+;   testq   $64, %rdx
 ;   movq    %r10, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq    %rsi, %rdx
@@ -52,16 +53,16 @@ block0(v0: i128, v1: i8):
 ;   sarq %cl, %r10
 ;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r11, %rax
-;   subq %rax, %rcx
-;   movq %rsi, %r9
-;   shlq %cl, %r9
-;   xorq %r11, %r11
-;   testq $0x7f, %rax
-;   cmoveq %r11, %r9
-;   orq %r9, %rdi
+;   movq %r11, %rdx
+;   subq %rdx, %rcx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   xorq %rax, %rax
+;   testq $0x7f, %rdx
+;   cmoveq %rax, %r11
+;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
-;   testq $0x40, %rax
+;   testq $0x40, %rdx
 ;   movq %r10, %rax
 ;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
@@ -81,20 +82,21 @@ block0(v0: i128, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r10
+;   movq    %rdx, %r11
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
-;   movq    %rcx, %r10
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r10, %rax
+;   movq    %r11, %rax
 ;   subq %rax, %rcx
-;   movq    %rsi, %r8
-;   shlq    %cl, %r8, %r8
-;   xorq    %r10, %r10, %r10
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   uninit  %r11
+;   xorq %r11, %r11
 ;   testq   $127, %rax
-;   cmovzq  %r10, %r8, %r8
-;   orq %r8, %rdi
+;   cmovzq  %r11, %r10, %r10
+;   orq %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -111,20 +113,20 @@ block0(v0: i128, v1: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r10
+;   movq %rdx, %r11
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
-;   movq %rcx, %r10
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r10, %rax
+;   movq %r11, %rax
 ;   subq %rax, %rcx
-;   movq %rsi, %r8
-;   shlq %cl, %r8
-;   xorq %r10, %r10
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmoveq %r10, %r8
-;   orq %r8, %rdi
+;   cmoveq %r11, %r10
+;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
@@ -146,20 +148,21 @@ block0(v0: i128, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r10
+;   movq    %rdx, %r11
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
-;   movq    %rcx, %r10
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r10, %rax
+;   movq    %r11, %rax
 ;   subq %rax, %rcx
-;   movq    %rsi, %r8
-;   shlq    %cl, %r8, %r8
-;   xorq    %r10, %r10, %r10
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   uninit  %r11
+;   xorq %r11, %r11
 ;   testq   $127, %rax
-;   cmovzq  %r10, %r8, %r8
-;   orq %r8, %rdi
+;   cmovzq  %r11, %r10, %r10
+;   orq %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -176,20 +179,20 @@ block0(v0: i128, v1: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r10
+;   movq %rdx, %r11
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
-;   movq %rcx, %r10
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r10, %rax
+;   movq %r11, %rax
 ;   subq %rax, %rcx
-;   movq %rsi, %r8
-;   shlq %cl, %r8
-;   xorq %r10, %r10
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmoveq %r10, %r8
-;   orq %r8, %rdi
+;   cmoveq %r11, %r10
+;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
@@ -211,20 +214,21 @@ block0(v0: i128, v1: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r10
+;   movq    %rdx, %r11
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
-;   movq    %rcx, %r10
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r10, %rax
+;   movq    %r11, %rax
 ;   subq %rax, %rcx
-;   movq    %rsi, %r8
-;   shlq    %cl, %r8, %r8
-;   xorq    %r10, %r10, %r10
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   uninit  %r11
+;   xorq %r11, %r11
 ;   testq   $127, %rax
-;   cmovzq  %r10, %r8, %r8
-;   orq %r8, %rdi
+;   cmovzq  %r11, %r10, %r10
+;   orq %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -241,20 +245,20 @@ block0(v0: i128, v1: i16):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r10
+;   movq %rdx, %r11
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
-;   movq %rcx, %r10
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r10, %rax
+;   movq %r11, %rax
 ;   subq %rax, %rcx
-;   movq %rsi, %r8
-;   shlq %cl, %r8
-;   xorq %r10, %r10
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmoveq %r10, %r8
-;   orq %r8, %rdi
+;   cmoveq %r11, %r10
+;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
@@ -276,20 +280,21 @@ block0(v0: i128, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
-;   movq    %rdx, %r10
+;   movq    %rdx, %r11
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
-;   movq    %rcx, %r10
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r10, %rax
+;   movq    %r11, %rax
 ;   subq %rax, %rcx
-;   movq    %rsi, %r8
-;   shlq    %cl, %r8, %r8
-;   xorq    %r10, %r10, %r10
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   uninit  %r11
+;   xorq %r11, %r11
 ;   testq   $127, %rax
-;   cmovzq  %r10, %r8, %r8
-;   orq %r8, %rdi
+;   cmovzq  %r11, %r10, %r10
+;   orq %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r9, %rax
@@ -306,20 +311,20 @@ block0(v0: i128, v1: i8):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
-;   movq %rdx, %r10
+;   movq %rdx, %r11
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
-;   movq %rcx, %r10
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r10, %rax
+;   movq %r11, %rax
 ;   subq %rax, %rcx
-;   movq %rsi, %r8
-;   shlq %cl, %r8
-;   xorq %r10, %r10
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmoveq %r10, %r8
-;   orq %r8, %rdi
+;   cmoveq %r11, %r10
+;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -143,102 +143,104 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $192, %rsp
-;   movq    %rbx, 144(%rsp)
-;   movq    %r12, 152(%rsp)
-;   movq    %r13, 160(%rsp)
-;   movq    %r14, 168(%rsp)
-;   movq    %r15, 176(%rsp)
+;   subq    %rsp, $176, %rsp
+;   movq    %rbx, 128(%rsp)
+;   movq    %r12, 136(%rsp)
+;   movq    %r13, 144(%rsp)
+;   movq    %r14, 152(%rsp)
+;   movq    %r15, 160(%rsp)
 ; block0:
-;   movq    0(%rdi), %rdx
-;   movq    %rdx, rsp(128 + virtual offset)
-;   movq    8(%rdi), %rdx
-;   movq    %rdx, rsp(8 + virtual offset)
-;   movq    16(%rdi), %rdx
-;   movq    %rdx, rsp(120 + virtual offset)
-;   movq    24(%rdi), %rdx
-;   movq    %rdx, rsp(112 + virtual offset)
-;   movq    32(%rdi), %rdx
-;   movq    %rdx, rsp(104 + virtual offset)
-;   movq    40(%rdi), %rdx
-;   movq    %rdx, rsp(96 + virtual offset)
-;   movq    48(%rdi), %rdx
-;   movq    %rdx, rsp(88 + virtual offset)
-;   movq    56(%rdi), %rdx
-;   movq    %rdx, rsp(80 + virtual offset)
-;   movq    64(%rdi), %rdx
-;   movq    %rdx, rsp(72 + virtual offset)
-;   movq    72(%rdi), %rdx
-;   movq    %rdx, rsp(64 + virtual offset)
-;   movq    80(%rdi), %rdx
-;   movq    %rdx, rsp(56 + virtual offset)
-;   movq    88(%rdi), %rdx
-;   movq    %rdx, rsp(48 + virtual offset)
-;   movq    96(%rdi), %rdx
-;   movq    %rdx, rsp(40 + virtual offset)
-;   movq    104(%rdi), %rdx
-;   movq    %rdx, rsp(32 + virtual offset)
-;   movq    112(%rdi), %rdx
+;   movq    0(%rdi), %r8
+;   movq    %r8, rsp(16 + virtual offset)
+;   movq    8(%rdi), %r8
+;   movq    %r8, rsp(8 + virtual offset)
+;   movq    16(%rdi), %r8
+;   movq    %r8, rsp(120 + virtual offset)
+;   movq    24(%rdi), %r8
+;   movq    %r8, rsp(112 + virtual offset)
+;   movq    32(%rdi), %r8
+;   movq    %r8, rsp(104 + virtual offset)
+;   movq    40(%rdi), %r8
+;   movq    %r8, rsp(96 + virtual offset)
+;   movq    48(%rdi), %r8
+;   movq    %r8, rsp(88 + virtual offset)
+;   movq    56(%rdi), %r8
+;   movq    %r8, rsp(80 + virtual offset)
+;   movq    64(%rdi), %r8
+;   movq    %r8, rsp(72 + virtual offset)
+;   movq    72(%rdi), %r8
+;   movq    %r8, rsp(64 + virtual offset)
+;   movq    80(%rdi), %r8
+;   movq    %r8, rsp(56 + virtual offset)
+;   movq    88(%rdi), %r8
+;   movq    %r8, rsp(48 + virtual offset)
+;   movq    96(%rdi), %r8
+;   movq    %r8, rsp(40 + virtual offset)
+;   movq    104(%rdi), %r8
+;   movq    %r8, rsp(32 + virtual offset)
+;   movq    112(%rdi), %r8
 ;   movq    %rdi, rsp(0 + virtual offset)
-;   movq    %rdx, rsp(24 + virtual offset)
-;   xorq    %rdi, %rdi, %rdi
+;   movq    %r8, rsp(24 + virtual offset)
+;   uninit  %rdi
+;   xorq %rdi, %rdi
 ;   %rdi = stack_switch_basic %rsi, %rsi, %rdi
-;   movq    rsp(128 + virtual offset), %rdx
-;   movq    %rdi, rsp(16 + virtual offset)
-;   movq    0(%rdx), %r8
-;   movq    rsp(8 + virtual offset), %rdx
-;   movq    0(%rdx), %r9
-;   movq    rsp(120 + virtual offset), %rdx
-;   movq    %r9, rsp(8 + virtual offset)
-;   movq    0(%rdx), %r10
-;   movq    rsp(112 + virtual offset), %rdx
-;   movq    0(%rdx), %r9
-;   movq    rsp(104 + virtual offset), %rdx
-;   movq    0(%rdx), %rsi
-;   movq    rsp(96 + virtual offset), %rdx
-;   movq    0(%rdx), %rax
-;   movq    rsp(88 + virtual offset), %rdx
-;   movq    0(%rdx), %rcx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    0(%rdx), %r15
-;   movq    rsp(72 + virtual offset), %rdx
-;   movq    0(%rdx), %r13
-;   movq    rsp(64 + virtual offset), %rdx
-;   movq    0(%rdx), %rbx
-;   movq    rsp(56 + virtual offset), %rdx
-;   movq    0(%rdx), %r14
-;   movq    rsp(48 + virtual offset), %rdx
-;   movq    0(%rdx), %r12
-;   movq    rsp(40 + virtual offset), %rdx
-;   movq    0(%rdx), %rdx
-;   movq    rsp(32 + virtual offset), %rdi
-;   movq    0(%rdi), %r11
+;   movq    rsp(16 + virtual offset), %r8
+;   movq    0(%r8), %r9
+;   movq    rsp(8 + virtual offset), %r8
+;   movq    %r9, rsp(16 + virtual offset)
+;   movq    0(%r8), %r10
+;   movq    rsp(120 + virtual offset), %r8
+;   movq    %r10, rsp(8 + virtual offset)
+;   movq    0(%r8), %r11
+;   movq    rsp(112 + virtual offset), %r8
+;   movq    0(%r8), %r10
+;   movq    rsp(104 + virtual offset), %r8
+;   movq    0(%r8), %rax
+;   movq    rsp(96 + virtual offset), %r8
+;   movq    0(%r8), %rcx
+;   movq    rsp(88 + virtual offset), %r8
+;   movq    0(%r8), %rdx
+;   movq    rsp(80 + virtual offset), %r8
+;   movq    0(%r8), %rbx
+;   movq    rsp(72 + virtual offset), %r8
+;   movq    0(%r8), %r14
+;   movq    rsp(64 + virtual offset), %r8
+;   movq    0(%r8), %r12
+;   movq    rsp(56 + virtual offset), %r8
+;   movq    0(%r8), %r15
+;   movq    rsp(48 + virtual offset), %r8
+;   movq    0(%r8), %r13
+;   movq    rsp(40 + virtual offset), %r8
+;   movq    0(%r8), %r8
+;   movq    rsp(32 + virtual offset), %r9
+;   movq    0(%r9), %rsi
+;   movq    %rdi, %r9
 ;   movq    rsp(16 + virtual offset), %rdi
-;   lea     0(%rdi,%r8,1), %r8
-;   movq    rsp(8 + virtual offset), %rdi
-;   lea     0(%rdi,%r10,1), %r10
-;   lea     0(%r8,%r10,1), %r8
-;   lea     0(%r9,%rsi,1), %r9
-;   lea     0(%rax,%rcx,1), %r10
-;   lea     0(%r15,%r13,1), %rsi
-;   lea     0(%r10,%rsi,1), %r10
-;   lea     0(%rbx,%r14,1), %rsi
-;   lea     0(%r10,%rsi,1), %r10
-;   lea     0(%r12,%rdx,1), %rdx
-;   lea     0(%r10,%rdx,1), %rdx
-;   lea     0(%r9,%rdx,1), %rdx
-;   lea     0(%r8,%rdx,1), %rdx
-;   movq    rsp(24 + virtual offset), %r8
-;   addq (%r8), %r11
+;   lea     0(%r9,%rdi,1), %rdi
+;   movq    rsp(8 + virtual offset), %r9
+;   lea     0(%r9,%r11,1), %r9
+;   lea     0(%rdi,%r9,1), %r9
+;   lea     0(%r10,%rax,1), %r10
+;   lea     0(%rcx,%rdx,1), %r11
+;   lea     0(%rbx,%r14,1), %rdi
+;   lea     0(%r11,%rdi,1), %r11
+;   lea     0(%r12,%r15,1), %rdi
+;   lea     0(%r11,%rdi,1), %r11
+;   lea     0(%r13,%r8,1), %r8
+;   lea     0(%r11,%r8,1), %r8
+;   lea     0(%r10,%r8,1), %r8
+;   lea     0(%r9,%r8,1), %r8
+;   movq    rsp(24 + virtual offset), %r9
+;   addq (%r9), %rsi
 ;   movq    rsp(0 + virtual offset), %rdi
-;   lea     0(%r11,%rdi,1), %r8
-;   lea     0(%rdx,%r8,1), %rax
-;   movq    144(%rsp), %rbx
-;   movq    152(%rsp), %r12
-;   movq    160(%rsp), %r13
-;   movq    168(%rsp), %r14
-;   movq    176(%rsp), %r15
-;   addq    %rsp, $192, %rsp
+;   lea     0(%rsi,%rdi,1), %r9
+;   lea     0(%r8,%r9,1), %rax
+;   movq    128(%rsp), %rbx
+;   movq    136(%rsp), %r12
+;   movq    144(%rsp), %r13
+;   movq    152(%rsp), %r14
+;   movq    160(%rsp), %r15
+;   addq    %rsp, $176, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -247,44 +249,44 @@ block0(v0: i64, v1: i64):
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0xc0, %rsp
-;   movq %rbx, 0x90(%rsp)
-;   movq %r12, 0x98(%rsp)
-;   movq %r13, 0xa0(%rsp)
-;   movq %r14, 0xa8(%rsp)
-;   movq %r15, 0xb0(%rsp)
+;   subq $0xb0, %rsp
+;   movq %rbx, 0x80(%rsp)
+;   movq %r12, 0x88(%rsp)
+;   movq %r13, 0x90(%rsp)
+;   movq %r14, 0x98(%rsp)
+;   movq %r15, 0xa0(%rsp)
 ; block1: ; offset 0x33
-;   movq (%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x80(%rsp)
-;   movq 8(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 8(%rsp)
-;   movq 0x10(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x78(%rsp)
-;   movq 0x18(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x70(%rsp)
-;   movq 0x20(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x68(%rsp)
-;   movq 0x28(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x60(%rsp)
-;   movq 0x30(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x58(%rsp)
-;   movq 0x38(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x50(%rsp)
-;   movq 0x40(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x48(%rsp)
-;   movq 0x48(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x40(%rsp)
-;   movq 0x50(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x38(%rsp)
-;   movq 0x58(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x30(%rsp)
-;   movq 0x60(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x28(%rsp)
-;   movq 0x68(%rdi), %rdx ; trap: heap_oob
-;   movq %rdx, 0x20(%rsp)
-;   movq 0x70(%rdi), %rdx ; trap: heap_oob
+;   movq (%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x10(%rsp)
+;   movq 8(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 8(%rsp)
+;   movq 0x10(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x78(%rsp)
+;   movq 0x18(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x70(%rsp)
+;   movq 0x20(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x68(%rsp)
+;   movq 0x28(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x60(%rsp)
+;   movq 0x30(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x58(%rsp)
+;   movq 0x38(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x50(%rsp)
+;   movq 0x40(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x48(%rsp)
+;   movq 0x48(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x40(%rsp)
+;   movq 0x50(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x38(%rsp)
+;   movq 0x58(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x30(%rsp)
+;   movq 0x60(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x28(%rsp)
+;   movq 0x68(%rdi), %r8 ; trap: heap_oob
+;   movq %r8, 0x20(%rsp)
+;   movq 0x70(%rdi), %r8 ; trap: heap_oob
 ;   movq %rdi, (%rsp)
-;   movq %rdx, 0x18(%rsp)
+;   movq %r8, 0x18(%rsp)
 ;   xorq %rdi, %rdi
 ;   movq (%rsi), %rax
 ;   movq %rsp, (%rsi)
@@ -296,62 +298,63 @@ block0(v0: i64, v1: i64):
 ;   leaq 6(%rip), %rcx
 ;   movq %rcx, 0x10(%rsi)
 ;   jmpq *%rax
-;   movq 0x80(%rsp), %rdx
-;   movq %rdi, 0x10(%rsp)
-;   movq (%rdx), %r8 ; trap: heap_oob
-;   movq 8(%rsp), %rdx
-;   movq (%rdx), %r9 ; trap: heap_oob
-;   movq 0x78(%rsp), %rdx
-;   movq %r9, 8(%rsp)
-;   movq (%rdx), %r10 ; trap: heap_oob
-;   movq 0x70(%rsp), %rdx
-;   movq (%rdx), %r9 ; trap: heap_oob
-;   movq 0x68(%rsp), %rdx
-;   movq (%rdx), %rsi ; trap: heap_oob
-;   movq 0x60(%rsp), %rdx
-;   movq (%rdx), %rax ; trap: heap_oob
-;   movq 0x58(%rsp), %rdx
-;   movq (%rdx), %rcx ; trap: heap_oob
-;   movq 0x50(%rsp), %rdx
-;   movq (%rdx), %r15 ; trap: heap_oob
-;   movq 0x48(%rsp), %rdx
-;   movq (%rdx), %r13 ; trap: heap_oob
-;   movq 0x40(%rsp), %rdx
-;   movq (%rdx), %rbx ; trap: heap_oob
-;   movq 0x38(%rsp), %rdx
-;   movq (%rdx), %r14 ; trap: heap_oob
-;   movq 0x30(%rsp), %rdx
-;   movq (%rdx), %r12 ; trap: heap_oob
-;   movq 0x28(%rsp), %rdx
-;   movq (%rdx), %rdx ; trap: heap_oob
-;   movq 0x20(%rsp), %rdi
-;   movq (%rdi), %r11 ; trap: heap_oob
+;   movq 0x10(%rsp), %r8
+;   movq (%r8), %r9 ; trap: heap_oob
+;   movq 8(%rsp), %r8
+;   movq %r9, 0x10(%rsp)
+;   movq (%r8), %r10 ; trap: heap_oob
+;   movq 0x78(%rsp), %r8
+;   movq %r10, 8(%rsp)
+;   movq (%r8), %r11 ; trap: heap_oob
+;   movq 0x70(%rsp), %r8
+;   movq (%r8), %r10 ; trap: heap_oob
+;   movq 0x68(%rsp), %r8
+;   movq (%r8), %rax ; trap: heap_oob
+;   movq 0x60(%rsp), %r8
+;   movq (%r8), %rcx ; trap: heap_oob
+;   movq 0x58(%rsp), %r8
+;   movq (%r8), %rdx ; trap: heap_oob
+;   movq 0x50(%rsp), %r8
+;   movq (%r8), %rbx ; trap: heap_oob
+;   movq 0x48(%rsp), %r8
+;   movq (%r8), %r14 ; trap: heap_oob
+;   movq 0x40(%rsp), %r8
+;   movq (%r8), %r12 ; trap: heap_oob
+;   movq 0x38(%rsp), %r8
+;   movq (%r8), %r15 ; trap: heap_oob
+;   movq 0x30(%rsp), %r8
+;   movq (%r8), %r13 ; trap: heap_oob
+;   movq 0x28(%rsp), %r8
+;   movq (%r8), %r8 ; trap: heap_oob
+;   movq 0x20(%rsp), %r9
+;   movq (%r9), %rsi ; trap: heap_oob
+;   movq %rdi, %r9
 ;   movq 0x10(%rsp), %rdi
-;   addq %rdi, %r8
-;   movq 8(%rsp), %rdi
-;   addq %rdi, %r10
+;   addq %r9, %rdi
+;   movq 8(%rsp), %r9
+;   addq %r11, %r9
+;   addq %rdi, %r9
+;   addq %rax, %r10
+;   leaq (%rcx, %rdx), %r11
+;   leaq (%rbx, %r14), %rdi
+;   addq %rdi, %r11
+;   leaq (%r12, %r15), %rdi
+;   addq %rdi, %r11
+;   addq %r13, %r8
+;   addq %r11, %r8
 ;   addq %r10, %r8
-;   addq %rsi, %r9
-;   leaq (%rax, %rcx), %r10
-;   leaq (%r15, %r13), %rsi
-;   addq %rsi, %r10
-;   leaq (%rbx, %r14), %rsi
-;   addq %rsi, %r10
-;   addq %r12, %rdx
-;   addq %r10, %rdx
-;   addq %r9, %rdx
-;   addq %r8, %rdx
-;   movq 0x18(%rsp), %r8
-;   addq (%r8), %r11 ; trap: heap_oob
+;   addq %r9, %r8
+;   movq 0x18(%rsp), %r9
+;   addq (%r9), %rsi ; trap: heap_oob
 ;   movq (%rsp), %rdi
-;   leaq (%r11, %rdi), %r8
-;   leaq (%rdx, %r8), %rax
-;   movq 0x90(%rsp), %rbx
-;   movq 0x98(%rsp), %r12
-;   movq 0xa0(%rsp), %r13
-;   movq 0xa8(%rsp), %r14
-;   movq 0xb0(%rsp), %r15
-;   addq $0xc0, %rsp
+;   leaq (%rsi, %rdi), %r9
+;   leaq (%r8, %r9), %rax
+;   movq 0x80(%rsp), %rbx
+;   movq 0x88(%rsp), %r12
+;   movq 0x90(%rsp), %r13
+;   movq 0x98(%rsp), %r14
+;   movq 0xa0(%rsp), %r15
+;   addq $0xb0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -419,73 +422,74 @@ block0(v0: i64, v1: i64):
 ;   movq    %r14, 280(%rsp)
 ;   movq    %r15, 288(%rsp)
 ; block0:
-;   movsd   0(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(240 + virtual offset)
-;   movsd   8(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(224 + virtual offset)
-;   movsd   16(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(208 + virtual offset)
-;   movsd   24(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(192 + virtual offset)
-;   movsd   32(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(176 + virtual offset)
-;   movsd   40(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(160 + virtual offset)
-;   movsd   48(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(144 + virtual offset)
-;   movsd   56(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(128 + virtual offset)
-;   movsd   64(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(112 + virtual offset)
-;   movsd   72(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(96 + virtual offset)
-;   movsd   80(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(80 + virtual offset)
-;   movsd   88(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(64 + virtual offset)
-;   movsd   96(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(48 + virtual offset)
-;   movsd   104(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(32 + virtual offset)
-;   movsd   112(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(16 + virtual offset)
-;   movsd   120(%rdi), %xmm7
-;   movdqu  %xmm7, rsp(0 + virtual offset)
-;   xorq    %rdi, %rdi, %rdi
+;   movsd   0(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(240 + virtual offset)
+;   movsd   8(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(224 + virtual offset)
+;   movsd   16(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(208 + virtual offset)
+;   movsd   24(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(192 + virtual offset)
+;   movsd   32(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(176 + virtual offset)
+;   movsd   40(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(160 + virtual offset)
+;   movsd   48(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(144 + virtual offset)
+;   movsd   56(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(128 + virtual offset)
+;   movsd   64(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(112 + virtual offset)
+;   movsd   72(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(96 + virtual offset)
+;   movsd   80(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(80 + virtual offset)
+;   movsd   88(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(64 + virtual offset)
+;   movsd   96(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(48 + virtual offset)
+;   movsd   104(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(32 + virtual offset)
+;   movsd   112(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(16 + virtual offset)
+;   movsd   120(%rdi), %xmm0
+;   movdqu  %xmm0, rsp(0 + virtual offset)
+;   uninit  %rdi
+;   xorq %rdi, %rdi
 ;   %rdi = stack_switch_basic %rsi, %rsi, %rdi
-;   u64_to_f64_seq %rdi, %xmm0, %rax, %rcx
-;   movdqu  rsp(240 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(224 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(208 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(192 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(176 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(160 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
+;   u64_to_f64_seq %rdi, %xmm0, %rcx, %rdx
+;   movdqu  rsp(240 + virtual offset), %xmm5
+;   addsd   %xmm0, %xmm5, %xmm0
+;   movdqu  rsp(224 + virtual offset), %xmm1
+;   addsd   %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(208 + virtual offset), %xmm3
+;   addsd   %xmm0, %xmm3, %xmm0
+;   movdqu  rsp(192 + virtual offset), %xmm6
+;   addsd   %xmm0, %xmm6, %xmm0
+;   movdqu  rsp(176 + virtual offset), %xmm1
+;   addsd   %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(160 + virtual offset), %xmm4
+;   addsd   %xmm0, %xmm4, %xmm0
 ;   movdqu  rsp(144 + virtual offset), %xmm7
 ;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(128 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(112 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(96 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(80 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(64 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(48 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(32 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(128 + virtual offset), %xmm2
+;   addsd   %xmm0, %xmm2, %xmm0
+;   movdqu  rsp(112 + virtual offset), %xmm5
+;   addsd   %xmm0, %xmm5, %xmm0
+;   movdqu  rsp(96 + virtual offset), %xmm1
+;   addsd   %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(80 + virtual offset), %xmm3
+;   addsd   %xmm0, %xmm3, %xmm0
+;   movdqu  rsp(64 + virtual offset), %xmm6
+;   addsd   %xmm0, %xmm6, %xmm0
+;   movdqu  rsp(48 + virtual offset), %xmm1
+;   addsd   %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(32 + virtual offset), %xmm4
+;   addsd   %xmm0, %xmm4, %xmm0
 ;   movdqu  rsp(16 + virtual offset), %xmm7
 ;   addsd   %xmm0, %xmm7, %xmm0
-;   movdqu  rsp(0 + virtual offset), %xmm7
-;   addsd   %xmm0, %xmm7, %xmm0
+;   movdqu  rsp(0 + virtual offset), %xmm2
+;   addsd   %xmm0, %xmm2, %xmm0
 ;   movq    256(%rsp), %rbx
 ;   movq    264(%rsp), %r12
 ;   movq    272(%rsp), %r13
@@ -507,38 +511,38 @@ block0(v0: i64, v1: i64):
 ;   movq %r14, 0x118(%rsp)
 ;   movq %r15, 0x120(%rsp)
 ; block1: ; offset 0x33
-;   movsd (%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xf0(%rsp)
-;   movsd 8(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xe0(%rsp)
-;   movsd 0x10(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xd0(%rsp)
-;   movsd 0x18(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xc0(%rsp)
-;   movsd 0x20(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xb0(%rsp)
-;   movsd 0x28(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0xa0(%rsp)
-;   movsd 0x30(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x90(%rsp)
-;   movsd 0x38(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x80(%rsp)
-;   movsd 0x40(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x70(%rsp)
-;   movsd 0x48(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x60(%rsp)
-;   movsd 0x50(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x50(%rsp)
-;   movsd 0x58(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x40(%rsp)
-;   movsd 0x60(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x30(%rsp)
-;   movsd 0x68(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x20(%rsp)
-;   movsd 0x70(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, 0x10(%rsp)
-;   movsd 0x78(%rdi), %xmm7 ; trap: heap_oob
-;   movdqu %xmm7, (%rsp)
+;   movsd (%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xf0(%rsp)
+;   movsd 8(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xe0(%rsp)
+;   movsd 0x10(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xd0(%rsp)
+;   movsd 0x18(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xc0(%rsp)
+;   movsd 0x20(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xb0(%rsp)
+;   movsd 0x28(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0xa0(%rsp)
+;   movsd 0x30(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x90(%rsp)
+;   movsd 0x38(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x80(%rsp)
+;   movsd 0x40(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x70(%rsp)
+;   movsd 0x48(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x60(%rsp)
+;   movsd 0x50(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x50(%rsp)
+;   movsd 0x58(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x40(%rsp)
+;   movsd 0x60(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x30(%rsp)
+;   movsd 0x68(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x20(%rsp)
+;   movsd 0x70(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, 0x10(%rsp)
+;   movsd 0x78(%rdi), %xmm0 ; trap: heap_oob
+;   movdqu %xmm0, (%rsp)
 ;   xorq %rdi, %rdi
 ;   movq (%rsi), %rax
 ;   movq %rsp, (%rsi)
@@ -554,45 +558,45 @@ block0(v0: i64, v1: i64):
 ;   jl 0x135
 ;   cvtsi2sdq %rdi, %xmm0
 ;   jmp 0x14f
-;   movq %rdi, %rax
-;   shrq $1, %rax
 ;   movq %rdi, %rcx
-;   andq $1, %rcx
-;   orq %rax, %rcx
-;   cvtsi2sdq %rcx, %xmm0
+;   shrq $1, %rcx
+;   movq %rdi, %rdx
+;   andq $1, %rdx
+;   orq %rcx, %rdx
+;   cvtsi2sdq %rdx, %xmm0
 ;   addsd %xmm0, %xmm0
-;   movdqu 0xf0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0xe0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0xd0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0xc0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0xb0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0xa0(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
+;   movdqu 0xf0(%rsp), %xmm5
+;   addsd %xmm5, %xmm0
+;   movdqu 0xe0(%rsp), %xmm1
+;   addsd %xmm1, %xmm0
+;   movdqu 0xd0(%rsp), %xmm3
+;   addsd %xmm3, %xmm0
+;   movdqu 0xc0(%rsp), %xmm6
+;   addsd %xmm6, %xmm0
+;   movdqu 0xb0(%rsp), %xmm1
+;   addsd %xmm1, %xmm0
+;   movdqu 0xa0(%rsp), %xmm4
+;   addsd %xmm4, %xmm0
 ;   movdqu 0x90(%rsp), %xmm7
 ;   addsd %xmm7, %xmm0
-;   movdqu 0x80(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x70(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x60(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x50(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x40(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x30(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
-;   movdqu 0x20(%rsp), %xmm7
-;   addsd %xmm7, %xmm0
+;   movdqu 0x80(%rsp), %xmm2
+;   addsd %xmm2, %xmm0
+;   movdqu 0x70(%rsp), %xmm5
+;   addsd %xmm5, %xmm0
+;   movdqu 0x60(%rsp), %xmm1
+;   addsd %xmm1, %xmm0
+;   movdqu 0x50(%rsp), %xmm3
+;   addsd %xmm3, %xmm0
+;   movdqu 0x40(%rsp), %xmm6
+;   addsd %xmm6, %xmm0
+;   movdqu 0x30(%rsp), %xmm1
+;   addsd %xmm1, %xmm0
+;   movdqu 0x20(%rsp), %xmm4
+;   addsd %xmm4, %xmm0
 ;   movdqu 0x10(%rsp), %xmm7
 ;   addsd %xmm7, %xmm0
-;   movdqu (%rsp), %xmm7
-;   addsd %xmm7, %xmm0
+;   movdqu (%rsp), %xmm2
+;   addsd %xmm2, %xmm0
 ;   movq 0x100(%rsp), %rbx
 ;   movq 0x108(%rsp), %r12
 ;   movq 0x110(%rsp), %r13

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -38,7 +38,8 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %ax, %dx, %si, %ax, %dx ; trap=int_divz
 ;   movq    %rbp, %rsp
@@ -67,7 +68,8 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %eax, %edx, %esi, %eax, %edx ; trap=int_divz
 ;   movq    %rbp, %rsp
@@ -96,7 +98,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %rax, %rdx, %rsi, %rax, %rdx ; trap=int_divz
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/udivrem.clif
+++ b/cranelift/filetests/filetests/isa/x64/udivrem.clif
@@ -54,14 +54,16 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %ax, %dx, %si, %ax, %dx ; trap=int_divz
-;   movq    %rax, %rcx
-;   xorq    %rdx, %rdx, %rdx
+;   movq    %rax, %r8
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %ax, %dx, %si, %ax, %dx ; trap=int_divz
-;   movq    %rcx, %rax
+;   movq    %r8, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -74,11 +76,11 @@ block0(v0: i16, v1: i16):
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divw %si ; trap: int_divz
-;   movq %rax, %rcx
+;   movq %rax, %r8
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divw %si ; trap: int_divz
-;   movq %rcx, %rax
+;   movq %r8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -94,14 +96,16 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %eax, %edx, %esi, %eax, %edx ; trap=int_divz
-;   movq    %rax, %rcx
-;   xorq    %rdx, %rdx, %rdx
+;   movq    %rax, %r8
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %eax, %edx, %esi, %eax, %edx ; trap=int_divz
-;   movq    %rcx, %rax
+;   movq    %r8, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -114,11 +118,11 @@ block0(v0: i32, v1: i32):
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divl %esi ; trap: int_divz
-;   movq %rax, %rcx
+;   movq %rax, %r8
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divl %esi ; trap: int_divz
-;   movq %rcx, %rax
+;   movq %r8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -134,14 +138,16 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %rax, %rdx, %rsi, %rax, %rdx ; trap=int_divz
-;   movq    %rax, %rcx
-;   xorq    %rdx, %rdx, %rdx
+;   movq    %rax, %r8
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %rax, %rdx, %rsi, %rax, %rdx ; trap=int_divz
-;   movq    %rcx, %rax
+;   movq    %r8, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -154,11 +160,11 @@ block0(v0: i64, v1: i64):
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divq %rsi ; trap: int_divz
-;   movq %rax, %rcx
+;   movq %rax, %r8
 ;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   divq %rsi ; trap: int_divz
-;   movq %rcx, %rax
+;   movq %r8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -40,7 +40,8 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %ax, %dx, %si, %ax, %dx ; trap=int_divz
 ;   movq    %rdx, %rax
@@ -71,7 +72,8 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %eax, %edx, %esi, %eax, %edx ; trap=int_divz
 ;   movq    %rdx, %rax
@@ -102,7 +104,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq    %rdi, %rax
 ;   div     %rax, %rdx, %rsi, %rax, %rdx ; trap=int_divz
 ;   movq    %rdx, %rax

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -40,31 +40,33 @@ block0:
 ;   movq    %r14, 24(%rsp)
 ;   movq    %r15, 32(%rsp)
 ; block0:
-;   xorl    %ebx, %ebx, %ebx
-;   movl    $1, %r14d
-;   movl    $2, %r15d
-;   lea     rsp(0 + virtual offset), %r11
-;   movl    $0, 0(%r11)
-;   lea     rsp(4 + virtual offset), %rsi
-;   movl    $1, 0(%rsi)
-;   lea     rsp(8 + virtual offset), %rdi
-;   movl    $2, 0(%rdi)
-;   movq    %rbx, %rdi
-;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
-;   lea     rsp(0 + virtual offset), %rcx
-;   movl    $1, 0(%rcx)
-;   lea     rsp(4 + virtual offset), %rdx
-;   movl    $2, 0(%rdx)
-;   movq    %rbx, %rdi
-;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
-;   lea     rsp(0 + virtual offset), %r9
-;   movl    $2, 0(%r9)
+;   uninit  %rdi
+;   xorl %edi, %edi
+;   movq    %rdi, %r14
+;   movl    $1, %r15d
+;   movl    $2, %ebx
+;   lea     rsp(0 + virtual offset), %rsi
+;   movl    $0, 0(%rsi)
+;   lea     rsp(4 + virtual offset), %rdi
+;   movl    $1, 0(%rdi)
+;   lea     rsp(8 + virtual offset), %rax
+;   movl    $2, 0(%rax)
 ;   movq    %r14, %rdi
 ;   call    User(userextname0)
-;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
+;   lea     rsp(0 + virtual offset), %rdx
+;   movl    $1, 0(%rdx)
+;   lea     rsp(4 + virtual offset), %r8
+;   movl    $2, 0(%r8)
+;   movq    %r14, %rdi
+;   call    User(userextname0)
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
+;   lea     rsp(0 + virtual offset), %r10
+;   movl    $2, 0(%r10)
 ;   movq    %r15, %rdi
+;   call    User(userextname0)
+;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
+;   movq    %rbx, %rdi
 ;   call    User(userextname0)
 ;   movq    16(%rsp), %rbx
 ;   movq    24(%rsp), %r14
@@ -83,29 +85,30 @@ block0:
 ;   movq %r14, 0x18(%rsp)
 ;   movq %r15, 0x20(%rsp)
 ; block1: ; offset 0x17
-;   xorl %ebx, %ebx
-;   movl $1, %r14d
-;   movl $2, %r15d
-;   leaq (%rsp), %r11
-;   movl $0, (%r11)
-;   leaq 4(%rsp), %rsi
-;   movl $1, (%rsi)
-;   leaq 8(%rsp), %rdi
-;   movl $2, (%rdi)
-;   movq %rbx, %rdi
-;   callq 0x4e ; reloc_external CallPCRel4 u0:0 -4
-;   leaq (%rsp), %rcx
-;   movl $1, (%rcx)
-;   leaq 4(%rsp), %rdx
-;   movl $2, (%rdx)
-;   movq %rbx, %rdi
-;   callq 0x6b ; reloc_external CallPCRel4 u0:0 -4
-;   leaq (%rsp), %r9
-;   movl $2, (%r9)
+;   xorl %edi, %edi
+;   movq %rdi, %r14
+;   movl $1, %r15d
+;   movl $2, %ebx
+;   leaq (%rsp), %rsi
+;   movl $0, (%rsi)
+;   leaq 4(%rsp), %rdi
+;   movl $1, (%rdi)
+;   leaq 8(%rsp), %rax
+;   movl $2, (%rax)
 ;   movq %r14, %rdi
-;   callq 0x7e ; reloc_external CallPCRel4 u0:0 -4
+;   callq 0x4f ; reloc_external CallPCRel4 u0:0 -4
+;   leaq (%rsp), %rdx
+;   movl $1, (%rdx)
+;   leaq 4(%rsp), %r8
+;   movl $2, (%r8)
+;   movq %r14, %rdi
+;   callq 0x6d ; reloc_external CallPCRel4 u0:0 -4
+;   leaq (%rsp), %r10
+;   movl $2, (%r10)
 ;   movq %r15, %rdi
-;   callq 0x86 ; reloc_external CallPCRel4 u0:0 -4
+;   callq 0x80 ; reloc_external CallPCRel4 u0:0 -4
+;   movq %rbx, %rdi
+;   callq 0x88 ; reloc_external CallPCRel4 u0:0 -4
 ;   movq 0x10(%rsp), %rbx
 ;   movq 0x18(%rsp), %r14
 ;   movq 0x20(%rsp), %r15

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -20,12 +20,13 @@ block0(v0: i128, v1: i8):
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   shrq    %cl, %r10, %r10
-;   movq    %rcx, %r9
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r9, %rax
+;   movq    %r11, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
@@ -46,9 +47,9 @@ block0(v0: i128, v1: i8):
 ;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   shrq %cl, %r10
-;   movq %rcx, %r9
+;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r9, %rax
+;   movq %r11, %rax
 ;   subq %rax, %rcx
 ;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
@@ -83,7 +84,8 @@ block0(v0: i128, v1: i64):
 ;   movq    %r10, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
@@ -142,7 +144,8 @@ block0(v0: i128, v1: i32):
 ;   movq    %r10, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
@@ -201,7 +204,8 @@ block0(v0: i128, v1: i16):
 ;   movq    %r10, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
@@ -260,7 +264,8 @@ block0(v0: i128, v1: i8):
 ;   movq    %r10, %rax
 ;   subq %rax, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rdx, %rdx, %rdx
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   testq   $127, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi

--- a/tests/disas/epoch-interruption-x86.wat
+++ b/tests/disas/epoch-interruption-x86.wat
@@ -28,12 +28,12 @@
 ;;       jae     0x64
 ;;       jmp     0x46
 ;;   57: movq    %r15, %rdi
-;;       callq   0xf5
+;;       callq   0xf6
 ;;       jmp     0x46
 ;;   64: movq    8(%r13), %rax
 ;;       cmpq    %rax, %r11
 ;;       jb      0x46
 ;;   71: movq    %r15, %rdi
-;;       callq   0xf5
+;;       callq   0xf6
 ;;       jmp     0x46
 ;;   7e: ud2

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -18,51 +18,51 @@
 ;;       movq    0x10(%r10), %r10
 ;;       addq    $0x50, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0xcf
+;;       ja      0xcc
 ;;   19: subq    $0x40, %rsp
-;;       movq    %r12, 0x20(%rsp)
-;;       movq    %r13, 0x28(%rsp)
-;;       movq    %r14, 0x30(%rsp)
-;;       movq    %rdx, %r14
+;;       movq    %r13, 0x20(%rsp)
+;;       movq    %r14, 0x28(%rsp)
+;;       movq    %r15, 0x30(%rsp)
+;;       movq    %rdx, %r13
 ;;       movdqu  %xmm0, 8(%rsp)
-;;       leaq    (%rsp), %r13
-;;       movl    %ecx, (%r13)
+;;       leaq    (%rsp), %r15
+;;       movl    %ecx, (%r15)
 ;;       movl    $0xb0000000, %esi
 ;;       xorl    %edx, %edx
 ;;       movl    $0x20, %ecx
 ;;       movl    $8, %r8d
-;;       movq    %rdi, %r12
-;;       callq   0x168
-;;       movq    8(%r12), %r8
+;;       movq    %rdi, %r14
+;;       callq   0x165
+;;       movq    8(%r14), %r9
 ;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[0]
-;;       movq    0x18(%r8), %r8
-;;       movq    %rax, %r9
-;;       movl    %r9d, %r10d
+;;       movq    0x18(%r9), %r9
+;;       movq    %rax, %r11
+;;       movl    %r11d, %r10d
 ;;       movdqu  8(%rsp), %xmm0
-;;       movss   %xmm0, 0x10(%r8, %r10)
-;;       movq    %r14, %rdx
-;;       movb    %dl, 0x14(%r8, %r10)
-;;       movl    (%r13), %r11d
-;;       movq    %r11, %rdx
-;;       andl    $1, %edx
-;;       testl   %r11d, %r11d
-;;       sete    %sil
-;;       movzbl  %sil, %esi
-;;       orl     %esi, %edx
-;;       testl   %edx, %edx
-;;       jne     0xab
-;;   9a: movl    %r11d, %ecx
-;;       leaq    (%r8, %rcx), %rax
-;;       movl    $1, %eax
-;;       addq    %rax, 8(%r8, %rcx)
-;;       movl    (%r13), %edx
-;;       movl    %edx, 0x18(%r8, %r10)
-;;       movq    %r9, %rax
-;;       movq    0x20(%rsp), %r12
-;;       movq    0x28(%rsp), %r13
-;;       movq    0x30(%rsp), %r14
+;;       movss   %xmm0, 0x10(%r9, %r10)
+;;       movq    %r13, %rdx
+;;       movb    %dl, 0x14(%r9, %r10)
+;;       movl    (%r15), %esi
+;;       movq    %rsi, %r8
+;;       andl    $1, %r8d
+;;       testl   %esi, %esi
+;;       sete    %dil
+;;       movzbl  %dil, %edi
+;;       orl     %edi, %r8d
+;;       testl   %r8d, %r8d
+;;       jne     0xa9
+;;   99: movl    %esi, %ecx
+;;       leaq    (%r9, %rcx), %rdx
+;;       movl    $1, %edx
+;;       addq    %rdx, 8(%r9, %rcx)
+;;       movl    (%r15), %r8d
+;;       movl    %r8d, 0x18(%r9, %r10)
+;;       movq    %r11, %rax
+;;       movq    0x20(%rsp), %r13
+;;       movq    0x28(%rsp), %r14
+;;       movq    0x30(%rsp), %r15
 ;;       addq    $0x40, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   cf: ud2
+;;   cc: ud2

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movl    %edx, %esi
-;;       subq    $4, %r10
-;;       xorq    %rax, %rax
-;;       movq    %rsi, %r11
-;;       addq    0x40(%rdi), %r11
-;;       cmpq    %r10, %rsi
-;;       cmovaq  %rax, %r11
-;;       movl    %ecx, (%r11)
+;;       movq    0x48(%rdi), %r11
+;;       movl    %edx, %eax
+;;       subq    $4, %r11
+;;       xorq    %rdx, %rdx
+;;       movq    %rax, %rsi
+;;       addq    0x40(%rdi), %rsi
+;;       cmpq    %r11, %rax
+;;       cmovaq  %rdx, %rsi
+;;       movl    %ecx, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -37,15 +37,15 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movl    %edx, %esi
-;;       subq    $4, %r10
-;;       xorq    %rax, %rax
-;;       movq    %rsi, %r11
-;;       addq    0x40(%rdi), %r11
-;;       cmpq    %r10, %rsi
-;;       cmovaq  %rax, %r11
-;;       movl    (%r11), %eax
+;;       movq    0x48(%rdi), %r11
+;;       movl    %edx, %eax
+;;       subq    $4, %r11
+;;       xorq    %rcx, %rcx
+;;       movq    %rax, %rsi
+;;       addq    0x40(%rdi), %rsi
+;;       cmpq    %r11, %rax
+;;       cmovaq  %rcx, %rsi
+;;       movl    (%rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       movl    %edx, %eax
-;;       subq    $0x1004, %r10
-;;       xorq    %rdx, %rdx
-;;       leaq    0x1000(%rdi, %rax), %rsi
-;;       cmpq    %r10, %rax
-;;       cmovaq  %rdx, %rsi
-;;       movl    %ecx, (%rsi)
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       movl    %edx, %edx
+;;       subq    $0x1004, %r11
+;;       xorq    %r8, %r8
+;;       leaq    0x1000(%rax, %rdx), %rdi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %r8, %rdi
+;;       movl    %ecx, (%rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -37,15 +37,15 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       movl    %edx, %eax
-;;       subq    $0x1004, %r10
-;;       xorq    %rcx, %rcx
-;;       leaq    0x1000(%rdi, %rax), %rsi
-;;       cmpq    %r10, %rax
-;;       cmovaq  %rcx, %rsi
-;;       movl    (%rsi), %eax
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       movl    %edx, %ecx
+;;       subq    $0x1004, %r11
+;;       xorq    %rdx, %rdx
+;;       leaq    0x1000(%rax, %rcx), %rdi
+;;       cmpq    %r11, %rcx
+;;       cmovaq  %rdx, %rdi
+;;       movl    (%rdi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,17 +22,17 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r10d
-;;       movq    %r10, %rax
-;;       addq    0x2f(%rip), %rax
+;;       movq    %r10, %rdx
+;;       addq    0x2f(%rip), %rdx
 ;;       jb      0x3a
-;;   17: movq    0x48(%rdi), %r8
-;;       xorq    %rdx, %rdx
+;;   17: movq    0x48(%rdi), %r9
+;;       xorq    %r8, %r8
 ;;       addq    0x40(%rdi), %r10
-;;       movl    $0xffff0000, %r9d
-;;       addq    %r10, %r9
-;;       cmpq    %r8, %rax
-;;       cmovaq  %rdx, %r9
-;;       movl    %ecx, (%r9)
+;;       movl    $0xffff0000, %r11d
+;;       addq    %r11, %r10
+;;       cmpq    %r9, %rdx
+;;       cmovaq  %r8, %r10
+;;       movl    %ecx, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -45,17 +45,17 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r10d
-;;       movq    %r10, %rax
-;;       addq    0x2f(%rip), %rax
+;;       movq    %r10, %rcx
+;;       addq    0x2f(%rip), %rcx
 ;;       jb      0x9a
-;;   77: movq    0x48(%rdi), %rdx
-;;       xorq    %rcx, %rcx
+;;   77: movq    0x48(%rdi), %r8
+;;       xorq    %rdx, %rdx
 ;;       addq    0x40(%rdi), %r10
-;;       movl    $0xffff0000, %r8d
-;;       addq    %r10, %r8
-;;       cmpq    %rdx, %rax
-;;       cmovaq  %rcx, %r8
-;;       movl    (%r8), %eax
+;;       movl    $0xffff0000, %r9d
+;;       addq    %r10, %r9
+;;       cmpq    %r8, %rcx
+;;       cmovaq  %rdx, %r9
+;;       movl    (%r9), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaeq %rsi, %r10
-;;       movb    %cl, (%r10)
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %edx
+;;       xorq    %rax, %rax
+;;       movq    %rdx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %rax, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaeq %rsi, %r10
-;;       movzbq  (%r10), %rax
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %ecx
+;;       xorq    %rax, %rax
+;;       movq    %rcx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rcx
+;;       cmovaeq %rax, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,15 +21,15 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       movl    %edx, %eax
-;;       subq    $0x1001, %r10
-;;       xorq    %rdx, %rdx
-;;       leaq    0x1000(%rdi, %rax), %rsi
-;;       cmpq    %r10, %rax
-;;       cmovaq  %rdx, %rsi
-;;       movb    %cl, (%rsi)
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       movl    %edx, %edx
+;;       subq    $0x1001, %r11
+;;       xorq    %r8, %r8
+;;       leaq    0x1000(%rax, %rdx), %rdi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %r8, %rdi
+;;       movb    %cl, (%rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -37,15 +37,15 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       movl    %edx, %eax
-;;       subq    $0x1001, %r10
-;;       xorq    %rcx, %rcx
-;;       leaq    0x1000(%rdi, %rax), %rsi
-;;       cmpq    %r10, %rax
-;;       cmovaq  %rcx, %rsi
-;;       movzbq  (%rsi), %rax
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       movl    %edx, %ecx
+;;       subq    $0x1001, %r11
+;;       xorq    %rdx, %rdx
+;;       leaq    0x1000(%rax, %rcx), %rdi
+;;       cmpq    %r11, %rcx
+;;       cmovaq  %rdx, %rdi
+;;       movzbq  (%rdi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,17 +22,17 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r10d
-;;       movq    %r10, %rax
-;;       addq    0x2f(%rip), %rax
+;;       movq    %r10, %rdx
+;;       addq    0x2f(%rip), %rdx
 ;;       jb      0x3a
-;;   17: movq    0x48(%rdi), %r8
-;;       xorq    %rdx, %rdx
+;;   17: movq    0x48(%rdi), %r9
+;;       xorq    %r8, %r8
 ;;       addq    0x40(%rdi), %r10
-;;       movl    $0xffff0000, %r9d
-;;       addq    %r10, %r9
-;;       cmpq    %r8, %rax
-;;       cmovaq  %rdx, %r9
-;;       movb    %cl, (%r9)
+;;       movl    $0xffff0000, %r11d
+;;       addq    %r11, %r10
+;;       cmpq    %r9, %rdx
+;;       cmovaq  %r8, %r10
+;;       movb    %cl, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -45,17 +45,17 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    %edx, %r10d
-;;       movq    %r10, %rax
-;;       addq    0x2f(%rip), %rax
+;;       movq    %r10, %rcx
+;;       addq    0x2f(%rip), %rcx
 ;;       jb      0x9b
-;;   77: movq    0x48(%rdi), %rdx
-;;       xorq    %rcx, %rcx
+;;   77: movq    0x48(%rdi), %r8
+;;       xorq    %rdx, %rdx
 ;;       addq    0x40(%rdi), %r10
-;;       movl    $0xffff0000, %r8d
-;;       addq    %r10, %r8
-;;       cmpq    %rdx, %rax
-;;       cmovaq  %rcx, %r8
-;;       movzbq  (%r8), %rax
+;;       movl    $0xffff0000, %r9d
+;;       addq    %r10, %r9
+;;       cmpq    %r8, %rcx
+;;       cmovaq  %rdx, %r9
+;;       movzbq  (%r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaq  %rsi, %r10
-;;       movl    %ecx, (%r10)
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %edx
+;;       xorq    %rax, %rax
+;;       movq    %rdx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %rax, %r11
+;;       movl    %ecx, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaq  %rsi, %r10
-;;       movl    (%r10), %eax
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %ecx
+;;       xorq    %rax, %rax
+;;       movq    %rcx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rcx
+;;       cmovaq  %rax, %r11
+;;       movl    (%r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %rsi
-;;       movq    0x40(%rdi), %rax
-;;       movl    %edx, %edx
-;;       xorq    %rdi, %rdi
-;;       leaq    0x1000(%rax, %rdx), %r11
-;;       cmpq    %rsi, %rdx
-;;       cmovaq  %rdi, %r11
-;;       movl    %ecx, (%r11)
+;;       movq    0x48(%rdi), %r10
+;;       movq    0x40(%rdi), %r9
+;;       movl    %edx, %r8d
+;;       xorq    %rax, %rax
+;;       leaq    0x1000(%r9, %r8), %rsi
+;;       cmpq    %r10, %r8
+;;       cmovaq  %rax, %rsi
+;;       movl    %ecx, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %rsi
-;;       movq    0x40(%rdi), %rax
-;;       movl    %edx, %ecx
-;;       xorq    %rdi, %rdi
-;;       leaq    0x1000(%rax, %rcx), %r11
-;;       cmpq    %rsi, %rcx
-;;       cmovaq  %rdi, %r11
-;;       movl    (%r11), %eax
+;;       movq    0x48(%rdi), %r8
+;;       movq    0x40(%rdi), %rcx
+;;       movl    %edx, %edx
+;;       xorq    %rax, %rax
+;;       leaq    0x1000(%rcx, %rdx), %rsi
+;;       cmpq    %r8, %rdx
+;;       cmovaq  %rax, %rsi
+;;       movl    (%rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,16 +21,16 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r8
-;;       movl    %edx, %edx
-;;       xorq    %rax, %rax
-;;       movq    %rdx, %r9
+;;       movq    0x48(%rdi), %rax
+;;       movl    %edx, %r8d
+;;       xorq    %rdx, %rdx
+;;       movq    %r8, %r9
 ;;       addq    0x40(%rdi), %r9
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r9, %rdi), %rsi
-;;       cmpq    %r8, %rdx
-;;       cmovaq  %rax, %rsi
-;;       movl    %ecx, (%rsi)
+;;       movl    $0xffff0000, %r10d
+;;       leaq    (%r9, %r10), %rdi
+;;       cmpq    %rax, %r8
+;;       cmovaq  %rdx, %rdi
+;;       movl    %ecx, (%rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,16 +38,16 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r9
-;;       movl    %edx, %ecx
-;;       xorq    %rax, %rax
-;;       movq    %rcx, %r8
+;;       movq    0x48(%rdi), %rax
+;;       movl    %edx, %edx
+;;       xorq    %rcx, %rcx
+;;       movq    %rdx, %r8
 ;;       addq    0x40(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r8, %rdi), %rsi
-;;       cmpq    %r9, %rcx
-;;       cmovaq  %rax, %rsi
-;;       movl    (%rsi), %eax
+;;       movl    $0xffff0000, %r9d
+;;       leaq    (%r8, %r9), %rdi
+;;       cmpq    %rax, %rdx
+;;       cmovaq  %rcx, %rdi
+;;       movl    (%rdi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaeq %rsi, %r10
-;;       movb    %cl, (%r10)
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %edx
+;;       xorq    %rax, %rax
+;;       movq    %rdx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %rax, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movl    %edx, %eax
-;;       xorq    %rsi, %rsi
-;;       movq    %rax, %r10
-;;       addq    0x40(%rdi), %r10
-;;       cmpq    %r11, %rax
-;;       cmovaeq %rsi, %r10
-;;       movzbq  (%r10), %rax
+;;       movq    0x48(%rdi), %rsi
+;;       movl    %edx, %ecx
+;;       xorq    %rax, %rax
+;;       movq    %rcx, %r11
+;;       addq    0x40(%rdi), %r11
+;;       cmpq    %rsi, %rcx
+;;       cmovaeq %rax, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %rsi
-;;       movq    0x40(%rdi), %rax
-;;       movl    %edx, %edx
-;;       xorq    %rdi, %rdi
-;;       leaq    0x1000(%rax, %rdx), %r11
-;;       cmpq    %rsi, %rdx
-;;       cmovaq  %rdi, %r11
-;;       movb    %cl, (%r11)
+;;       movq    0x48(%rdi), %r10
+;;       movq    0x40(%rdi), %r9
+;;       movl    %edx, %r8d
+;;       xorq    %rax, %rax
+;;       leaq    0x1000(%r9, %r8), %rsi
+;;       cmpq    %r10, %r8
+;;       cmovaq  %rax, %rsi
+;;       movb    %cl, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %rsi
-;;       movq    0x40(%rdi), %rax
-;;       movl    %edx, %ecx
-;;       xorq    %rdi, %rdi
-;;       leaq    0x1000(%rax, %rcx), %r11
-;;       cmpq    %rsi, %rcx
-;;       cmovaq  %rdi, %r11
-;;       movzbq  (%r11), %rax
+;;       movq    0x48(%rdi), %r8
+;;       movq    0x40(%rdi), %rcx
+;;       movl    %edx, %edx
+;;       xorq    %rax, %rax
+;;       leaq    0x1000(%rcx, %rdx), %rsi
+;;       cmpq    %r8, %rdx
+;;       cmovaq  %rax, %rsi
+;;       movzbq  (%rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,16 +21,16 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r8
-;;       movl    %edx, %edx
-;;       xorq    %rax, %rax
-;;       movq    %rdx, %r9
+;;       movq    0x48(%rdi), %rax
+;;       movl    %edx, %r8d
+;;       xorq    %rdx, %rdx
+;;       movq    %r8, %r9
 ;;       addq    0x40(%rdi), %r9
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r9, %rdi), %rsi
-;;       cmpq    %r8, %rdx
-;;       cmovaq  %rax, %rsi
-;;       movb    %cl, (%rsi)
+;;       movl    $0xffff0000, %r10d
+;;       leaq    (%r9, %r10), %rdi
+;;       cmpq    %rax, %r8
+;;       cmovaq  %rdx, %rdi
+;;       movb    %cl, (%rdi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,16 +38,16 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r9
-;;       movl    %edx, %ecx
-;;       xorq    %rax, %rax
-;;       movq    %rcx, %r8
+;;       movq    0x48(%rdi), %rax
+;;       movl    %edx, %edx
+;;       xorq    %rcx, %rcx
+;;       movq    %rdx, %r8
 ;;       addq    0x40(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r8, %rdi), %rsi
-;;       cmpq    %r9, %rcx
-;;       cmovaq  %rax, %rsi
-;;       movzbq  (%rsi), %rax
+;;       movl    $0xffff0000, %r9d
+;;       leaq    (%r8, %r9), %rdi
+;;       cmpq    %rax, %rdx
+;;       cmovaq  %rcx, %rdi
+;;       movzbq  (%rdi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       subq    $4, %r10
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %r11, %rsi
-;;       movl    %ecx, (%rsi)
+;;       movq    0x48(%rdi), %r11
+;;       subq    $4, %r11
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rsi, %rax
+;;       movl    %ecx, (%rax)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       subq    $4, %r10
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %r11, %rsi
-;;       movl    (%rsi), %eax
+;;       movq    0x48(%rdi), %r11
+;;       subq    $4, %r11
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rsi, %rax
+;;       movl    (%rax), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       subq    $0x1004, %r10
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r11
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movl    %ecx, (%r11)
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       subq    $0x1004, %r11
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %rsi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rdi, %rsi
+;;       movl    %ecx, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       subq    $0x1004, %r10
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r11
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movl    (%r11), %eax
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       subq    $0x1004, %r11
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %rsi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rdi, %rsi
+;;       movl    (%rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,45 +21,39 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r8
-;;       addq    0x32(%rip), %r8
-;;       jb      0x37
+;;       movq    %rdx, %rax
+;;       addq    0x2a(%rip), %rax
+;;       jb      0x36
 ;;   14: movq    0x48(%rdi), %r9
-;;       xorq    %rax, %rax
+;;       xorq    %r8, %r8
 ;;       addq    0x40(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
-;;       leaq    (%rdx, %r10), %rdi
-;;       cmpq    %r9, %r8
-;;       cmovaq  %rax, %rdi
-;;       movl    %ecx, (%rdi)
+;;       addq    %r10, %rdx
+;;       cmpq    %r9, %rax
+;;       cmovaq  %r8, %rdx
+;;       movl    %ecx, (%rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   37: ud2
-;;   39: addb    %al, (%rax)
-;;   3b: addb    %al, (%rax)
-;;   3d: addb    %al, (%rax)
-;;   3f: addb    %al, (%rax, %rax)
+;;   36: ud2
+;;   38: addb    $0, %al
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %rcx
-;;       addq    0x32(%rip), %rcx
-;;       jb      0x97
-;;   74: movq    0x48(%rdi), %r8
-;;       xorq    %rax, %rax
+;;       movq    %rdx, %rax
+;;       addq    0x2a(%rip), %rax
+;;       jb      0x76
+;;   54: movq    0x48(%rdi), %r8
+;;       xorq    %rcx, %rcx
 ;;       addq    0x40(%rdi), %rdx
 ;;       movl    $0xffff0000, %r9d
-;;       leaq    (%rdx, %r9), %rdi
-;;       cmpq    %r8, %rcx
-;;       cmovaq  %rax, %rdi
-;;       movl    (%rdi), %eax
+;;       addq    %r9, %rdx
+;;       cmpq    %r8, %rax
+;;       cmovaq  %rcx, %rdx
+;;       movl    (%rdx), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   97: ud2
-;;   99: addb    %al, (%rax)
-;;   9b: addb    %al, (%rax)
-;;   9d: addb    %al, (%rax)
-;;   9f: addb    %al, (%rax, %rax)
+;;   76: ud2
+;;   78: addb    $0, %al

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaeq %r10, %r9
-;;       movb    %cl, (%r9)
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %r11, %r10
+;;       movb    %cl, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaeq %r10, %r9
-;;       movzbq  (%r9), %rax
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %r11, %r10
+;;       movzbq  (%r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       subq    $0x1001, %r10
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r11
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movb    %cl, (%r11)
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       subq    $0x1001, %r11
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %rsi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rdi, %rsi
+;;       movb    %cl, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r10
-;;       movq    0x40(%rdi), %rdi
-;;       subq    $0x1001, %r10
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r11
-;;       cmpq    %r10, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movzbq  (%r11), %rax
+;;       movq    0x48(%rdi), %r11
+;;       movq    0x40(%rdi), %rax
+;;       subq    $0x1001, %r11
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %rsi
+;;       cmpq    %r11, %rdx
+;;       cmovaq  %rdi, %rsi
+;;       movzbq  (%rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,50 +21,42 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %r8
-;;       addq    0x32(%rip), %r8
-;;       jb      0x37
+;;       movq    %rdx, %rax
+;;       addq    0x2a(%rip), %rax
+;;       jb      0x36
 ;;   14: movq    0x48(%rdi), %r9
-;;       xorq    %rax, %rax
+;;       xorq    %r8, %r8
 ;;       addq    0x40(%rdi), %rdx
 ;;       movl    $0xffff0000, %r10d
-;;       leaq    (%rdx, %r10), %rdi
-;;       cmpq    %r9, %r8
-;;       cmovaq  %rax, %rdi
-;;       movb    %cl, (%rdi)
+;;       addq    %r10, %rdx
+;;       cmpq    %r9, %rax
+;;       cmovaq  %r8, %rdx
+;;       movb    %cl, (%rdx)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   37: ud2
-;;   39: addb    %al, (%rax)
-;;   3b: addb    %al, (%rax)
-;;   3d: addb    %al, (%rax)
-;;   3f: addb    %al, (%rcx)
-;;   41: addb    %bh, %bh
-;;   43: incl    (%rax)
-;;   45: addb    %al, (%rax)
+;;   36: ud2
+;;   38: addl    %eax, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdx, %rcx
-;;       addq    0x32(%rip), %rcx
-;;       jb      0x99
-;;   74: movq    0x48(%rdi), %r8
-;;       xorq    %rax, %rax
+;;       movq    %rdx, %rax
+;;       addq    0x32(%rip), %rax
+;;       jb      0x78
+;;   54: movq    0x48(%rdi), %r8
+;;       xorq    %rcx, %rcx
 ;;       addq    0x40(%rdi), %rdx
 ;;       movl    $0xffff0000, %r9d
-;;       leaq    (%rdx, %r9), %rdi
-;;       cmpq    %r8, %rcx
-;;       cmovaq  %rax, %rdi
-;;       movzbq  (%rdi), %rax
+;;       addq    %r9, %rdx
+;;       cmpq    %r8, %rax
+;;       cmovaq  %rcx, %rdx
+;;       movzbq  (%rdx), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   99: ud2
-;;   9b: addb    %al, (%rax)
-;;   9d: addb    %al, (%rax)
-;;   9f: addb    %al, (%rcx)
-;;   a1: addb    %bh, %bh
-;;   a3: incl    (%rax)
-;;   a5: addb    %al, (%rax)
+;;   78: ud2
+;;   7a: addb    %al, (%rax)
+;;   7c: addb    %al, (%rax)
+;;   7e: addb    %al, (%rax)
+;;   80: addl    %eax, (%rax)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    %ecx, (%r9)
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %r11, %r10
+;;       movl    %ecx, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    (%r9), %eax
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %r11, %r10
+;;       movl    (%r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movq    0x40(%rdi), %rdi
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r10
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %rsi, %r10
-;;       movl    %ecx, (%r10)
+;;       movq    0x48(%rdi), %rsi
+;;       movq    0x40(%rdi), %rax
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %rdi, %r11
+;;       movl    %ecx, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movq    0x40(%rdi), %rdi
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r10
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %rsi, %r10
-;;       movl    (%r10), %eax
+;;       movq    0x48(%rdi), %rsi
+;;       movq    0x40(%rdi), %rax
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %rdi, %r11
+;;       movl    (%r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,14 +22,15 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    0x48(%rdi), %rax
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r9
+;;       xorq    %rdi, %rdi
 ;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r8, %rdi), %r11
+;;       addq    0x40(%r9), %r8
+;;       movl    $0xffff0000, %r9d
+;;       leaq    (%r8, %r9), %rsi
 ;;       cmpq    %rax, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movl    %ecx, (%r11)
+;;       cmovaq  %rdi, %rsi
+;;       movl    %ecx, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,14 +39,15 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    0x48(%rdi), %rax
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r8
+;;       xorq    %rdi, %rdi
 ;;       movq    %rdx, %rcx
-;;       addq    0x40(%rdi), %rcx
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%rcx, %rdi), %r11
+;;       addq    0x40(%r8), %rcx
+;;       movl    $0xffff0000, %r8d
+;;       leaq    (%rcx, %r8), %rsi
 ;;       cmpq    %rax, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movl    (%r11), %eax
+;;       cmovaq  %rdi, %rsi
+;;       movl    (%rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaeq %r10, %r9
-;;       movb    %cl, (%r9)
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %r11, %r10
+;;       movb    %cl, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       xorq    %r10, %r10
-;;       movq    %rdx, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    %r11, %rdx
-;;       cmovaeq %r10, %r9
-;;       movzbq  (%r9), %rax
+;;       movq    0x48(%rdi), %rsi
+;;       xorq    %r11, %r11
+;;       movq    %rdx, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    %rsi, %rdx
+;;       cmovaeq %r11, %r10
+;;       movzbq  (%r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,13 +21,13 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movq    0x40(%rdi), %rdi
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r10
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %rsi, %r10
-;;       movb    %cl, (%r10)
+;;       movq    0x48(%rdi), %rsi
+;;       movq    0x40(%rdi), %rax
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %rdi, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,13 +35,13 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x48(%rdi), %r11
-;;       movq    0x40(%rdi), %rdi
-;;       xorq    %rsi, %rsi
-;;       leaq    0x1000(%rdi, %rdx), %r10
-;;       cmpq    %r11, %rdx
-;;       cmovaq  %rsi, %r10
-;;       movzbq  (%r10), %rax
+;;       movq    0x48(%rdi), %rsi
+;;       movq    0x40(%rdi), %rax
+;;       xorq    %rdi, %rdi
+;;       leaq    0x1000(%rax, %rdx), %r11
+;;       cmpq    %rsi, %rdx
+;;       cmovaq  %rdi, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,14 +22,15 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    0x48(%rdi), %rax
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r9
+;;       xorq    %rdi, %rdi
 ;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%r8, %rdi), %r11
+;;       addq    0x40(%r9), %r8
+;;       movl    $0xffff0000, %r9d
+;;       leaq    (%r8, %r9), %rsi
 ;;       cmpq    %rax, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movb    %cl, (%r11)
+;;       cmovaq  %rdi, %rsi
+;;       movb    %cl, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,14 +39,15 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    0x48(%rdi), %rax
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r8
+;;       xorq    %rdi, %rdi
 ;;       movq    %rdx, %rcx
-;;       addq    0x40(%rdi), %rcx
-;;       movl    $0xffff0000, %edi
-;;       leaq    (%rcx, %rdi), %r11
+;;       addq    0x40(%r8), %rcx
+;;       movl    $0xffff0000, %r8d
+;;       leaq    (%rcx, %r8), %rsi
 ;;       cmpq    %rax, %rdx
-;;       cmovaq  %rsi, %r11
-;;       movzbq  (%r11), %rax
+;;       cmovaq  %rdi, %rsi
+;;       movzbq  (%rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,33 +21,33 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r11d
-;;       xorq    %r10, %r10
-;;       movq    %r11, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    0x10(%rip), %r11
-;;       cmovaq  %r10, %r9
-;;       movl    %ecx, (%r9)
+;;       movl    %edx, %esi
+;;       xorq    %r11, %r11
+;;       movq    %rsi, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    0x11(%rip), %rsi
+;;       cmovaq  %r11, %r10
+;;       movl    %ecx, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   24: addb    %al, (%rax)
-;;   26: addb    %al, (%rax)
-;;   28: cld
+;;   23: addb    %al, (%rax)
+;;   25: addb    %al, (%rax)
+;;   27: addb    %bh, %ah
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %r11d
-;;       xorq    %r10, %r10
-;;       movq    %r11, %r9
-;;       addq    0x40(%rdi), %r9
-;;       cmpq    0x10(%rip), %r11
-;;       cmovaq  %r10, %r9
-;;       movl    (%r9), %eax
+;;       movl    %edx, %esi
+;;       xorq    %r11, %r11
+;;       movq    %rsi, %r10
+;;       addq    0x40(%rdi), %r10
+;;       cmpq    0x11(%rip), %rsi
+;;       cmovaq  %r11, %r10
+;;       movl    (%r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: cld
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %bh, %ah

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,37 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %esi
-;;       xorq    %r11, %r11
-;;       movq    0x40(%rdi), %rdi
-;;       leaq    0x1000(%rdi, %rsi), %r10
-;;       cmpq    0xc(%rip), %rsi
-;;       cmovaq  %r11, %r10
-;;       movl    %ecx, (%r10)
+;;       movq    %rdi, %rax
+;;       movl    %edx, %edi
+;;       xorq    %rsi, %rsi
+;;       movq    %rax, %rdx
+;;       movq    0x40(%rdx), %rax
+;;       leaq    0x1000(%rax, %rdi), %r11
+;;       cmpq    0xe(%rip), %rdi
+;;       cmovaq  %rsi, %r11
+;;       movl    %ecx, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   28: cld
-;;   29: outl    %eax, %dx
+;;   2e: addb    %al, (%rax)
+;;   30: cld
+;;   31: outl    %eax, %dx
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %esi
-;;       xorq    %r11, %r11
-;;       movq    0x40(%rdi), %rdi
-;;       leaq    0x1000(%rdi, %rsi), %r10
-;;       cmpq    0xc(%rip), %rsi
-;;       cmovaq  %r11, %r10
-;;       movl    (%r10), %eax
+;;       movq    %rdi, %rax
+;;       movl    %edx, %edi
+;;       xorq    %rsi, %rsi
+;;       movq    %rax, %rdx
+;;       movq    0x40(%rdx), %rax
+;;       leaq    0x1000(%rax, %rdi), %r11
+;;       cmpq    0xe(%rip), %rdi
+;;       cmovaq  %rsi, %r11
+;;       movl    (%r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: cld
-;;   69: outl    %eax, %dx
+;;   6e: addb    %al, (%rax)
+;;   70: cld
+;;   71: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,17 +21,16 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdi, %rax
-;;       movl    %edx, %edi
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r8
+;;       movl    %edx, %eax
+;;       xorq    %rdi, %rdi
 ;;       movq    %rax, %rdx
-;;       movq    %rdi, %rax
-;;       addq    0x40(%rdx), %rax
-;;       movl    $0xffff0000, %edx
-;;       leaq    (%rax, %rdx), %r11
-;;       cmpq    $0xfffc, %rdi
-;;       cmovaq  %rsi, %r11
-;;       movl    %ecx, (%r11)
+;;       addq    0x40(%r8), %rdx
+;;       movl    $0xffff0000, %r8d
+;;       leaq    (%rdx, %r8), %rsi
+;;       cmpq    $0xfffc, %rax
+;;       cmovaq  %rdi, %rsi
+;;       movl    %ecx, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -39,17 +38,17 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdi, %rax
-;;       movl    %edx, %edi
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %rcx
+;;       movl    %edx, %eax
+;;       xorq    %rdi, %rdi
+;;       movq    %rcx, %r8
 ;;       movq    %rax, %rcx
-;;       movq    %rdi, %rax
-;;       addq    0x40(%rcx), %rax
-;;       movl    $0xffff0000, %ecx
-;;       leaq    (%rax, %rcx), %r11
-;;       cmpq    $0xfffc, %rdi
-;;       cmovaq  %rsi, %r11
-;;       movl    (%r11), %eax
+;;       addq    0x40(%r8), %rcx
+;;       movl    $0xffff0000, %edx
+;;       leaq    (%rcx, %rdx), %rsi
+;;       cmpq    $0xfffc, %rax
+;;       cmovaq  %rdi, %rsi
+;;       movl    (%rsi), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,32 +21,34 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %esi
-;;       xorq    %r11, %r11
-;;       movq    0x40(%rdi), %rdi
-;;       leaq    0x1000(%rdi, %rsi), %r10
-;;       cmpq    0xc(%rip), %rsi
-;;       cmovaq  %r11, %r10
-;;       movb    %cl, (%r10)
+;;       movq    %rdi, %rax
+;;       movl    %edx, %edi
+;;       xorq    %rsi, %rsi
+;;       movq    %rax, %rdx
+;;       movq    0x40(%rdx), %rax
+;;       leaq    0x1000(%rax, %rdi), %r11
+;;       cmpq    0xe(%rip), %rdi
+;;       cmovaq  %rsi, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   2e: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    %edx, %esi
-;;       xorq    %r11, %r11
-;;       movq    0x40(%rdi), %rdi
-;;       leaq    0x1000(%rdi, %rsi), %r10
-;;       cmpq    0x14(%rip), %rsi
-;;       cmovaq  %r11, %r10
-;;       movzbq  (%r10), %rax
+;;       movq    %rdi, %rax
+;;       movl    %edx, %edi
+;;       xorq    %rsi, %rsi
+;;       movq    %rax, %rdx
+;;       movq    0x40(%rdx), %rax
+;;       leaq    0x1000(%rax, %rdi), %r11
+;;       cmpq    0xe(%rip), %rdi
+;;       cmovaq  %rsi, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: addb    %al, (%rax)
-;;   6b: addb    %al, (%rax)
-;;   6d: addb    %al, (%rax)
 ;;   6f: addb    %bh, %bh
 ;;   71: outl    %eax, %dx

--- a/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,17 +21,16 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdi, %rax
-;;       movl    %edx, %edi
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %r8
+;;       movl    %edx, %eax
+;;       xorq    %rdi, %rdi
 ;;       movq    %rax, %rdx
-;;       movq    %rdi, %rax
-;;       addq    0x40(%rdx), %rax
-;;       movl    $0xffff0000, %edx
-;;       leaq    (%rax, %rdx), %r11
-;;       cmpq    $0xffff, %rdi
-;;       cmovaq  %rsi, %r11
-;;       movb    %cl, (%r11)
+;;       addq    0x40(%r8), %rdx
+;;       movl    $0xffff0000, %r8d
+;;       leaq    (%rdx, %r8), %rsi
+;;       cmpq    $0xffff, %rax
+;;       cmovaq  %rdi, %rsi
+;;       movb    %cl, (%rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -39,17 +38,17 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    %rdi, %rax
-;;       movl    %edx, %edi
-;;       xorq    %rsi, %rsi
+;;       movq    %rdi, %rcx
+;;       movl    %edx, %eax
+;;       xorq    %rdi, %rdi
+;;       movq    %rcx, %r8
 ;;       movq    %rax, %rcx
-;;       movq    %rdi, %rax
-;;       addq    0x40(%rcx), %rax
-;;       movl    $0xffff0000, %ecx
-;;       leaq    (%rax, %rcx), %r11
-;;       cmpq    $0xffff, %rdi
-;;       cmovaq  %rsi, %r11
-;;       movzbq  (%r11), %rax
+;;       addq    0x40(%r8), %rcx
+;;       movl    $0xffff0000, %edx
+;;       leaq    (%rcx, %rdx), %rsi
+;;       cmpq    $0xffff, %rax
+;;       cmovaq  %rdi, %rsi
+;;       movzbq  (%rsi), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movl    %ecx, (%r8)
+;;       cmovaq  %r10, %r9
+;;       movl    %ecx, (%r9)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,12 +38,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movl    (%r8), %eax
+;;       cmovaq  %r10, %r9
+;;       movl    (%r9), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    %ecx, (%r9)
+;;       cmovaq  %r11, %r10
+;;       movl    %ecx, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -37,12 +37,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    (%r9), %eax
+;;       cmovaq  %r11, %r10
+;;       movl    (%r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xfffc, %rdx
-;;       cmovaq  %r11, %r10
-;;       movl    %ecx, (%r10)
+;;       cmovaq  %rsi, %r11
+;;       movl    %ecx, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xfffc, %rdx
-;;       cmovaq  %r11, %r10
-;;       movl    (%r10), %eax
+;;       cmovaq  %rsi, %r11
+;;       movl    (%r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movb    %cl, (%r8)
+;;       cmovaq  %r10, %r9
+;;       movb    %cl, (%r9)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,12 +38,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movzbq  (%r8), %rax
+;;       cmovaq  %r10, %r9
+;;       movzbq  (%r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movb    %cl, (%r9)
+;;       cmovaq  %r11, %r10
+;;       movb    %cl, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,12 +35,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movzbq  (%r9), %rax
+;;       cmovaq  %r11, %r10
+;;       movzbq  (%r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xffff, %rdx
-;;       cmovaq  %r11, %r10
-;;       movb    %cl, (%r10)
+;;       cmovaq  %rsi, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xffff, %rdx
-;;       cmovaq  %r11, %r10
-;;       movzbq  (%r10), %rax
+;;       cmovaq  %rsi, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movl    %ecx, (%r8)
+;;       cmovaq  %r10, %r9
+;;       movl    %ecx, (%r9)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,12 +38,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movl    (%r8), %eax
+;;       cmovaq  %r10, %r9
+;;       movl    (%r9), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    %ecx, (%r9)
+;;       cmovaq  %r11, %r10
+;;       movl    %ecx, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -37,12 +37,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movl    (%r9), %eax
+;;       cmovaq  %r11, %r10
+;;       movl    (%r10), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xfffc, %rdx
-;;       cmovaq  %r11, %r10
-;;       movl    %ecx, (%r10)
+;;       cmovaq  %rsi, %r11
+;;       movl    %ecx, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xfffc, %rdx
-;;       cmovaq  %r11, %r10
-;;       movl    (%r10), %eax
+;;       cmovaq  %rsi, %r11
+;;       movl    (%r11), %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movb    %cl, (%r8)
+;;       cmovaq  %r10, %r9
+;;       movb    %cl, (%r9)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -38,12 +38,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r9, %r9
-;;       movq    %rdx, %r8
-;;       addq    0x40(%rdi), %r8
+;;       xorq    %r10, %r10
+;;       movq    %rdx, %r9
+;;       addq    0x40(%rdi), %r9
 ;;       cmpq    0x13(%rip), %rdx
-;;       cmovaq  %r9, %r8
-;;       movzbq  (%r8), %rax
+;;       cmovaq  %r10, %r9
+;;       movzbq  (%r9), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,12 +21,12 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movb    %cl, (%r9)
+;;       cmovaq  %r11, %r10
+;;       movb    %cl, (%r10)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -35,12 +35,12 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r10, %r10
-;;       movq    0x40(%rdi), %r11
-;;       leaq    0x1000(%r11, %rdx), %r9
+;;       xorq    %r11, %r11
+;;       movq    0x40(%rdi), %rsi
+;;       leaq    0x1000(%rsi, %rdx), %r10
 ;;       cmpq    0xe(%rip), %rdx
-;;       cmovaq  %r10, %r9
-;;       movzbq  (%r9), %rax
+;;       cmovaq  %r11, %r10
+;;       movzbq  (%r10), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,14 +21,14 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xffff, %rdx
-;;       cmovaq  %r11, %r10
-;;       movb    %cl, (%r10)
+;;       cmovaq  %rsi, %r11
+;;       movb    %cl, (%r11)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -36,14 +36,14 @@
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       xorq    %r11, %r11
-;;       movq    %rdx, %rsi
-;;       addq    0x40(%rdi), %rsi
+;;       xorq    %rsi, %rsi
+;;       movq    %rdx, %rax
+;;       addq    0x40(%rdi), %rax
 ;;       movl    $0xffff0000, %edi
-;;       leaq    (%rsi, %rdi), %r10
+;;       leaq    (%rax, %rdi), %r11
 ;;       cmpq    $0xffff, %rdx
-;;       cmovaq  %r11, %r10
-;;       movzbq  (%r10), %rax
+;;       cmovaq  %rsi, %r11
+;;       movzbq  (%r11), %rax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/pcc-imported-memory.wat
+++ b/tests/disas/pcc-imported-memory.wat
@@ -37,22 +37,22 @@
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    0x38(%rdi), %rcx
-;;       movq    8(%rcx), %rax
-;;       shrq    $0x10, %rax
-;;       movq    %rax, %rcx
-;;       shll    $0x10, %ecx
-;;       leal    4(%rax), %edx
-;;       cmpl    %edx, %ecx
-;;       jbe     0x3b
-;;   21: testl   %eax, %eax
-;;       jle     0x3b
-;;   29: movq    0x38(%rdi), %rsi
-;;       movq    (%rsi), %rsi
-;;       movl    %eax, %edi
-;;       movl    (%rsi, %rdi), %r10d
-;;       jmp     0x3e
-;;   3b: xorl    %r10d, %r10d
+;;       movq    0x38(%rdi), %rdx
+;;       movq    8(%rdx), %rcx
+;;       shrq    $0x10, %rcx
+;;       movq    %rcx, %rdx
+;;       shll    $0x10, %edx
+;;       leal    4(%rcx), %r8d
+;;       cmpl    %r8d, %edx
+;;       jbe     0x3d
+;;   23: testl   %ecx, %ecx
+;;       jle     0x3d
+;;   2b: movq    0x38(%rdi), %rdi
+;;       movq    (%rdi), %rdi
+;;       movl    %ecx, %eax
+;;       movl    (%rdi, %rax), %r10d
+;;       jmp     0x40
+;;   3d: xorl    %r10d, %r10d
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -72,7 +72,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x2f0
+;;       callq   0x2f1
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14

--- a/tests/disas/winch/x64/epoch/func.wat
+++ b/tests/disas/winch/x64/epoch/func.wat
@@ -23,7 +23,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x126
+;;       callq   0x127
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/epoch/loop.wat
+++ b/tests/disas/winch/x64/epoch/loop.wat
@@ -25,7 +25,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x51
 ;;   44: movq    %r14, %rdi
-;;       callq   0x150
+;;       callq   0x151
 ;;       movq    8(%rsp), %r14
 ;;       movq    0x20(%r14), %rdx
 ;;       movq    (%rdx), %rdx
@@ -34,7 +34,7 @@
 ;;       cmpq    %rcx, %rdx
 ;;       jb      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x150
+;;       callq   0x151
 ;;       movq    8(%rsp), %r14
 ;;       jmp     0x51
 ;;   7b: addq    $0x10, %rsp

--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -28,7 +28,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x1dd
+;;       callq   0x1de
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11
@@ -74,7 +74,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x108
 ;;   fb: movq    %r14, %rdi
-;;       callq   0x1dd
+;;       callq   0x1de
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/fuel/func.wat
+++ b/tests/disas/winch/x64/fuel/func.wat
@@ -24,7 +24,7 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x12d
+;;       callq   0x12e
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/winch/x64/fuel/loop.wat
+++ b/tests/disas/winch/x64/fuel/loop.wat
@@ -26,14 +26,14 @@
 ;;       cmpq    $0, %rcx
 ;;       jl      0x58
 ;;   4b: movq    %r14, %rdi
-;;       callq   0x15e
+;;       callq   0x15f
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rcx
 ;;       movq    (%rcx), %rcx
 ;;       cmpq    $0, %rcx
 ;;       jl      0x76
 ;;   69: movq    %r14, %rdi
-;;       callq   0x15e
+;;       callq   0x15f
 ;;       movq    8(%rsp), %r14
 ;;       movq    8(%r14), %rax
 ;;       movq    (%rax), %r11

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x470
+;;       callq   0x471
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
@@ -133,7 +133,7 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x4b1
+;;       callq   0x4b2
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2bc
+;;       callq   0x2bd
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x87e
+;;       callq   0x87f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x8dd
+;;       callq   0x8de
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x87e
+;;       callq   0x87f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x8dd
+;;       callq   0x8de
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x91c
+;;       callq   0x91d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x91c
+;;       callq   0x91d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x91c
+;;       callq   0x91d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x91c
+;;       callq   0x91d
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x91c
+;;       callq   0x91d
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -243,7 +243,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x97b
+;;       callq   0x97c
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -109,7 +109,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x473
+;;       callq   0x474
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14


### PR DESCRIPTION
This change uses an "uninitialized value" to resolve the register allocation issues that come up when clearing a GPR with `xor`; this tries out the approach suggested in #10632 and will replace that if merged. The problem is that, in `xor <tmp>, <tmp>`, we need some way to communicate to the register allocator that the previous values of `<tmp>` are completely cleared--i.e., not used. While #10632 started down the path of allowing the register allocator to make a different decision about `<tmp>`--the approach currently taken for `AluConstOp`--this change instead adopts the "uninitialized value" approach. As was done previously with `XmmUninitializedValue`, we create a new pseudo-instruction called `GprUninitializedValue` whose registers are defined out of thin air.