### PR TITLE
Simplify module features in serialization

### DIFF
--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -386,6 +386,9 @@ impl Metadata<'_> {
         for (name, flag) in difference.iter_names() {
             let found = module_features.contains(flag);
             let expected = other.contains(flag);
+            // Give a slightly more specialized error message for the `GC_TYPES`
+            // feature which isn't actually part of wasm itself but is gated by
+            // compile-time crate features.
             if flag == wasmparser::WasmFeatures::GC_TYPES {
                 Self::check_cfg_bool(
                     cfg!(feature = "gc"),


### PR DESCRIPTION
This commit simplifies how wasm features are handled in module serialization. Instead of serializing a struct-of-bools this uses the bitflags representation that wasmparser has. There are prior checks to ensure that the wasmtime version for a serialized artifact is matching so we know that the bits mean the same things too.

This reduces the boilerplate in implementing new wasm proposals and should hopefully make it so that we get all the same benefit as before just with less maintenance over time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
