### PR TITLE
[32.0.0] Add audits for new crates in Wasmtime 

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -160,6 +160,14 @@ start = "2021-10-29"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.cranelift-srcgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-04-21"
+end = "2026-04-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.cranelift-wasm]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -611,6 +619,14 @@ criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-03-20"
 end = "2025-07-30"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-tls]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-04-21"
+end = "2026-04-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wast]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -85,6 +85,9 @@ audit-as-crates-io = true
 [policy.cranelift-serde]
 audit-as-crates-io = true
 
+[policy.cranelift-srcgen]
+audit-as-crates-io = true
+
 [policy.isle-fuzz]
 criteria = []
 
@@ -179,6 +182,9 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-wasi-threads]
+audit-as-crates-io = true
+
+[policy.wasmtime-wasi-tls]
 audit-as-crates-io = true
 
 [policy.wasmtime-wast]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -512,6 +512,12 @@ when = "2025-02-25"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-srcgen]]
+version = "0.119.0"
+when = "2025-04-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.derive_arbitrary]]
 version = "1.4.0"
 when = "2024-11-04"
@@ -1204,6 +1210,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "30.0.2"
 when = "2025-02-25"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-tls]]
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Backport of #10622 to the release branch.

Closes #10682