### PR TITLE
x64: remove `AluConstOp`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -29,11 +29,6 @@
                   (src2 GprMem)
                   (dst WritableGpr))
 
-       ;; Production of a zero value into a register of the specified size.
-       (AluConstOp (op AluRmiROpcode)
-                   (size OperandSize)
-                   (dst WritableGpr))
-
        ;; Instructions on general-purpose registers that only read src and
        ;; defines dst (dst is not modified). `bsr`, etc.
        (UnaryRmR (size OperandSize) ;; 2, 4, or 8

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -234,22 +234,6 @@ pub(crate) fn emit(
             }
         }
 
-        &Inst::AluConstOp { op, size, dst } => {
-            let dst = WritableGpr::from_writable_reg(dst.to_writable_reg()).unwrap();
-            emit(
-                &Inst::AluRmiR {
-                    size,
-                    op,
-                    dst,
-                    src1: dst.to_reg(),
-                    src2: dst.to_reg().into(),
-                },
-                sink,
-                info,
-                state,
-            );
-        }
-
         Inst::AluRmRVex {
             size,
             op,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -142,8 +142,7 @@ impl Inst {
             | Inst::MachOTlsGetAddr { .. }
             | Inst::CoffTlsGetAddr { .. }
             | Inst::Unwind { .. }
-            | Inst::DummyUse { .. }
-            | Inst::AluConstOp { .. } => smallvec![],
+            | Inst::DummyUse { .. } => smallvec![],
 
             Inst::LockCmpxchg16b { .. }
             | Inst::Atomic128RmwSeq { .. }
@@ -707,12 +706,6 @@ impl PrettyPrint for Inst {
                 let src2 = src2.pretty_print(size_bytes);
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
                 format!("{op} {src1}, {src2}, {dst}")
-            }
-            Inst::AluConstOp { op, dst, size } => {
-                let size_bytes = size.to_bytes();
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes);
-                let op = ljustify2(op.to_string(), suffix_lqb(*size));
-                format!("{op} {dst}, {dst}, {dst}")
             }
             Inst::AluRmRVex {
                 size,
@@ -2024,7 +2017,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_reuse_def(dst, 0);
             src2.get_operands(collector);
         }
-        Inst::AluConstOp { dst, .. } => collector.reg_def(dst),
         Inst::AluRmRVex {
             src1, src2, dst, ..
         } => {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -173,16 +173,6 @@ pub(crate) fn check(
             RegMem::Reg { .. } => undefined_result(ctx, vcode, dst, 64, size.to_bits().into()),
         },
 
-        Inst::AluConstOp {
-            op: AluRmiROpcode::Xor,
-            dst,
-            ..
-        } => check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
-            Ok(Some(Fact::constant(64, 0)))
-        }),
-
-        Inst::AluConstOp { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
-
         Inst::UnaryRmR {
             size, ref src, dst, ..
         }


### PR DESCRIPTION
After #10648, this `Inst` variant is no longer used.