### PR TITLE
Avoid unnecessary register moves during memory to memory copies of `f16` on riscv64 without `Zfhmin`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -2214,6 +2214,12 @@
         (amode AMode (amode addr offset)))
     (vec_store eew (VecAMode.UnitStride amode) src flags (unmasked) ty)))
 
+;; Avoid unnecessary moves to floating point registers for `F16` memory to memory copies when
+;; `Zfhmin` is unavailable.
+(rule 3 (lower (store store_flags (sinkable_load inst $F16 load_flags load_addr load_offset) store_addr store_offset))
+  (if-let false (has_zfhmin))
+  (rv_store (amode store_addr store_offset) (StoreOP.Sh) store_flags (gen_sunk_load inst (amode load_addr load_offset) (LoadOP.Lh) load_flags)))
+
 
 ;;;;;  Rules for `icmp`;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/riscv64/f16-memory.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/f16-memory.clif
@@ -123,3 +123,22 @@ block0(v0: f16):
 ;   addi sp, sp, 0x10
 ;   ret
 
+function %copy_f16(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = load.f16 v0
+    store.f16 v2, v1
+    return
+}
+
+; VCode:
+; block0:
+;   flh fa3,0(a0)
+;   fsh fa3,0(a1)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x87, 0x16, 0x05, 0x00 ; trap: heap_oob
+;   .byte 0x27, 0x90, 0xd5, 0x00 ; trap: heap_oob
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/store-f16-f128.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/store-f16-f128.clif
@@ -38,3 +38,22 @@ block0(v0: f128, v1: i64):
 ;   sd a1, 8(a2) ; trap: heap_oob
 ;   ret
 
+function %copy_f16(i64, i64) {
+block0(v0: i64, v1: i64):
+    v2 = load.f16 v0
+    store.f16 v2, v1
+    return
+}
+
+; VCode:
+; block0:
+;   lh a3,0(a0)
+;   sh a3,0(a1)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lh a3, 0(a0) ; trap: heap_oob
+;   sh a3, 0(a1) ; trap: heap_oob
+;   ret
+


### PR DESCRIPTION
On riscv64 when the `Zfhmin` extension is unavailable, `f16` loads/stores have to go via integer registers. However, when the only use of a loaded `f16` is to store it to a memory location, there's no need to move it to a floating point register just to move it back, so this PR adds a rule to avoid that.