### PR TITLE
Add support for loading, storing and bitcasting small vectors on x64 and aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -10,6 +10,7 @@ use crate::{settings, CodegenError, CodegenResult};
 use crate::machinst::{PrettyPrint, Reg, RegClass, Writable};
 
 use alloc::vec::Vec;
+use core::slice;
 use smallvec::{smallvec, SmallVec};
 use std::fmt::Write;
 use std::string::{String, ToString};
@@ -231,31 +232,17 @@ impl Inst {
                 mem,
                 flags,
             },
-            F16 => Inst::FpuLoad16 {
-                rd: into_reg,
-                mem,
-                flags,
-            },
-            F32 => Inst::FpuLoad32 {
-                rd: into_reg,
-                mem,
-                flags,
-            },
-            F64 => Inst::FpuLoad64 {
-                rd: into_reg,
-                mem,
-                flags,
-            },
             _ => {
                 if ty.is_vector() || ty.is_float() {
                     let bits = ty_bits(ty);
                     let rd = into_reg;
 
-                    if bits == 128 {
-                        Inst::FpuLoad128 { rd, mem, flags }
-                    } else {
-                        assert_eq!(bits, 64);
-                        Inst::FpuLoad64 { rd, mem, flags }
+                    match bits {
+                        128 => Inst::FpuLoad128 { rd, mem, flags },
+                        64 => Inst::FpuLoad64 { rd, mem, flags },
+                        32 => Inst::FpuLoad32 { rd, mem, flags },
+                        16 => Inst::FpuLoad16 { rd, mem, flags },
+                        _ => unimplemented!("gen_load({})", ty),
                     }
                 } else {
                     unimplemented!("gen_load({})", ty);
@@ -287,31 +274,17 @@ impl Inst {
                 mem,
                 flags,
             },
-            F16 => Inst::FpuStore16 {
-                rd: from_reg,
-                mem,
-                flags,
-            },
-            F32 => Inst::FpuStore32 {
-                rd: from_reg,
-                mem,
-                flags,
-            },
-            F64 => Inst::FpuStore64 {
-                rd: from_reg,
-                mem,
-                flags,
-            },
             _ => {
                 if ty.is_vector() || ty.is_float() {
                     let bits = ty_bits(ty);
                     let rd = from_reg;
 
-                    if bits == 128 {
-                        Inst::FpuStore128 { rd, mem, flags }
-                    } else {
-                        assert_eq!(bits, 64);
-                        Inst::FpuStore64 { rd, mem, flags }
+                    match bits {
+                        128 => Inst::FpuStore128 { rd, mem, flags },
+                        64 => Inst::FpuStore64 { rd, mem, flags },
+                        32 => Inst::FpuStore32 { rd, mem, flags },
+                        16 => Inst::FpuStore16 { rd, mem, flags },
+                        _ => unimplemented!("gen_store({})", ty),
                     }
                 } else {
                     unimplemented!("gen_store({})", ty);
@@ -1123,9 +1096,12 @@ impl MachInst for Inst {
             F64 => Ok((&[RegClass::Float], &[F64])),
             F128 => Ok((&[RegClass::Float], &[F128])),
             I128 => Ok((&[RegClass::Int, RegClass::Int], &[I64, I64])),
-            _ if ty.is_vector() => {
-                assert!(ty.bits() <= 128);
-                Ok((&[RegClass::Float], &[I8X16]))
+            _ if ty.is_vector() && ty.bits() <= 128 => {
+                let types = &[types::I8X2, types::I8X4, types::I8X8, types::I8X16];
+                Ok((
+                    &[RegClass::Float],
+                    slice::from_ref(&types[ty.bytes().ilog2() as usize - 1]),
+                ))
             }
             _ if ty.is_dynamic_vector() => Ok((&[RegClass::Float], &[I8X16])),
             _ => Err(CodegenError::Unsupported(format!(

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2547,33 +2547,25 @@
        (has_type $I64 (load flags address offset)))
       (aarch64_uload64 (amode $I64 address offset) flags))
 (rule (lower
-       (has_type $F16 (load flags address offset)))
-      (aarch64_fpuload16 (amode $F16 address offset) flags))
-(rule (lower
-       (has_type $F32 (load flags address offset)))
-      (aarch64_fpuload32 (amode $F32 address offset) flags))
-(rule (lower
-       (has_type $F64 (load flags address offset)))
-      (aarch64_fpuload64 (amode $F64 address offset) flags))
-(rule (lower
-       (has_type $F128 (load flags address offset)))
-      (aarch64_fpuload128 (amode $F128 address offset) flags))
-(rule (lower
        (has_type $I128 (load flags address offset)))
       (aarch64_loadp64 (pair_amode address offset) flags))
 (rule -1 (lower
-       (has_type (ty_vec64 _)
-                        (load flags address offset)))
-      (aarch64_fpuload64 (amode $F64 address offset) flags))
-(rule -3 (lower
-       (has_type (ty_vec128 _)
-                        (load flags address offset)))
-      (aarch64_fpuload128 (amode $I8X16 address offset) flags))
+       (has_type (ty_float_or_vec (ty_16 _)) (load flags address offset)))
+      (aarch64_fpuload16 (amode $F16 address offset) flags))
 (rule -2 (lower
+       (has_type (ty_float_or_vec (ty_32 _)) (load flags address offset)))
+      (aarch64_fpuload32 (amode $F32 address offset) flags))
+(rule -3 (lower
+       (has_type (ty_float_or_vec (ty_64 _)) (load flags address offset)))
+      (aarch64_fpuload64 (amode $F64 address offset) flags))
+(rule -4 (lower
+       (has_type (ty_float_or_vec (ty_128 _)) (load flags address offset)))
+      (aarch64_fpuload128 (amode $F128 address offset) flags))
+(rule -5 (lower
        (has_type (ty_dyn_vec64 _)
                         (load flags address offset)))
       (aarch64_fpuload64 (amode $F64 address offset) flags))
-(rule -4 (lower
+(rule -6 (lower
        (has_type (ty_dyn_vec128 _)
                         (load flags address offset)))
       (aarch64_fpuload128 (amode $I8X16 address offset) flags))
@@ -2667,23 +2659,6 @@
        (aarch64_store32 (amode $I32 address offset) flags value)))
 
 (rule (lower
-       (store flags value @ (value_type $F16) address offset))
-      (side_effect
-       (aarch64_fpustore16 (amode $F16 address offset) flags value)))
-(rule (lower
-       (store flags value @ (value_type $F32) address offset))
-      (side_effect
-       (aarch64_fpustore32 (amode $F32 address offset) flags value)))
-(rule (lower
-       (store flags value @ (value_type $F64) address offset))
-      (side_effect
-       (aarch64_fpustore64 (amode $F64 address offset) flags value)))
-(rule (lower
-       (store flags value @ (value_type $F128) address offset))
-      (side_effect
-       (aarch64_fpustore128 (amode $F128 address offset) flags value)))
-
-(rule (lower
        (store flags value @ (value_type $I128) address offset))
       (side_effect
        (aarch64_storep64 (pair_amode address offset) flags
@@ -2691,18 +2666,27 @@
                          (value_regs_get value 1))))
 
 (rule -1 (lower
-       (store flags value @ (value_type (ty_vec64 _)) address offset))
+       (store flags value @ (value_type (ty_float_or_vec (ty_16 _))) address offset))
       (side_effect
-       (aarch64_fpustore64 (amode $F64 address offset) flags value)))
-(rule -3 (lower
-       (store flags value @ (value_type (ty_vec128 _)) address offset))
-      (side_effect
-       (aarch64_fpustore128 (amode $I8X16 address offset) flags value)))
+       (aarch64_fpustore16 (amode $F16 address offset) flags value)))
 (rule -2 (lower
-       (store flags value @ (value_type (ty_dyn_vec64 _)) address offset))
+       (store flags value @ (value_type (ty_float_or_vec (ty_32 _))) address offset))
+      (side_effect
+       (aarch64_fpustore32 (amode $F32 address offset) flags value)))
+(rule -3 (lower
+       (store flags value @ (value_type (ty_float_or_vec (ty_64 _))) address offset))
       (side_effect
        (aarch64_fpustore64 (amode $F64 address offset) flags value)))
 (rule -4 (lower
+       (store flags value @ (value_type (ty_float_or_vec (ty_128 _))) address offset))
+      (side_effect
+       (aarch64_fpustore128 (amode $F128 address offset) flags value)))
+
+(rule -5 (lower
+       (store flags value @ (value_type (ty_dyn_vec64 _)) address offset))
+      (side_effect
+       (aarch64_fpustore64 (amode $F64 address offset) flags value)))
+(rule -6 (lower
        (store flags value @ (value_type (ty_dyn_vec128 _)) address offset))
       (side_effect
        (aarch64_fpustore128 (amode $I8X16 address offset) flags value)))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1421,7 +1421,7 @@ pub(crate) fn emit(
                 types::F32X4 => SseOpcode::Movaps,
                 types::F64X2 => SseOpcode::Movapd,
                 ty => {
-                    debug_assert!((ty.is_float() || ty.is_vector()) && ty.bytes() == 16);
+                    debug_assert!((ty.is_float() || ty.is_vector()) && ty.bytes() <= 16);
                     SseOpcode::Movdqa
                 }
             };

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3029,19 +3029,17 @@
 ;; For `$F32` and `$F64` this is important--we only want to load 32 or 64 bits.
 ;; But for the 128-bit types, this is not strictly necessary for performance but
 ;; might help with clarity during disassembly.
-(rule (lower (has_type $F16 (load flags address offset)))
+(rule 4 (lower (has_type (is_xmm_type (ty_16 _)) (load flags address offset)))
       (x64_pinsrw (xmm_uninit_value) (to_amode flags address offset) 0))
-(rule (lower (has_type $F32 (load flags address offset)))
+(rule 3 (lower (has_type (is_xmm_type (ty_32 _)) (load flags address offset)))
       (x64_movss_load (to_amode flags address offset)))
-(rule (lower (has_type $F64 (load flags address offset)))
+(rule 2 (lower (has_type (is_xmm_type (ty_64 _)) (load flags address offset)))
       (x64_movsd_load (to_amode flags address offset)))
-(rule (lower (has_type $F128 (load flags address offset)))
-      (x64_movdqu_load (to_amode flags address offset)))
-(rule (lower (has_type $F32X4 (load flags address offset)))
+(rule 1 (lower (has_type $F32X4 (load flags address offset)))
       (x64_movups_load (to_amode flags address offset)))
-(rule (lower (has_type $F64X2 (load flags address offset)))
+(rule 1 (lower (has_type $F64X2 (load flags address offset)))
       (x64_movupd_load (to_amode flags address offset)))
-(rule -2 (lower (has_type (ty_vec128 ty) (load flags address offset)))
+(rule 0 (lower (has_type (is_xmm_type (ty_128 _)) (load flags address offset)))
       (x64_movdqu_load (to_amode flags address offset)))
 
 ;; We can load an I128 by doing two 64-bit loads.
@@ -3115,15 +3113,15 @@
        (x64_movimm_m ty (to_amode flags address offset) imm)))
 
 ;; F16 stores of values in XMM registers.
-(rule 0 (lower (store flags
-                    value @ (value_type $F16)
+(rule -2 (lower (store flags
+                    value @ (value_type (is_xmm_type (ty_16 _)))
                     address
                     offset))
       (side_effect
        (x64_movrm $I16 (to_amode flags address offset) (bitcast_xmm_to_gpr 16 value))))
 
-(rule 1 (lower (store flags
-                    value @ (value_type $F16)
+(rule -1 (lower (store flags
+                    value @ (value_type (is_xmm_type (ty_16 _)))
                     address
                     offset))
       (if-let true (use_sse41))
@@ -3131,28 +3129,20 @@
        (x64_pextrw_store (to_amode flags address offset) value 0)))
 
 ;; F32 stores of values in XMM registers.
-(rule 1 (lower (store flags
-                    value @ (value_type $F32)
+(rule -3 (lower (store flags
+                    value @ (value_type (is_xmm_type (ty_32 _)))
                     address
                     offset))
       (side_effect
        (x64_movss_store (to_amode flags address offset) value)))
 
 ;; F64 stores of values in XMM registers.
-(rule 1 (lower (store flags
-                    value @ (value_type $F64)
+(rule -4 (lower (store flags
+                    value @ (value_type (is_xmm_type (ty_64 _)))
                     address
                     offset))
       (side_effect
        (x64_movsd_store (to_amode flags address offset) value)))
-
-;; F128 stores of values in XMM registers.
-(rule 1 (lower (store flags
-                    value @ (value_type $F128)
-                    address
-                    offset))
-      (side_effect
-       (x64_movdqu_store (to_amode flags address offset) value)))
 
 ;; Stores of F32X4 vectors.
 (rule 1 (lower (store flags
@@ -3171,8 +3161,8 @@
        (x64_movupd_store (to_amode flags address offset) value)))
 
 ;; Stores of all other 128-bit vector types with integer lanes.
-(rule -1 (lower (store flags
-                    value @ (value_type (ty_vec128_int _))
+(rule -5 (lower (store flags
+                    value @ (value_type (is_xmm_type (ty_128 _)))
                     address
                     offset))
       (side_effect

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -552,7 +552,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             Some(RegisterClass::Gpr {
                 single_register: ty != I128,
             })
-        } else if ty.is_float() || (ty.is_vector() && ty.bits() == 128) {
+        } else if ty.is_float() || (ty.is_vector() && ty.bits() <= 128) {
             Some(RegisterClass::Xmm)
         } else {
             None

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -397,6 +397,15 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn ty_16(&mut self, ty: Type) -> Option<Type> {
+            if ty.bits() == 16 {
+                Some(ty)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
         fn ty_32(&mut self, ty: Type) -> Option<Type> {
             if ty.bits() == 32 {
                 Some(ty)
@@ -408,6 +417,15 @@ macro_rules! isle_common_prelude_methods {
         #[inline]
         fn ty_64(&mut self, ty: Type) -> Option<Type> {
             if ty.bits() == 64 {
+                Some(ty)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        fn ty_128(&mut self, ty: Type) -> Option<Type> {
+            if ty.bits() == 128 {
                 Some(ty)
             } else {
                 None

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -564,6 +564,10 @@
 (decl fits_in_64 (Type) Type)
 (extern extractor fits_in_64 fits_in_64)
 
+;; An extractor that only matches types that fit in exactly 16 bits.
+(decl ty_16 (Type) Type)
+(extern extractor ty_16 ty_16)
+
 ;; An extractor that only matches types that fit in exactly 32 bits.
 (decl ty_32 (Type) Type)
 (extern extractor ty_32 ty_32)
@@ -571,6 +575,10 @@
 ;; An extractor that only matches types that fit in exactly 64 bits.
 (decl ty_64 (Type) Type)
 (extern extractor ty_64 ty_64)
+
+;; An extractor that only matches types that fit in exactly 128 bits.
+(decl ty_128 (Type) Type)
+(extern extractor ty_128 ty_128)
 
 ;; A pure constructor/extractor that only matches scalar integers, and
 ;; references that can fit in 64 bits.

--- a/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
@@ -169,3 +169,99 @@ block0(v0: i128):
 ;   mov v0.d[1], x1
 ;   ret
 
+function %bitcast_i32x2_to_i64(i32x2) -> i64 {
+block0(v0: i32x2):
+  v1 = bitcast.i64 little v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   mov x0, v0.d[0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, v0.d[0]
+;   ret
+
+function %bitcast_i64_to_i32x2(i64) -> i32x2 {
+block0(v0: i64):
+  v1 = bitcast.i32x2 little v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fmov d0, x0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d0, x0
+;   ret
+
+function %bitcast_i16x2_to_i32(i16x2) -> i32 {
+block0(v0: i16x2):
+  v1 = bitcast.i32 little v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   mov w0, v0.s[0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, v0.s[0]
+;   ret
+
+function %bitcast_i32_to_i16x2(i32) -> i16x2 {
+block0(v0: i32):
+  v1 = bitcast.i16x2 little v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fmov s0, w0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov s0, w0
+;   ret
+
+function %bitcast_i8x2_to_i16(i8x2) -> i16 {
+block0(v0: i8x2):
+    v1 = bitcast.i16 little v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   umov w0, v0.h[0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   umov w0, v0.h[0]
+;   ret
+
+function %bitcast_i16_to_i8x2(i16) -> i8x2 {
+block0(v0: i16):
+    v1 = bitcast.i8x2 little v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   fmov s0, w0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov s0, w0
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/load-small-vector.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/load-small-vector.clif
@@ -1,0 +1,51 @@
+test compile precise-output
+target aarch64
+
+function %load_i8x2(i64) -> i8x2 {
+block0(v0: i64):
+    v1 = load.i8x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   ldr h0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr h0, [x0] ; trap: heap_oob
+;   ret
+
+function %load_i16x2(i64) -> i16x2 {
+block0(v0: i64):
+    v1 = load.i16x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   ldr s0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr s0, [x0] ; trap: heap_oob
+;   ret
+
+function %load_i32x2(i64) -> i32x2 {
+block0(v0: i64):
+    v1 = load.i32x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   ldr d0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr d0, [x0] ; trap: heap_oob
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/store-small-vector.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/store-small-vector.clif
@@ -1,0 +1,51 @@
+test compile precise-output
+target aarch64
+
+function %store_i8x2(i8x2, i64) {
+block0(v0: i8x2, v1: i64):
+    store.i8x2 v0, v1
+    return
+}
+
+; VCode:
+; block0:
+;   str h0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   str h0, [x0] ; trap: heap_oob
+;   ret
+
+function %store_i16x2(i16x2, i64) {
+block0(v0: i16x2, v1: i64):
+    store.i16x2 v0, v1
+    return
+}
+
+; VCode:
+; block0:
+;   str s0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   str s0, [x0] ; trap: heap_oob
+;   ret
+
+function %store_i32x2(i32x2, i64) {
+block0(v0: i32x2, v1: i64):
+    store.i32x2 v0, v1
+    return
+}
+
+; VCode:
+; block0:
+;   str d0, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   str d0, [x0] ; trap: heap_oob
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -269,3 +269,154 @@ block0(v0: i128):
 ;   popq %rbp
 ;   retq
 
+function %bitcast_i32x2_to_i64(i32x2) -> i64 {
+block0(v0: i32x2):
+  v1 = bitcast.i64 little v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %xmm0, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %xmm0, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %bitcast_i64_to_i32x2(i64) -> i32x2 {
+block0(v0: i64):
+  v1 = bitcast.i32x2 little v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %bitcast_i16x2_to_i32(i16x2) -> i32 {
+block0(v0: i16x2):
+  v1 = bitcast.i32 little v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movd    %xmm0, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movd %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %bitcast_i32_to_i16x2(i32) -> i16x2 {
+block0(v0: i32):
+  v1 = bitcast.i16x2 little v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movd    %edi, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movd %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %bitcast_i8x2_to_i16(i8x2) -> i16 {
+block0(v0: i8x2):
+    v1 = bitcast.i16 little v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   pextrw  $0, %xmm0, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   pextrw $0, %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %bitcast_i16_to_i8x2(i16) -> i8x2 {
+block0(v0: i16):
+    v1 = bitcast.i8x2 little v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   uninit  %xmm0
+;   pinsrw  $0, %xmm0, %rdi, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   pinsrw $0, %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/load-small-vector.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-small-vector.clif
@@ -1,0 +1,79 @@
+test compile precise-output
+target x86_64
+
+function %load_i8x2(i64) -> i8x2 {
+block0(v0: i64):
+    v1 = load.i8x2 v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   uninit  %xmm0
+;   pinsrw  $0, %xmm0, 0(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   pinsrw $0, (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %load_i16x2(i64) -> i16x2 {
+block0(v0: i64):
+    v1 = load.i16x2 v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %load_i32x2(i64) -> i32x2 {
+block0(v0: i64):
+    v1 = load.i32x2 v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movsd   0(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movsd (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/store-small-vector.clif
+++ b/cranelift/filetests/filetests/isa/x64/store-small-vector.clif
@@ -1,0 +1,80 @@
+test compile precise-output
+target x86_64
+
+function %store_i8x2(i8x2, i64) {
+block0(v0: i8x2, v1: i64):
+    store.i8x2 v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   pextrw  $0, %xmm0, %rcx
+;   movw    %cx, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   pextrw $0, %xmm0, %ecx
+;   movw %cx, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %store_i16x2(i16x2, i64) {
+block0(v0: i16x2, v1: i64):
+    store.i16x2 v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   %xmm0, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss %xmm0, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %store_i32x2(i32x2, i64) {
+block0(v0: i32x2, v1: i64):
+    store.i32x2 v0, v1
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movsd   %xmm0, 0(%rdi)
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movsd %xmm0, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/simd-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-small.clif
@@ -1,0 +1,176 @@
+test run
+set enable_multi_ret_implicit_sret
+set enable_llvm_abi_extensions
+target x86_64
+target x86_64 has_avx
+target aarch64
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
+
+function %bitcast_i32x2_to_i64(i32x2) -> i64 {
+block0(v0: i32x2):
+    v1 = bitcast.i64 little v0
+    return v1
+}
+; run: %bitcast_i32x2_to_i64([0xBEEF 0xC0FFEE]) == 0x00c0ffee_0000beef
+; run: %bitcast_i32x2_to_i64([-1 127]) == 0x0000007f_ffffffff
+
+function %bitcast_i64_to_i32x2(i64) -> i32x2 {
+block0(v0: i64):
+    v1 = bitcast.i32x2 little v0
+    return v1
+}
+; run: %bitcast_i64_to_i32x2(0x00c0ffee_0000beef) == [0xBEEF 0xC0FFEE]
+; run: %bitcast_i64_to_i32x2(0x0000007f_ffffffff) == [-1 127]
+
+function %bitcast_i32x2_to_f64(i32x2) -> f64 {
+block0(v0: i32x2):
+    v1 = bitcast.f64 little v0
+    return v1
+}
+; run: %bitcast_i32x2_to_f64([0xBEEF 0xC0FFEE]) == 0x1.0ffee0000beefp-1011
+; run: %bitcast_i32x2_to_f64([-1 127]) == 0x0.0007fffffffffp-1022
+
+function %bitcast_f64_to_i32x2(f64) -> i32x2 {
+block0(v0: f64):
+    v1 = bitcast.i32x2 little v0
+    return v1
+}
+; run: %bitcast_f64_to_i32x2(0x1.0ffee0000beefp-1011) == [0xBEEF 0xC0FFEE]
+; run: %bitcast_f64_to_i32x2(0x0.0007fffffffffp-1022) == [-1 127]
+
+function %store_i32x2(i32x2) -> i64 {
+    ss0 = explicit_slot 8
+block0(v0: i32x2):
+    stack_store.i32x2 v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+; run: %store_i32x2([0xBEEF 0xC0FFEE]) == 0x00c0ffee_0000beef
+; run: %store_i32x2([-1 127]) == 0x0000007f_ffffffff
+
+function %load_i32x2(i64) -> i32x2 {
+    ss0 = explicit_slot 8
+block0(v0: i64):
+    stack_store.i64 v0, ss0
+    v1 = stack_load.i32x2 ss0
+    return v1
+}
+; run: %bitcast_i64_to_i32x2(0x00c0ffee_0000beef) == [0xBEEF 0xC0FFEE]
+; run: %bitcast_i64_to_i32x2(0x0000007f_ffffffff) == [-1 127]
+
+
+
+function %bitcast_i16x2_to_i32(i16x2) -> i32 {
+block0(v0: i16x2):
+    v1 = bitcast.i32 little v0
+    return v1
+}
+; run: %bitcast_i16x2_to_i32([0xBEEF 0xC0FE]) == 0xc0fe_beef
+; run: %bitcast_i16x2_to_i32([-1 127]) == 0x007f_ffff
+
+function %bitcast_i32_to_i16x2(i32) -> i16x2 {
+block0(v0: i32):
+    v1 = bitcast.i16x2 little v0
+    return v1
+}
+; run: %bitcast_i32_to_i16x2(0xc0fe_beef) == [0xBEEF 0xC0FE]
+; run: %bitcast_i32_to_i16x2(0x007f_ffff) == [-1 127]
+
+function %bitcast_i16x2_to_f32(i16x2) -> f32 {
+block0(v0: i16x2):
+    v1 = bitcast.f32 little v0
+    return v1
+}
+; run: %bitcast_i16x2_to_f32([0xBEEF 0xC0FE]) == -0x1.fd7ddep2
+; run: %bitcast_i16x2_to_f32([-1 127]) == 0x0.fffffep-126
+
+function %bitcast_f32_to_i16x2(f32) -> i16x2 {
+block0(v0: f32):
+    v1 = bitcast.i16x2 little v0
+    return v1
+}
+; run: %bitcast_f32_to_i16x2(-0x1.fd7ddep2) == [0xBEEF 0xC0FE]
+; run: %bitcast_f32_to_i16x2(0x0.fffffep-126) == [-1 127]
+
+function %store_i16x2(i16x2) -> i32 {
+    ss0 = explicit_slot 4
+block0(v0: i16x2):
+    stack_store.i16x2 v0, ss0
+    v1 = stack_load.i32 ss0
+    return v1
+}
+; run: %store_i16x2([0xBEEF 0xC0FE]) == 0xc0fe_beef
+; run: %store_i16x2([-1 127]) == 0x007f_ffff
+
+function %load_i16x2(i32) -> i16x2 {
+    ss0 = explicit_slot 4
+block0(v0: i32):
+    stack_store.i32 v0, ss0
+    v1 = stack_load.i16x2 ss0
+    return v1
+}
+; run: %bitcast_i32_to_i16x2(0xc0fe_beef) == [0xBEEF 0xC0FE]
+; run: %bitcast_i32_to_i16x2(0x007f_ffff) == [-1 127]
+
+
+
+function %bitcast_i8x2_to_i16(i8x2) -> i16 {
+block0(v0: i8x2):
+    v1 = bitcast.i16 little v0
+    return v1
+}
+; run: %bitcast_i8x2_to_i16([0xFE 0xC0]) == 0xc0fe
+; run: %bitcast_i8x2_to_i16([-1 127]) == 0x7fff
+
+function %bitcast_i16_to_i8x2(i16) -> i8x2 {
+block0(v0: i16):
+    v1 = bitcast.i8x2 little v0
+    return v1
+}
+; run: %bitcast_i16_to_i8x2(0xc0fe) == [0xFE 0xC0]
+; run: %bitcast_i16_to_i8x2(0x7fff) == [-1 127]
+
+function %bitcast_i8x2_to_f16(i8x2) -> f16 {
+block0(v0: i8x2):
+    v1 = bitcast.f16 little v0
+    return v1
+}
+; run: %bitcast_i8x2_to_f16([0xFE 0xC0]) == -0x1.3f8p1
+; run: %bitcast_i8x2_to_f16([-1 127]) == +NaN:0x1ff
+
+function %bitcast_f16_to_i8x2(f16) -> i8x2 {
+block0(v0: f16):
+    v1 = bitcast.i8x2 little v0
+    return v1
+}
+; run: %bitcast_f16_to_i8x2(-0x1.3f8p1) == [0xFE 0xC0]
+; run: %bitcast_f16_to_i8x2(+NaN:0x1ff) == [-1 127]
+
+function %store_i8x2(i8x2) -> i16 {
+    ss0 = explicit_slot 2
+block0(v0: i8x2):
+    stack_store.i8x2 v0, ss0
+    v1 = stack_load.i16 ss0
+    return v1
+}
+; run: %store_i8x2([0xFE 0xC0]) == 0xc0fe
+; run: %store_i8x2([-1 127]) == 0x7fff
+
+function %load_i8x2(i16) -> i8x2 {
+    ss0 = explicit_slot 2
+block0(v0: i16):
+    stack_store.i16 v0, ss0
+    v1 = stack_load.i8x2 ss0
+    return v1
+}
+; run: %bitcast_i16_to_i8x2(0xc0fe) == [0xFE 0xC0]
+; run: %bitcast_i16_to_i8x2(0x7fff) == [-1 127]
+
+
+
+function %rearrange(i8x2, i16x2, i32x2) -> i16x2, i32x2, i8x2 {
+block0(v0: i8x2, v1: i16x2, v2: i32x2):
+    return v1, v2, v0
+}
+; run: %rearrange([1 2], [3 4], [5 6]) == [[3 4], [5 6], [1 2]]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -108,6 +108,8 @@ where
                     (_, Opcode::F128const) => DataValue::F128(buffer.try_into().expect("a 16-byte data buffer")),
                     (16, Opcode::Vconst) => DataValue::V128(buffer.as_slice().try_into().expect("a 16-byte data buffer")),
                     (8, Opcode::Vconst) => DataValue::V64(buffer.as_slice().try_into().expect("an 8-byte data buffer")),
+                    (4, Opcode::Vconst) => DataValue::V32(buffer.as_slice().try_into().expect("a 4-byte data buffer")),
+                    (2, Opcode::Vconst) => DataValue::V16(buffer.as_slice().try_into().expect("a 2-byte data buffer")),
                     (length, opcode) => panic!("unexpected UnaryConst controlling type size {length} for opcode {opcode:?}"),
                 }
             }
@@ -122,6 +124,8 @@ where
                 match mask.len() {
                     16 => DataValue::V128(mask.try_into().expect("a 16-byte vector mask")),
                     8 => DataValue::V64(mask.try_into().expect("an 8-byte vector mask")),
+                    4 => DataValue::V32(mask.try_into().expect("a 4-byte vector mask")),
+                    2 => DataValue::V16(mask.try_into().expect("a 2-byte vector mask")),
                     length => panic!("unexpected Shuffle mask length {length}"),
                 }
             }


### PR DESCRIPTION
This PR adds support for loading, storing and bitcasting 16-bit, 32-bit and 64-bit vectors on the x64 and aarch64 backends (aarch64 already supported 64-bit vectors; additionally, the riscv64 backend already supports all three small vector sizes).

Fixes (for x64 and aarch64) #10254