### PR TITLE
[DWARF] Fix "simulated" DWARF

### DIFF
--- a/crates/test-programs/src/bin/dwarf_generic.cpp
+++ b/crates/test-programs/src/bin/dwarf_generic.cpp
@@ -63,10 +63,26 @@ int TestInstanceMethod() {
   return 0;
 }
 
+__asm("FunctionWithoutWasmDWARF:\n"
+      ".global	FunctionWithoutWasmDWARF\n"
+      ".functype	FunctionWithoutWasmDWARF (i32, i32) -> (i32)\n"
+      "local.get	0\n"
+      "local.get	1\n"
+      "i32.div_u\n"
+      "end_function\n");
+extern "C" int FunctionWithoutWasmDWARF(int a, int b);
+
+int TestFunctionWithoutWasmDWARF() {
+  debug_break();
+  int x = FunctionWithoutWasmDWARF(9, 10);
+  return x == 0 ? 0 : 4;
+}
+
 int main() {
   int exitCode = 0;
   exitCode += TestClassDefinitionSpreadAcrossCompileUnits();
   exitCode += TestInheritance();
   exitCode += TestInstanceMethod();
+  exitCode += TestFunctionWithoutWasmDWARF();
   return exitCode;
 }

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -206,6 +206,12 @@ c
 p __this->BaseValue + __this->DerivedValue
 c
 p __this->BaseValue + __this->DerivedValue
+c
+f
+n
+s
+v var0
+v var1
 c"#,
     )?;
 
@@ -227,6 +233,9 @@ check: stop reason = breakpoint 1.1
 check: 7
 check: stop reason = breakpoint 1.1
 check: 8
+check: stop reason = breakpoint 1.1
+check: 9
+check: 10
 check: exited with status = 0
 "#,
     )?;


### PR DESCRIPTION
We need to record the correct ranges for the CU and include an offset zero entry in the line table, otherwise LLDB won't class our functions as "having debug info".

Fixes #10676.