### PR TITLE
Switch to using Wasmtime-style builtins for ceil, floor, etc.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -223,6 +223,10 @@ impl TargetIsa for AArch64Backend {
         true
     }
 
+    fn has_round(&self) -> bool {
+        true
+    }
+
     fn has_x86_blendv_lowering(&self, _: Type) -> bool {
         false
     }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -385,6 +385,9 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// not detected.
     fn has_native_fma(&self) -> bool;
 
+    /// Returns whether this ISA has instructions for `ceil`, `floor`, etc.
+    fn has_round(&self) -> bool;
+
     /// Returns whether the CLIF `x86_blendv` instruction is implemented for
     /// this ISA for the specified type.
     fn has_x86_blendv_lowering(&self, ty: Type) -> bool;

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -225,7 +225,8 @@ where
     }
 
     fn has_native_fma(&self) -> bool {
-        false
+        // The pulley interpreter does have fma opcodes.
+        true
     }
 
     fn has_round(&self) -> bool {

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -228,6 +228,11 @@ where
         false
     }
 
+    fn has_round(&self) -> bool {
+        // The pulley interpreter does have rounding opcodes.
+        true
+    }
+
     fn has_x86_blendv_lowering(&self, _ty: ir::Type) -> bool {
         false
     }

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -201,6 +201,10 @@ impl TargetIsa for Riscv64Backend {
         true
     }
 
+    fn has_round(&self) -> bool {
+        true
+    }
+
     fn has_x86_blendv_lowering(&self, _: Type) -> bool {
         false
     }

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -183,6 +183,10 @@ impl TargetIsa for S390xBackend {
         true
     }
 
+    fn has_round(&self) -> bool {
+        true
+    }
+
     fn has_x86_blendv_lowering(&self, _: Type) -> bool {
         false
     }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -167,6 +167,10 @@ impl TargetIsa for X64Backend {
         self.x64_flags.use_fma()
     }
 
+    fn has_round(&self) -> bool {
+        self.x64_flags.use_sse41()
+    }
+
     fn has_x86_blendv_lowering(&self, ty: Type) -> bool {
         // The `blendvpd`, `blendvps`, and `pblendvb` instructions are all only
         // available from SSE 4.1 and onwards. Otherwise the i16x8 type has no

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -12,7 +12,7 @@ use cranelift_codegen::ir::immediates::{Imm64, Offset32};
 use cranelift_codegen::ir::pcc::Fact;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, types};
-use cranelift_codegen::ir::{ArgumentPurpose, Function, InstBuilder, MemFlags};
+use cranelift_codegen::ir::{ArgumentPurpose, ConstantData, Function, InstBuilder, MemFlags};
 use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
 use cranelift_frontend::FunctionBuilder;
@@ -3219,10 +3219,6 @@ impl FuncEnvironment<'_> {
         self.isa.has_x86_blendv_lowering(ty)
     }
 
-    pub fn use_x86_pshufb_for_relaxed_swizzle(&self) -> bool {
-        self.isa.has_x86_pshufb_lowering()
-    }
-
     pub fn use_x86_pmulhrsw_for_relaxed_q15mul(&self) -> bool {
         self.isa.has_x86_pmulhrsw_lowering()
     }
@@ -3321,6 +3317,172 @@ impl FuncEnvironment<'_> {
         }
         #[cfg(not(feature = "wmemcheck"))]
         let _ = (builder, num_pages, mem_index);
