### PR TITLE
Strip prefixes in file names

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -211,6 +211,13 @@ fn run_compilation(compilation: &IsleCompilation) -> Result<(), Errors> {
         // https://github.com/rust-lang/rust/issues/47995.)
         options.exclude_global_allow_pragmas = true;
 
+        if let Ok(out_dir) = std::env::var("OUT_DIR") {
+            options.prefixes.push(isle::codegen::Prefix {
+                prefix: out_dir,
+                name: "<OUT_DIR>".to_string(),
+            })
+        };
+
         isle::compile::from_files(file_paths, &options)?
     };
 

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -17,6 +17,20 @@ pub struct CodegenOptions {
     /// Do not include the `#![allow(...)]` pragmas in the generated
     /// source. Useful if it must be include!()'d elsewhere.
     pub exclude_global_allow_pragmas: bool,
+
+    /// Prefixes to remove when printing file names in generaed files. This
+    /// helps keep codegen deterministic.
+    pub prefixes: Vec<Prefix>,
+}
+
+/// A path prefix which should be replaced when printing file names.
+#[derive(Clone, Debug)]
+pub struct Prefix {
+    /// Prefix to strip
+    pub prefix: String,
+
+    /// Name replacing the stripped prefix.
+    pub name: String,
 }
 
 /// Emit Rust source code for the given type and term environments.

--- a/cranelift/isle/isle/src/compile.rs
+++ b/cranelift/isle/isle/src/compile.rs
@@ -37,7 +37,7 @@ pub fn from_files<P: AsRef<Path>>(
     inputs: impl IntoIterator<Item = P>,
     options: &codegen::CodegenOptions,
 ) -> Result<String, Errors> {
-    let files = match Files::from_paths(inputs) {
+    let files = match Files::from_paths(inputs, &options.prefixes) {
         Ok(files) => files,
         Err((path, err)) => {
             return Err(Errors::from_io(
@@ -70,7 +70,7 @@ pub fn from_files<P: AsRef<Path>>(
 pub fn create_envs(
     inputs: Vec<std::path::PathBuf>,
 ) -> Result<(sema::TypeEnv, sema::TermEnv, Vec<Def>), Errors> {
-    let files = match Files::from_paths(inputs) {
+    let files = match Files::from_paths(inputs, &[]) {
         Ok(files) => files,
         Err((path, err)) => {
             return Err(Errors::from_io(


### PR DESCRIPTION
Allow codegen to remove certain prefixes from source file paths when printing the paths in generated files. This currently is only applied to the `OUT_DIR` and allows generated code to be deterministic.

This resolves https://github.com/bytecodealliance/wasmtime/issues/10639 and the issue with comments mentioned in https://github.com/bytecodealliance/wasmtime/issues/9553. It is a variation on the solution proposed in https://github.com/bytecodealliance/wasmtime/pull/9580 (instead of removing prefixes when printing names, they are removed in the constructor `Files::from_paths`).