### PR TITLE
Test out Windows aarch64 runners in CI

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -17,6 +17,7 @@ const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
 const ubuntu = 'ubuntu-24.04';
 const windows = 'windows-2025';
+const windows_arm = 'windows-11-arm';
 const macos = 'macos-14';
 
 // This is the small, fast-to-execute matrix we use for PRs before they enter
@@ -94,6 +95,12 @@ const FULL_MATRIX = [
     "os": windows,
     "name": "Test Windows MSVC x86_64",
     "filter": "windows-x64",
+  },
+  {
+    "os": windows_arm,
+    "name": "Test Windows MSVC aarch64",
+    "filter": "windows-aarch64",
+    "target": "aarch64-pc-windows-msvc",
   },
   {
     "os": windows,


### PR DESCRIPTION
Looks like they're new on GitHub, let's see if tests pass?

prtest:windows-aarch64

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
