### PR TITLE
update cli help text for WASI listenfd and tcplisten options

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -421,9 +421,11 @@ wasmtime_option_group! {
         /// Enable support for WASI key-value imports (experimental)
         pub keyvalue: Option<bool>,
         /// Inherit environment variables and file descriptors following the
-        /// systemd listen fd specification (UNIX only)
+        /// systemd listen fd specification (UNIX only) (legacy wasip1
+        /// implementation only)
         pub listenfd: Option<bool>,
-        /// Grant access to the given TCP listen socket
+        /// Grant access to the given TCP listen socket (experimental, legacy
+        /// wasip1 implementation only)
         #[serde(default)]
         pub tcplisten: Vec<String>,
         /// Enable support for WASI TLS (Transport Layer Security) imports (experimental)


### PR DESCRIPTION
* tcplisten is experimental (not described in a ratified standard) and legacy wasip1 implementation (aka wasi-common) only.
* listenfd is not nonstandard, but its also legacy wasip1 only.

See https://github.com/yoshuawuyts/wstd/issues/67
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
