### PR TITLE
Test C/C++ headers can be included in isolation

### DIFF
--- a/crates/c-api/include/wasmtime/error.hh
+++ b/crates/c-api/include/wasmtime/error.hh
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <variant>
 #include <wasmtime/error.h>

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -11,6 +11,8 @@
 #include <wasmtime/conf.h>
 #include <wasmtime/error.h>
 #include <wasmtime/extern.h>
+#include <wasmtime/func.h>
+#include <wasmtime/instance.h>
 #include <wasmtime/store.h>
 
 #ifdef __cplusplus

--- a/crates/c-api/include/wasmtime/profiling.h
+++ b/crates/c-api/include/wasmtime/profiling.h
@@ -10,6 +10,8 @@
 #include <wasm.h>
 #include <wasmtime/conf.h>
 #include <wasmtime/error.h>
+#include <wasmtime/module.h>
+#include <wasmtime/store.h>
 
 #ifdef WASMTIME_FEATURE_PROFILING
 

--- a/crates/c-api/include/wasmtime/span.hh
+++ b/crates/c-api/include/wasmtime/span.hh
@@ -12,7 +12,9 @@
 #endif
 
 #ifndef __cpp_lib_span
+#include <cstddef>
 #include <limits>
+#include <type_traits>
 #endif
 
 namespace wasmtime {

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -61,6 +61,10 @@ add_capi_test(tests FILES
 cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR "../include" OUTPUT_VARIABLE header_root)
 file(GLOB_RECURSE cpp_headers "${header_root}/*.h*")
 foreach(header IN LISTS cpp_headers)
+  cmake_path(GET header EXTENSION header_extension)
+  if(header_extension STREQUAL ".h.in")
+    continue()
+  endif()
   cmake_path(GET header FILENAME header_filename)
   cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "header-test" "${header_filename}.cc"
     OUTPUT_VARIABLE test_filename)

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -50,6 +50,30 @@ add_capi_test(tests FILES
   linker.cc
 )
 
+# Create a list of all wasmtime headers with `GLOB_RECURSE`, then emit a file
+# into the current binary directory which tests that if the header is included
+# that the file compiles correctly.
+#
+# Gather everything into a list and then create a test which links all these
+# compilations together. This binary doesn't actually run any tests itself but
+# it does test that all headers compile in isolation at least. Not perfect but
+# hopefully at least something.
+cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "../include" OUTPUT_VARIABLE header_root)
+file(GLOB_RECURSE cpp_headers "${header_root}/*.h*")
+foreach(header IN LISTS cpp_headers)
+  cmake_path(GET header FILENAME header_filename)
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "header-test" "${header_filename}.cc"
+    OUTPUT_VARIABLE test_filename)
+  list(APPEND header_tests ${test_filename})
+
+  cmake_path(
+    RELATIVE_PATH header
+    BASE_DIRECTORY ${header_root}
+    OUTPUT_VARIABLE rel_header)
+  file(WRITE ${test_filename} "#include <${rel_header}>")
+endforeach()
+add_capi_test(standalone-headers FILES ${header_tests})
+
 # Add a custom test where two files include `wasmtime.hh` and are compiled into
 # the same executable (basically makes sure any defined functions in the header
 # are tagged with `inline`).

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ add_capi_test(tests FILES
 # compilations together. This binary doesn't actually run any tests itself but
 # it does test that all headers compile in isolation at least. Not perfect but
 # hopefully at least something.
-cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "../include" OUTPUT_VARIABLE header_root)
+cmake_path(APPEND CMAKE_CURRENT_SOURCE_DIR "../include" OUTPUT_VARIABLE header_root)
 file(GLOB_RECURSE cpp_headers "${header_root}/*.h*")
 foreach(header IN LISTS cpp_headers)
   cmake_path(GET header FILENAME header_filename)


### PR DESCRIPTION
I frequently make mistakes about this, so I figure it's good to at least try to test this. It's not possible to fully test AFAIK but this is hopefully at least something.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
