### PR TITLE
Test i128<->vector bitcasts on all non-Pulley architectures

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-bitcast-i128.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast-i128.clif
@@ -1,7 +1,12 @@
 test run
 set enable_multi_ret_implicit_sret
+set enable_llvm_abi_extensions
+target x86_64
+target x86_64 has_avx
+target aarch64
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
+target s390x
 
 function %bitcast_i64x2_to_i128(i64x2) -> i128 {
 block0(v0: i64x2):


### PR DESCRIPTION
Cranelift now supports i128<->vector bitcasts on all non-Pulley architectures, so expand the test to ensure it doesn't regress.

Fixes #6104