### PR TITLE
Handle another failure in `tls_sample_application`

### DIFF
--- a/crates/test-programs/src/bin/tls_sample_application.rs
+++ b/crates/test-programs/src/bin/tls_sample_application.rs
@@ -72,14 +72,16 @@ fn try_live_endpoints(test: impl Fn(&str, IpAddress) -> Result<()>) {
     let net = Network::default();
 
     for &domain in DOMAINS {
-        let lookup = net
-            .permissive_blocking_resolve_addresses(domain)
-            .unwrap()
-            .first()
-            .map(|a| a.to_owned())
-            .ok_or_else(|| anyhow!("DNS lookup failed."));
+        let result = (|| {
+            let ip = net
+                .permissive_blocking_resolve_addresses(domain)?
+                .first()
+                .map(|a| a.to_owned())
+                .ok_or_else(|| anyhow!("DNS lookup failed."))?;
+            test(&domain, ip)
+        })();
 
-        match lookup.and_then(|ip| test(&domain, ip)) {
+        match result {
             Ok(()) => return,
             Err(e) => {
                 eprintln!("test for {domain} failed: {e:#}");


### PR DESCRIPTION
Will hopefully help address the failure in
https://github.com/bytecodealliance/wasmtime/actions/runs/14625390199/job/41035685400 for future CI runs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
