### PR TITLE
Update cargo-deny used in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     - uses: ./.github/actions/install-rust
     - run: |
         set -e
-        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.14.5/cargo-deny-0.14.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.18.2/cargo-deny-0.18.2-x86_64-unknown-linux-musl.tar.gz | tar xzf -
         mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
         echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check bans licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 # Documentation for this configuration file can be found here
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
 
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-apple-darwin" },
@@ -13,14 +14,13 @@ targets = [
 allow = [
     "Apache-2.0 WITH LLVM-exception",
     "Apache-2.0",
-    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "MIT",
     "MPL-2.0",
-    "OpenSSL",
     "Unicode-DFS-2016",
     "Zlib",
+    "Unicode-3.0",
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
Our pinned version is pretty out-of-date and seems like it's having difficulty parsing more recent Cargo syntax in the wasip3-prototyping fork.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
