### PR TITLE
c-api: component-model: Lookup function from an instance

### DIFF
--- a/crates/c-api/include/wasmtime/component.h
+++ b/crates/c-api/include/wasmtime/component.h
@@ -2,6 +2,7 @@
 #define WASMTIME_COMPONENT_H
 
 #include <wasmtime/component/component.h>
+#include <wasmtime/component/func.h>
 #include <wasmtime/component/instance.h>
 #include <wasmtime/component/linker.h>
 

--- a/crates/c-api/include/wasmtime/component/component.h
+++ b/crates/c-api/include/wasmtime/component/component.h
@@ -118,13 +118,14 @@ typedef struct wasmtime_component_export_index_t
  * \param component the component to look up \p name in
  * \param instance_export_index optional (i.e. nullable) instance to look up in
  * \param name the name of the export
- * \param out the export index if found
- * \return boolean indicating if found
+ * \param name_len length of \p name in bytes
+ * \return export index if found, else NULL
  */
-WASM_API_EXTERN bool wasmtime_component_get_export_index(
+WASM_API_EXTERN wasmtime_component_export_index_t *
+wasmtime_component_get_export_index(
     const wasmtime_component_t *component,
     const wasmtime_component_export_index_t *instance_export_index,
-    wasm_name_t *name, wasmtime_component_export_index_t **out);
+    const char *name, size_t name_len);
 
 /**
  * \brief Deletes a #wasmtime_component_export_index_t

--- a/crates/c-api/include/wasmtime/component/component.h
+++ b/crates/c-api/include/wasmtime/component/component.h
@@ -108,6 +108,32 @@ wasmtime_component_clone(const wasmtime_component_t *component);
  */
 WASM_API_EXTERN void wasmtime_component_delete(wasmtime_component_t *component);
 
