### PR TITLE
Support custom yield behavior for epoch interrupts

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -260,6 +260,15 @@ pub enum UpdateDeadline {
     /// configured via [`Config::async_support`](crate::Config::async_support).
     #[cfg(feature = "async")]
     Yield(u64),
+    /// Extend the deadline by the specified number of ticks after yielding to
+    /// the async executor loop. This can only be used with an async [`Store`]
+    /// configured via [`Config::async_support`](crate::Config::async_support).
+    ///
+    /// The yield will be performed by the future provided; when using `tokio`
+    /// it is recommended to provide [`tokio::task::yield_now`](https://docs.rs/tokio/latest/tokio/task/fn.yield_now.html)
+    /// here.
+    #[cfg(feature = "async")]
+    YieldCustom(u64, Box<dyn ::core::future::Future<Output = ()> + Send>),
 }
 
 // Forward methods on `StoreOpaque` to also being on `StoreInner<T>`
@@ -942,10 +951,10 @@ impl<T> Store<T> {
     /// add to the epoch deadline, as well as indicating what
     /// to do after the callback returns. If the [`Store`] is
     /// configured with async support, then the callback may return
-    /// [`UpdateDeadline::Yield`] to yield to the async executor before
-    /// updating the epoch deadline. Alternatively, the callback may
-    /// return [`UpdateDeadline::Continue`] to update the epoch deadline
-    /// immediately.
+    /// [`UpdateDeadline::Yield`] or [`UpdateDeadline::YieldCustom`]
+    /// to yield to the async executor before updating the epoch deadline.
+    /// Alternatively, the callback may return [`UpdateDeadline::Continue`] to
+    /// update the epoch deadline immediately.
     ///
     /// This setting is intended to allow for coarse-grained
     /// interruption, but not a deterministic deadline of a fixed,
@@ -2104,7 +2113,6 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
             Some(callback) => callback((&mut *self).as_context_mut()).and_then(|update| {
                 let delta = match update {
                     UpdateDeadline::Continue(delta) => delta,
-
                     #[cfg(feature = "async")]
                     UpdateDeadline::Yield(delta) => {
                         assert!(
@@ -2114,6 +2122,27 @@ unsafe impl<T> crate::runtime::vm::VMStore for StoreInner<T> {
                         // Do the async yield. May return a trap if future was
                         // canceled while we're yielded.
                         self.async_yield_impl()?;
+                        delta
+                    }
+                    #[cfg(feature = "async")]
+                    UpdateDeadline::YieldCustom(delta, future) => {
+                        assert!(
+                            self.async_support(),
+                            "cannot use `UpdateDeadline::YieldCustom` without enabling async support in the config"
+                        );
+
+                        // When control returns, we have a `Result<()>` passed
+                        // in from the host fiber. If this finished successfully then
+                        // we were resumed normally via a `poll`, so keep going.  If
+                        // the future was dropped while we were yielded, then we need
+                        // to clean up this fiber. Do so by raising a trap which will
+                        // abort all wasm and get caught on the other side to clean
+                        // things up.
+                        unsafe {
+                            self.async_cx()
+                                .expect("attempted to pull async context during shutdown")
+                                .block_on(::core::pin::Pin::new_unchecked(future))?
+                        }
                         delta
                     }
                 };

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -399,7 +399,7 @@ async fn epoch_callback_yield_custom(config: &mut Config) {
             InterruptMode::Callback(|mut cx| {
                 let s = cx.data_mut();
                 *s += 1;
-                let fut = Box::new(tokio::task::yield_now());
+                let fut = Box::pin(tokio::task::yield_now());
                 Ok(UpdateDeadline::YieldCustom(1, fut))
             }),
             |_| {},

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -382,6 +382,33 @@ async fn epoch_callback_yield(config: &mut Config) {
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
+async fn epoch_callback_yield_custom(config: &mut Config) {
+    assert_eq!(
+        Some((1, 1)),
+        run_and_count_yields_or_trap(
+            config,
+            "
+            (module
+                (import \"\" \"bump_epoch\" (func $bump))
+                (func (export \"run\")
+                    call $bump  ;; bump epoch
+                    call $subfunc) ;; call func; will notice new epoch and yield
+                (func $subfunc))
+            ",
+            1,
+            InterruptMode::Callback(|mut cx| {
+                let s = cx.data_mut();
+                *s += 1;
+                let fut = Box::new(tokio::task::yield_now());
+                Ok(UpdateDeadline::YieldCustom(1, fut))
+            }),
+            |_| {},
+        )
+        .await
+    );
+}
+
+#[wasmtime_test(with = "#[tokio::test]")]
 async fn epoch_callback_trap(config: &mut Config) {
     assert_eq!(
         None,


### PR DESCRIPTION
As described in
https://github.com/bytecodealliance/wasmtime/issues/10667, the yield future provided in-tree when a epoch callback cannot always trigger the specific behavior desired in async schedulers like tokio.

This change introduces a new variant to the UpdateDeadline callback with the future implementing the desired task suspension behavior desired for yielding control within the async runtime.

Note that this change does not allow for controlling this behavior for fuel yielding at this time.

CC @aturon @fitzgen -- at first I looked at adding a separate async callback but this felt a little cleaner but happy to change things up.  There's definitely some overhead here in needing to frequently do the future boxing so would be happy to look at other paths to optimize if we have concerns (though my gut says it shouldn't be _too_ bad).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
