### PR TITLE
Remove some `#![expect(clippy::allow_attributes_without_reason)]`

### DIFF
--- a/cranelift/interpreter/src/lib.rs
+++ b/cranelift/interpreter/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This module is a project for interpreting Cranelift IR.
 
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
-
 pub mod address;
 pub mod environment;
 pub mod frame;

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -59,7 +59,6 @@ fn collect_block_args(
 /// Interpret a single Cranelift instruction. Note that program traps and interpreter errors are
 /// distinct: a program trap results in `Ok(Flow::Trap(...))` whereas an interpretation error (e.g.
 /// the types of two values are incompatible) results in `Err(...)`.
-#[allow(unused_variables)]
 pub fn step<'a, I>(state: &mut dyn State<'a>, inst_context: I) -> Result<ControlFlow<'a>, StepError>
 where
     I: InstructionContext,
@@ -123,7 +122,7 @@ where
                 match mask.len() {
                     16 => DataValue::V128(mask.try_into().expect("a 16-byte vector mask")),
                     8 => DataValue::V64(mask.try_into().expect("an 8-byte vector mask")),
-                    length => panic!("unexpected Shuffle mask length {}", mask.len()),
+                    length => panic!("unexpected Shuffle mask length {length}"),
                 }
             }
             // 8-bit.
@@ -259,6 +258,7 @@ where
     };
 
     // Based on `condition`, indicate where to continue the control flow.
+    #[expect(unused_variables, reason = "here in case it's needed in the future")]
     let branch_when = |condition: bool, block| -> Result<ControlFlow, StepError> {
         if condition {
             continue_at(block)

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -1,7 +1,7 @@
 //! The [DataValueExt] trait is an extension trait for [DataValue]. It provides a lot of functions
 //! used by the rest of the interpreter.
 
-#![allow(trivial_numeric_casts)]
+#![expect(trivial_numeric_casts, reason = "macro-generated code")]
 
 use core::fmt::{self, Display, Formatter};
 use core::ops::Neg;

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -1,6 +1,6 @@
 //! Abstract syntax tree (AST) created from parsed ISLE.
 
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "fields mostly self-describing")]
 
 use crate::lexer::Pos;
 use crate::log;

--- a/cranelift/isle/isle/src/files.rs
+++ b/cranelift/isle/isle/src/files.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "fields mostly self-describing")]
 
 use crate::codegen::Prefix;
 use std::ops::Index;

--- a/cranelift/isle/isle/src/lib.rs
+++ b/cranelift/isle/isle/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 macro_rules! declare_id {
     (

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::allow_attributes, reason = "crate not migrated yet")]
 #![no_std]
 
 #[cfg(any(feature = "std", unix, windows))]

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -69,7 +69,6 @@
 
 #![warn(clippy::cast_sign_loss)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 pub mod clocks;
 mod ctx;

--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -1,5 +1,3 @@
-// This is mostly stubs
-#![allow(unused_variables, dead_code)]
 //! Virtual pipes.
 //!
 //! These types provide easy implementations of `WasiFile` that mimic much of the behavior of Unix

--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -124,9 +124,9 @@ fn from_raw_os_error(err: Option<i32>) -> Option<Error> {
         RustixErrno::TIMEDOUT => Errno::Timedout.into(),
 
         // On some platforms.into(), these have the same value as other errno values.
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, reason = "see comment")]
         RustixErrno::WOULDBLOCK => Errno::Again.into(),
-        #[allow(unreachable_patterns)]
+        #[allow(unreachable_patterns, reason = "see comment")]
         RustixErrno::OPNOTSUPP => Errno::Notsup.into(),
 
         _ => return None,

