### PR TITLE
x64: remove unused ISLE constructor

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3071,16 +3071,6 @@
 (rule 0 (x64_and $I32 src1 (is_gpr_mem src2)) (x64_andl_rm src1 src2))
 (rule 0 (x64_and $I64 src1 (is_gpr_mem src2)) (x64_andq_rm src1 src2))
 
-(decl x64_and_with_flags_paired (Type Gpr GprMemImm) ProducesFlags)
-(rule (x64_and_with_flags_paired ty src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr)))
-           (ProducesFlags.ProducesFlagsSideEffect
-                 (MInst.AluRmiR (operand_size_of_type_32_64 ty)
-                       (AluRmiROpcode.And)
-                       src1
-                       src2
-                       dst))))
-
 
 
 ;; Helper for emitting raw `or` instructions.


### PR DESCRIPTION
The `x64_and_with_paired_flags` is unused throughout the x64 backend.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
