### PR TITLE
Run `clang-format` over more files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       with:
         submodules: true
     - run: |
-        git ls-files '*.h' '*.c' '*.cpp' | \
+        git ls-files '*.h' '*.c' '*.cpp' '*.hh' '*.cc' | \
           grep -v wasmtime-platform.h | \
           grep -v wasm.h | \
           xargs clang-format-18 --dry-run --Werror --verbose

--- a/crates/c-api/include/wasmtime.hh
+++ b/crates/c-api/include/wasmtime.hh
@@ -310,11 +310,13 @@ public:
                 bool> = true>
   Result<std::monostate> func_new(std::string_view module,
                                   std::string_view name, const FuncType &ty,
-                                  F&& f) {
+                                  F &&f) {
 
     auto *error = wasmtime_linker_define_func(
         ptr.get(), module.data(), module.length(), name.data(), name.length(),
-        ty.ptr.get(), Func::raw_callback<std::remove_reference_t<F>>, std::make_unique<std::remove_reference_t<F>>(std::forward<F>(f)).release(),
+        ty.ptr.get(), Func::raw_callback<std::remove_reference_t<F>>,
+        std::make_unique<std::remove_reference_t<F>>(std::forward<F>(f))
+            .release(),
         Func::raw_finalize<std::remove_reference_t<F>>);
 
     if (error != nullptr) {
@@ -330,7 +332,7 @@ public:
             std::enable_if_t<WasmHostFunc<F>::Params::valid, bool> = true,
             std::enable_if_t<WasmHostFunc<F>::Results::valid, bool> = true>
   Result<std::monostate> func_wrap(std::string_view module,
-                                   std::string_view name, F&& f) {
+                                   std::string_view name, F &&f) {
     using HostFunc = WasmHostFunc<F>;
     auto params = HostFunc::Params::types();
     auto results = HostFunc::Results::types();
@@ -338,7 +340,9 @@ public:
     auto *error = wasmtime_linker_define_func_unchecked(
         ptr.get(), module.data(), module.length(), name.data(), name.length(),
         ty.ptr.get(), Func::raw_callback_unchecked<std::remove_reference_t<F>>,
-        std::make_unique<std::remove_reference_t<F>>(std::forward<F>(f)).release(), Func::raw_finalize<std::remove_reference_t<F>>);
+        std::make_unique<std::remove_reference_t<F>>(std::forward<F>(f))
+            .release(),
+        Func::raw_finalize<std::remove_reference_t<F>>);
 
     if (error != nullptr) {
       return Error(error);

--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -368,21 +368,22 @@ public:
     wasmtime_config_wasm_memory64_set(ptr.get(), enable);
   }
 
-  /// \brief Configures whether the WebAssembly Garbage Collection proposal will be enabled
+  /// \brief Configures whether the WebAssembly Garbage Collection proposal will
+  /// be enabled
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_gc
-  void wasm_gc(bool enable) {
-    wasmtime_config_wasm_gc_set(ptr.get(), enable);
-  }
+  void wasm_gc(bool enable) { wasmtime_config_wasm_gc_set(ptr.get(), enable); }
 
-  /// \brief Configures whether the WebAssembly function references proposal will be enabled
+  /// \brief Configures whether the WebAssembly function references proposal
+  /// will be enabled
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_function_references
   void wasm_function_references(bool enable) {
     wasmtime_config_wasm_function_references_set(ptr.get(), enable);
   }
 
-  /// \brief Configures whether the WebAssembly wide arithmetic proposal will be enabled
+  /// \brief Configures whether the WebAssembly wide arithmetic proposal will be
+  /// enabled
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_wide_arithmetic
   void wasm_wide_arithmetic(bool enable) {
@@ -390,7 +391,8 @@ public:
   }
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
-  /// \brief Configures whether the WebAssembly component model proposal will be enabled
+  /// \brief Configures whether the WebAssembly component model proposal will be
+  /// enabled
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model
   void wasm_component_model(bool enable) {
@@ -399,7 +401,8 @@ public:
 #endif // WASMTIME_FEATURE_COMPONENT_MODEL
 
 #ifdef WASMTIME_FEATURE_PARALLEL_COMPILATION
-  /// \brief Configure whether wasmtime should compile a module using multiple threads.
+  /// \brief Configure whether wasmtime should compile a module using multiple
+  /// threads.
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.parallel_compilation
   void parallel_compilation(bool enable) {
@@ -468,7 +471,8 @@ public:
     wasmtime_config_memory_reservation_set(ptr.get(), size);
   }
 
-  /// \brief Configures the size of the bytes to reserve beyond the end of linear memory to grow into.
+  /// \brief Configures the size of the bytes to reserve beyond the end of
+  /// linear memory to grow into.
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.memory_reservation_for_growth
   void memory_reservation_for_growth(size_t size) {
@@ -482,7 +486,8 @@ public:
     wasmtime_config_memory_guard_size_set(ptr.get(), size);
   }
 
-  /// \brief Configures whether the base pointer of linear memory is allowed to move.
+  /// \brief Configures whether the base pointer of linear memory is allowed to
+  /// move.
   ///
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.memory_may_move
   void memory_may_move(bool enable) {
@@ -535,13 +540,13 @@ public:
 #endif // WASMTIME_FEATURE_CACHE
 
 private:
-  template <typename T>
-  static void raw_finalize(void *env) {
+  template <typename T> static void raw_finalize(void *env) {
     std::unique_ptr<T> ptr(reinterpret_cast<T *>(env));
   }
 
   template <typename M>
-  static uint8_t *raw_get_memory(void *env, size_t *byte_size, size_t *byte_capacity) {
+  static uint8_t *raw_get_memory(void *env, size_t *byte_size,
+                                 size_t *byte_capacity) {
     M *memory = reinterpret_cast<M *>(env);
     return memory->get_memory(byte_size, byte_capacity);
   }
@@ -556,19 +561,16 @@ private:
   }
 
   template <typename T>
-  static wasmtime_error_t *raw_new_memory(
-    void *env, const wasm_memorytype_t *ty, size_t minimum, size_t maximum,
-    size_t reserved_size_in_bytes, size_t guard_size_in_bytes,
-    wasmtime_linear_memory_t *memory_ret)
-  {
+  static wasmtime_error_t *
+  raw_new_memory(void *env, const wasm_memorytype_t *ty, size_t minimum,
+                 size_t maximum, size_t reserved_size_in_bytes,
+                 size_t guard_size_in_bytes,
+                 wasmtime_linear_memory_t *memory_ret) {
     using Memory = typename T::Memory;
     T *creator = reinterpret_cast<T *>(env);
-    Result<Memory> result = creator->new_memory(
-        MemoryType::Ref(ty),
-        minimum,
-        maximum,
-        reserved_size_in_bytes,
-        guard_size_in_bytes);
+    Result<Memory> result =
+        creator->new_memory(MemoryType::Ref(ty), minimum, maximum,
+                            reserved_size_in_bytes, guard_size_in_bytes);
     if (!result) {
       return result.err().release();
     }
@@ -581,21 +583,18 @@ private:
   }
 
 public:
-
   /// \brief Configures a custom memory creator for this configuration and
   /// eventual Engine.
   ///
   /// This can be used to use `creator` to allocate linear memories for the
   /// engine that this configuration will be used for.
-  template<typename T>
-  void host_memory_creator(T creator) {
+  template <typename T> void host_memory_creator(T creator) {
     wasmtime_memory_creator_t config = {0};
-    config.env =  std::make_unique<T>(creator).release();
+    config.env = std::make_unique<T>(creator).release();
     config.finalizer = raw_finalize<T>;
     config.new_memory = raw_new_memory<T>;
     wasmtime_config_host_memory_creator_set(ptr.get(), &config);
   }
-
 
 #ifdef WASMTIME_FEATURE_POOLING_ALLOCATOR
   /// \brief Enables and configures the pooling allocation strategy.

--- a/crates/c-api/include/wasmtime/engine.hh
+++ b/crates/c-api/include/wasmtime/engine.hh
@@ -61,4 +61,3 @@ public:
 } // namespace wasmtime
 
 #endif // WASMTIME_ENGINE_HH
-

--- a/crates/c-api/include/wasmtime/error.hh
+++ b/crates/c-api/include/wasmtime/error.hh
@@ -62,9 +62,7 @@ public:
   Trace trace() const;
 
   /// Release ownership of this error, acquiring the underlying C raw pointer.
-  wasmtime_error_t *release() {
-    return ptr.release();
-  }
+  wasmtime_error_t *release() { return ptr.release(); }
 };
 
 /// \brief Used to print an error.

--- a/crates/c-api/include/wasmtime/extern.hh
+++ b/crates/c-api/include/wasmtime/extern.hh
@@ -5,8 +5,8 @@
 #ifndef WASMTIME_EXTERN_HH
 #define WASMTIME_EXTERN_HH
 
-#include <wasmtime/extern.h>
 #include <variant>
+#include <wasmtime/extern.h>
 
 namespace wasmtime {
 

--- a/crates/c-api/include/wasmtime/func.hh
+++ b/crates/c-api/include/wasmtime/func.hh
@@ -11,8 +11,8 @@
 #include <wasmtime/span.hh>
 #include <wasmtime/store.hh>
 #include <wasmtime/trap.hh>
-#include <wasmtime/types/val.hh>
 #include <wasmtime/types/func.hh>
+#include <wasmtime/types/val.hh>
 #include <wasmtime/val.hh>
 
 namespace wasmtime {
@@ -49,7 +49,9 @@ namespace detail {
 
 /// A "trait" for native types that correspond to WebAssembly types for use with
 /// `Func::wrap` and `TypedFunc::call`
-template <typename T> struct WasmType { static const bool valid = false; };
+template <typename T> struct WasmType {
+  static const bool valid = false;
+};
 
 /// Helper macro to define `WasmType` definitions for primitive types like
 /// int32_t and such.
@@ -577,11 +579,11 @@ public:
         storage;
     wasmtime_val_raw_t *ptr = storage.data();
     if (ptr == nullptr)
-      ptr = reinterpret_cast<wasmtime_val_raw_t*>(alignof(wasmtime_val_raw_t));
+      ptr = reinterpret_cast<wasmtime_val_raw_t *>(alignof(wasmtime_val_raw_t));
     WasmTypeList<Params>::store(cx, ptr, params);
     wasm_trap_t *trap = nullptr;
-    auto *error = wasmtime_func_call_unchecked(
-        cx.raw_context(), &f.func, ptr, storage.size(), &trap);
+    auto *error = wasmtime_func_call_unchecked(cx.raw_context(), &f.func, ptr,
+                                               storage.size(), &trap);
     if (error != nullptr) {
       return TrapError(Error(error));
     }

--- a/crates/c-api/include/wasmtime/module.hh
+++ b/crates/c-api/include/wasmtime/module.hh
@@ -188,4 +188,3 @@ public:
 } // namespace wasmtime
 
 #endif // WASMTIME_MODULE_HH
-

--- a/crates/c-api/include/wasmtime/span.hh
+++ b/crates/c-api/include/wasmtime/span.hh
@@ -99,4 +99,3 @@ private:
 } // namespace wasmtime
 
 #endif // WASMTIME_SPAN_HH
-

--- a/crates/c-api/include/wasmtime/types/memory.hh
+++ b/crates/c-api/include/wasmtime/types/memory.hh
@@ -120,34 +120,34 @@ public:
     Builder() : _min(0), _memory64(false), _shared(false) {}
 
     /// \brief Configure the minimum size, in pages, of linear memory.
-    Builder& min(uint64_t min) {
+    Builder &min(uint64_t min) {
       _min = min;
       return *this;
     }
 
     /// \brief Configure the maximal size, in pages, of linear memory.
-    Builder& max(std::optional<uint64_t> max) {
+    Builder &max(std::optional<uint64_t> max) {
       _max = max;
       return *this;
     }
 
     /// \brief Configure whether this is a 64-bit linear memory.
-    Builder& memory64(bool enable) {
+    Builder &memory64(bool enable) {
       _memory64 = enable;
       return *this;
     }
 
     /// \brief Configure whether this is a shared linear memory.
-    Builder& shared(bool enable) {
+    Builder &shared(bool enable) {
       _shared = enable;
       return *this;
     }
 
     /// \brief Construct the final `MemoryType` value.
     MemoryType build() const {
-      return MemoryType(wasmtime_memorytype_new(
-            _min, _max.has_value(), _max.has_value() ? *_max : 0,
-            _memory64, _shared));
+      return MemoryType(wasmtime_memorytype_new(_min, _max.has_value(),
+                                                _max.has_value() ? *_max : 0,
+                                                _memory64, _shared));
     }
   };
 };

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -46,7 +46,7 @@ public:
   template <typename T> explicit ExternRef(Store::Context cx, T val) {
     void *ptr = std::make_unique<std::any>(std::move(val)).release();
     bool ok = wasmtime_externref_new(cx.ptr, ptr, finalizer, &this->val);
-    if (!ok)  {
+    if (!ok) {
       fprintf(stderr, "failed to allocate a new externref");
       abort();
     }
@@ -66,9 +66,7 @@ public:
 
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
-  void unroot(Store::Context cx) {
-    wasmtime_externref_unroot(cx.ptr, &val);
-  }
+  void unroot(Store::Context cx) { wasmtime_externref_unroot(cx.ptr, &val); }
 
   /// Returns the raw underlying C API value.
   ///
@@ -105,9 +103,7 @@ public:
 
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
-  void unroot(Store::Context cx) {
-    wasmtime_anyref_unroot(cx.ptr, &val);
-  }
+  void unroot(Store::Context cx) { wasmtime_anyref_unroot(cx.ptr, &val); }
 
   /// Returns the raw underlying C API value.
   ///
@@ -335,9 +331,7 @@ public:
   std::optional<Func> funcref() const;
 
   /// Unroots any GC references this `Val` points to within the `cx` provided.
-  void unroot(Store::Context cx) {
-    wasmtime_val_unroot(cx.ptr, &val);
-  }
+  void unroot(Store::Context cx) { wasmtime_val_unroot(cx.ptr, &val); }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/wasi.hh
+++ b/crates/c-api/include/wasmtime/wasi.hh
@@ -98,9 +98,9 @@ public:
   /// Opens `path` to be opened as `guest_path` in the WASI pseudo-filesystem.
   [[nodiscard]] bool preopen_dir(const std::string &path,
                                  const std::string &guest_path,
-                                 size_t dir_perms,
-                                 size_t file_perms) {
-    return wasi_config_preopen_dir(ptr.get(), path.c_str(), guest_path.c_str(), dir_perms, file_perms);
+                                 size_t dir_perms, size_t file_perms) {
+    return wasi_config_preopen_dir(ptr.get(), path.c_str(), guest_path.c_str(),
+                                   dir_perms, file_perms);
   }
 };
 

--- a/crates/c-api/tests/config.cc
+++ b/crates/c-api/tests/config.cc
@@ -1,6 +1,6 @@
-#include <wasmtime/config.hh>
 #include <gtest/gtest.h>
 #include <wasmtime.hh>
+#include <wasmtime/config.hh>
 
 using namespace wasmtime;
 
@@ -91,13 +91,9 @@ struct MyMemoryCreator {
     }
   };
 
-  Result<Memory> new_memory(
-      const MemoryType::Ref &ty,
-      size_t minimum,
-      size_t maximum,
-      size_t reserved_size_in_bytes,
-      size_t guard_size_in_bytes)
-  {
+  Result<Memory> new_memory(const MemoryType::Ref &ty, size_t minimum,
+                            size_t maximum, size_t reserved_size_in_bytes,
+                            size_t guard_size_in_bytes) {
     EXPECT_EQ(guard_size_in_bytes, 0);
     EXPECT_EQ(reserved_size_in_bytes, 0);
 
@@ -115,7 +111,8 @@ TEST(Config, MemoryCreator) {
   config.host_memory_creator(MyMemoryCreator());
 
   Engine engine(std::move(config));
-  Module m = Module::compile(engine, "(module (memory (export \"x\") 1))").unwrap();
+  Module m =
+      Module::compile(engine, "(module (memory (export \"x\") 1))").unwrap();
 
   Store store(engine);
   Instance i = Instance::create(store, m, {}).unwrap();

--- a/crates/c-api/tests/error.cc
+++ b/crates/c-api/tests/error.cc
@@ -1,5 +1,5 @@
-#include <wasmtime/error.hh>
 #include <gtest/gtest.h>
+#include <wasmtime/error.hh>
 
 using namespace wasmtime;
 

--- a/crates/c-api/tests/export_type.cc
+++ b/crates/c-api/tests/export_type.cc
@@ -12,7 +12,8 @@ TEST(ExportType, Smoke) {
 
   module = Module::compile(engine, "(module"
                                    "(global (export \"x\") i32 (i32.const 0))"
-                                   ")").unwrap();
+                                   ")")
+               .unwrap();
 
   auto exports = module.exports();
   EXPECT_EQ(exports.size(), 1);

--- a/crates/c-api/tests/extern_type.cc
+++ b/crates/c-api/tests/extern_type.cc
@@ -8,10 +8,12 @@ using namespace wasmtime;
 TEST(ExternType, Smoke) {
   Engine engine;
 
-  Module module = Module::compile(engine, "(module"
-                                   "(import \"a\" \"b\" (func))"
-                                   "(global (export \"x\") i32 (i32.const 0))"
-                                   ")").unwrap();
+  Module module =
+      Module::compile(engine, "(module"
+                              "(import \"a\" \"b\" (func))"
+                              "(global (export \"x\") i32 (i32.const 0))"
+                              ")")
+          .unwrap();
 
   auto imports = module.imports();
   EXPECT_EQ(imports.size(), 1);

--- a/crates/c-api/tests/func.cc
+++ b/crates/c-api/tests/func.cc
@@ -89,7 +89,8 @@ TEST(TypedFunc, Call) {
     Func f(store, ty, [](auto caller, auto params, auto results) {
       caller.context().gc();
       EXPECT_TRUE(params[0].externref(caller));
-      EXPECT_EQ(std::any_cast<int>(params[0].externref(caller)->data(caller)), 100);
+      EXPECT_EQ(std::any_cast<int>(params[0].externref(caller)->data(caller)),
+                100);
       EXPECT_FALSE(params[1].externref(caller));
       results[0] = ExternRef(caller, int(3));
       results[1] = std::optional<ExternRef>(std::nullopt);

--- a/crates/c-api/tests/import_type.cc
+++ b/crates/c-api/tests/import_type.cc
@@ -12,7 +12,8 @@ TEST(ImportType, Smoke) {
 
   module = Module::compile(engine, "(module"
                                    "(import \"a\" \"b\" (func))"
-                                   ")").unwrap();
+                                   ")")
+               .unwrap();
 
   auto imports = module.imports();
   EXPECT_EQ(imports.size(), 1);

--- a/crates/c-api/tests/memory_type.cc
+++ b/crates/c-api/tests/memory_type.cc
@@ -1,5 +1,5 @@
-#include <wasmtime/types/memory.hh>
 #include <gtest/gtest.h>
+#include <wasmtime/types/memory.hh>
 
 using namespace wasmtime;
 
@@ -46,10 +46,14 @@ TEST(MemoryType, Builder) {
   EXPECT_TRUE(ty->is_64());
   EXPECT_TRUE(ty->is_shared());
 
-  ty = MemoryType::Builder().min(5).max(500).shared(true).memory64(false).build();
+  ty = MemoryType::Builder()
+           .min(5)
+           .max(500)
+           .shared(true)
+           .memory64(false)
+           .build();
   EXPECT_EQ(ty->min(), 5);
   EXPECT_EQ(ty->max(), 500);
   EXPECT_FALSE(ty->is_64());
   EXPECT_TRUE(ty->is_shared());
-
 }

--- a/crates/c-api/tests/module.cc
+++ b/crates/c-api/tests/module.cc
@@ -11,7 +11,6 @@ TEST(Module, Simple) {
   Module::compile(engine, wasm).unwrap();
   Module::validate(engine, wasm).unwrap();
 
-
   auto serialized = m.serialize().unwrap();
   Module::deserialize(engine, serialized).unwrap();
 }

--- a/crates/c-api/tests/simple.cc
+++ b/crates/c-api/tests/simple.cc
@@ -74,11 +74,10 @@ TEST(Instance, Smoke) {
   Global g = unwrap(Global::create(store, GlobalType(ValKind::I32, false), 1));
   Table t = unwrap(Table::create(store, TableType(ValKind::FuncRef, 1),
                                  std::optional<Func>()));
-  Func f(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        return std::monostate();
-      });
+  Func f(store, FuncType({}, {}),
+         [](auto caller, auto params, auto results) -> auto {
+           return std::monostate();
+         });
 
   Module mod =
       unwrap(Module::compile(engine, "(module"
@@ -117,11 +116,10 @@ TEST(Linker, Smoke) {
   Global g = unwrap(Global::create(store, GlobalType(ValKind::I32, false), 1));
   unwrap(linker.define(store, "a", "g", g));
   unwrap(linker.define_wasi());
-  unwrap(linker.func_new(
-      "a", "f", FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        return std::monostate();
-      }));
+  unwrap(linker.func_new("a", "f", FuncType({}, {}),
+                         [](auto caller, auto params, auto results) -> auto {
+                           return std::monostate();
+                         }));
   unwrap(linker.func_wrap("a", "f2", []() {}));
   unwrap(linker.func_wrap("a", "f3", [](Caller arg) {}));
   unwrap(linker.func_wrap("a", "f4", [](Caller arg, int32_t a) {}));
@@ -144,10 +142,11 @@ TEST(Linker, CallableMove) {
 
   struct CallableFunc {
     CallableFunc() = default;
-    CallableFunc(const CallableFunc&) = delete;
-    CallableFunc(CallableFunc&&) = default;
+    CallableFunc(const CallableFunc &) = delete;
+    CallableFunc(CallableFunc &&) = default;
 
-    Result<std::monostate, Trap> operator()(Caller caller, Span<const Val> params, Span<Val> results) {
+    Result<std::monostate, Trap>
+    operator()(Caller caller, Span<const Val> params, Span<Val> results) {
       return std::monostate();
     }
   };
@@ -164,10 +163,11 @@ TEST(Linker, CallableCopy) {
 
   struct CallableFunc {
     CallableFunc() = default;
-    CallableFunc(const CallableFunc&) = default;
-    CallableFunc(CallableFunc&&) = default;
+    CallableFunc(const CallableFunc &) = default;
+    CallableFunc(CallableFunc &&) = default;
 
-    Result<std::monostate, Trap> operator()(Caller caller, Span<const Val> params, Span<Val> results) {
+    Result<std::monostate, Trap>
+    operator()(Caller caller, Span<const Val> params, Span<Val> results) {
       return std::monostate();
     }
   };
@@ -179,12 +179,11 @@ TEST(Linker, CallableCopy) {
 TEST(Caller, Smoke) {
   Engine engine;
   Store store(engine);
-  Func f(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        EXPECT_FALSE(caller.get_export("foo"));
-        return std::monostate();
-      });
+  Func f(store, FuncType({}, {}),
+         [](auto caller, auto params, auto results) -> auto {
+           EXPECT_FALSE(caller.get_export("foo"));
+           return std::monostate();
+         });
   unwrap(f.call(store, {}));
 
   Module m = unwrap(Module::compile(engine, "(module "
@@ -192,16 +191,15 @@ TEST(Caller, Smoke) {
                                             "(memory (export \"m\") 1)"
                                             "(func (export \"f\") call 0)"
                                             ")"));
-  Func f2(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        EXPECT_FALSE(caller.get_export("foo"));
-        EXPECT_TRUE(caller.get_export("m"));
-        EXPECT_TRUE(caller.get_export("f"));
-        Memory m = std::get<Memory>(*caller.get_export("m"));
-        EXPECT_EQ(m.type(caller)->min(), 1);
-        return std::monostate();
-      });
+  Func f2(store, FuncType({}, {}),
+          [](auto caller, auto params, auto results) -> auto {
+            EXPECT_FALSE(caller.get_export("foo"));
+            EXPECT_TRUE(caller.get_export("m"));
+            EXPECT_TRUE(caller.get_export("f"));
+            Memory m = std::get<Memory>(*caller.get_export("m"));
+            EXPECT_EQ(m.type(caller)->min(), 1);
+            return std::monostate();
+          });
   Instance i = unwrap(Instance::create(store, m, {f2}));
   f = std::get<Func>(*i.get(store, "f"));
   unwrap(f.call(store, {}));
@@ -210,18 +208,16 @@ TEST(Caller, Smoke) {
 TEST(Func, Smoke) {
   Engine engine;
   Store store(engine);
-  Func f(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        return std::monostate();
-      });
+  Func f(store, FuncType({}, {}),
+         [](auto caller, auto params, auto results) -> auto {
+           return std::monostate();
+         });
   unwrap(f.call(store, {}));
 
-  Func f2(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        return Trap("message");
-      });
+  Func f2(store, FuncType({}, {}),
+          [](auto caller, auto params, auto results) -> auto {
+            return Trap("message");
+          });
   EXPECT_EQ(f2.call(store, {}).err().message(), "message");
 }
 

--- a/crates/c-api/tests/trap.cc
+++ b/crates/c-api/tests/trap.cc
@@ -12,7 +12,8 @@ TEST(Trap, Smoke) {
 
   Engine engine;
   Module m =
-      Module::compile(engine, "(module (func (export \"\") unreachable))").unwrap();
+      Module::compile(engine, "(module (func (export \"\") unreachable))")
+          .unwrap();
   Store store(engine);
   Instance i = Instance::create(store, m, {}).unwrap();
   auto func = std::get<Func>(*i.get(store, ""));

--- a/crates/c-api/tests/val.cc
+++ b/crates/c-api/tests/val.cc
@@ -64,11 +64,10 @@ TEST(Val, Smoke) {
   EXPECT_EQ(val.kind(), ValKind::FuncRef);
   EXPECT_EQ(val.funcref(), std::nullopt);
 
-  Func func(
-      store, FuncType({}, {}),
-      [](auto caller, auto params, auto results) -> auto{
-        return std::monostate();
-      });
+  Func func(store, FuncType({}, {}),
+            [](auto caller, auto params, auto results) -> auto {
+              return std::monostate();
+            });
 
   val = std::optional<Func>(func);
   EXPECT_EQ(val.kind(), ValKind::FuncRef);

--- a/crates/test-programs/src/bin/dwarf_fraction_norm.cc
+++ b/crates/test-programs/src/bin/dwarf_fraction_norm.cc
@@ -7,20 +7,17 @@ struct Fraction {
   long denominator;
 };
 
-inline long abs(long x)
-{
-  return x >= 0 ? x : -x;  
-}
+inline long abs(long x) { return x >= 0 ? x : -x; }
 
-extern "C"
-void norm(Fraction &n)
-{
+extern "C" void norm(Fraction &n) {
   long a = abs(n.numerator), b = abs(n.denominator);
-  if (a == 0 || b == 0) return;
+  if (a == 0 || b == 0)
+    return;
   do {
-   a %= b;
-   if (a == 0) break;
-   b %= a;
+    a %= b;
+    if (a == 0)
+      break;
+    b %= a;
   } while (b > 0);
   long gcd = a + b;
   if (n.denominator > 0) {
@@ -32,8 +29,7 @@ void norm(Fraction &n)
   }
 }
 
-int main()
-{
+int main() {
   Fraction c = {6, 27};
   norm(c);
   return 0;

--- a/examples/hello.cc
+++ b/examples/hello.cc
@@ -1,7 +1,7 @@
-#include <wasmtime.hh>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <wasmtime.hh>
 
 using namespace wasmtime;
 


### PR DESCRIPTION
We were already running it over most `*.c` files and other ones but forgot the `*.hh` and `*.cc` extensions which are being used for C++ bindings, so add those in and then run the formatter.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