+    }
+
+    pub fn ceil_f32(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // If the ISA has rounding instructions, let Cranelift use them. But if
+        // not, lower to a libcall here, rather than having Cranelift do it. We
+        // can pass our libcall the vmctx pointer, which we use for stack
+        // overflow checking.
+        if self.isa.has_round() {
+            builder.ins().ceil(value)
+        } else {
+            let ceil = self.builtin_functions.ceil_f32(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(ceil, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn ceil_f64(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().ceil(value)
+        } else {
+            let ceil = self.builtin_functions.ceil_f64(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(ceil, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn floor_f32(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().floor(value)
+        } else {
+            let floor = self.builtin_functions.floor_f32(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(floor, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn floor_f64(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().floor(value)
+        } else {
+            let floor = self.builtin_functions.floor_f64(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(floor, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn trunc_f32(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().trunc(value)
+        } else {
+            let trunc = self.builtin_functions.trunc_f32(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(trunc, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn trunc_f64(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().trunc(value)
+        } else {
+            let trunc = self.builtin_functions.trunc_f64(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(trunc, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn nearest_f32(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().nearest(value)
+        } else {
+            let nearest = self.builtin_functions.nearest_f32(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(nearest, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn nearest_f64(&mut self, builder: &mut FunctionBuilder, value: ir::Value) -> ir::Value {
+        // See the comments in `ceil_f32` about libcalls.
+        if self.isa.has_round() {
+            builder.ins().nearest(value)
+        } else {
+            let nearest = self.builtin_functions.nearest_f64(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(nearest, &[vmctx, value]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn swizzle(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        a: ir::Value,
+        b: ir::Value,
+    ) -> ir::Value {
+        // On x86, swizzle would typically be compiled to `pshufb`, except
+        // that that's not available on CPUs that lack SSSE3. In that case,
+        // fall back to a builtin function.
+        if !self.is_x86() || self.isa.has_x86_pshufb_lowering() {
+            builder.ins().swizzle(a, b)
+        } else {
+            let swizzle = self.builtin_functions.i8x16_swizzle(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(swizzle, &[vmctx, a, b]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn relaxed_swizzle(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        a: ir::Value,
+        b: ir::Value,
+    ) -> ir::Value {
+        // As above, fall back to a builtin if we lack SSSE3.
+        if !self.is_x86() || self.isa.has_x86_pshufb_lowering() {
+            if self.relaxed_simd_deterministic() || self.isa.triple().is_pulley() {
+                builder.ins().swizzle(a, b)
+            } else {
+                builder.ins().x86_pshufb(a, b)
+            }
+        } else {
+            let swizzle = self.builtin_functions.i8x16_swizzle(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(swizzle, &[vmctx, a, b]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
+    }
+
+    pub fn i8x16_shuffle(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        a: ir::Value,
+        b: ir::Value,
+        lanes: &[u8; 16],
+    ) -> ir::Value {
+        // As with swizzle, i8x16.shuffle would also commonly be implemented
+        // with pshufb, so if we lack SSSE3, fall back to a builtin.
+        if !self.is_x86() || self.isa.has_x86_pshufb_lowering() {
+            let lanes = ConstantData::from(&lanes[..]);
+            let mask = builder.func.dfg.immediates.push(lanes);
+            builder.ins().shuffle(a, b, mask)
+        } else {
+            let lanes = builder
+                .func
+                .dfg
+                .constants
+                .insert(ConstantData::from(&lanes[..]));
+            let lanes = builder.ins().vconst(I8X16, lanes);
+            let i8x16_shuffle = self.builtin_functions.i8x16_shuffle(builder.func);
+            let vmctx = self.vmctx_val(&mut builder.cursor());
+            let call = builder.ins().call(i8x16_shuffle, &[vmctx, a, b, lanes]);
+            *builder.func.dfg.inst_results(call).first().unwrap()
+        }
     }
 
     pub fn isa(&self) -> &dyn TargetIsa {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3445,7 +3445,7 @@ impl FuncEnvironment<'_> {
     ) -> ir::Value {
         // As above, fall back to a builtin if we lack SSSE3.
         if !self.is_x86() || self.isa.has_x86_pshufb_lowering() {
-            if self.relaxed_simd_deterministic() || self.isa.triple().is_pulley() {
+            if !self.is_x86() || self.relaxed_simd_deterministic() {
                 builder.ins().swizzle(a, b)
             } else {
                 builder.ins().x86_pshufb(a, b)

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -372,6 +372,14 @@ impl BuiltinFunctionSignatures {
         AbiParam::new(ir::types::I8X16)
     }
 
+    fn f32x4(&self) -> AbiParam {
+        AbiParam::new(ir::types::F32X4)
+    }
+
+    fn f64x2(&self) -> AbiParam {
+        AbiParam::new(ir::types::F64X2)
+    }
+
     fn bool(&self) -> AbiParam {
         AbiParam::new(ir::types::I8)
     }

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -307,8 +307,9 @@ fn mach_reloc_to_reloc(
             }
         }
         FinalizedRelocTarget::ExternalName(ExternalName::LibCall(libcall)) => {
-            let libcall = libcall_cranelift_to_wasmtime(libcall);
-            RelocationTarget::HostLibcall(libcall)
+            // We should have avoided any code that needs this style of libcalls
+            // in the Wasm-to-Cranelift translator.
+            panic!("unexpected libcall {libcall:?}");
         }
         _ => panic!("unrecognized external name"),
     };
@@ -317,24 +318,6 @@ fn mach_reloc_to_reloc(
         reloc_target,
         offset,
         addend,
-    }
-}
-
-fn libcall_cranelift_to_wasmtime(call: ir::LibCall) -> wasmtime_environ::obj::LibCall {
-    use wasmtime_environ::obj::LibCall as LC;
-    match call {
-        ir::LibCall::FloorF32 => LC::FloorF32,
-        ir::LibCall::FloorF64 => LC::FloorF64,
-        ir::LibCall::NearestF32 => LC::NearestF32,
-        ir::LibCall::NearestF64 => LC::NearestF64,
-        ir::LibCall::CeilF32 => LC::CeilF32,
-        ir::LibCall::CeilF64 => LC::CeilF64,
-        ir::LibCall::TruncF32 => LC::TruncF32,
-        ir::LibCall::TruncF64 => LC::TruncF64,
-        ir::LibCall::FmaF32 => LC::FmaF32,
-        ir::LibCall::FmaF64 => LC::FmaF64,
-        ir::LibCall::X86Pshufb => LC::X86Pshufb,
-        _ => panic!("cranelift emitted a libcall wasmtime does not support: {call:?}"),
     }
 }
 
@@ -373,8 +356,20 @@ impl BuiltinFunctionSignatures {
         AbiParam::new(ir::types::I64)
     }
 
+    fn f32(&self) -> AbiParam {
+        AbiParam::new(ir::types::F32)
+    }
+
+    fn f64(&self) -> AbiParam {
+        AbiParam::new(ir::types::F64)
+    }
+
     fn u8(&self) -> AbiParam {
         AbiParam::new(ir::types::I8)
+    }
+
+    fn i8x16(&self) -> AbiParam {
+        AbiParam::new(ir::types::I8X16)
     }
 
     fn bool(&self) -> AbiParam {

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -82,7 +82,7 @@ use crate::Reachability;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{
-    self, AtomicRmwOp, ConstantData, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
+    self, AtomicRmwOp, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
 };
 use cranelift_codegen::ir::{types::*, BlockArg};
 use cranelift_codegen::packed_option::ReservedValue;
@@ -979,21 +979,37 @@ pub fn translate_operator(
             let arg = state.pop1();
             state.push1(builder.ins().sqrt(arg));
         }
-        Operator::F32Ceil | Operator::F64Ceil => {
+        Operator::F32Ceil => {
             let arg = state.pop1();
-            state.push1(builder.ins().ceil(arg));
+            state.push1(environ.ceil_f32(builder, arg));
         }
-        Operator::F32Floor | Operator::F64Floor => {
+        Operator::F64Ceil => {
             let arg = state.pop1();
-            state.push1(builder.ins().floor(arg));
+            state.push1(environ.ceil_f64(builder, arg));
         }
-        Operator::F32Trunc | Operator::F64Trunc => {
+        Operator::F32Floor => {
             let arg = state.pop1();
-            state.push1(builder.ins().trunc(arg));
+            state.push1(environ.floor_f32(builder, arg));
         }
-        Operator::F32Nearest | Operator::F64Nearest => {
+        Operator::F64Floor => {
             let arg = state.pop1();
-            state.push1(builder.ins().nearest(arg));
+            state.push1(environ.floor_f64(builder, arg));
+        }
+        Operator::F32Trunc => {
+            let arg = state.pop1();
+            state.push1(environ.trunc_f32(builder, arg));
+        }
+        Operator::F64Trunc => {
+            let arg = state.pop1();
+            state.push1(environ.trunc_f64(builder, arg));
+        }
+        Operator::F32Nearest => {
+            let arg = state.pop1();
+            state.push1(environ.nearest_f32(builder, arg));
+        }
+        Operator::F64Nearest => {
+            let arg = state.pop1();
+            state.push1(environ.nearest_f64(builder, arg));
         }
         Operator::F32Abs | Operator::F64Abs => {
             let val = state.pop1();
@@ -1724,10 +1740,7 @@ pub fn translate_operator(
         }
         Operator::I8x16Shuffle { lanes, .. } => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            let lanes = ConstantData::from(lanes.as_ref());
-            let mask = builder.func.dfg.immediates.push(lanes);
-            let shuffled = builder.ins().shuffle(a, b, mask);
-            state.push1(shuffled)
+            state.push1(environ.i8x16_shuffle(builder, a, b, lanes));
             // At this point the original types of a and b are lost; users of this value (i.e. this
             // WASM-to-CLIF translator) may need to bitcast for type-correctness. This is due
             // to WASM using the less specific v128 type for certain operations and more specific
@@ -1735,7 +1748,7 @@ pub fn translate_operator(
         }
         Operator::I8x16Swizzle => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().swizzle(a, b))
+            state.push1(environ.swizzle(builder, a, b));
         }
         Operator::I8x16Add | Operator::I16x8Add | Operator::I32x4Add | Operator::I64x2Add => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
@@ -2279,17 +2292,7 @@ pub fn translate_operator(
 
         Operator::I8x16RelaxedSwizzle => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(
-                if environ.relaxed_simd_deterministic()
-                    || !environ.use_x86_pshufb_for_relaxed_swizzle()
-                {
-                    // Deterministic semantics match the `i8x16.swizzle`
-                    // instruction which is the CLIF `swizzle`.
-                    builder.ins().swizzle(a, b)
-                } else {
-                    builder.ins().x86_pshufb(a, b)
-                },
-            );
+            state.push1(environ.relaxed_swizzle(builder, a, b));
         }
 
         Operator::F32x4RelaxedMadd | Operator::F64x2RelaxedMadd => {

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -214,6 +214,8 @@ macro_rules! foreach_builtin_function {
             nearest_f64(vmctx: vmctx, x: f64) -> f64;
             i8x16_swizzle(vmctx: vmctx, a: i8x16, b: i8x16) -> i8x16;
             i8x16_shuffle(vmctx: vmctx, a: i8x16, b: i8x16, c: i8x16) -> i8x16;
+            fma_f32x4(vmctx: vmctx, x: f32x4, y: f32x4, z: f32x4) -> f32x4;
+            fma_f64x2(vmctx: vmctx, x: f64x2, y: f64x2, z: f64x2) -> f64x2;
 
             // Raises an unconditional trap with the specified code.
             //
@@ -401,6 +403,8 @@ impl BuiltinFunctionIndex {
             (@get nearest_f64 f64) => (return None);
             (@get i8x16_swizzle i8x16) => (return None);
             (@get i8x16_shuffle i8x16) => (return None);
+            (@get fma_f32x4 f32x4) => (return None);
+            (@get fma_f64x2 f64x2) => (return None);
 
             // Bool-returning functions use `false` as an indicator of a trap.
             (@get $name:ident bool) => (TrapSentinel::Falsy);

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -203,6 +203,18 @@ macro_rules! foreach_builtin_function {
             #[cfg(feature = "gc")]
             table_fill_gc_ref(vmctx: vmctx, table: u32, dst: u64, val: u32, len: u64) -> bool;
 
+            // Wasm floating-point routines for when the CPU instructions aren't available.
+            ceil_f32(vmctx: vmctx, x: f32) -> f32;
+            ceil_f64(vmctx: vmctx, x: f64) -> f64;
+            floor_f32(vmctx: vmctx, x: f32) -> f32;
+            floor_f64(vmctx: vmctx, x: f64) -> f64;
+            trunc_f32(vmctx: vmctx, x: f32) -> f32;
+            trunc_f64(vmctx: vmctx, x: f64) -> f64;
+            nearest_f32(vmctx: vmctx, x: f32) -> f32;
+            nearest_f64(vmctx: vmctx, x: f64) -> f64;
+            i8x16_swizzle(vmctx: vmctx, a: i8x16, b: i8x16) -> i8x16;
+            i8x16_shuffle(vmctx: vmctx, a: i8x16, b: i8x16, c: i8x16) -> i8x16;
+
             // Raises an unconditional trap with the specified code.
             //
             // This is used when signals-based-traps are disabled for backends
@@ -379,6 +391,16 @@ impl BuiltinFunctionIndex {
             (@get get_interned_func_ref pointer) => (return None);
             (@get intern_func_ref_for_gc_heap u64) => (return None);
             (@get is_subtype u32) => (return None);
+            (@get ceil_f32 f32) => (return None);
+            (@get ceil_f64 f64) => (return None);
+            (@get floor_f32 f32) => (return None);
+            (@get floor_f64 f64) => (return None);
+            (@get trunc_f32 f32) => (return None);
+            (@get trunc_f64 f64) => (return None);
+            (@get nearest_f32 f32) => (return None);
+            (@get nearest_f64 f64) => (return None);
+            (@get i8x16_swizzle i8x16) => (return None);
+            (@get i8x16_shuffle i8x16) => (return None);
 
             // Bool-returning functions use `false` as an indicator of a trap.
             (@get $name:ident bool) => (TrapSentinel::Falsy);

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -79,8 +79,6 @@ pub enum RelocationTarget {
     Wasm(FuncIndex),
     /// This is a reference to a trampoline for a builtin function.
     Builtin(BuiltinFunctionIndex),
-    /// A compiler-generated libcall.
-    HostLibcall(obj::LibCall),
     /// A pulley->host call from the interpreter.
     PulleyHostcall(u32),
 }

--- a/crates/environ/src/obj.rs
+++ b/crates/environ/src/obj.rs
@@ -156,49 +156,6 @@ pub const ELF_NAME_DATA: &'static str = ".name.wasm";
 /// metadata.
 pub const ELF_WASMTIME_DWARF: &str = ".wasmtime.dwarf";
 
-macro_rules! libcalls {
-    ($($rust:ident = $sym:tt)*) => (
-        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
-        #[expect(missing_docs, reason = "self-describing variants")]
-        pub enum LibCall {
-            $($rust,)*
-        }
-
-        impl LibCall {
-            /// Returns the libcall corresponding to the provided symbol name,
-            /// if one matches.
-            pub fn from_str(s: &str) -> Option<LibCall> {
-                match s {
-                    $($sym => Some(LibCall::$rust),)*
-                    _ => None,
-                }
-            }
-
-            /// Returns the symbol name in object files associated with this
-            /// libcall.
-            pub fn symbol(&self) -> &'static str {
-                match self {
-                    $(LibCall::$rust => $sym,)*
-                }
-            }
-        }
-    )
-}
-
-libcalls! {
-    FloorF32 = "libcall_floor32"
-    FloorF64 = "libcall_floor64"
-    NearestF32 = "libcall_nearestf32"
-    NearestF64 = "libcall_nearestf64"
-    CeilF32 = "libcall_ceilf32"
-    CeilF64 = "libcall_ceilf64"
-    TruncF32 = "libcall_truncf32"
-    TruncF64 = "libcall_truncf64"
-    FmaF32 = "libcall_fmaf32"
-    FmaF64 = "libcall_fmaf64"
-    X86Pshufb = "libcall_x86_pshufb"
-}
-
 /// Workaround to implement `core::error::Error` until
 /// gimli-rs/object#747 is settled.
 pub struct ObjectCrateErrorWrapper(pub object::Error);

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -750,7 +750,7 @@ impl FunctionIndices {
                     [&CompileKey::WASM_TO_BUILTIN_TRAMPOLINE_KIND]
                     [&CompileKey::wasm_to_builtin_trampoline(builtin)]
                     .unwrap_function(),
-                RelocationTarget::HostLibcall(_) | RelocationTarget::PulleyHostcall(_) => {
+                RelocationTarget::PulleyHostcall(_) => {
                     unreachable!("relocation is resolved at runtime, not compile time");
                 }
             },

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -5,6 +5,19 @@
 // selectively enabled here.
 #![warn(clippy::cast_sign_loss)]
 
+// Polyfill `std::simd::i8x16` until it's stable.
+#[cfg(target_arch = "x86_64")]
+#[allow(non_camel_case_types)]
+pub(crate) type i8x16 = core::arch::x86_64::__m128i;
+// On platforms other than x86_64, define i8x16 to a non-constructible type;
+// we need a type because we have a lot of macros for defining builtin
+// functions that are awkward to make conditional on the target, but it
+// doesn't need to actually be constructible unless we're on x86_64.
+#[cfg(not(target_arch = "x86_64"))]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) struct i8x16(());
+
 use crate::prelude::*;
 use crate::store::StoreOpaque;
 use alloc::sync::Arc;

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -6,14 +6,14 @@
 #![warn(clippy::cast_sign_loss)]
 
 // Polyfill `std::simd::i8x16` until it's stable.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
 #[allow(non_camel_case_types)]
 pub(crate) type i8x16 = core::arch::x86_64::__m128i;
 // On platforms other than x86_64, define i8x16 to a non-constructible type;
 // we need a type because we have a lot of macros for defining builtin
 // functions that are awkward to make conditional on the target, but it
 // doesn't need to actually be constructible unless we're on x86_64.
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
 pub(crate) struct i8x16(());

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -5,10 +5,17 @@
 // selectively enabled here.
 #![warn(clippy::cast_sign_loss)]
 
-// Polyfill `std::simd::i8x16` until it's stable.
+// Polyfill `std::simd::i8x16` etc. until they're stable.
 #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
 #[allow(non_camel_case_types)]
 pub(crate) type i8x16 = core::arch::x86_64::__m128i;
+#[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
+#[allow(non_camel_case_types)]
+pub(crate) type f32x4 = core::arch::x86_64::__m128;
+#[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
+#[allow(non_camel_case_types)]
+pub(crate) type f64x2 = core::arch::x86_64::__m128d;
+
 // On platforms other than x86_64, define i8x16 to a non-constructible type;
 // we need a type because we have a lot of macros for defining builtin
 // functions that are awkward to make conditional on the target, but it
@@ -17,6 +24,14 @@ pub(crate) type i8x16 = core::arch::x86_64::__m128i;
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
 pub(crate) struct i8x16(());
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) struct f32x4(());
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) struct f64x2(());
 
 use crate::prelude::*;
 use crate::store::StoreOpaque;

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -342,8 +342,8 @@ impl InterpreterRef<'_> {
             (@set bool $reg:ident $val:ident) => (self.0[$reg].set_i32(i32::from($val)));
             (@set u32 $reg:ident $val:ident) => (self.0[$reg].set_u32($val));
             (@set u64 $reg:ident $val:ident) => (self.0[$reg].set_u64($val));
-            (@set f32 $reg:ident $val:ident) => (self.0[$reg].set_f32($val));
-            (@set f64 $reg:ident $val:ident) => (self.0[$reg].set_f64($val));
+            (@set f32 $reg:ident $val:ident) => (unreachable::<f32, _>(($reg, $val)));
+            (@set f64 $reg:ident $val:ident) => (unreachable::<f64, _>(($reg, $val)));
             (@set i8x16 $reg:ident $val:ident) => (unreachable::<i8x16, _>(($reg, $val)));
             (@set pointer $reg:ident $val:ident) => (self.0[$reg].set_ptr($val));
             (@set size $reg:ident $val:ident) => (self.0[$reg].set_ptr($val as *mut u8));

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -325,8 +325,8 @@ impl InterpreterRef<'_> {
             (@get u8 $reg:ident) => (self.0[$reg].get_i32() as u8);
             (@get u32 $reg:ident) => (self.0[$reg].get_u32());
             (@get u64 $reg:ident) => (self.0[$reg].get_u64());
-            (@get f32 $reg:ident) => (self.0[$reg].get_f32());
-            (@get f64 $reg:ident) => (self.0[$reg].get_f64());
+            (@get f32 $reg:ident) => (unreachable::<f32, _>($reg));
+            (@get f64 $reg:ident) => (unreachable::<f64, _>($reg));
             (@get i8x16 $reg:ident) => (unreachable::<i8x16, _>($reg));
             (@get vmctx $reg:ident) => (self.0[$reg].get_ptr());
             (@get pointer $reg:ident) => (self.0[$reg].get_ptr());

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -1,6 +1,8 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::VMArrayCallNative;
-use crate::runtime::vm::{i8x16, tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext};
+use crate::runtime::vm::{
+    f32x4, f64x2, i8x16, tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext,
+};
 use crate::{Engine, ValRaw};
 use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
@@ -313,6 +315,8 @@ impl InterpreterRef<'_> {
             (@ty f32) => (f32);
             (@ty f64) => (f64);
             (@ty i8x16) => (i8x16);
+            (@ty f32x4) => (f32x4);
+            (@ty f64x2) => (f64x2);
             (@ty vmctx) => (*mut VMContext);
             (@ty pointer) => (*mut u8);
             (@ty ptr_u8) => (*mut u8);
@@ -328,6 +332,8 @@ impl InterpreterRef<'_> {
             (@get f32 $reg:ident) => (unreachable::<f32, _>($reg));
             (@get f64 $reg:ident) => (unreachable::<f64, _>($reg));
             (@get i8x16 $reg:ident) => (unreachable::<i8x16, _>($reg));
+            (@get f32x4 $reg:ident) => (unreachable::<f32x4, _>($reg));
+            (@get f64x2 $reg:ident) => (unreachable::<f64x2, _>($reg));
             (@get vmctx $reg:ident) => (self.0[$reg].get_ptr());
             (@get pointer $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr $reg:ident) => (self.0[$reg].get_ptr());
@@ -345,6 +351,8 @@ impl InterpreterRef<'_> {
             (@set f32 $reg:ident $val:ident) => (unreachable::<f32, _>(($reg, $val)));
             (@set f64 $reg:ident $val:ident) => (unreachable::<f64, _>(($reg, $val)));
             (@set i8x16 $reg:ident $val:ident) => (unreachable::<i8x16, _>(($reg, $val)));
+            (@set f32x4 $reg:ident $val:ident) => (unreachable::<f32x4, _>(($reg, $val)));
+            (@set f64x2 $reg:ident $val:ident) => (unreachable::<f64x2, _>(($reg, $val)));
             (@set pointer $reg:ident $val:ident) => (self.0[$reg].set_ptr($val));
             (@set size $reg:ident $val:ident) => (self.0[$reg].set_ptr($val as *mut u8));
         }

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::vmcontext::VMArrayCallNative;
-use crate::runtime::vm::{tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext};
+use crate::runtime::vm::{i8x16, tls, TrapRegisters, TrapTest, VMContext, VMOpaqueContext};
 use crate::{Engine, ValRaw};
 use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
@@ -266,8 +266,11 @@ impl InterpreterRef<'_> {
         /// `call(@host Ty(ty1, ty2, ...) -> retty)` - invoke a host function
         /// with the type `Ty`. The other types in the macro are checked by
         /// rustc to match the actual `Ty` definition in Rust.
+        ///
+        /// Ignore improper ctypes to permit `__m128i` on x86_64.
         macro_rules! call {
             (@builtin($($param:ident),*) $(-> $result:ident)?) => {{
+                #[allow(improper_ctypes_definitions)]
                 type T = unsafe extern "C" fn($(call!(@ty $param)),*) $(-> call!(@ty $result))?;
                 call!(@host T($($param),*) $(-> $result)?);
             }};
@@ -307,6 +310,9 @@ impl InterpreterRef<'_> {
             (@ty i32) => (i32);
             (@ty u64) => (u64);
             (@ty i64) => (i64);
+            (@ty f32) => (f32);
+            (@ty f64) => (f64);
+            (@ty i8x16) => (i8x16);
             (@ty vmctx) => (*mut VMContext);
             (@ty pointer) => (*mut u8);
             (@ty ptr_u8) => (*mut u8);
@@ -319,6 +325,9 @@ impl InterpreterRef<'_> {
             (@get u8 $reg:ident) => (self.0[$reg].get_i32() as u8);
             (@get u32 $reg:ident) => (self.0[$reg].get_u32());
             (@get u64 $reg:ident) => (self.0[$reg].get_u64());
+            (@get f32 $reg:ident) => (self.0[$reg].get_f32());
+            (@get f64 $reg:ident) => (self.0[$reg].get_f64());
+            (@get i8x16 $reg:ident) => (unreachable::<i8x16, _>($reg));
             (@get vmctx $reg:ident) => (self.0[$reg].get_ptr());
             (@get pointer $reg:ident) => (self.0[$reg].get_ptr());
             (@get ptr $reg:ident) => (self.0[$reg].get_ptr());
@@ -333,6 +342,9 @@ impl InterpreterRef<'_> {
             (@set bool $reg:ident $val:ident) => (self.0[$reg].set_i32(i32::from($val)));
             (@set u32 $reg:ident $val:ident) => (self.0[$reg].set_u32($val));
             (@set u64 $reg:ident $val:ident) => (self.0[$reg].set_u64($val));
+            (@set f32 $reg:ident $val:ident) => (self.0[$reg].set_f32($val));
+            (@set f64 $reg:ident $val:ident) => (self.0[$reg].set_f64($val));
+            (@set i8x16 $reg:ident $val:ident) => (unreachable::<i8x16, _>(($reg, $val)));
             (@set pointer $reg:ident $val:ident) => (self.0[$reg].set_ptr($val));
             (@set size $reg:ident $val:ident) => (self.0[$reg].set_ptr($val as *mut u8));
         }
@@ -401,7 +413,11 @@ impl InterpreterRef<'_> {
         }
 
         // if we got this far then something has gone seriously wrong.
-        unreachable!()
+        return unreachable(());
+
+        fn unreachable<T, U>(_: U) -> T {
+            unreachable!()
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -59,7 +59,7 @@ use crate::runtime::vm::table::{Table, TableElementType};
 use crate::runtime::vm::vmcontext::VMFuncRef;
 #[cfg(feature = "gc")]
 use crate::runtime::vm::VMGcRef;
-use crate::runtime::vm::{HostResultHasUnwindSentinel, Instance, TrapReason, VMStore};
+use crate::runtime::vm::{i8x16, HostResultHasUnwindSentinel, Instance, TrapReason, VMStore};
 use core::convert::Infallible;
 use core::ptr::NonNull;
 #[cfg(feature = "threads")]
@@ -92,7 +92,7 @@ pub mod raw {
     // between doc comments and `cfg`s.
     #![allow(unused_doc_comments, unused_attributes)]
 
-    use crate::runtime::vm::{InstanceAndStore, VMContext};
+    use crate::runtime::vm::{i8x16, InstanceAndStore, VMContext};
     use core::ptr::NonNull;
 
     macro_rules! libcall {
@@ -109,7 +109,10 @@ pub mod raw {
                 // This will delegate to the outer module to the actual
                 // implementation and automatically perform `catch_unwind` along
                 // with conversion of the return value in the face of traps.
+                //
+                // Ignore improper ctypes to permit `__m128i` on x86_64.
                 #[allow(unused_variables, missing_docs)]
+                #[allow(improper_ctypes_definitions)]
                 pub unsafe extern "C" fn $name(
                     vmctx: NonNull<VMContext>,
                     $( $pname : libcall!(@ty $param), )*
@@ -132,9 +135,12 @@ pub mod raw {
                 // This works around a `rustc` bug where compiling with LTO
                 // will sometimes strip out some of these symbols resulting
                 // in a linking failure.
+                //
+                // Ignore improper ctypes to permit `__m128i` on x86_64.
                 #[allow(non_upper_case_globals)]
                 const _: () = {
                     #[used]
+                    #[allow(improper_ctypes_definitions)]
                     static I_AM_USED: unsafe extern "C" fn(
                         NonNull<VMContext>,
                         $( $pname : libcall!(@ty $param), )*
@@ -145,7 +151,10 @@ pub mod raw {
 
         (@ty u32) => (u32);
         (@ty u64) => (u64);
+        (@ty f32) => (f32);
+        (@ty f64) => (f64);
         (@ty u8) => (u8);
+        (@ty i8x16) => (i8x16);
         (@ty bool) => (bool);
         (@ty pointer) => (*mut u8);
     }
@@ -1228,6 +1237,163 @@ fn update_mem_size(_store: &mut dyn VMStore, instance: &mut Instance, num_pages:
     }
 }
 
+fn floor_f32(_store: &mut dyn VMStore, _instance: &mut Instance, val: f32) -> f32 {
+    wasmtime_math::WasmFloat::wasm_floor(val)
+}
+
+fn floor_f64(_store: &mut dyn VMStore, _instance: &mut Instance, val: f64) -> f64 {
+    wasmtime_math::WasmFloat::wasm_floor(val)
+}
+
+fn ceil_f32(_store: &mut dyn VMStore, _instance: &mut Instance, val: f32) -> f32 {
+    wasmtime_math::WasmFloat::wasm_ceil(val)
+}
+
+fn ceil_f64(_store: &mut dyn VMStore, _instance: &mut Instance, val: f64) -> f64 {
+    wasmtime_math::WasmFloat::wasm_ceil(val)
+}
+
+fn trunc_f32(_store: &mut dyn VMStore, _instance: &mut Instance, val: f32) -> f32 {
+    wasmtime_math::WasmFloat::wasm_trunc(val)
+}
+
+fn trunc_f64(_store: &mut dyn VMStore, _instance: &mut Instance, val: f64) -> f64 {
+    wasmtime_math::WasmFloat::wasm_trunc(val)
+}
+
+fn nearest_f32(_store: &mut dyn VMStore, _instance: &mut Instance, val: f32) -> f32 {
+    wasmtime_math::WasmFloat::wasm_nearest(val)
+}
+
+fn nearest_f64(_store: &mut dyn VMStore, _instance: &mut Instance, val: f64) -> f64 {
+    wasmtime_math::WasmFloat::wasm_nearest(val)
+}
+
+// This intrinsic is only used on x86_64 platforms as an implementation of
+// the `i8x16.swizzle` instruction when `pshufb` in SSSE3 is not available.
+#[cfg(target_arch = "x86_64")]
+fn i8x16_swizzle(_store: &mut dyn VMStore, _instance: &mut Instance, a: i8x16, b: i8x16) -> i8x16 {
+    union U {
+        reg: i8x16,
+        mem: [u8; 16],
+    }
+
+    unsafe {
+        let a = U { reg: a }.mem;
+        let b = U { reg: b }.mem;
+
+        // Use the `swizzle` semantics of returning 0 on any out-of-bounds
+        // index, rather than the x86 pshufb semantics, since Wasmtime uses
+        // this to implement `i8x16.swizzle`.
+        let select = |arr: &[u8; 16], byte: u8| {
+            if byte >= 16 {
+                0x00
+            } else {
+                arr[byte as usize]
+            }
+        };
+
+        U {
+            mem: [
+                select(&a, b[0]),
+                select(&a, b[1]),
+                select(&a, b[2]),
+                select(&a, b[3]),
+                select(&a, b[4]),
+                select(&a, b[5]),
+                select(&a, b[6]),
+                select(&a, b[7]),
+                select(&a, b[8]),
+                select(&a, b[9]),
+                select(&a, b[10]),
+                select(&a, b[11]),
+                select(&a, b[12]),
+                select(&a, b[13]),
+                select(&a, b[14]),
+                select(&a, b[15]),
+            ],
+        }
+        .reg
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn i8x16_swizzle(
+    _store: &mut dyn VMStore,
+    _instance: &mut Instance,
+    _a: i8x16,
+    _b: i8x16,
+) -> i8x16 {
+    unreachable!()
+}
+
+// This intrinsic is only used on x86_64 platforms as an implementation of
+// the `i8x16.shuffle` instruction when `pshufb` in SSSE3 is not available.
+#[cfg(target_arch = "x86_64")]
+fn i8x16_shuffle(
+    _store: &mut dyn VMStore,
+    _instance: &mut Instance,
+    a: i8x16,
+    b: i8x16,
+    c: i8x16,
+) -> i8x16 {
+    union U {
+        reg: i8x16,
+        mem: [u8; 16],
+    }
+
+    unsafe {
+        let ab = [U { reg: a }.mem, U { reg: b }.mem];
+        let c = U { reg: c }.mem;
+
+        // Use the `shuffle` semantics of returning 0 on any out-of-bounds
+        // index, rather than the x86 pshufb semantics, since Wasmtime uses
+        // this to implement `i8x16.shuffle`.
+        let select = |arr: &[[u8; 16]; 2], byte: u8| {
+            if byte >= 32 {
+                0x00
+            } else if byte >= 16 {
+                arr[1][byte as usize - 16]
+            } else {
+                arr[0][byte as usize]
+            }
+        };
+
+        U {
+            mem: [
+                select(&ab, c[0]),
+                select(&ab, c[1]),
+                select(&ab, c[2]),
+                select(&ab, c[3]),
+                select(&ab, c[4]),
+                select(&ab, c[5]),
+                select(&ab, c[6]),
+                select(&ab, c[7]),
+                select(&ab, c[8]),
+                select(&ab, c[9]),
+                select(&ab, c[10]),
+                select(&ab, c[11]),
+                select(&ab, c[12]),
+                select(&ab, c[13]),
+                select(&ab, c[14]),
+                select(&ab, c[15]),
+            ],
+        }
+        .reg
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn i8x16_shuffle(
+    _store: &mut dyn VMStore,
+    _instance: &mut Instance,
+    _a: i8x16,
+    _b: i8x16,
+    _c: i8x16,
+) -> i8x16 {
+    unreachable!()
+}
+
 /// This intrinsic is just used to record trap information.
 ///
 /// The `Infallible` "ok" type here means that this never returns success, it
@@ -1256,104 +1422,4 @@ fn raise(_store: &mut dyn VMStore, _instance: &mut Instance) {
     // just insert a stub to catch bugs if it's accidentally called.
     #[cfg(not(has_host_compiler_backend))]
     unreachable!()
-}
-
-/// This module contains functions which are used for resolving relocations at
-/// runtime if necessary.
-///
-/// These functions are not used by default and currently the only platform
-/// they're used for is on x86_64 when SIMD is disabled and then SSE features
-/// are further disabled. In these configurations Cranelift isn't allowed to use
-/// native CPU instructions so it falls back to libcalls and we rely on the Rust
-/// standard library generally for implementing these.
-#[allow(missing_docs)]
-pub mod relocs {
-    pub extern "C" fn floorf32(f: f32) -> f32 {
-        wasmtime_math::WasmFloat::wasm_floor(f)
-    }
-
-    pub extern "C" fn floorf64(f: f64) -> f64 {
-        wasmtime_math::WasmFloat::wasm_floor(f)
-    }
-
-    pub extern "C" fn ceilf32(f: f32) -> f32 {
-        wasmtime_math::WasmFloat::wasm_ceil(f)
-    }
-
-    pub extern "C" fn ceilf64(f: f64) -> f64 {
-        wasmtime_math::WasmFloat::wasm_ceil(f)
-    }
-
-    pub extern "C" fn truncf32(f: f32) -> f32 {
-        wasmtime_math::WasmFloat::wasm_trunc(f)
-    }
-
-    pub extern "C" fn truncf64(f: f64) -> f64 {
-        wasmtime_math::WasmFloat::wasm_trunc(f)
-    }
-
-    pub extern "C" fn nearestf32(x: f32) -> f32 {
-        wasmtime_math::WasmFloat::wasm_nearest(x)
-    }
-
-    pub extern "C" fn nearestf64(x: f64) -> f64 {
-        wasmtime_math::WasmFloat::wasm_nearest(x)
-    }
-
-    pub extern "C" fn fmaf32(a: f32, b: f32, c: f32) -> f32 {
-        wasmtime_math::WasmFloat::wasm_mul_add(a, b, c)
-    }
-
-    pub extern "C" fn fmaf64(a: f64, b: f64, c: f64) -> f64 {
-        wasmtime_math::WasmFloat::wasm_mul_add(a, b, c)
-    }
-
-    // This intrinsic is only used on x86_64 platforms as an implementation of
-    // the `pshufb` instruction when SSSE3 is not available.
-    #[cfg(target_arch = "x86_64")]
-    use core::arch::x86_64::__m128i;
-    #[cfg(target_arch = "x86_64")]
-    #[target_feature(enable = "sse")]
-    #[allow(improper_ctypes_definitions)]
-    pub unsafe extern "C" fn x86_pshufb(a: __m128i, b: __m128i) -> __m128i {
-        union U {
-            reg: __m128i,
-            mem: [u8; 16],
-        }
-
-        unsafe {
-            let a = U { reg: a }.mem;
-            let b = U { reg: b }.mem;
-
-            let select = |arr: &[u8; 16], byte: u8| {
-                if byte & 0x80 != 0 {
-                    0x00
-                } else {
-                    arr[(byte & 0xf) as usize]
-                }
-            };
-
-            U {
-                mem: [
-                    select(&a, b[0]),
-                    select(&a, b[1]),
-                    select(&a, b[2]),
-                    select(&a, b[3]),
-                    select(&a, b[4]),
-                    select(&a, b[5]),
-                    select(&a, b[6]),
-                    select(&a, b[7]),
-                    select(&a, b[8]),
-                    select(&a, b[9]),
-                    select(&a, b[10]),
-                    select(&a, b[11]),
-                    select(&a, b[12]),
-                    select(&a, b[13]),
-                    select(&a, b[14]),
-                    select(&a, b[15]),
-                ],
-            }
-            .reg
-        }
-    }
 }

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -18,7 +18,7 @@ pub use self::signals::*;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
 use crate::runtime::vm::sys::traphandlers;
-use crate::runtime::vm::{i8x16, InterpreterRef, VMContext, VMStoreContext};
+use crate::runtime::vm::{f32x4, f64x2, i8x16, InterpreterRef, VMContext, VMStoreContext};
 use crate::{prelude::*, EntryStoreContext};
 use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
@@ -179,6 +179,8 @@ host_result_no_catch! {
     f32,
     f64,
     i8x16,
+    f32x4,
+    f64x2,
 }
 
 impl HostResult for NonNull<u8> {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -18,7 +18,7 @@ pub use self::signals::*;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
 use crate::runtime::vm::sys::traphandlers;
-use crate::runtime::vm::{InterpreterRef, VMContext, VMStoreContext};
+use crate::runtime::vm::{i8x16, InterpreterRef, VMContext, VMStoreContext};
 use crate::{prelude::*, EntryStoreContext};
 use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
@@ -176,6 +176,9 @@ host_result_no_catch! {
     u32,
     *mut u8,
     u64,
+    f32,
+    f64,
+    i8x16,
 }
 
 impl HostResult for NonNull<u8> {

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -5,7 +5,7 @@ mod vm_host_func_context;
 
 pub use self::vm_host_func_context::VMArrayCallHostFuncContext;
 use crate::prelude::*;
-use crate::runtime::vm::{i8x16, GcStore, InterpreterRef, VMGcRef, VmPtr, VmSafe};
+use crate::runtime::vm::{f32x4, f64x2, i8x16, GcStore, InterpreterRef, VMGcRef, VmPtr, VmSafe};
 use crate::store::StoreOpaque;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
@@ -454,6 +454,8 @@ mod test_vmglobal_definition {
         assert!(align_of::<VMGlobalDefinition>() >= align_of::<f32>());
         assert!(align_of::<VMGlobalDefinition>() >= align_of::<f64>());
         assert!(align_of::<VMGlobalDefinition>() >= align_of::<[u8; 16]>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<[f32; 4]>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<[f64; 2]>());
     }
 
     #[test]
@@ -976,6 +978,8 @@ macro_rules! define_builtin_array {
     (@ty f64) => (f64);
     (@ty u8) => (u8);
     (@ty i8x16) => (i8x16);
+    (@ty f32x4) => (f32x4);
+    (@ty f64x2) => (f64x2);
     (@ty bool) => (bool);
     (@ty pointer) => (*mut u8);
     (@ty vmctx) => (NonNull<VMContext>);

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -472,6 +472,16 @@ impl XRegVal {
         u64::from_le(x)
     }
 
+    pub fn get_f32(&self) -> f32 {
+        let x = unsafe { self.0.u32 };
+        f32::from_bits(u32::from_le(x))
+    }
+
+    pub fn get_f64(&self) -> f64 {
+        let x = unsafe { self.0.u64 };
+        f64::from_bits(u64::from_le(x))
+    }
+
     pub fn get_ptr<T>(&self) -> *mut T {
         let ptr = unsafe { self.0.ptr };
         core::ptr::with_exposed_provenance_mut(usize::from_le(ptr))
@@ -491,6 +501,14 @@ impl XRegVal {
 
     pub fn set_u64(&mut self, x: u64) {
         self.0.u64 = x.to_le();
+    }
+
+    pub fn set_f32(&mut self, x: f32) {
+        self.0.u32 = x.to_bits().to_le();
+    }
+
+    pub fn set_f64(&mut self, x: f64) {
+        self.0.u64 = x.to_bits().to_le();
     }
 
     pub fn set_ptr<T>(&mut self, ptr: *mut T) {

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -493,14 +493,6 @@ impl XRegVal {
         self.0.u64 = x.to_le();
     }
 
-    pub fn set_f32(&mut self, x: f32) {
-        self.0.u32 = x.to_bits().to_le();
-    }
-
-    pub fn set_f64(&mut self, x: f64) {
-        self.0.u64 = x.to_bits().to_le();
-    }
-
     pub fn set_ptr<T>(&mut self, ptr: *mut T) {
         self.0.ptr = ptr.expose_provenance().to_le();
     }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -472,16 +472,6 @@ impl XRegVal {
         u64::from_le(x)
     }
 
-    pub fn get_f32(&self) -> f32 {
-        let x = unsafe { self.0.u32 };
-        f32::from_bits(u32::from_le(x))
-    }
-
-    pub fn get_f64(&self) -> f64 {
-        let x = unsafe { self.0.u64 };
-        f64::from_bits(u64::from_le(x))
-    }
-
     pub fn get_ptr<T>(&self) -> *mut T {
         let ptr = unsafe { self.0.ptr };
         core::ptr::with_exposed_provenance_mut(usize::from_le(ptr))

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -47,7 +47,7 @@
 ;;       ret
 ;;       mv      a1, s1
 ;;       ld      a4, 0x10(a1)
-;;       ld      a4, 0x140(a4)
+;;       ld      a4, 0x190(a4)
 ;;       mv      a0, a1
 ;;       jalr    a4
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -47,7 +47,7 @@
 ;;       ret
 ;;       mv      a1, s1
 ;;       ld      a4, 0x10(a1)
-;;       ld      a4, 0x190(a4)
+;;       ld      a4, 0x1a0(a4)
 ;;       mv      a0, a1
 ;;       jalr    a4
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -35,7 +35,7 @@
 ;;
 ;; block1 cold:
 ;;     v15 = load.i64 notrap aligned readonly v1+16
-;;     v16 = load.i64 notrap aligned readonly v15+400
+;;     v16 = load.i64 notrap aligned readonly v15+416
 ;;     call_indirect sig1, v16(v1)
 ;;     trap user1
 ;;

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -35,7 +35,7 @@
 ;;
 ;; block1 cold:
 ;;     v15 = load.i64 notrap aligned readonly v1+16
-;;     v16 = load.i64 notrap aligned readonly v15+320
+;;     v16 = load.i64 notrap aligned readonly v15+400
 ;;     call_indirect sig1, v16(v1)
 ;;     trap user1
 ;;

--- a/tests/disas/winch/x64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/x64/f32_ceil/f32_ceil_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $4, %rsp
 ;;       movss   %xmm15, (%rsp)
 ;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/x64/f32_floor/f32_floor_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $4, %rsp
 ;;       movss   %xmm15, (%rsp)
 ;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/x64/f32_nearest/f32_nearest_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $4, %rsp
 ;;       movss   %xmm15, (%rsp)
 ;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/x64/f32_trunc/f32_trunc_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $4, %rsp
 ;;       movss   %xmm15, (%rsp)
 ;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/x64/f64_ceil/f64_ceil_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $8, %rsp
 ;;       movsd   %xmm15, (%rsp)
 ;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/x64/f64_floor/f64_floor_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $8, %rsp
 ;;       movsd   %xmm15, (%rsp)
 ;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/x64/f64_nearest/f64_nearest_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $8, %rsp
 ;;       movsd   %xmm15, (%rsp)
 ;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/x64/f64_trunc/f64_trunc_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6e
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,13 +24,13 @@
 ;;       subq    $8, %rsp
 ;;       movsd   %xmm15, (%rsp)
 ;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       movabsq $0, %r11
-;;       callq   *%r11
+;;       callq   0xe6
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6e: ud2
+;;   69: ud2

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -125,6 +125,14 @@ macro_rules! declare_function_sig {
                 WasmValType::V128
             }
 
+            fn f32x4(&self) -> WasmValType {
+                WasmValType::V128
+            }
+
+            fn f64x2(&self) -> WasmValType {
+                WasmValType::V128
+            }
+
             fn bool(&self) -> WasmValType {
                 WasmValType::I32
             }

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -6,7 +6,6 @@ use crate::{
     CallingConvention,
 };
 use anyhow::Result;
-use cranelift_codegen::ir::LibCall;
 use std::sync::Arc;
 use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmValType};
 
@@ -14,9 +13,6 @@ use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmValType};
 pub(crate) enum BuiltinType {
     /// Dynamic built-in function, derived from the VMContext.
     Builtin(BuiltinFunctionIndex),
-    /// A known libcall.
-    /// See [`cranelift_codegen::ir::LibCall`] for more details.
-    LibCall(LibCall),
 }
 
 impl BuiltinType {
@@ -24,12 +20,6 @@ impl BuiltinType {
     /// enumerated with a [`BuiltinFunctionIndex`].
     pub fn builtin(idx: BuiltinFunctionIndex) -> Self {
         Self::Builtin(idx)
-    }
-
-    /// Creates a new builtin from a Compiler-defined [`LibCall`] typically used
-    /// late in lowering.
-    pub fn libcall(libcall: LibCall) -> Self {
-        Self::LibCall(libcall)
     }
 }
 
@@ -72,22 +62,6 @@ macro_rules! declare_function_sig {
             wasm_call_conv: CallingConvention,
             /// The target pointer type, as a WebAssembly type.
             ptr_type: WasmValType,
-            /// F32 Ceil.
-            ceil_f32: Option<BuiltinFunction>,
-            /// F64 Ceil.
-            ceil_f64: Option<BuiltinFunction>,
-            /// F32 Floor.
-            floor_f32: Option<BuiltinFunction>,
-            /// F64 Floor.
-            floor_f64: Option<BuiltinFunction>,
-            /// F32 Trunc.
-            trunc_f32: Option<BuiltinFunction>,
-            /// F64 Trunc.
-            trunc_f64: Option<BuiltinFunction>,
-            /// F32 Nearest.
-            nearest_f32: Option<BuiltinFunction>,
-            /// F64 Nearest.
-            nearest_f64: Option<BuiltinFunction>,
             $(
                 $( #[ $attr ] )*
                 $name: Option<BuiltinFunction>,
@@ -108,14 +82,6 @@ macro_rules! declare_function_sig {
                     host_call_conv,
                     wasm_call_conv,
                     ptr_type: ptr_type_from_ptr_size(size),
-                    ceil_f32: None,
-                    ceil_f64: None,
-                    floor_f32: None,
-                    floor_f64: None,
-                    trunc_f32: None,
-                    trunc_f64: None,
-                    nearest_f32: None,
-                    nearest_f64: None,
                     $(
                         $( #[ $attr ] )*
                         $name: None,
@@ -155,6 +121,10 @@ macro_rules! declare_function_sig {
                 WasmValType::I64
             }
 
+            fn i8x16(&self) -> WasmValType {
+                WasmValType::V128
+            }
+
             fn bool(&self) -> WasmValType {
                 WasmValType::I32
             }
@@ -165,94 +135,6 @@ macro_rules! declare_function_sig {
 
             fn over_f32<A: ABI>(&self) -> Result<ABISig> {
                 A::sig_from(&[self.f64()], &[self.f64()], &self.host_call_conv)
-            }
-
-            pub(crate) fn ceil_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.ceil_f32.is_none() {
-                    let sig = self.over_f32::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::CeilF32) });
-                    self.ceil_f32 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.ceil_f32.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn ceil_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.ceil_f64.is_none() {
-                    let sig = self.over_f64::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::CeilF64) });
-                    self.ceil_f64 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.ceil_f64.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn floor_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.floor_f32.is_none() {
-                    let sig = self.over_f32::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::FloorF32) });
-                    self.floor_f32 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.floor_f32.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn floor_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.floor_f64.is_none() {
-                    let sig = self.over_f64::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::FloorF64) });
-                    self.floor_f64 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.floor_f64.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn trunc_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.trunc_f32.is_none() {
-                    let sig = self.over_f32::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::TruncF32) });
-                    self.trunc_f32 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.trunc_f32.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn trunc_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.trunc_f64.is_none() {
-                    let sig = self.over_f64::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::TruncF64) });
-                    self.trunc_f64 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.trunc_f64.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn nearest_f32<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.nearest_f32.is_none() {
-                    let sig = self.over_f32::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::NearestF32) });
-                    self.nearest_f32 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.nearest_f32.as_ref().unwrap().clone())
-            }
-
-            pub(crate) fn nearest_f64<A: ABI>(&mut self) -> Result<BuiltinFunction> {
-                if self.nearest_f64.is_none() {
-                    let sig = self.over_f64::<A>()?;
-                    let inner = Arc::new(BuiltinFunctionInner { sig, ty: BuiltinType::libcall(LibCall::NearestF64) });
-                    self.nearest_f64 = Some(BuiltinFunction {
-                        inner,
-                    });
-                }
-                Ok(self.nearest_f64.as_ref().unwrap().clone())
             }
 
             $(

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -165,7 +165,6 @@ impl FnCall {
                 CalleeKind::direct(env.name_builtin(idx)),
                 ContextArgs::pinned_vmctx(),
             ),
-            BuiltinType::LibCall(c) => (CalleeKind::libcall(c), ContextArgs::none()),
         }
     }
 

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use cranelift_codegen::isa::aarch64::inst::{ASIMDFPModImm, FpuToIntOp, UImm5, NZCV};
 use cranelift_codegen::{
-    ir::{ExternalName, LibCall, MemFlags, SourceLoc, TrapCode, UserExternalNameRef},
+    ir::{ExternalName, MemFlags, SourceLoc, TrapCode, UserExternalNameRef},
     isa::aarch64::inst::{
         self,
         emit::{EmitInfo, EmitState},
@@ -1091,18 +1091,6 @@ impl Assembler {
                 call_conv.into(),
             )),
         })
-    }
-
-    /// Emit a call to a well-known libcall.
-    /// `dst` is used as a scratch register to hold the address of the libcall function.
-    pub fn call_with_lib(&mut self, lib: LibCall, dst: Reg, call_conv: CallingConvention) {
-        let name = ExternalName::LibCall(lib);
-        self.emit(Inst::LoadExtName {
-            rd: writable!(dst.into()),
-            name: name.into(),
-            offset: 0,
-        });
-        self.call_with_reg(dst, call_conv)
     }
 
     /// Load the min value for an integer of size out_size, as a floating-point

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1,10 +1,4 @@
-use super::{
-    abi::Aarch64ABI,
-    address::Address,
-    asm::Assembler,
-    regs::{self, scratch},
-    ABI,
-};
+use super::{abi::Aarch64ABI, address::Address, asm::Assembler, regs, ABI};
 use crate::{
     abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx},
     codegen::{ptr_type_from_ptr_size, CodeGenContext, CodeGenError, Emission, FuncEnv},
@@ -290,7 +284,6 @@ impl Masm for MacroAssembler {
         match callee {
             CalleeKind::Indirect(reg) => self.asm.call_with_reg(reg, call_conv),
             CalleeKind::Direct(idx) => self.asm.call_with_name(idx, call_conv),
-            CalleeKind::LibCall(lib) => self.asm.call_with_lib(lib, scratch(), call_conv),
         }
 
         Ok(total_stack)

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 use cranelift_codegen::{
     ir::{
-        types, ConstantPool, ExternalName, LibCall, MemFlags, SourceLoc, TrapCode, Type,
-        UserExternalNameRef,
+        types, ConstantPool, ExternalName, MemFlags, SourceLoc, TrapCode, Type, UserExternalNameRef,
     },
     isa::{
         unwind::UnwindInst,
@@ -28,7 +27,7 @@ use cranelift_codegen::{
         },
     },
     settings, CallInfo, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState,
-    MachLabel, PatchRegion, RelocDistance, VCodeConstantData, VCodeConstants, Writable,
+    MachLabel, PatchRegion, VCodeConstantData, VCodeConstants, Writable,
 };
 
 use crate::reg::WritableReg;
@@ -1636,26 +1635,6 @@ impl Assembler {
         self.emit(Inst::CallKnown {
             info: Box::new(CallInfo::empty(ExternalName::user(name), cc.into())),
         });
-    }
-
-    /// Emit a call to a well-known libcall.
-    pub fn call_with_lib(&mut self, cc: CallingConvention, lib: LibCall, dst: Reg) {
-        let dest = ExternalName::LibCall(lib);
-
-        // `use_colocated_libcalls` is never `true` from within Wasmtime,
-        // so always require loading the libcall to a register and use
-        // a `Far` relocation distance to ensure the right relocation when
-        // emitting to binary.
-        //
-        // See [wasmtime::engine::Engine::check_compatible_with_shared_flag] and
-        // [wasmtime_cranelift::obj::ModuleTextBuilder::append_func]
-        self.emit(Inst::LoadExtName {
-            dst: Writable::from_reg(dst.into()),
-            name: Box::new(dest),
-            offset: 0,
-            distance: RelocDistance::Far,
-        });
-        self.call_with_reg(cc, dst);
     }
 
     /// Emits a conditional jump to the given label.

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -319,7 +319,6 @@ impl Masm for MacroAssembler {
         match callee {
             CalleeKind::Indirect(reg) => self.asm.call_with_reg(cc, reg),
             CalleeKind::Direct(idx) => self.asm.call_with_name(cc, idx),
-            CalleeKind::LibCall(lib) => self.asm.call_with_lib(cc, lib, regs::scratch()),
         };
         Ok(total_stack)
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -778,7 +778,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.floor_f32::<M::ABI>()?;
+                let builtin = env.builtins.floor_f32::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -791,7 +791,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.floor_f64::<M::ABI>()?;
+                let builtin = env.builtins.floor_f64::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -804,7 +804,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.ceil_f32::<M::ABI>()?;
+                let builtin = env.builtins.ceil_f32::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -817,7 +817,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.ceil_f64::<M::ABI>()?;
+                let builtin = env.builtins.ceil_f64::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -830,7 +830,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.nearest_f32::<M::ABI>()?;
+                let builtin = env.builtins.nearest_f32::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -843,7 +843,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.nearest_f64::<M::ABI>()?;
+                let builtin = env.builtins.nearest_f64::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -856,7 +856,7 @@ where
             &mut self.context,
             OperandSize::S32,
             |env, cx, masm| {
-                let builtin = env.builtins.trunc_f32::<M::ABI>()?;
+                let builtin = env.builtins.trunc_f32::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )
@@ -869,7 +869,7 @@ where
             &mut self.context,
             OperandSize::S64,
             |env, cx, masm| {
-                let builtin = env.builtins.trunc_f64::<M::ABI>()?;
+                let builtin = env.builtins.trunc_f64::<M::ABI, M::Ptr>()?;
                 FnCall::emit::<M>(env, masm, cx, Callee::Builtin(builtin))
             },
         )


### PR DESCRIPTION
With this patch, all emitted calls are Wasmtime-style builtins, rather than Cranelift-style libcalls. This ensures that all calls from Cranelift-generated code into Wasmtime host code use the same mechanism, and eliminates the relocation handling code for the libcall mechanism.

This is split out from #9093.