--- a/crates/wasi-http/src/bindings.rs
+++ b/crates/wasi-http/src/bindings.rs
@@ -1,6 +1,6 @@
 //! Raw bindings to the `wasi:http` package.
 
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "bindgen-generated code")]
 mod generated {
     use crate::body;
     use crate::types;
@@ -51,9 +51,8 @@ pub use self::generated::{Proxy, ProxyIndices, ProxyPre};
 
 /// Sync implementation of the `wasi:http/proxy` world.
 pub mod sync {
-    #[allow(missing_docs)]
+    #[expect(missing_docs, reason = "bindgen-generated code")]
     mod generated {
-        #![allow(missing_docs)]
         wasmtime::component::bindgen!({
             world: "wasi:http/proxy",
             tracing: true,

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -217,7 +217,6 @@
 #![deny(missing_docs)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 mod error;
 mod http_impl;

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -12,7 +12,6 @@
         reason = "stripped down in proxy build",
     )
 )]
-#![expect(clippy::allow_attributes, reason = "crate not migrated yet")]
 
 use crate::bindings::wasi::clocks::{monotonic_clock, wall_clock};
 use crate::bindings::wasi::io::poll;

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 //! # Wasmtime's WASI Implementation
 //!

--- a/crates/wasi/src/p2/host/clocks.rs
+++ b/crates/wasi/src/p2/host/clocks.rs
@@ -1,5 +1,3 @@
-#![allow(unused_variables)]
-
 use crate::p2::bindings::{
     clocks::monotonic_clock::{self, Duration as WasiDuration, Instant},
     clocks::wall_clock::{self, Datetime},

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -942,8 +942,10 @@ fn from_raw_os_error(err: Option<i32>) -> Option<ErrorCode> {
         RustixErrno::INPROGRESS => ErrorCode::InProgress,
         RustixErrno::INTR => ErrorCode::Interrupted,
 
-        // On some platforms, these have the same value as other errno values.
-        #[allow(unreachable_patterns)]
+        #[allow(
+            unreachable_patterns,
+            reason = "on some platforms, these have the same value as other errno values"
+        )]
         RustixErrno::OPNOTSUPP => ErrorCode::Unsupported,
 
         _ => return None,

--- a/crates/wasi/src/p2/host/network.rs
+++ b/crates/wasi/src/p2/host/network.rs
@@ -87,7 +87,10 @@ impl From<&Errno> for ErrorCode {
     fn from(value: &Errno) -> Self {
         match *value {
             Errno::WOULDBLOCK => ErrorCode::WouldBlock,
-            #[allow(unreachable_patterns)] // EWOULDBLOCK and EAGAIN can have the same value.
+            #[allow(
+                unreachable_patterns,
+                reason = "EWOULDBLOCK and EAGAIN can have the same value"
+            )]
             Errno::AGAIN => ErrorCode::WouldBlock,
             Errno::INTR => ErrorCode::WouldBlock,
             #[cfg(not(windows))]
@@ -391,7 +394,6 @@ pub(crate) mod util {
 
     // Even though SO_REUSEADDR is a SOL_* level option, this function contain a
     // compatibility fix specific to TCP. That's why it contains the `_tcp_` infix instead of `_socket_`.
-    #[allow(unused_variables)] // Parameters are not used on Windows
     pub fn set_tcp_reuseaddr<Fd: AsFd>(sockfd: Fd, value: bool) -> rustix::io::Result<()> {
         // When a TCP socket is closed, the system may
         // temporarily reserve that specific address+port pair in a so called
@@ -413,6 +415,8 @@ pub(crate) mod util {
 
         #[cfg(not(windows))]
         sockopt::set_socket_reuseaddr(sockfd, value)?;
+        #[cfg(windows)]
+        let _ = (sockfd, value);
 
         Ok(())
     }

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -2571,7 +2571,6 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         Ok(())
     }
 
-    #[allow(unused_variables)]
     #[instrument(skip(self, _memory))]
     fn sock_accept(
         &mut self,
@@ -2584,7 +2583,6 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         Err(types::Errno::Notsock.into())
     }
 
-    #[allow(unused_variables)]
     #[instrument(skip(self, _memory))]
     fn sock_recv(
         &mut self,
@@ -2598,7 +2596,6 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         Err(types::Errno::Notsock.into())
     }
 
-    #[allow(unused_variables)]
     #[instrument(skip(self, _memory))]
     fn sock_send(
         &mut self,
@@ -2612,7 +2609,6 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         Err(types::Errno::Notsock.into())
     }
 
-    #[allow(unused_variables)]
     #[instrument(skip(self, _memory))]
     fn sock_shutdown(
         &mut self,

--- a/crates/wasi/tests/all/p2/api.rs
+++ b/crates/wasi/tests/all/p2/api.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
-
 use anyhow::Result;
 use std::io::Write;
 use std::sync::Mutex;
@@ -115,19 +113,22 @@ async fn api_read_only() -> Result<()> {
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
-// This is tested in the wasi-http crate, but need to satisfy the `foreach_api!`
-// macro above.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "tested in the wasi-http crate, satisfying foreach_api! macro"
+)]
 fn api_proxy() {}
 
-// This is tested in the wasi-http crate, but need to satisfy the `foreach_api!`
-// macro above.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "tested in the wasi-http crate, satisfying foreach_api! macro"
+)]
 fn api_proxy_streaming() {}
 
-// This is tested in the wasi-http crate, but need to satisfy the `foreach_api!`
-// macro above.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "tested in the wasi-http crate, satisfying foreach_api! macro"
+)]
 fn api_proxy_forward_request() {}
 
 wasmtime::component::bindgen!({

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1111,7 +1111,7 @@ mod test_programs {
 
     macro_rules! assert_test_exists {
         ($name:ident) => {
-            #[allow(unused_imports)]
+            #[expect(unused_imports, reason = "just here to assert the test is here")]
             use self::$name as _;
         };
     }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1,5 +1,4 @@
 #![cfg(not(miri))]
-#![allow(dead_code)]
 
 use super::engine;
 use anyhow::Result;
@@ -336,6 +335,7 @@ mod async_config {
         async: true,
     });
 
+    #[expect(dead_code, reason = "just here for bindings")]
     struct T;
 
     impl T1Imports for T {

--- a/tests/all/debug/dump.rs
+++ b/tests/all/debug/dump.rs
@@ -3,17 +3,14 @@ use std::env;
 use std::process::Command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum DwarfDumpSection {
     DebugInfo,
-    DebugLine,
 }
 
 pub fn get_dwarfdump(obj: &str, section: DwarfDumpSection) -> Result<String> {
     let dwarfdump = env::var("DWARFDUMP").unwrap_or("llvm-dwarfdump".to_string());
     let section_flag = match section {
         DwarfDumpSection::DebugInfo => "-debug-info",
-        DwarfDumpSection::DebugLine => "-debug-line",
     };
     let output = Command::new(&dwarfdump)
         .args(&[section_flag, obj])

--- a/tests/all/debug/gdb.rs
+++ b/tests/all/debug/gdb.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::{bail, format_err, Result};
 use filecheck::{CheckerBuilder, NO_VARIABLES};
 use std::env;
@@ -53,8 +51,7 @@ fn check_gdb_output(output: &str, directives: &str) -> Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
-pub fn test_debug_dwarf_gdb() -> Result<()> {
+fn test_debug_dwarf_gdb() -> Result<()> {
     let output = gdb_with_script(
         &[
             "-Ccache=n",

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::{bail, format_err, Result};
 use filecheck::{CheckerBuilder, NO_VARIABLES};
 use std::env;
@@ -443,7 +441,7 @@ mod test_programs {
 
     macro_rules! assert_test_exists {
         ($name:ident) => {
-            #[allow(unused_imports)]
+            #[expect(unused_imports, reason = "used to assert functions exist")]
             use self::$name as _;
         };
     }

--- a/tests/all/debug/simulate.rs
+++ b/tests/all/debug/simulate.rs
@@ -5,7 +5,7 @@ use filecheck::{CheckerBuilder, NO_VARIABLES};
 use tempfile::NamedTempFile;
 use wat::parse_str;
 
-#[allow(dead_code)]
+#[allow(dead_code, reason = "used by conditionally-defined tests below")]
 fn check_wat(wat: &str) -> Result<()> {
     let wasm = parse_str(wat)?;
     let obj_file = NamedTempFile::new()?;
@@ -33,9 +33,9 @@ fn check_wat(wat: &str) -> Result<()> {
 fn test_debug_dwarf_simulate_simple_x86_64() -> Result<()> {
     check_wat(
         r#"
-;; check: DW_TAG_compile_unit 
+;; check: DW_TAG_compile_unit
 (module
-;; check: DW_TAG_subprogram 
+;; check: DW_TAG_subprogram
 ;; check: DW_AT_name	("wasm-function[0]")
 ;; check:   DW_TAG_formal_parameter
 ;; check:     DW_AT_name	("var0")
@@ -64,9 +64,9 @@ fn test_debug_dwarf_simulate_simple_x86_64() -> Result<()> {
 fn test_debug_dwarf_simulate_with_imports_x86_64() -> Result<()> {
     check_wat(
         r#"
-;; check: DW_TAG_compile_unit 
+;; check: DW_TAG_compile_unit
 (module
-;; check: DW_TAG_subprogram 
+;; check: DW_TAG_subprogram
 ;; check: DW_AT_name	("func1")
     (import "foo" "bar" (func $import1) )
     (func $func1 (result i32)
@@ -85,9 +85,9 @@ fn test_debug_dwarf_simulate_with_imports_x86_64() -> Result<()> {
 fn test_debug_dwarf_simulate_with_invalid_name_x86_64() -> Result<()> {
     check_wat(
         r#"
-;; check: DW_TAG_compile_unit 
+;; check: DW_TAG_compile_unit
 (module (@name "\00")
-;; check: DW_TAG_subprogram 
+;; check: DW_TAG_subprogram
 ;; check: DW_AT_name	("wasm-function[1]")
     (import "foo" "bar" (func $import1) )
     (func (@name "\00f") (result i32)

--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -5,7 +5,6 @@ use filecheck::{CheckerBuilder, NO_VARIABLES};
 use std::fs::read;
 use tempfile::NamedTempFile;
 
-#[allow(dead_code)]
 fn check_wasm(wasm_path: &str, directives: &str) -> Result<()> {
     let wasm = read(wasm_path)?;
     let obj_file = NamedTempFile::new()?;
@@ -24,31 +23,8 @@ fn check_wasm(wasm_path: &str, directives: &str) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
-fn check_line_program(wasm_path: &str, directives: &str) -> Result<()> {
-    let wasm = read(wasm_path)?;
-    let obj_file = NamedTempFile::new()?;
-    let obj_path = obj_file.path().to_str().unwrap();
-    compile_cranelift(&wasm, Some(wasm_path.as_ref()), None, obj_path)?;
-    let dump = get_dwarfdump(obj_path, DwarfDumpSection::DebugLine)?;
-    let mut builder = CheckerBuilder::new();
-    builder
-        .text(directives)
-        .map_err(|e| format_err!("unable to build checker: {:?}", e))?;
-    let checker = builder.finish();
-    let check = checker
-        .explain(&dump, NO_VARIABLES)
-        .map_err(|e| format_err!("{:?}", e))?;
-    assert!(check.0, "didn't pass check {}", check.1);
-    Ok(())
-}
-
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_dwarf_translate_dead_code() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/dead_code.wasm",
@@ -69,10 +45,6 @@ check:      DW_AT_name	("baz")
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_dwarf_translate() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/fib-wasm.wasm",
@@ -102,10 +74,6 @@ check:        DW_AT_decl_line	(10)
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_dwarf5_translate() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/fib-wasm-dwarf5.wasm",
@@ -135,10 +103,6 @@ check:        DW_AT_decl_line	(10)
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_split_dwarf4_translate() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/fib-wasm-split4.wasm",
@@ -168,10 +132,6 @@ check:        DW_AT_decl_line	(10)
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_dwarf_translate_generated() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/fraction-norm.wasm",
@@ -191,10 +151,6 @@ check:     DW_AT_decl_line	(124)
 
 #[test]
 #[ignore]
-#[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
-    target_pointer_width = "64"
-))]
 fn test_debug_dwarf_translate_fission() -> Result<()> {
     check_wasm(
         "tests/all/debug/testsuite/dwarf_fission.wasm",

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1255,7 +1255,7 @@ fn wrap_multiple_results(config: &mut Config) -> anyhow::Result<()> {
 
     macro_rules! equal_tuples {
         ($($cnt:tt ($($a:ident),*))*) => ($(
-            #[allow(non_snake_case)]
+            #[allow(non_snake_case, reason = "macro-generated code")]
             impl<$($a: EqualToValue,)*> EqualToValues for ($($a,)*) {
                 fn eq_values(&self, values: &[Val]) -> bool {
                     let ($($a,)*) = self;

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 #![cfg_attr(miri, allow(dead_code, unused_imports))]
 
 use wasmtime::Result;

--- a/tests/all/piped_tests.rs
+++ b/tests/all/piped_tests.rs
@@ -44,7 +44,7 @@ mod test_programs {
 
     macro_rules! assert_test_exists {
         ($name:ident) => {
-            #[allow(unused_imports)]
+            #[expect(unused_imports, reason = "here to assert function is here")]
             use self::$name as _;
         };
     }

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -209,7 +209,6 @@ fn test_trap_through_host() -> Result<()> {
 }
 
 #[test]
-#[allow(deprecated)]
 fn test_trap_backtrace_disabled() -> Result<()> {
     let mut config = Config::default();
     config.wasm_backtrace(false);
@@ -1147,7 +1146,6 @@ fn standalone_backtrace() -> Result<()> {
 }
 
 #[test]
-#[allow(deprecated)]
 fn standalone_backtrace_disabled() -> Result<()> {
     let mut config = Config::new();
     config.wasm_backtrace(false);

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -536,7 +536,7 @@ impl ABIParams {
     }
 
     /// Get the [`ABIOperand`] param in the nth position.
-    #[allow(unused)]
+    #[cfg(test)]
     pub fn get(&self, n: usize) -> Option<&ABIOperand> {
         self.operands.inner.get(n)
     }

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -94,8 +94,7 @@ macro_rules! declare_function_sig {
             )*
         }
 
-        // Until all the builtin functions are used.
-        #[allow(dead_code)]
+        #[expect(dead_code, reason = "not all functions used yet")]
         impl BuiltinFunctions {
             pub fn new<P: PtrSize>(
                 vmoffsets: &VMOffsets<P>,
@@ -103,7 +102,6 @@ macro_rules! declare_function_sig {
                 wasm_call_conv: CallingConvention,
             ) -> Self {
                 let size = vmoffsets.ptr.size();
-                #[allow(unused_doc_comments)]
                 Self {
                     host_call_conv,
                     wasm_call_conv,

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -68,7 +68,7 @@ pub(crate) enum LookupError {
     // enables the `all-arch` feature; in such case, this variant
     // will never be used. This is most likely going to change
     // in the future; this is one of the simplest options for now.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "see comment")]
     SupportDisabled,
 }
 

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -30,7 +30,7 @@ mod masm;
 // Not all the fpr and gpr constructors are used at the moment;
 // in that sense, this directive is a temporary measure to avoid
 // dead code warnings.
-#[allow(dead_code)]
+#[expect(dead_code, reason = "not everything used yet, will be in the future")]
 mod regs;
 
 /// Create an ISA builder.

--- a/winch/codegen/src/lib.rs
+++ b/winch/codegen/src/lib.rs
@@ -1,6 +1,5 @@
 //! Code generation library for Winch.
 
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 // Unless this library is compiled with `all-arch`, the rust compiler
 // is going to emit dead code warnings. This directive is fine as long
 // as we configure to run CI at least once with the `all-arch` feature


### PR DESCRIPTION
Clean up some crates by migrating from `#[allow]` to `#[expect]` (ideally) or `#[allow]`-with-reason

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
