### PR TITLE
Define dummy simd types as uninhabited

### DIFF
--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -23,15 +23,15 @@ pub(crate) type f64x2 = core::arch::x86_64::__m128d;
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-pub(crate) struct i8x16(());
+pub(crate) struct i8x16(crate::uninhabited::Uninhabited);
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-pub(crate) struct f32x4(());
+pub(crate) struct f32x4(crate::uninhabited::Uninhabited);
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-pub(crate) struct f64x2(());
+pub(crate) struct f64x2(crate::uninhabited::Uninhabited);
 
 use crate::prelude::*;
 use crate::store::StoreOpaque;

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -246,7 +246,7 @@ impl InterpreterRef<'_> {
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
-        unused_macro_rules,
+        unused,
         reason = "macro-generated code"
     )]
     #[cfg_attr(

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1275,7 +1275,7 @@ fn nearest_f64(_store: &mut dyn VMStore, _instance: &mut Instance, val: f64) -> 
 
 // This intrinsic is only used on x86_64 platforms as an implementation of
 // the `i8x16.swizzle` instruction when `pshufb` in SSSE3 is not available.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
 fn i8x16_swizzle(_store: &mut dyn VMStore, _instance: &mut Instance, a: i8x16, b: i8x16) -> i8x16 {
     union U {
         reg: i8x16,
@@ -1321,7 +1321,7 @@ fn i8x16_swizzle(_store: &mut dyn VMStore, _instance: &mut Instance, a: i8x16, b
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 fn i8x16_swizzle(
     _store: &mut dyn VMStore,
     _instance: &mut Instance,
@@ -1333,7 +1333,7 @@ fn i8x16_swizzle(
 
 // This intrinsic is only used on x86_64 platforms as an implementation of
 // the `i8x16.shuffle` instruction when `pshufb` in SSSE3 is not available.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
 fn i8x16_shuffle(
     _store: &mut dyn VMStore,
     _instance: &mut Instance,
@@ -1387,7 +1387,7 @@ fn i8x16_shuffle(
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
 fn i8x16_shuffle(
     _store: &mut dyn VMStore,
     _instance: &mut Instance,


### PR DESCRIPTION
Reflecting a bit on #10657 I realized it might be better to define these dummy types as uninhabited in Rust instead of zero-size to help prevent their misuse by accident. This additionally changes the libcall intrinsics to requiring the `sse` target feature on x86_64 since otherwise the types are uninhabited.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
