### PR TITLE
asm: simplify visiting `Amode` registers

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -147,14 +147,11 @@ impl dsl::Inst {
                             let reg_lower = reg.to_lowercase();
                             f.add_block(&format!("match &mut self.{loc}"), |f| {
                                 fmtln!(f, "{reg}Mem::{reg}(r) => visitor.{mutability}_{reg_lower}(r),");
-                                fmtln!(
-                                    f,
-                                    "{reg}Mem::Mem(m) => m.registers_mut().iter_mut().for_each(|r| visitor.read_gpr(r)),"
-                                );
+                                fmtln!(f, "{reg}Mem::Mem(m) => visit_amode(m, visitor),");
                             });
                         }
                         Mem(loc) => {
-                            fmtln!(f, "self.{loc}.registers_mut().iter_mut().for_each(|r| visitor.read_gpr(r));");
+                            fmtln!(f, "visit_amode(&mut self.{loc}, visitor);");
                         }
                     }
                 }

--- a/cranelift/assembler-x64/src/inst.rs
+++ b/cranelift/assembler-x64/src/inst.rs
@@ -6,7 +6,7 @@
 use crate::api::{AsReg, CodeSink, KnownOffsetTable, RegisterVisitor, Registers};
 use crate::gpr::{self, Gpr, Size};
 use crate::imm::{Extension, Imm16, Imm32, Imm8, Simm32, Simm8};
-use crate::mem::{emit_modrm_sib_disp, Amode, GprMem, XmmMem};
+use crate::mem::{emit_modrm_sib_disp, visit_amode, Amode, GprMem, XmmMem};
 use crate::rex::{self, RexFlags};
 use crate::xmm::Xmm;
 use crate::Fixed;


### PR DESCRIPTION
Previously, the `Amode::registers_mut` method returned a list of registers that generated code iterated over. This was because it was difficult to capture the type needed for constraining the `Amode` (i.e., `Registers::ReadGpr`). This change moves that functionality to a helper function with identical behavior, simplifying the generated code and API surface.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