+typedef struct wasmtime_component_export_index_t
+    wasmtime_component_export_index_t;
+
+/**
+ * \brief Looks up a specific export of this component by \p name optionally
+ * nested within the \p instance provided.
+ *
+ * \param component the component to look up \p name in
+ * \param instance_export_index optional (i.e. nullable) instance to look up in
+ * \param name the name of the export
+ * \param out the export index if found
+ * \return boolean indicating if found
+ */
+WASM_API_EXTERN bool wasmtime_component_get_export_index(
+    const wasmtime_component_t *component,
+    const wasmtime_component_export_index_t *instance_export_index,
+    wasm_name_t *name, wasmtime_component_export_index_t **out);
+
+/**
+ * \brief Deletes a #wasmtime_component_export_index_t
+ *
+ * \param export_index the export index to delete
+ */
+WASM_API_EXTERN void wasmtime_component_export_index_delete(
+    wasmtime_component_export_index_t *export_index);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/component/func.h
+++ b/crates/c-api/include/wasmtime/component/func.h
@@ -12,10 +12,10 @@ extern "C" {
 /// \brief Representation of a function in Wasmtime.
 ///
 /// Functions in Wasmtime are represented as an index into a store and don't
-/// have any data or destructor associated with the #wasmtime_component_func_t
-/// value. Functions cannot interoperate between #wasmtime_store_t instances and
-/// if the wrong function is passed to the wrong store then it may trigger an
-/// assertion to abort the process.
+/// have any data or destructor associated with the value. Functions cannot
+/// interoperate between #wasmtime_store_t instances and if the wrong function
+/// is passed to the wrong store then it may trigger an assertion to abort the
+/// process.
 typedef struct wasmtime_component_func {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;

--- a/crates/c-api/include/wasmtime/component/func.h
+++ b/crates/c-api/include/wasmtime/component/func.h
@@ -1,0 +1,32 @@
+#ifndef WASMTIME_COMPONENT_FUNC_H
+#define WASMTIME_COMPONENT_FUNC_H
+
+#include <wasmtime/conf.h>
+
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// \brief Representation of a function in Wasmtime.
+///
+/// Functions in Wasmtime are represented as an index into a store and don't
+/// have any data or destructor associated with the #wasmtime_component_func_t
+/// value. Functions cannot interoperate between #wasmtime_store_t instances and
+/// if the wrong function is passed to the wrong store then it may trigger an
+/// assertion to abort the process.
+typedef struct wasmtime_component_func {
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
+} wasmtime_component_func_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
+
+#endif // WASMTIME_COMPONENT_FUNC_H

--- a/crates/c-api/include/wasmtime/component/instance.h
+++ b/crates/c-api/include/wasmtime/component/instance.h
@@ -1,6 +1,7 @@
 #ifndef WASMTIME_COMPONENT_INSTANCE_H
 #define WASMTIME_COMPONENT_INSTANCE_H
 
+#include <wasmtime/component/component.h>
 #include <wasmtime/component/func.h>
 #include <wasmtime/conf.h>
 #include <wasmtime/store.h>
@@ -26,18 +27,35 @@ typedef struct wasmtime_component_instance {
 } wasmtime_component_instance_t;
 
 /**
+ * \brief A methods similar to \fn wasmtime_component_get_export_index() except
+ * for this instance.
+ *
+ * \param instance the instance to look up \p name in
+ * \param context the context where \p instance lives in
+ * \param instance_export_index optional (i.e. nullable) instance to look up in
+ * \param name the name of the export
+ * \param out the export index if found
+ * \return boolean indicating if found
+ */
+WASM_API_EXTERN bool wasmtime_component_instance_get_export_index(
+    const wasmtime_component_instance_t *instance, wasmtime_context_t *context,
+    const wasmtime_component_export_index_t *instance_export_index,
+    wasm_name_t *name, wasmtime_component_export_index_t **out);
+
+/**
  * \brief Looks up an exported function by name within this
  * #wasmtime_component_instance_t.
  *
  * \param instance the instance to look up this name in
  * \param context the store that \p instance lives in
- * \param name the name of the function to look up
+ * \param export_index the export index of the function
  * \param func_out if found, the function corresponding to \p name
  * \return boolean marking if a function for \p name was found
  */
 WASM_API_EXTERN bool wasmtime_component_instance_get_func(
     const wasmtime_component_instance_t *instance, wasmtime_context_t *context,
-    const char *name, wasmtime_component_func_t *func_out);
+    const wasmtime_component_export_index_t *export_index,
+    wasmtime_component_func_t *func_out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/component/instance.h
+++ b/crates/c-api/include/wasmtime/component/instance.h
@@ -1,7 +1,9 @@
 #ifndef WASMTIME_COMPONENT_INSTANCE_H
 #define WASMTIME_COMPONENT_INSTANCE_H
 
+#include <wasmtime/component/func.h>
 #include <wasmtime/conf.h>
+#include <wasmtime/store.h>
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
 
@@ -22,6 +24,20 @@ typedef struct wasmtime_component_instance {
   /// Internal index within the store.
   size_t index;
 } wasmtime_component_instance_t;
+
+/**
+ * \brief Looks up an exported function by name within this
+ * #wasmtime_component_instance_t.
+ *
+ * \param instance the instance to look up this name in
+ * \param context the store that \p instance lives in
+ * \param name the name of the function to look up
+ * \param func_out if found, the function corresponding to \p name
+ * \return boolean marking if a function for \p name was found
+ */
+WASM_API_EXTERN bool wasmtime_component_instance_get_func(
+    const wasmtime_component_instance_t *instance, wasmtime_context_t *context,
+    const char *name, wasmtime_component_func_t *func_out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/component/instance.h
+++ b/crates/c-api/include/wasmtime/component/instance.h
@@ -34,13 +34,14 @@ typedef struct wasmtime_component_instance {
  * \param context the context where \p instance lives in
  * \param instance_export_index optional (i.e. nullable) instance to look up in
  * \param name the name of the export
- * \param out the export index if found
- * \return boolean indicating if found
+ * \param name_len length of \p name in bytes
+ * \return export index if found, else NULL
  */
-WASM_API_EXTERN bool wasmtime_component_instance_get_export_index(
+WASM_API_EXTERN wasmtime_component_export_index_t *
+wasmtime_component_instance_get_export_index(
     const wasmtime_component_instance_t *instance, wasmtime_context_t *context,
     const wasmtime_component_export_index_t *instance_export_index,
-    wasm_name_t *name, wasmtime_component_export_index_t **out);
+    const char *name, size_t name_len);
 
 /**
  * \brief Looks up an exported function by name within this

--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -80,13 +80,15 @@ wasmtime_component_linker_delete(wasmtime_component_linker_t *linker);
  * by #wasmtime_component_linker_instance_delete.
  *
  * \param linker_instance the linker instance from which the new one is created
- * \param name new instance name, takes ownership
+ * \param name new instance name
+ * \param name_len length of \p name in bytes
  * \param linker_instance_out on success, the new #component_linker_instance_t
  * \return on success `NULL`, otherwise an error
  */
 WASM_API_EXTERN wasmtime_error_t *
 wasmtime_component_linker_instance_add_instance(
-    wasmtime_component_linker_instance_t *linker_instance, wasm_name_t *name,
+    wasmtime_component_linker_instance_t *linker_instance, const char *name,
+    size_t name_len,
     wasmtime_component_linker_instance_t **linker_instance_out);
 
 /**
@@ -97,13 +99,14 @@ wasmtime_component_linker_instance_add_instance(
  * linker for the specified \p name in this instance.
  *
  * \param linker_instance the instance to define the module in
- * \param name the module name, takes ownership
+ * \param name the module name
+ * \param name_len length of \p name in bytes
  * \param module the module
  * \return on success `NULL`, otherwise an error
  */
 WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instance_add_module(
-    wasmtime_component_linker_instance_t *linker_instance, wasm_name_t *name,
-    const wasmtime_module_t *module);
+    wasmtime_component_linker_instance_t *linker_instance, const char *name,
+    size_t name_len, const wasmtime_module_t *module);
 
 /**
  * \brief Deletes a #wasmtime_component_linker_instance_t

--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -80,13 +80,13 @@ wasmtime_component_linker_delete(wasmtime_component_linker_t *linker);
  * by #wasmtime_component_linker_instance_delete.
  *
  * \param linker_instance the linker instance from which the new one is created
- * \param name new instance name
+ * \param name new instance name, takes ownership
  * \param linker_instance_out on success, the new #component_linker_instance_t
  * \return on success `NULL`, otherwise an error
  */
 WASM_API_EXTERN wasmtime_error_t *
 wasmtime_component_linker_instance_add_instance(
-    wasmtime_component_linker_instance_t *linker_instance, const char *name,
+    wasmtime_component_linker_instance_t *linker_instance, wasm_name_t *name,
     wasmtime_component_linker_instance_t **linker_instance_out);
 
 /**
@@ -97,12 +97,12 @@ wasmtime_component_linker_instance_add_instance(
  * linker for the specified \p name in this instance.
  *
  * \param linker_instance the instance to define the module in
- * \param name the module name
+ * \param name the module name, takes ownership
  * \param module the module
  * \return on success `NULL`, otherwise an error
  */
 WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instance_add_module(
-    wasmtime_component_linker_instance_t *linker_instance, const char *name,
+    wasmtime_component_linker_instance_t *linker_instance, wasm_name_t *name,
     const wasmtime_module_t *module);
 
 /**

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn wasmtime_component_get_export_index(
     name_len: usize,
 ) -> Option<Box<wasmtime_component_export_index_t>> {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
-    let Ok(name) = str::from_utf8(name) else {
+    let Ok(name) = std::str::from_utf8(name) else {
         return None;
     };
 

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -1,9 +1,9 @@
 use std::ffi::{c_char, CStr};
 
 use anyhow::Context;
-use wasmtime::component::Component;
+use wasmtime::component::{Component, ComponentExportIndex};
 
-use crate::{wasm_byte_vec_t, wasm_config_t, wasm_engine_t, wasmtime_error_t};
+use crate::{wasm_byte_vec_t, wasm_config_t, wasm_engine_t, wasm_name_t, wasmtime_error_t};
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_config_wasm_component_model_set(
@@ -85,3 +85,44 @@ pub unsafe extern "C" fn wasmtime_component_clone(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_component_delete(_component: Box<wasmtime_component_t>) {}
+
+#[repr(transparent)]
+pub struct wasmtime_component_export_index_t {
+    pub(crate) export_index: ComponentExportIndex,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_get_export_index(
+    component: &wasmtime_component_t,
+    instance_export_index: *const wasmtime_component_export_index_t,
+    name: &mut wasm_name_t,
+    out: &mut *mut wasmtime_component_export_index_t,
+) -> bool {
+    let name = name.take();
+    let Ok(name) = String::from_utf8(name) else {
+        return false;
+    };
+
+    let instance_export_index = if instance_export_index.is_null() {
+        None
+    } else {
+        Some((*instance_export_index).export_index)
+    };
+
+    let export_index = component
+        .component
+        .get_export_index(instance_export_index.as_ref(), &name);
+
+    if let Some(export_index) = export_index {
+        *out = Box::into_raw(Box::new(wasmtime_component_export_index_t { export_index }));
+        true
+    } else {
+        false
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_export_index_delete(
+    _export_index: Box<wasmtime_component_export_index_t>,
+) {
+}

--- a/crates/c-api/src/component/instance.rs
+++ b/crates/c-api/src/component/instance.rs
@@ -1,22 +1,46 @@
-use std::ffi::{c_char, CStr};
-
 use wasmtime::component::{Func, Instance};
 
-use crate::WasmtimeStoreContextMut;
+use crate::{wasm_name_t, WasmtimeStoreContextMut};
+
+use super::wasmtime_component_export_index_t;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_instance_get_export_index(
+    instance: &Instance,
+    context: WasmtimeStoreContextMut<'_>,
+    instance_export_index: *const wasmtime_component_export_index_t,
+    name: &mut wasm_name_t,
+    out: &mut *mut wasmtime_component_export_index_t,
+) -> bool {
+    let name = name.take();
+    let Ok(name) = String::from_utf8(name) else {
+        return false;
+    };
+
+    let instance_export_index = if instance_export_index.is_null() {
+        None
+    } else {
+        Some((*instance_export_index).export_index)
+    };
+
+    let export_index = instance.get_export_index(context, instance_export_index.as_ref(), &name);
+
+    if let Some(export_index) = export_index {
+        *out = Box::into_raw(Box::new(wasmtime_component_export_index_t { export_index }));
+        true
+    } else {
+        false
+    }
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_component_instance_get_func(
     instance: &Instance,
     context: WasmtimeStoreContextMut<'_>,
-    name: *const c_char,
+    export_index: &wasmtime_component_export_index_t,
     func_out: &mut Func,
 ) -> bool {
-    let name = unsafe { CStr::from_ptr(name) };
-    let Ok(name) = name.to_str() else {
-        return false;
-    };
-
-    if let Some(func) = instance.get_func(context, name) {
+    if let Some(func) = instance.get_func(context, export_index.export_index) {
         *func_out = func;
         true
     } else {

--- a/crates/c-api/src/component/instance.rs
+++ b/crates/c-api/src/component/instance.rs
@@ -1,0 +1,25 @@
+use std::ffi::{c_char, CStr};
+
+use wasmtime::component::{Func, Instance};
+
+use crate::WasmtimeStoreContextMut;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_instance_get_func(
+    instance: &Instance,
+    context: WasmtimeStoreContextMut<'_>,
+    name: *const c_char,
+    func_out: &mut Func,
+) -> bool {
+    let name = unsafe { CStr::from_ptr(name) };
+    let Ok(name) = name.to_str() else {
+        return false;
+    };
+
+    if let Some(func) = instance.get_func(context, name) {
+        *func_out = func;
+        true
+    } else {
+        false
+    }
+}

--- a/crates/c-api/src/component/instance.rs
+++ b/crates/c-api/src/component/instance.rs
@@ -13,7 +13,7 @@ pub unsafe extern "C" fn wasmtime_component_instance_get_export_index(
     name_len: usize,
 ) -> Option<Box<wasmtime_component_export_index_t>> {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
-    let Ok(name) = str::from_utf8(name) else {
+    let Ok(name) = std::str::from_utf8(name) else {
         return None;
     };
 

--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_instance<'a>(
     linker_instance_out: &mut *mut wasmtime_component_linker_instance_t<'a>,
 ) -> Option<Box<wasmtime_error_t>> {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
-    let Ok(name) = str::from_utf8(name) else {
+    let Ok(name) = std::str::from_utf8(name) else {
         return crate::bad_utf8();
     };
 
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_module(
     module: &wasmtime_module_t,
 ) -> Option<Box<wasmtime_error_t>> {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
-    let Ok(name) = str::from_utf8(name) else {
+    let Ok(name) = std::str::from_utf8(name) else {
         return crate::bad_utf8();
     };
 

--- a/crates/c-api/src/component/mod.rs
+++ b/crates/c-api/src/component/mod.rs
@@ -1,5 +1,7 @@
 mod component;
+mod instance;
 mod linker;
 
 pub use component::*;
+pub use instance::*;
 pub use linker::*;

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_capi_test(tests FILES
   func.cc
   component/instantiate.cc
   component/define_module.cc
+  component/lookup_func.cc
   error.cc
   config.cc
   wat.cc

--- a/crates/c-api/tests/component/define_module.cc
+++ b/crates/c-api/tests/component/define_module.cc
@@ -60,10 +60,13 @@ TEST(component, define_module) {
   const auto root = wasmtime_component_linker_root(linker);
 
   wasmtime_component_linker_instance_t *x_y_z = nullptr;
-  err = wasmtime_component_linker_instance_add_instance(root, "x:y/z", &x_y_z);
+  auto name = wasm_name_t{};
+  wasm_name_new_from_string(&name, "x:y/z");
+  err = wasmtime_component_linker_instance_add_instance(root, &name, &x_y_z);
   CHECK(err);
 
-  err = wasmtime_component_linker_instance_add_module(x_y_z, "mod", module);
+  wasm_name_new_from_string(&name, "mod");
+  err = wasmtime_component_linker_instance_add_module(x_y_z, &name, module);
   CHECK(err);
 
   wasmtime_component_linker_instance_delete(x_y_z);

--- a/crates/c-api/tests/component/define_module.cc
+++ b/crates/c-api/tests/component/define_module.cc
@@ -1,14 +1,7 @@
+#include "utils.h"
+
 #include <gtest/gtest.h>
 #include <wasmtime.h>
-
-#define CHECK(err)                                                             \
-  do {                                                                         \
-    if (err) {                                                                 \
-      auto msg = wasm_name_t{};                                                \
-      wasmtime_error_message(err, &msg);                                       \
-      EXPECT_EQ(err, nullptr) << std::string_view{msg.data, msg.size};         \
-    }                                                                          \
-  } while (false)
 
 TEST(component, define_module) {
   static constexpr auto module_wat = std::string_view{
@@ -37,12 +30,12 @@ TEST(component, define_module) {
 
   wasm_byte_vec_t wasm;
   auto err = wasmtime_wat2wasm(module_wat.data(), module_wat.size(), &wasm);
-  CHECK(err);
+  CHECK_ERR(err);
 
   wasmtime_module_t *module = nullptr;
   err = wasmtime_module_new(
       engine, reinterpret_cast<const uint8_t *>(wasm.data), wasm.size, &module);
-  CHECK(err);
+  CHECK_ERR(err);
 
   const auto store = wasmtime_store_new(engine, nullptr, nullptr);
   const auto context = wasmtime_store_context(store);
@@ -53,7 +46,7 @@ TEST(component, define_module) {
       engine, reinterpret_cast<const uint8_t *>(component_text.data()),
       component_text.size(), &component);
 
-  CHECK(err);
+  CHECK_ERR(err);
 
   const auto linker = wasmtime_component_linker_new(engine);
 
@@ -63,11 +56,11 @@ TEST(component, define_module) {
   auto name = wasm_name_t{};
   wasm_name_new_from_string(&name, "x:y/z");
   err = wasmtime_component_linker_instance_add_instance(root, &name, &x_y_z);
-  CHECK(err);
+  CHECK_ERR(err);
 
   wasm_name_new_from_string(&name, "mod");
   err = wasmtime_component_linker_instance_add_module(x_y_z, &name, module);
-  CHECK(err);
+  CHECK_ERR(err);
 
   wasmtime_component_linker_instance_delete(x_y_z);
   wasmtime_component_linker_instance_delete(root);
@@ -75,7 +68,7 @@ TEST(component, define_module) {
   wasmtime_component_instance_t instance = {};
   err = wasmtime_component_linker_instantiate(linker, context, component,
                                               &instance);
-  CHECK(err);
+  CHECK_ERR(err);
 
   wasmtime_component_linker_delete(linker);
 

--- a/crates/c-api/tests/component/define_module.cc
+++ b/crates/c-api/tests/component/define_module.cc
@@ -53,13 +53,12 @@ TEST(component, define_module) {
   const auto root = wasmtime_component_linker_root(linker);
 
   wasmtime_component_linker_instance_t *x_y_z = nullptr;
-  auto name = wasm_name_t{};
-  wasm_name_new_from_string(&name, "x:y/z");
-  err = wasmtime_component_linker_instance_add_instance(root, &name, &x_y_z);
+  err = wasmtime_component_linker_instance_add_instance(
+      root, "x:y/z", strlen("x:y/z"), &x_y_z);
   CHECK_ERR(err);
 
-  wasm_name_new_from_string(&name, "mod");
-  err = wasmtime_component_linker_instance_add_module(x_y_z, &name, module);
+  err = wasmtime_component_linker_instance_add_module(x_y_z, "mod",
+                                                      strlen("mod"), module);
   CHECK_ERR(err);
 
   wasmtime_component_linker_instance_delete(x_y_z);

--- a/crates/c-api/tests/component/instantiate.cc
+++ b/crates/c-api/tests/component/instantiate.cc
@@ -1,3 +1,5 @@
+#include "utils.h"
+
 #include <gtest/gtest.h>
 #include <wasmtime.h>
 
@@ -24,8 +26,7 @@ TEST(component, instantiate) {
       engine, reinterpret_cast<const uint8_t *>(bytes.data()), bytes.size(),
       &component);
 
-  EXPECT_EQ(error, nullptr);
-  EXPECT_NE(component, nullptr);
+  CHECK_ERR(error);
 
   const auto linker = wasmtime_component_linker_new(engine);
   EXPECT_NE(linker, nullptr);
@@ -33,7 +34,8 @@ TEST(component, instantiate) {
   wasmtime_component_instance_t instance = {};
   error = wasmtime_component_linker_instantiate(linker, context, component,
                                                 &instance);
-  EXPECT_EQ(error, nullptr);
+
+  CHECK_ERR(error);
 
   wasmtime_component_linker_delete(linker);
 

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+#include <wasmtime.h>
+
+#define CHECK(err)                                                             \
+  do {                                                                         \
+    if (err) {                                                                 \
+      auto msg = wasm_name_t{};                                                \
+      wasmtime_error_message(err, &msg);                                       \
+      EXPECT_EQ(err, nullptr) << std::string_view{msg.data, msg.size};         \
+    }                                                                          \
+  } while (false)
+
+TEST(component, lookup_func) {
+  static constexpr auto component_text = std::string_view{
+      R"END(
+(component
+    (core module $m
+        (func (export "f"))
+    )
+    (core instance $i (instantiate $m))
+    (func (export "f")
+        (canon lift (core func $i "f")))
+)
+      )END",
+  };
+  const auto engine = wasm_engine_new();
+  EXPECT_NE(engine, nullptr);
+
+  const auto store = wasmtime_store_new(engine, nullptr, nullptr);
+  const auto context = wasmtime_store_context(store);
+
+  wasmtime_component_t *component = nullptr;
+
+  auto err = wasmtime_component_new(
+      engine, reinterpret_cast<const uint8_t *>(component_text.data()),
+      component_text.size(), &component);
+
+  CHECK(err);
+
+  const auto linker = wasmtime_component_linker_new(engine);
+
+  wasmtime_component_instance_t instance = {};
+  err = wasmtime_component_linker_instantiate(linker, context, component,
+                                              &instance);
+  CHECK(err);
+
+  wasmtime_component_func_t func = {};
+  auto found =
+      wasmtime_component_instance_get_func(&instance, context, "f", &func);
+  EXPECT_TRUE(found);
+  EXPECT_NE(func.store_id, 0);
+
+  func = {};
+  found = wasmtime_component_instance_get_func(&instance, context, "ff", &func);
+  EXPECT_FALSE(found);
+
+  wasmtime_component_linker_delete(linker);
+
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+}

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -30,20 +30,13 @@ TEST(component, lookup_func) {
 
   CHECK_ERR(err);
 
-  auto name = wasm_name_t{};
-  wasm_name_new_from_string(&name, "ff");
+  auto f = wasmtime_component_get_export_index(component, nullptr, "ff",
+                                               strlen("ff"));
 
-  wasmtime_component_export_index_t *f = nullptr;
-  auto found =
-      wasmtime_component_get_export_index(component, nullptr, &name, &f);
-
-  EXPECT_FALSE(found);
   EXPECT_EQ(f, nullptr);
 
-  wasm_name_new_from_string(&name, "f");
-  found = wasmtime_component_get_export_index(component, nullptr, &name, &f);
+  f = wasmtime_component_get_export_index(component, nullptr, "f", strlen("f"));
 
-  EXPECT_TRUE(found);
   EXPECT_NE(f, nullptr);
 
   const auto linker = wasmtime_component_linker_new(engine);
@@ -54,18 +47,15 @@ TEST(component, lookup_func) {
   CHECK_ERR(err);
 
   wasmtime_component_func_t func = {};
-  found = wasmtime_component_instance_get_func(&instance, context, f, &func);
+  const auto found =
+      wasmtime_component_instance_get_func(&instance, context, f, &func);
   EXPECT_TRUE(found);
   EXPECT_NE(func.store_id, 0);
 
   wasmtime_component_export_index_delete(f);
-  found = false;
-  f = nullptr;
 
-  wasm_name_new_from_string(&name, "f");
-  found = wasmtime_component_instance_get_export_index(&instance, context,
-                                                       nullptr, &name, &f);
-  EXPECT_TRUE(found);
+  f = wasmtime_component_instance_get_export_index(&instance, context, nullptr,
+                                                   "f", strlen("f"));
   EXPECT_NE(f, nullptr);
 
   wasmtime_component_export_index_delete(f);

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -37,6 +37,22 @@ TEST(component, lookup_func) {
 
   CHECK(err);
 
+  auto name = wasm_name_t{};
+  wasm_name_new_from_string(&name, "ff");
+
+  wasmtime_component_export_index_t *f = nullptr;
+  auto found =
+      wasmtime_component_get_export_index(component, nullptr, &name, &f);
+
+  EXPECT_FALSE(found);
+  EXPECT_EQ(f, nullptr);
+
+  wasm_name_new_from_string(&name, "f");
+  found = wasmtime_component_get_export_index(component, nullptr, &name, &f);
+
+  EXPECT_TRUE(found);
+  EXPECT_NE(f, nullptr);
+
   const auto linker = wasmtime_component_linker_new(engine);
 
   wasmtime_component_instance_t instance = {};
@@ -45,15 +61,21 @@ TEST(component, lookup_func) {
   CHECK(err);
 
   wasmtime_component_func_t func = {};
-  auto found =
-      wasmtime_component_instance_get_func(&instance, context, "f", &func);
+  found = wasmtime_component_instance_get_func(&instance, context, f, &func);
   EXPECT_TRUE(found);
   EXPECT_NE(func.store_id, 0);
 
-  func = {};
-  found = wasmtime_component_instance_get_func(&instance, context, "ff", &func);
-  EXPECT_FALSE(found);
+  wasmtime_component_export_index_delete(f);
+  found = false;
+  f = nullptr;
 
+  wasm_name_new_from_string(&name, "f");
+  found = wasmtime_component_instance_get_export_index(&instance, context,
+                                                       nullptr, &name, &f);
+  EXPECT_TRUE(found);
+  EXPECT_NE(f, nullptr);
+
+  wasmtime_component_export_index_delete(f);
   wasmtime_component_linker_delete(linker);
 
   wasmtime_store_delete(store);

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -1,14 +1,7 @@
+#include "utils.h"
+
 #include <gtest/gtest.h>
 #include <wasmtime.h>
-
-#define CHECK(err)                                                             \
-  do {                                                                         \
-    if (err) {                                                                 \
-      auto msg = wasm_name_t{};                                                \
-      wasmtime_error_message(err, &msg);                                       \
-      EXPECT_EQ(err, nullptr) << std::string_view{msg.data, msg.size};         \
-    }                                                                          \
-  } while (false)
 
 TEST(component, lookup_func) {
   static constexpr auto component_text = std::string_view{
@@ -35,7 +28,7 @@ TEST(component, lookup_func) {
       engine, reinterpret_cast<const uint8_t *>(component_text.data()),
       component_text.size(), &component);
 
-  CHECK(err);
+  CHECK_ERR(err);
 
   auto name = wasm_name_t{};
   wasm_name_new_from_string(&name, "ff");
@@ -58,7 +51,7 @@ TEST(component, lookup_func) {
   wasmtime_component_instance_t instance = {};
   err = wasmtime_component_linker_instantiate(linker, context, component,
                                               &instance);
-  CHECK(err);
+  CHECK_ERR(err);
 
   wasmtime_component_func_t func = {};
   found = wasmtime_component_instance_get_func(&instance, context, f, &func);

--- a/crates/c-api/tests/component/utils.h
+++ b/crates/c-api/tests/component/utils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define CHECK_ERR(err)                                                         \
+  do {                                                                         \
+    if (err) {                                                                 \
+      auto msg = wasm_name_t{};                                                \
+      wasmtime_error_message(err, &msg);                                       \
+      EXPECT_EQ(err, nullptr) << std::string_view{msg.data, msg.size};         \
+    }                                                                          \
+  } while (false)


### PR DESCRIPTION
Only `get_func()` as of now, should https://github.com/bytecodealliance/wasmtime/pull/9812#discussion_r1884473950 come in a later PR?

One thing of note, if name isn't UTF-8, it returns false instead of returning an error, is that fine?