### PR TITLE
Allow creation of a CacheConfig without loading from a file

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -436,7 +436,7 @@ impl BenchState {
     ) -> Result<Self> {
         let mut config = options.config(None)?;
         // NB: always disable the compilation cache.
-        config.disable_cache();
+        config.cache_config(None);
         let engine = Engine::new(&config)?;
         let mut linker = Linker::<HostState>::new(&engine);
 

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -436,7 +436,7 @@ impl BenchState {
     ) -> Result<Self> {
         let mut config = options.config(None)?;
         // NB: always disable the compilation cache.
-        config.cache_config(None)?;
+        config.cache(None);
         let engine = Engine::new(&config)?;
         let mut linker = Linker::<HostState>::new(&engine);
 

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -436,7 +436,7 @@ impl BenchState {
     ) -> Result<Self> {
         let mut config = options.config(None)?;
         // NB: always disable the compilation cache.
-        config.cache_config(None);
+        config.cache_config(None)?;
         let engine = Engine::new(&config)?;
         let mut linker = Linker::<HostState>::new(&engine);
 

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -211,12 +211,17 @@ pub unsafe extern "C" fn wasmtime_config_cache_config_load(
     c: &mut wasm_config_t,
     filename: *const c_char,
 ) -> Option<Box<wasmtime_error_t>> {
+    use std::path::Path;
+
+    use wasmtime::CacheConfig;
+
     handle_result(
         if filename.is_null() {
-            c.config.cache_config_load_default()
+            CacheConfig::from_file(None).map(|cfg| c.config.cache_config(Some(cfg)))
         } else {
             match CStr::from_ptr(filename).to_str() {
-                Ok(s) => c.config.cache_config_load(s),
+                Ok(s) => CacheConfig::from_file(Some(&Path::new(s)))
+                    .map(|cfg| c.config.cache_config(Some(cfg))),
                 Err(e) => Err(e.into()),
             }
         },

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -213,15 +213,16 @@ pub unsafe extern "C" fn wasmtime_config_cache_config_load(
 ) -> Option<Box<wasmtime_error_t>> {
     use std::path::Path;
 
-    use wasmtime::CacheConfig;
+    use wasmtime::Cache;
 
     handle_result(
         if filename.is_null() {
-            CacheConfig::from_file(None).map(|cfg| c.config.cache_config(Some(cfg)))
+            Cache::from_file(None).map(|cache| c.config.cache(Some(cache)))
         } else {
             match CStr::from_ptr(filename).to_str() {
-                Ok(s) => CacheConfig::from_file(Some(&Path::new(s)))
-                    .map(|cfg| c.config.cache_config(Some(cfg))),
+                Ok(s) => {
+                    Cache::from_file(Some(&Path::new(s))).map(|cache| c.config.cache(Some(cache)))
+                }
                 Err(e) => Err(e.into()),
             }
         },

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -37,6 +37,9 @@ macro_rules! generate_config_setting_getter {
 impl Cache {
     /// Builds a [`Cache`] from the configuration and spawns the cache worker.
     ///
+    /// If you want to load the cache configuration from a file, use [`CacheConfig::from_file`].
+    /// You can call [`CacheConfig::new`] for the default configuration.
+    ///
     /// # Errors
     /// Returns an error if the configuration is invalid.
     pub fn new(mut config: CacheConfig) -> Result<Self> {
@@ -46,6 +49,28 @@ impl Cache {
             config,
             state: Default::default(),
         })
+    }
+
+    /// Loads cache configuration specified at `path`.
+    ///
+    /// This method will read the file specified by `path` on the filesystem and
+    /// attempt to load cache configuration from it. This method can also fail
+    /// due to I/O errors, misconfiguration, syntax errors, etc. For expected
+    /// syntax in the configuration file see the [documentation online][docs].
+    ///
+    /// Passing in `None` loads cache configuration from the system default path.
+    /// This is located, for example, on Unix at `$HOME/.config/wasmtime/config.toml`
+    /// and is typically created with the `wasmtime config new` command.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail due to any error that happens when loading the file
+    /// pointed to by `path` and attempting to load the cache configuration.
+    ///
+    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
+    pub fn from_file(path: Option<&Path>) -> Result<Self> {
+        let config = CacheConfig::from_file(path)?;
+        Self::new(config)
     }
 
     generate_config_setting_getter!(worker_event_queue_size: u64);

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -589,7 +589,6 @@ impl CacheConfig {
 /// A builder for `CacheConfig`s.
 #[derive(Debug, Clone, Default)]
 pub struct CacheConfigBuilder {
-    enabled: bool,
     directory: Option<PathBuf>,
     worker_event_queue_size: Option<u64>,
     baseline_compression_level: Option<i32>,
@@ -605,12 +604,6 @@ pub struct CacheConfigBuilder {
 }
 
 impl CacheConfigBuilder {
-    /// Specifies whether the cache system is used or not.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.enabled = enabled;
-        self
-    }
-
     /// Specifies where the cache directory is. Must be an absolute path.
     pub fn directory(mut self, directory: impl Into<PathBuf>) -> Self {
         self.directory = Some(directory.into());
@@ -728,7 +721,6 @@ impl CacheConfigBuilder {
 
     pub fn build(self) -> Result<CacheConfig> {
         let CacheConfigBuilder {
-            enabled,
             directory,
             worker_event_queue_size,
             baseline_compression_level,
@@ -744,7 +736,7 @@ impl CacheConfigBuilder {
         } = self;
 
         let mut config = CacheConfig {
-            enabled,
+            enabled: true,
             directory,
             worker_event_queue_size,
             baseline_compression_level,

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -346,7 +346,23 @@ impl CacheConfig {
         conf
     }
 
-    /// Parses cache configuration from the file specified
+    /// Loads cache configuration specified at `path`.
+    ///
+    /// This method will read the file specified by `path` on the filesystem and
+    /// attempt to load cache configuration from it. This method can also fail
+    /// due to I/O errors, misconfiguration, syntax errors, etc. For expected
+    /// syntax in the configuration file see the [documentation online][docs].
+    ///
+    /// Passing in `None` loads cache configuration from the system default path.
+    /// This is located, for example, on Unix at `$HOME/.config/wasmtime/config.toml`
+    /// and is typically created with the `wasmtime config new` command.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail due to any error that happens when loading the file
+    /// pointed to by `path` and attempting to load the cache configuration.
+    ///
+    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     pub fn from_file(config_file: Option<&Path>) -> Result<Self> {
         let mut config = Self::load_and_parse_file(config_file)?;
         config.validate_or_default()?;

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -455,6 +455,12 @@ impl CacheConfig {
     ///
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     pub fn from_file(config_file: Option<&Path>) -> Result<Self> {
+        let mut config = Self::load_and_parse_file(config_file)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn load_and_parse_file(config_file: Option<&Path>) -> Result<Self> {
         // get config file path
         let (config_file, user_custom_file) = match config_file {
             Some(path) => (path.to_path_buf(), true),

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -605,35 +605,35 @@ pub struct CacheConfigBuilder {
 
 impl CacheConfigBuilder {
     /// Specifies where the cache directory is. Must be an absolute path.
-    pub fn directory(mut self, directory: impl Into<PathBuf>) -> Self {
+    pub fn directory(&mut self, directory: impl Into<PathBuf>) -> &mut Self {
         self.directory = Some(directory.into());
         self
     }
 
     /// Size of cache worker event queue. If the queue is full, incoming cache usage events will be
     /// dropped.
-    pub fn worker_event_queue_size(mut self, size: u64) -> Self {
+    pub fn worker_event_queue_size(&mut self, size: u64) -> &mut Self {
         self.worker_event_queue_size = Some(size);
         self
     }
 
     /// Compression level used when a new cache file is being written by the cache system. Wasmtime
     /// uses zstd compression.
-    pub fn baseline_compression_level(mut self, level: i32) -> Self {
+    pub fn baseline_compression_level(&mut self, level: i32) -> &mut Self {
         self.baseline_compression_level = Some(level);
         self
     }
 
     /// Compression level used when the cache worker decides to recompress a cache file. Wasmtime
     /// uses zstd compression.
-    pub fn optimized_compression_level(mut self, level: i32) -> Self {
+    pub fn optimized_compression_level(&mut self, level: i32) -> &mut Self {
         self.optimized_compression_level = Some(level);
         self
     }
 
     /// One of the conditions for the cache worker to recompress a cache file is to have usage
     /// count of the file exceeding this threshold.
-    pub fn optimized_compression_usage_counter_threshold(mut self, threshold: u64) -> Self {
+    pub fn optimized_compression_usage_counter_threshold(&mut self, threshold: u64) -> &mut Self {
         self.optimized_compression_usage_counter_threshold = Some(threshold);
         self
     }
@@ -641,7 +641,7 @@ impl CacheConfigBuilder {
     /// When the cache worker is notified about a cache file being updated by the cache system and
     /// this interval has already passed since last cleaning up, the worker will attempt a new
     /// cleanup.
-    pub fn cleanup_interval(mut self, interval: Duration) -> Self {
+    pub fn cleanup_interval(&mut self, interval: Duration) -> &mut Self {
         self.cleanup_interval = Some(interval);
         self
     }
@@ -650,7 +650,7 @@ impl CacheConfigBuilder {
     /// worker has started the task for this file within the last
     /// optimizing-compression-task-timeout interval. If some worker has started working on it,
     /// other workers are skipping this task.
-    pub fn optimizing_compression_task_timeout(mut self, timeout: Duration) -> Self {
+    pub fn optimizing_compression_task_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.optimizing_compression_task_timeout = Some(timeout);
         self
     }
@@ -672,7 +672,7 @@ impl CacheConfigBuilder {
     /// limits are not reached, the cache files will not be deleted. Otherwise, they will be
     /// treated as the oldest files, so they might survive. If the user actually uses the cache
     /// file, the modification time will be updated.
-    pub fn allowed_clock_drift_for_files_from_future(mut self, drift: Duration) -> Self {
+    pub fn allowed_clock_drift_for_files_from_future(&mut self, drift: Duration) -> &mut Self {
         self.allowed_clock_drift_for_files_from_future = Some(drift);
         self
     }
@@ -681,7 +681,7 @@ impl CacheConfigBuilder {
     ///
     /// This doesn't include files with metadata. To learn more, please refer to the cache system
     /// section.
-    pub fn file_count_soft_limit(mut self, limit: u64) -> Self {
+    pub fn file_count_soft_limit(&mut self, limit: u64) -> &mut Self {
         self.file_count_soft_limit = Some(limit);
         self
     }
@@ -692,7 +692,7 @@ impl CacheConfigBuilder {
     /// section.
     ///
     /// *this is the file size, not the space physically occupied on the disk.
-    pub fn files_total_size_soft_limit(mut self, limit: u64) -> Self {
+    pub fn files_total_size_soft_limit(&mut self, limit: u64) -> &mut Self {
         self.files_total_size_soft_limit = Some(limit);
         self
     }
@@ -703,7 +703,7 @@ impl CacheConfigBuilder {
     ///
     /// This doesn't include files with metadata. To learn more, please refer to the cache system
     /// section.
-    pub fn file_count_limit_percent_if_deleting(mut self, percent: u8) -> Self {
+    pub fn file_count_limit_percent_if_deleting(&mut self, percent: u8) -> &mut Self {
         self.file_count_limit_percent_if_deleting = Some(percent);
         self
     }
@@ -714,7 +714,7 @@ impl CacheConfigBuilder {
     ///
     /// This doesn't include files with metadata. To learn more, please refer to the cache system
     /// section.
-    pub fn files_total_size_limit_percent_if_deleting(mut self, percent: u8) -> Self {
+    pub fn files_total_size_limit_percent_if_deleting(&mut self, percent: u8) -> &mut Self {
         self.files_total_size_limit_percent_if_deleting = Some(percent);
         self
     }

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -1,6 +1,5 @@
 //! Module for configuring the cache system.
 
-use super::Worker;
 use anyhow::{anyhow, bail, Context, Result};
 use directories_next::ProjectDirs;
 use log::{trace, warn};
@@ -11,118 +10,7 @@ use serde::{
 use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
-use std::sync::Arc;
 use std::time::Duration;
-
-/// Global configuration for how the cache is managed
-#[derive(Debug, Clone)]
-pub struct Cache {
-    config: CacheConfig,
-    worker: Worker,
-    state: Arc<CacheState>,
-}
-
-macro_rules! generate_config_setting_getter {
-    ($setting:ident: $setting_type:ty) => {
-        /// Returns `$setting`.
-        ///
-        /// Panics if the cache is disabled.
-        pub fn $setting(&self) -> $setting_type {
-            self.config.$setting()
-        }
-    };
-}
-
-impl Cache {
-    /// Builds a [`Cache`] from the configuration and spawns the cache worker.
-    ///
-    /// If you want to load the cache configuration from a file, use [`CacheConfig::from_file`].
-    /// You can call [`CacheConfig::new`] for the default configuration.
-    ///
-    /// # Errors
-    /// Returns an error if the configuration is invalid.
-    pub fn new(mut config: CacheConfig) -> Result<Self> {
-        config.validate()?;
-        Ok(Self {
-            worker: Worker::start_new(&config),
-            config,
-            state: Default::default(),
-        })
-    }
-
-    /// Loads cache configuration specified at `path`.
-    ///
-    /// This method will read the file specified by `path` on the filesystem and
-    /// attempt to load cache configuration from it. This method can also fail
-    /// due to I/O errors, misconfiguration, syntax errors, etc. For expected
-    /// syntax in the configuration file see the [documentation online][docs].
-    ///
-    /// Passing in `None` loads cache configuration from the system default path.
-    /// This is located, for example, on Unix at `$HOME/.config/wasmtime/config.toml`
-    /// and is typically created with the `wasmtime config new` command.
-    ///
-    /// # Errors
-    ///
-    /// This method can fail due to any error that happens when loading the file
-    /// pointed to by `path` and attempting to load the cache configuration.
-    ///
-    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
-    pub fn from_file(path: Option<&Path>) -> Result<Self> {
-        let config = CacheConfig::from_file(path)?;
-        Self::new(config)
-    }
-
-    generate_config_setting_getter!(worker_event_queue_size: u64);
-    generate_config_setting_getter!(baseline_compression_level: i32);
-    generate_config_setting_getter!(optimized_compression_level: i32);
-    generate_config_setting_getter!(optimized_compression_usage_counter_threshold: u64);
-    generate_config_setting_getter!(cleanup_interval: Duration);
-    generate_config_setting_getter!(optimizing_compression_task_timeout: Duration);
-    generate_config_setting_getter!(allowed_clock_drift_for_files_from_future: Duration);
-    generate_config_setting_getter!(file_count_soft_limit: u64);
-    generate_config_setting_getter!(files_total_size_soft_limit: u64);
-    generate_config_setting_getter!(file_count_limit_percent_if_deleting: u8);
-    generate_config_setting_getter!(files_total_size_limit_percent_if_deleting: u8);
-
-    /// Returns path to the cache directory.
-    ///
-    /// Panics if the cache directory is not set.
-    pub fn directory(&self) -> &PathBuf {
-        &self.config.directory()
-    }
-
-    #[cfg(test)]
-    pub(super) fn worker(&self) -> &Worker {
-        &self.worker
-    }
-
-    /// Returns the number of cache hits seen so far
-    pub fn cache_hits(&self) -> usize {
-        self.state.hits.load(SeqCst)
-    }
-
-    /// Returns the number of cache misses seen so far
-    pub fn cache_misses(&self) -> usize {
-        self.state.misses.load(SeqCst)
-    }
-
-    pub(crate) fn on_cache_get_async(&self, path: impl AsRef<Path>) {
-        self.state.hits.fetch_add(1, SeqCst);
-        self.worker.on_cache_get_async(path)
-    }
-
-    pub(crate) fn on_cache_update_async(&self, path: impl AsRef<Path>) {
-        self.state.misses.fetch_add(1, SeqCst);
-        self.worker.on_cache_update_async(path)
-    }
-}
-
-#[derive(Default, Debug)]
-struct CacheState {
-    hits: AtomicUsize,
-    misses: AtomicUsize,
-}
 
 // wrapped, so we have named section in config,
 // also, for possible future compatibility
@@ -625,7 +513,7 @@ impl CacheConfig {
     }
 
     /// validate values and fill in defaults
-    fn validate(&mut self) -> Result<()> {
+    pub(crate) fn validate(&mut self) -> Result<()> {
         self.validate_directory_or_default()?;
         self.validate_worker_event_queue_size();
         self.validate_baseline_compression_level()?;

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -521,12 +521,11 @@ fn test_percent_settings() {
 /// Default builder produces a disabled cache configuration with the same defaults.
 #[test]
 fn test_builder_default() {
-    let dir = tempfile::tempdir().expect("Can't create temporary directory");
-    let config_path = dir.path().join("cache-config.toml");
+    let (_td, _cd, cp) = test_prolog();
     let config_content = "[cache]\n\
                           enabled = false\n";
-    fs::write(&config_path, config_content).expect("Failed to write test config file");
-    let expected_config = CacheConfig::from_file(Some(&config_path)).unwrap();
+    fs::write(&cp, config_content).expect("Failed to write test config file");
+    let expected_config = CacheConfig::from_file(Some(&cp)).unwrap();
 
     let config = CacheConfig::builder()
         .build()

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -464,7 +464,10 @@ fn test_builder_default() {
     fs::write(&cp, config_content).expect("Failed to write test config file");
     let expected_config = CacheConfig::from_file(Some(&cp)).unwrap();
 
-    let config = CacheConfig::new();
+    let mut config = CacheConfig::new();
+    config
+        .validate()
+        .expect("Failed to validate default config");
 
     assert_eq!(config.directory, expected_config.directory);
     assert_eq!(

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -523,7 +523,7 @@ fn test_percent_settings() {
 fn test_builder_default() {
     let (_td, _cd, cp) = test_prolog();
     let config_content = "[cache]\n\
-                          enabled = false\n";
+                          enabled = true\n";
     fs::write(&cp, config_content).expect("Failed to write test config file");
     let expected_config = CacheConfig::from_file(Some(&cp)).unwrap();
 
@@ -581,7 +581,6 @@ fn test_builder_all_settings() {
     let (_td, cd, _cp) = test_prolog();
 
     let conf = CacheConfig::builder()
-        .enabled(true)
         .directory(&cd)
         .worker_event_queue_size(0x10)
         .baseline_compression_level(3)

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -580,7 +580,8 @@ fn test_builder_default() {
 fn test_builder_all_settings() {
     let (_td, cd, _cp) = test_prolog();
 
-    let conf = CacheConfig::builder()
+    let mut builder = CacheConfig::builder();
+    builder
         .directory(&cd)
         .worker_event_queue_size(0x10)
         .baseline_compression_level(3)
@@ -592,9 +593,8 @@ fn test_builder_all_settings() {
         .file_count_soft_limit(0x10_000)
         .files_total_size_soft_limit(512 * (1u64 << 20))
         .file_count_limit_percent_if_deleting(70)
-        .files_total_size_limit_percent_if_deleting(70)
-        .build()
-        .expect("Failed to build config");
+        .files_total_size_limit_percent_if_deleting(70);
+    let conf = builder.build().expect("Failed to build config");
     check_conf(&conf, &cd);
 
     fn check_conf(conf: &CacheConfig, cd: &PathBuf) {

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -1,3 +1,5 @@
+use crate::CacheConfigBuilder;
+
 use super::CacheConfig;
 use std::fs;
 use std::path::PathBuf;
@@ -527,7 +529,7 @@ fn test_builder_default() {
     fs::write(&cp, config_content).expect("Failed to write test config file");
     let expected_config = CacheConfig::from_file(Some(&cp)).unwrap();
 
-    let config = CacheConfig::builder()
+    let config = CacheConfigBuilder::new()
         .build()
         .expect("Failed to build CacheConfig");
 
@@ -580,20 +582,20 @@ fn test_builder_default() {
 fn test_builder_all_settings() {
     let (_td, cd, _cp) = test_prolog();
 
-    let mut builder = CacheConfig::builder();
+    let mut builder = CacheConfigBuilder::new();
     builder
-        .directory(&cd)
-        .worker_event_queue_size(0x10)
-        .baseline_compression_level(3)
-        .optimized_compression_level(20)
-        .optimized_compression_usage_counter_threshold(0x100)
-        .cleanup_interval(Duration::from_secs(60 * 60))
-        .optimizing_compression_task_timeout(Duration::from_secs(30 * 60))
-        .allowed_clock_drift_for_files_from_future(Duration::from_secs(60 * 60 * 24))
-        .file_count_soft_limit(0x10_000)
-        .files_total_size_soft_limit(512 * (1u64 << 20))
-        .file_count_limit_percent_if_deleting(70)
-        .files_total_size_limit_percent_if_deleting(70);
+        .with_directory(&cd)
+        .with_worker_event_queue_size(0x10)
+        .with_baseline_compression_level(3)
+        .with_optimized_compression_level(20)
+        .with_optimized_compression_usage_counter_threshold(0x100)
+        .with_cleanup_interval(Duration::from_secs(60 * 60))
+        .with_optimizing_compression_task_timeout(Duration::from_secs(30 * 60))
+        .with_allowed_clock_drift_for_files_from_future(Duration::from_secs(60 * 60 * 24))
+        .with_file_count_soft_limit(0x10_000)
+        .with_files_total_size_soft_limit(512 * (1u64 << 20))
+        .with_file_count_limit_percent_if_deleting(70)
+        .with_files_total_size_limit_percent_if_deleting(70);
     let conf = builder.build().expect("Failed to build config");
     check_conf(&conf, &cd);
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -12,7 +12,7 @@ use std::{fs, io};
 mod config;
 mod worker;
 
-pub use config::{create_new_config, Cache, CacheConfig, CacheConfigBuilder};
+pub use config::{create_new_config, Cache, CacheConfig};
 use worker::Worker;
 
 /// Module level cache entry.

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use base64::Engine;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
@@ -6,14 +7,126 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use std::sync::Arc;
+use std::time::Duration;
 use std::{fs, io};
 
 #[macro_use] // for tests
 mod config;
 mod worker;
 
-pub use config::{create_new_config, Cache, CacheConfig};
+pub use config::{create_new_config, CacheConfig};
 use worker::Worker;
+
+/// Global configuration for how the cache is managed
+#[derive(Debug, Clone)]
+pub struct Cache {
+    config: CacheConfig,
+    worker: Worker,
+    state: Arc<CacheState>,
+}
+
+macro_rules! generate_config_setting_getter {
+    ($setting:ident: $setting_type:ty) => {
+        /// Returns `$setting`.
+        ///
+        /// Panics if the cache is disabled.
+        pub fn $setting(&self) -> $setting_type {
+            self.config.$setting()
+        }
+    };
+}
+
+impl Cache {
+    /// Builds a [`Cache`] from the configuration and spawns the cache worker.
+    ///
+    /// If you want to load the cache configuration from a file, use [`CacheConfig::from_file`].
+    /// You can call [`CacheConfig::new`] for the default configuration.
+    ///
+    /// # Errors
+    /// Returns an error if the configuration is invalid.
+    pub fn new(mut config: CacheConfig) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            worker: Worker::start_new(&config),
+            config,
+            state: Default::default(),
+        })
+    }
+
+    /// Loads cache configuration specified at `path`.
+    ///
+    /// This method will read the file specified by `path` on the filesystem and
+    /// attempt to load cache configuration from it. This method can also fail
+    /// due to I/O errors, misconfiguration, syntax errors, etc. For expected
+    /// syntax in the configuration file see the [documentation online][docs].
+    ///
+    /// Passing in `None` loads cache configuration from the system default path.
+    /// This is located, for example, on Unix at `$HOME/.config/wasmtime/config.toml`
+    /// and is typically created with the `wasmtime config new` command.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail due to any error that happens when loading the file
+    /// pointed to by `path` and attempting to load the cache configuration.
+    ///
+    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
+    pub fn from_file(path: Option<&Path>) -> Result<Self> {
+        let config = CacheConfig::from_file(path)?;
+        Self::new(config)
+    }
+
+    generate_config_setting_getter!(worker_event_queue_size: u64);
+    generate_config_setting_getter!(baseline_compression_level: i32);
+    generate_config_setting_getter!(optimized_compression_level: i32);
+    generate_config_setting_getter!(optimized_compression_usage_counter_threshold: u64);
+    generate_config_setting_getter!(cleanup_interval: Duration);
+    generate_config_setting_getter!(optimizing_compression_task_timeout: Duration);
+    generate_config_setting_getter!(allowed_clock_drift_for_files_from_future: Duration);
+    generate_config_setting_getter!(file_count_soft_limit: u64);
+    generate_config_setting_getter!(files_total_size_soft_limit: u64);
+    generate_config_setting_getter!(file_count_limit_percent_if_deleting: u8);
+    generate_config_setting_getter!(files_total_size_limit_percent_if_deleting: u8);
+
+    /// Returns path to the cache directory.
+    ///
+    /// Panics if the cache directory is not set.
+    pub fn directory(&self) -> &PathBuf {
+        &self.config.directory()
+    }
+
+    #[cfg(test)]
+    fn worker(&self) -> &Worker {
+        &self.worker
+    }
+
+    /// Returns the number of cache hits seen so far
+    pub fn cache_hits(&self) -> usize {
+        self.state.hits.load(SeqCst)
+    }
+
+    /// Returns the number of cache misses seen so far
+    pub fn cache_misses(&self) -> usize {
+        self.state.misses.load(SeqCst)
+    }
+
+    pub(crate) fn on_cache_get_async(&self, path: impl AsRef<Path>) {
+        self.state.hits.fetch_add(1, SeqCst);
+        self.worker.on_cache_get_async(path)
+    }
+
+    pub(crate) fn on_cache_update_async(&self, path: impl AsRef<Path>) {
+        self.state.misses.fetch_add(1, SeqCst);
+        self.worker.on_cache_update_async(path)
+    }
+}
+
+#[derive(Default, Debug)]
+struct CacheState {
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+}
 
 /// Module level cache entry.
 pub struct ModuleCacheEntry<'cache>(Option<ModuleCacheEntryInner<'cache>>);

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -27,14 +27,13 @@ struct Sha256Hasher(Sha256);
 
 impl<'config> ModuleCacheEntry<'config> {
     /// Create the cache entry.
-    pub fn new(compiler_name: &str, cache_config: &'config CacheConfig) -> Self {
-        if cache_config.enabled() {
-            Self(Some(ModuleCacheEntryInner::new(
+    pub fn new(compiler_name: &str, cache_config: Option<&'config CacheConfig>) -> Self {
+        match cache_config {
+            Some(cache_config) if cache_config.enabled() => Self(Some(ModuleCacheEntryInner::new(
                 compiler_name,
                 cache_config,
-            )))
-        } else {
-            Self(None)
+            ))),
+            Some(_) | None => Self(None),
         }
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -12,7 +12,7 @@ use std::{fs, io};
 mod config;
 mod worker;
 
-pub use config::{create_new_config, CacheConfig};
+pub use config::{create_new_config, CacheConfig, CacheConfigBuilder};
 use worker::Worker;
 
 /// Module level cache entry.

--- a/crates/cache/src/worker/tests.rs
+++ b/crates/cache/src/worker/tests.rs
@@ -14,11 +14,9 @@ fn test_on_get_create_stats_file() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -41,12 +39,10 @@ fn test_on_get_update_usage_counter() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -75,7 +71,6 @@ fn test_on_get_recompress_no_mod_file() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          baseline-compression-level = 3\n\
@@ -83,7 +78,6 @@ fn test_on_get_recompress_no_mod_file() {
          optimized-compression-usage-counter-threshold = '256'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -117,7 +111,6 @@ fn test_on_get_recompress_with_mod_file() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          baseline-compression-level = 3\n\
@@ -125,7 +118,6 @@ fn test_on_get_recompress_with_mod_file() {
          optimized-compression-usage-counter-threshold = '256'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -192,7 +184,6 @@ fn test_on_get_recompress_lock() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          baseline-compression-level = 3\n\
@@ -202,7 +193,6 @@ fn test_on_get_recompress_lock() {
          allowed-clock-drift-for-files-from-future = '1d'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -262,7 +252,6 @@ fn test_on_update_fresh_stats_file() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          baseline-compression-level = 3\n\
@@ -270,7 +259,6 @@ fn test_on_update_fresh_stats_file() {
          cleanup-interval = '1h'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
@@ -311,7 +299,6 @@ fn test_on_update_cleanup_limits_trash_locks() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          cleanup-interval = '30m'\n\
@@ -324,7 +311,6 @@ fn test_on_update_cleanup_limits_trash_locks() {
          ",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
     let content_10k = "a".repeat(10_000);
@@ -452,7 +438,6 @@ fn test_on_update_cleanup_lru_policy() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          file-count-soft-limit = '5'\n\
@@ -461,7 +446,6 @@ fn test_on_update_cleanup_lru_policy() {
          files-total-size-limit-percent-if-deleting = '70%'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
     let content_5k = "a".repeat(5_000);
@@ -584,7 +568,6 @@ fn test_on_update_cleanup_future_files() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          allowed-clock-drift-for-files-from-future = '1d'\n\
@@ -594,7 +577,6 @@ fn test_on_update_cleanup_future_files() {
          files-total-size-limit-percent-if-deleting = '70%'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
 
@@ -692,14 +674,12 @@ fn test_on_update_cleanup_self_lock() {
     let cache_config = load_config!(
         config_path,
         "[cache]\n\
-         enabled = true\n\
          directory = '{cache_dir}'\n\
          worker-event-queue-size = '16'\n\
          cleanup-interval = '30m'\n\
          allowed-clock-drift-for-files-from-future = '1d'",
         cache_dir
     );
-    assert!(cache_config.enabled());
     let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -737,10 +737,12 @@ impl CommonOptions {
         if self.codegen.cache != Some(false) {
             match &self.codegen.cache_config {
                 Some(path) => {
-                    config.cache_config_load(path)?;
+                    config.cache_config(Some(wasmtime::CacheConfig::from_file(Some(Path::new(
+                        path,
+                    )))?));
                 }
                 None => {
-                    config.cache_config_load_default()?;
+                    config.cache_config(Some(wasmtime::CacheConfig::from_file(None)?));
                 }
             }
         }

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -737,12 +737,12 @@ impl CommonOptions {
         if self.codegen.cache != Some(false) {
             match &self.codegen.cache_config {
                 Some(path) => {
-                    config.cache_config(Some(wasmtime::CacheConfig::from_file(Some(Path::new(
-                        path,
-                    )))?));
+                    config.cache_config(Some(wasmtime::CacheConfig::from_file(Some(
+                        Path::new(path),
+                    ))?))?;
                 }
                 None => {
-                    config.cache_config(Some(wasmtime::CacheConfig::from_file(None)?));
+                    config.cache_config(Some(wasmtime::CacheConfig::from_file(None)?))?;
                 }
             }
         }

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -735,16 +735,12 @@ impl CommonOptions {
 
         #[cfg(feature = "cache")]
         if self.codegen.cache != Some(false) {
-            match &self.codegen.cache_config {
-                Some(path) => {
-                    config.cache_config(Some(wasmtime::CacheConfig::from_file(Some(
-                        Path::new(path),
-                    ))?))?;
-                }
-                None => {
-                    config.cache_config(Some(wasmtime::CacheConfig::from_file(None)?))?;
-                }
-            }
+            use wasmtime::Cache;
+            let cache = match &self.codegen.cache_config {
+                Some(path) => Cache::from_file(Some(Path::new(path)))?,
+                None => Cache::from_file(None)?,
+            };
+            config.cache(Some(cache));
         }
         #[cfg(not(feature = "cache"))]
         if self.codegen.cache == Some(true) {

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -39,7 +39,7 @@ impl<'a> CodeBuilder<'a> {
                 NotHashed(state),
             );
             let (code, info_and_types) =
-                wasmtime_cache::ModuleCacheEntry::new("wasmtime", self.engine.cache_config())
+                wasmtime_cache::ModuleCacheEntry::new("wasmtime", self.engine.cache())
                     .get_data_raw(
                         &state,
                         // Cache miss, compute the actual artifacts

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1369,10 +1369,10 @@ impl Config {
         self
     }
 
-    /// Set a custom cache configuration.
+    /// Set a custom [`Cache`].
     ///
-    /// If you want to load the cache configuration from a file, use [`CacheConfig::from_file`].
-    /// You can call [`CacheConfig::from_file(None)`] for the default, enabled configuration.
+    /// To load a cache from a file, use [`Cache::from_file`]. Otherwise, you can create a new
+    /// cache config using [`CacheConfig::new`] and passing that to [`Cache::new`].
     ///
     /// If you want to disable the cache, you can call this method with `None`.
     ///
@@ -1385,13 +1385,9 @@ impl Config {
     ///
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
-    pub fn cache_config(&mut self, cache_config: Option<CacheConfig>) -> Result<&mut Self> {
-        self.cache = if let Some(cache_config) = cache_config {
-            Some(Cache::new(cache_config)?)
-        } else {
-            None
-        };
-        Ok(self)
+    pub fn cache(&mut self, cache: Option<Cache>) -> &mut Self {
+        self.cache = cache;
+        self
     }
 
     /// Sets a custom memory creator.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -27,7 +27,7 @@ use wasmtime_fiber::RuntimeFiberStackCreator;
 #[cfg(feature = "runtime")]
 pub use crate::runtime::code_memory::CustomCodeMemory;
 #[cfg(feature = "cache")]
-pub use wasmtime_cache::{Cache, CacheConfig, CacheConfigBuilder};
+pub use wasmtime_cache::{Cache, CacheConfig};
 #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
 pub use wasmtime_environ::CacheStore;
 
@@ -1386,8 +1386,8 @@ impl Config {
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
     pub fn cache_config(&mut self, cache_config: Option<CacheConfig>) -> Result<&mut Self> {
-        self.cache = if let Some(mut cache_config) = cache_config {
-            Some(cache_config.spawn()?)
+        self.cache = if let Some(cache_config) = cache_config {
+            Some(Cache::new(cache_config)?)
         } else {
             None
         };

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -128,7 +128,7 @@ pub struct Config {
     tunables: ConfigTunables,
 
     #[cfg(feature = "cache")]
-    pub(crate) cache_config: CacheConfig,
+    pub(crate) cache_config: Option<CacheConfig>,
     #[cfg(feature = "runtime")]
     pub(crate) mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
     #[cfg(feature = "runtime")]
@@ -231,7 +231,7 @@ impl Config {
             #[cfg(feature = "gc")]
             collector: Collector::default(),
             #[cfg(feature = "cache")]
-            cache_config: CacheConfig::new_cache_disabled(),
+            cache_config: None,
             profiling_strategy: ProfilingStrategy::None,
             #[cfg(feature = "runtime")]
             mem_creator: None,
@@ -1386,7 +1386,7 @@ impl Config {
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
     pub fn cache_config(&mut self, cache_config: Option<CacheConfig>) -> &mut Self {
-        self.cache_config = cache_config.unwrap_or_else(|| CacheConfig::new_cache_disabled());
+        self.cache_config = cache_config;
         self
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1371,86 +1371,23 @@ impl Config {
 
     /// Set a custom cache configuration.
     ///
-    /// If you want to load the cache configuration from a file, use [`Config::cache_config_load`]
-    /// or [`Config::cache_config_load_default`] for the default enabled configuration.
+    /// If you want to load the cache configuration from a file, use [`CacheConfig::from_file`].
+    /// You can call [`CacheConfig::from_file(None)`] for the default, enabled configuration.
     ///
-    /// By default cache configuration is not enabled or loaded.
+    /// If you want to disable the cache, you can call this method with `None`.
+    ///
+    /// By default, new configs do not have caching enabled.
+    /// Every call to [`Module::new(my_wasm)`][crate::Module::new] will recompile `my_wasm`,
+    /// even when it is unchanged, unless an enabled `CacheConfig` is provided.
     ///
     /// This method is only available when the `cache` feature of this crate is
     /// enabled.
     ///
     /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
     #[cfg(feature = "cache")]
-    pub fn cache_config(&mut self, cache_config: CacheConfig) -> &mut Self {
-        self.cache_config = cache_config;
+    pub fn cache_config(&mut self, cache_config: Option<CacheConfig>) -> &mut Self {
+        self.cache_config = cache_config.unwrap_or_else(|| CacheConfig::new_cache_disabled());
         self
-    }
-
-    /// Loads cache configuration specified at `path`.
-    ///
-    /// This method will read the file specified by `path` on the filesystem and
-    /// attempt to load cache configuration from it. This method can also fail
-    /// due to I/O errors, misconfiguration, syntax errors, etc. For expected
-    /// syntax in the configuration file see the [documentation online][docs].
-    ///
-    /// By default cache configuration is not enabled or loaded.
-    ///
-    /// This method is only available when the `cache` feature of this crate is
-    /// enabled.
-    ///
-    /// # Errors
-    ///
-    /// This method can fail due to any error that happens when loading the file
-    /// pointed to by `path` and attempting to load the cache configuration.
-    ///
-    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
-    #[cfg(feature = "cache")]
-    pub fn cache_config_load(&mut self, path: impl AsRef<Path>) -> Result<&mut Self> {
-        self.cache_config = CacheConfig::from_file(Some(path.as_ref()))?;
-        Ok(self)
-    }
-
-    /// Disable caching.
-    ///
-    /// Every call to [`Module::new(my_wasm)`][crate::Module::new] will
-    /// recompile `my_wasm`, even when it is unchanged.
-    ///
-    /// By default, new configs do not have caching enabled. This method is only
-    /// useful for disabling a previous cache configuration.
-    ///
-    /// This method is only available when the `cache` feature of this crate is
-    /// enabled.
-    #[cfg(feature = "cache")]
-    pub fn disable_cache(&mut self) -> &mut Self {
-        self.cache_config = CacheConfig::new_cache_disabled();
-        self
-    }
-
-    /// Loads cache configuration from the system default path.
-    ///
-    /// This commit is the same as [`Config::cache_config_load`] except that it
-    /// does not take a path argument and instead loads the default
-    /// configuration present on the system. This is located, for example, on
-    /// Unix at `$HOME/.config/wasmtime/config.toml` and is typically created
-    /// with the `wasmtime config new` command.
-    ///
-    /// By default cache configuration is not enabled or loaded.
-    ///
-    /// This method is only available when the `cache` feature of this crate is
-    /// enabled.
-    ///
-    /// # Errors
-    ///
-    /// This method can fail due to any error that happens when loading the
-    /// default system configuration. Note that it is not an error if the
-    /// default config file does not exist, in which case the default settings
-    /// for an enabled cache are applied.
-    ///
-    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
-    #[cfg(feature = "cache")]
-    pub fn cache_config_load_default(&mut self) -> Result<&mut Self> {
-        self.cache_config = CacheConfig::from_file(None)?;
-        Ok(self)
     }
 
     /// Sets a custom memory creator.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -6,8 +6,6 @@ use core::str::FromStr;
 #[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]
 use std::path::Path;
 use wasmparser::WasmFeatures;
-#[cfg(feature = "cache")]
-use wasmtime_cache::CacheConfig;
 use wasmtime_environ::{ConfigTunables, TripleExt, Tunables};
 
 #[cfg(feature = "runtime")]
@@ -28,6 +26,8 @@ use wasmtime_fiber::RuntimeFiberStackCreator;
 
 #[cfg(feature = "runtime")]
 pub use crate::runtime::code_memory::CustomCodeMemory;
+#[cfg(feature = "cache")]
+pub use wasmtime_cache::{CacheConfig, CacheConfigBuilder};
 #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
 pub use wasmtime_environ::CacheStore;
 
@@ -1366,6 +1366,23 @@ impl Config {
         self.compiler_config
             .settings
             .insert(name.to_string(), value.to_string());
+        self
+    }
+
+    /// Set a custom cache configuration.
+    ///
+    /// If you want to load the cache configuration from a file, use [`Config::cache_config_load`]
+    /// or [`Config::cache_config_load_default`] for the default enabled configuration.
+    ///
+    /// By default cache configuration is not enabled or loaded.
+    ///
+    /// This method is only available when the `cache` feature of this crate is
+    /// enabled.
+    ///
+    /// [docs]: https://bytecodealliance.github.io/wasmtime/cli-cache.html
+    #[cfg(feature = "cache")]
+    pub fn cache_config(&mut self, cache_config: CacheConfig) -> &mut Self {
+        self.cache_config = cache_config;
         self
     }
 

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -684,8 +684,8 @@ impl Engine {
     }
 
     #[cfg(all(feature = "cache", any(feature = "cranelift", feature = "winch")))]
-    pub(crate) fn cache_config(&self) -> &wasmtime_cache::CacheConfig {
-        &self.config().cache_config
+    pub(crate) fn cache_config(&self) -> Option<&wasmtime_cache::CacheConfig> {
+        self.config().cache_config.as_ref()
     }
 
     pub(crate) fn signatures(&self) -> &TypeRegistry {

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -684,8 +684,8 @@ impl Engine {
     }
 
     #[cfg(all(feature = "cache", any(feature = "cranelift", feature = "winch")))]
-    pub(crate) fn cache_config(&self) -> Option<&wasmtime_cache::CacheConfig> {
-        self.config().cache_config.as_ref()
+    pub(crate) fn cache(&self) -> Option<&wasmtime_cache::Cache> {
+        self.config().cache.as_ref()
     }
 
     pub(crate) fn signatures(&self) -> &TypeRegistry {

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -656,7 +656,6 @@ Caused by:
             &format!(
                 "
                     [cache]
-                    enabled = true
                     directory = '{}'
                 ",
                 td.path().join("cache").display()
@@ -785,7 +784,6 @@ Caused by:
             &format!(
                 "
                     [cache]
-                    enabled = true
                     directory = '{}'
                 ",
                 td.path().join("cache").display()

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -664,12 +664,12 @@ Caused by:
         )?;
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::None)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         let cache_config = engine
             .config()
-            .cache_config
+            .cache
             .as_ref()
             .expect("Missing cache config");
         assert_eq!(cache_config.cache_hits(), 0);
@@ -680,11 +680,11 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::Speed)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
-            .cache_config
+            .cache
             .as_ref()
             .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
@@ -696,11 +696,11 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::SpeedAndSize)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
-            .cache_config
+            .cache
             .as_ref()
             .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
@@ -712,11 +712,11 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.debug_info(true)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
-            .cache_config
+            .cache
             .as_ref()
             .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
@@ -792,11 +792,11 @@ Caused by:
             ),
         )?;
         let mut cfg = Config::new();
-        cfg.cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
+        cfg.cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
-            .cache_config
+            .cache
             .as_ref()
             .expect("Missing cache config");
         Component::new(&engine, "(component (core module (func)))")?;

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -446,7 +446,7 @@ impl Metadata<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{CacheConfig, Config, Module, OptLevel};
+    use crate::{Cache, Config, Module, OptLevel};
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
@@ -663,7 +663,7 @@ Caused by:
         )?;
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::None)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
+            .cache(Some(Cache::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         let cache_config = engine
@@ -679,7 +679,7 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::Speed)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
+            .cache(Some(Cache::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
@@ -695,7 +695,7 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::SpeedAndSize)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
+            .cache(Some(Cache::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
@@ -711,7 +711,7 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.debug_info(true)
-            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
+            .cache(Some(Cache::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()
@@ -790,7 +790,7 @@ Caused by:
             ),
         )?;
         let mut cfg = Config::new();
-        cfg.cache_config(Some(CacheConfig::from_file(Some(&config_path))?))?;
+        cfg.cache(Some(Cache::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         let cache_config = engine
             .config()

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -667,44 +667,64 @@ Caused by:
             .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 0);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        let cache_config = engine
+            .config()
+            .cache_config
+            .as_ref()
+            .expect("Missing cache config");
+        assert_eq!(cache_config.cache_hits(), 0);
+        assert_eq!(cache_config.cache_misses(), 1);
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 1);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 1);
+        assert_eq!(cache_config.cache_misses(), 1);
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::Speed)
             .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
+        let cache_config = engine
+            .config()
+            .cache_config
+            .as_ref()
+            .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 0);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 0);
+        assert_eq!(cache_config.cache_misses(), 1);
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 1);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 1);
+        assert_eq!(cache_config.cache_misses(), 1);
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::SpeedAndSize)
             .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
+        let cache_config = engine
+            .config()
+            .cache_config
+            .as_ref()
+            .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 0);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 0);
+        assert_eq!(cache_config.cache_misses(), 1);
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 1);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 1);
+        assert_eq!(cache_config.cache_misses(), 1);
 
         let mut cfg = Config::new();
         cfg.debug_info(true)
             .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
+        let cache_config = engine
+            .config()
+            .cache_config
+            .as_ref()
+            .expect("Missing cache config");
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 0);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 0);
+        assert_eq!(cache_config.cache_misses(), 1);
         Module::new(&engine, "(module (func))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 1);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 1);
+        assert_eq!(cache_config.cache_misses(), 1);
 
         Ok(())
     }
@@ -774,12 +794,17 @@ Caused by:
         let mut cfg = Config::new();
         cfg.cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
+        let cache_config = engine
+            .config()
+            .cache_config
+            .as_ref()
+            .expect("Missing cache config");
         Component::new(&engine, "(component (core module (func)))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 0);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 0);
+        assert_eq!(cache_config.cache_misses(), 1);
         Component::new(&engine, "(component (core module (func)))")?;
-        assert_eq!(engine.config().cache_config.cache_hits(), 1);
-        assert_eq!(engine.config().cache_config.cache_misses(), 1);
+        assert_eq!(cache_config.cache_hits(), 1);
+        assert_eq!(cache_config.cache_misses(), 1);
 
         Ok(())
     }

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -446,7 +446,7 @@ impl Metadata<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Config, Module, OptLevel};
+    use crate::{CacheConfig, Config, Module, OptLevel};
     use std::{
         collections::hash_map::DefaultHasher,
         hash::{Hash, Hasher},
@@ -664,7 +664,7 @@ Caused by:
         )?;
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::None)
-            .cache_config_load(&config_path)?;
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         assert_eq!(engine.config().cache_config.cache_hits(), 0);
@@ -675,7 +675,7 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::Speed)
-            .cache_config_load(&config_path)?;
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         assert_eq!(engine.config().cache_config.cache_hits(), 0);
@@ -686,7 +686,7 @@ Caused by:
 
         let mut cfg = Config::new();
         cfg.cranelift_opt_level(OptLevel::SpeedAndSize)
-            .cache_config_load(&config_path)?;
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         assert_eq!(engine.config().cache_config.cache_hits(), 0);
@@ -696,7 +696,8 @@ Caused by:
         assert_eq!(engine.config().cache_config.cache_misses(), 1);
 
         let mut cfg = Config::new();
-        cfg.debug_info(true).cache_config_load(&config_path)?;
+        cfg.debug_info(true)
+            .cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Module::new(&engine, "(module (func))")?;
         assert_eq!(engine.config().cache_config.cache_hits(), 0);
@@ -771,7 +772,7 @@ Caused by:
             ),
         )?;
         let mut cfg = Config::new();
-        cfg.cache_config_load(&config_path)?;
+        cfg.cache_config(Some(CacheConfig::from_file(Some(&config_path))?));
         let engine = Engine::new(&cfg)?;
         Component::new(&engine, "(component (core module (func)))")?;
         assert_eq!(engine.config().cache_config.cache_hits(), 0);

--- a/docs/cli-cache.md
+++ b/docs/cli-cache.md
@@ -18,7 +18,6 @@ Wasmtime assumes all the options are in the `cache` section.
 Example config:
 ```toml
 [cache]
-enabled = true
 directory = "/nfs-share/wasmtime-cache/"
 cleanup-interval = "30m"
 files-total-size-soft-limit = "1Gi"

--- a/examples/fast_compilation.rs
+++ b/examples/fast_compilation.rs
@@ -3,14 +3,14 @@
 //! If your application design is compatible with pre-compiling Wasm programs,
 //! prefer doing that.
 
-use wasmtime::{Config, Engine, Result, Strategy};
+use wasmtime::{CacheConfig, Config, Engine, Result, Strategy};
 
 fn main() -> Result<()> {
     let mut config = Config::new();
 
     // Enable the compilation cache, using the default cache configuration
     // settings.
-    config.cache_config_load_default()?;
+    config.cache_config(Some(CacheConfig::from_file(None)?));
 
     // Enable Winch, Wasmtime's baseline compiler.
     config.strategy(Strategy::Winch);

--- a/examples/fast_compilation.rs
+++ b/examples/fast_compilation.rs
@@ -3,14 +3,14 @@
 //! If your application design is compatible with pre-compiling Wasm programs,
 //! prefer doing that.
 
-use wasmtime::{CacheConfig, Config, Engine, Result, Strategy};
+use wasmtime::{Cache, Config, Engine, Result, Strategy};
 
 fn main() -> Result<()> {
     let mut config = Config::new();
 
     // Enable the compilation cache, using the default cache configuration
     // settings.
-    config.cache_config(Some(CacheConfig::from_file(None)?))?;
+    config.cache(Some(Cache::from_file(None)?));
 
     // Enable Winch, Wasmtime's baseline compiler.
     config.strategy(Strategy::Winch);

--- a/examples/fast_compilation.rs
+++ b/examples/fast_compilation.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
 
     // Enable the compilation cache, using the default cache configuration
     // settings.
-    config.cache_config(Some(CacheConfig::from_file(None)?));
+    config.cache_config(Some(CacheConfig::from_file(None)?))?;
 
     // Enable Winch, Wasmtime's baseline compiler.
     config.strategy(Strategy::Winch);

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -51,7 +51,7 @@ impl ExploreCommand {
         let clif_dir = if let Some(Strategy::Cranelift) | None = self.common.codegen.compiler {
             let clif_dir = tempdir()?;
             config.emit_clif(clif_dir.path());
-            config.cache_config(None); // cache does not emit clif
+            config.cache_config(None)?; // cache does not emit clif
             Some(clif_dir)
         } else {
             None

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -51,7 +51,7 @@ impl ExploreCommand {
         let clif_dir = if let Some(Strategy::Cranelift) | None = self.common.codegen.compiler {
             let clif_dir = tempdir()?;
             config.emit_clif(clif_dir.path());
-            config.disable_cache(); // cache does not emit clif
+            config.cache_config(None); // cache does not emit clif
             Some(clif_dir)
         } else {
             None

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -51,7 +51,7 @@ impl ExploreCommand {
         let clif_dir = if let Some(Strategy::Cranelift) | None = self.common.codegen.compiler {
             let clif_dir = tempdir()?;
             config.emit_clif(clif_dir.path());
-            config.cache_config(None)?; // cache does not emit clif
+            config.cache(None); // cache does not emit clif
             Some(clif_dir)
         } else {
             None


### PR DESCRIPTION
Addresses issue #10638

Since creating a `CacheConfig` also creates the worker thread, I opted for a Builder pattern, so that this worker thread, validation, and default values could be created in the `build` method, much like what happens when deserializing from a file.

If there is a preferred alternate approach though, let me know.

One thing that came to mind is that we may make it easier to create these worker threads, because it is easier to construct the `CacheConfig`, but since these threads get cleaned up once the `CacheConfig` is dropped, maybe this is not an issue?

I'm also not sure if there is any danger in having multiple `CacheConfig`s pointing to the same directory in terms of the worker threads. But this issue could have existed with multiple `Config` with the same default config, so I assume this is not a huge issue.

If there are any changes needed, let me know, especially around coding guidelines or best testing practices.

Thanks!
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
