### PR TITLE
Update `F128` argument ABI for `windows_fastcall` to match LLVM 21

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -211,10 +211,10 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 );
             }
 
-            // Windows fastcall dictates that `__m128i` parameters to a function
-            // are passed indirectly as pointers, so handle that as a special
-            // case before the loop below.
-            if param.value_type.is_vector()
+            // Windows fastcall dictates that `__m128i` and `f128` parameters to
+            // a function are passed indirectly as pointers, so handle that as a
+            // special case before the loop below.
+            if (param.value_type.is_vector() || param.value_type.is_float())
                 && param.value_type.bits() >= 128
                 && args_or_rets == ArgsOrRets::Args
                 && is_fastcall
@@ -504,9 +504,9 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     fn gen_load_base_offset(into_reg: Writable<Reg>, base: Reg, offset: i32, ty: Type) -> Self::I {
-        // Only ever used for I64s and vectors; if that changes, see if the
-        // ExtKind below needs to be changed.
-        assert!(ty == I64 || ty.is_vector());
+        // Only ever used for I64s, F128s and vectors; if that changes, see if
+        // the ExtKind below needs to be changed.
+        assert!(ty == I64 || ty.is_vector() || ty == F128);
         let mem = Amode::imm_reg(offset, base);
         Inst::load(ty, mem, into_reg, ExtKind::None)
     }

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -658,7 +658,7 @@ block0(v0: f128, v1: f128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm1, %xmm0
+;   movdqu  0(%rdx), %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -668,7 +668,8 @@ block0(v0: f128, v1: f128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm1, %xmm0
+;   movdqu (%rdx), %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+


### PR DESCRIPTION
LLVM updated the `windows_fastcall` ABI for `f128`  in https://github.com/llvm/llvm-project/pull/128848 to be passed indirectly (like `__m128i`), as that is more consistent with the rest of the `windows_fastcall` ABI. This PR updates Cranelift to match (`f128` can only be used with `windows_fastcall` in Cranelift with `enable_llvm_abi_extensions`).