### PR TITLE
c-api: component-model: Values and function calling

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -166,6 +166,7 @@ target_include_directories(
 
 if (BUILD_TESTS)
   message(STATUS "Building tests")
+  set(CMAKE_CXX_STANDARD 20)
 
   enable_language(CXX)
   set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)

--- a/crates/c-api/include/wasmtime/component.h
+++ b/crates/c-api/include/wasmtime/component.h
@@ -5,5 +5,6 @@
 #include <wasmtime/component/func.h>
 #include <wasmtime/component/instance.h>
 #include <wasmtime/component/linker.h>
+#include <wasmtime/component/val.h>
 
 #endif // WASMTIME_COMPONENT_H

--- a/crates/c-api/include/wasmtime/component/func.h
+++ b/crates/c-api/include/wasmtime/component/func.h
@@ -1,7 +1,10 @@
 #ifndef WASMTIME_COMPONENT_FUNC_H
 #define WASMTIME_COMPONENT_FUNC_H
 
+#include <wasmtime/component/val.h>
 #include <wasmtime/conf.h>
+#include <wasmtime/error.h>
+#include <wasmtime/store.h>
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
 
@@ -22,6 +25,11 @@ typedef struct wasmtime_component_func {
   /// Internal index within the store.
   size_t index;
 } wasmtime_component_func_t;
+
+WASM_API_EXTERN wasmtime_error_t *wasmtime_component_func_call(
+    const wasmtime_component_func_t *func, wasmtime_context_t *context,
+    const wasmtime_component_val_t *args, size_t args_size,
+    wasmtime_component_val_t *results, size_t results_size);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/component/val.h
+++ b/crates/c-api/include/wasmtime/component/val.h
@@ -1,0 +1,51 @@
+#ifndef WASMTIME_COMPONENT_VAL_H
+#define WASMTIME_COMPONENT_VAL_H
+
+#include <wasmtime/conf.h>
+
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint8_t wasmtime_component_valkind_t;
+
+#define WASMTIME_COMPONENT_BOOL 0
+#define WASMTIME_COMPONENT_S8 1
+#define WASMTIME_COMPONENT_U8 2
+#define WASMTIME_COMPONENT_S16 3
+#define WASMTIME_COMPONENT_U16 4
+#define WASMTIME_COMPONENT_S32 5
+#define WASMTIME_COMPONENT_U32 6
+#define WASMTIME_COMPONENT_S64 7
+#define WASMTIME_COMPONENT_U64 8
+#define WASMTIME_COMPONENT_F32 9
+#define WASMTIME_COMPONENT_F64 10
+
+typedef union {
+  bool boolean;
+  int8_t s8;
+  uint8_t u8;
+  int16_t s16;
+  uint16_t u16;
+  int32_t s32;
+  uint32_t u32;
+  int64_t s64;
+  uint64_t u64;
+  float32_t f32;
+  float64_t f64;
+} wasmtime_component_valunion_t;
+
+typedef struct {
+  wasmtime_component_valkind_t kind;
+  wasmtime_component_valunion_t of;
+} wasmtime_component_val_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
+
+#endif // WASMTIME_COMPONENT_VAL_H

--- a/crates/c-api/src/component/func.rs
+++ b/crates/c-api/src/component/func.rs
@@ -1,0 +1,31 @@
+use wasmtime::component::{Func, Val};
+
+use crate::{wasmtime_error_t, WasmtimeStoreContextMut};
+
+use super::wasmtime_component_val_t;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_func_call(
+    func: &Func,
+    mut context: WasmtimeStoreContextMut<'_>,
+    args: *const wasmtime_component_val_t,
+    args_len: usize,
+    results: *mut wasmtime_component_val_t,
+    results_len: usize,
+) -> Option<Box<wasmtime_error_t>> {
+    let c_args = unsafe { std::slice::from_raw_parts(args, args_len) };
+    let c_results = unsafe { std::slice::from_raw_parts_mut(results, results_len) };
+
+    let args = c_args.iter().cloned().map(Val::from).collect::<Vec<_>>();
+    let mut results = vec![Val::Bool(false); results_len];
+
+    let result = func
+        .call(&mut context, &args, &mut results)
+        .and_then(|_| func.post_return(&mut context));
+
+    crate::handle_result(result, |_| {
+        for (c_val, rust_val) in std::iter::zip(c_results, results) {
+            *c_val = wasmtime_component_val_t::from(rust_val);
+        }
+    })
+}

--- a/crates/c-api/src/component/mod.rs
+++ b/crates/c-api/src/component/mod.rs
@@ -1,7 +1,9 @@
 mod component;
 mod instance;
 mod linker;
+mod val;
 
 pub use component::*;
 pub use instance::*;
 pub use linker::*;
+pub use val::*;

--- a/crates/c-api/src/component/mod.rs
+++ b/crates/c-api/src/component/mod.rs
@@ -1,9 +1,11 @@
 mod component;
+mod func;
 mod instance;
 mod linker;
 mod val;
 
 pub use component::*;
+pub use func::*;
 pub use instance::*;
 pub use linker::*;
 pub use val::*;

--- a/crates/c-api/src/component/val.rs
+++ b/crates/c-api/src/component/val.rs
@@ -1,0 +1,64 @@
+use wasmtime::component::Val;
+
+#[repr(C, u8)]
+#[derive(Clone)]
+pub enum wasmtime_component_val_t {
+    Bool(bool),
+    S8(i8),
+    U8(u8),
+    S16(i16),
+    U16(u16),
+    S32(i32),
+    U32(u32),
+    S64(i64),
+    U64(u64),
+    F32(f32),
+    F64(f64),
+}
+
+impl From<wasmtime_component_val_t> for Val {
+    fn from(value: wasmtime_component_val_t) -> Self {
+        match value {
+            wasmtime_component_val_t::Bool(x) => Val::Bool(x),
+            wasmtime_component_val_t::S8(x) => Val::S8(x),
+            wasmtime_component_val_t::U8(x) => Val::U8(x),
+            wasmtime_component_val_t::S16(x) => Val::S16(x),
+            wasmtime_component_val_t::U16(x) => Val::U16(x),
+            wasmtime_component_val_t::S32(x) => Val::S32(x),
+            wasmtime_component_val_t::U32(x) => Val::U32(x),
+            wasmtime_component_val_t::S64(x) => Val::S64(x),
+            wasmtime_component_val_t::U64(x) => Val::U64(x),
+            wasmtime_component_val_t::F32(x) => Val::Float32(x),
+            wasmtime_component_val_t::F64(x) => Val::Float64(x),
+        }
+    }
+}
+
+impl From<Val> for wasmtime_component_val_t {
+    fn from(value: Val) -> Self {
+        match value {
+            Val::Bool(x) => wasmtime_component_val_t::Bool(x),
+            Val::S8(x) => wasmtime_component_val_t::S8(x),
+            Val::U8(x) => wasmtime_component_val_t::U8(x),
+            Val::S16(x) => wasmtime_component_val_t::S16(x),
+            Val::U16(x) => wasmtime_component_val_t::U16(x),
+            Val::S32(x) => wasmtime_component_val_t::S32(x),
+            Val::U32(x) => wasmtime_component_val_t::U32(x),
+            Val::S64(x) => wasmtime_component_val_t::S64(x),
+            Val::U64(x) => wasmtime_component_val_t::U64(x),
+            Val::Float32(x) => wasmtime_component_val_t::F32(x),
+            Val::Float64(x) => wasmtime_component_val_t::F64(x),
+            Val::Char(_) => todo!(),
+            Val::String(_) => todo!(),
+            Val::List(_vals) => todo!(),
+            Val::Record(_items) => todo!(),
+            Val::Tuple(_vals) => todo!(),
+            Val::Variant(_, _val) => todo!(),
+            Val::Enum(_) => todo!(),
+            Val::Option(_val) => todo!(),
+            Val::Result(_val) => todo!(),
+            Val::Flags(_items) => todo!(),
+            Val::Resource(_resource_any) => todo!(),
+        }
+    }
+}

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_capi_test(tests FILES
   component/instantiate.cc
   component/define_module.cc
   component/lookup_func.cc
+  component/call_func.cc
   error.cc
   config.cc
   wat.cc

--- a/crates/c-api/tests/component/call_func.cc
+++ b/crates/c-api/tests/component/call_func.cc
@@ -1,0 +1,81 @@
+#include "utils.h"
+
+#include <array>
+#include <gtest/gtest.h>
+#include <wasmtime.h>
+
+TEST(component, call_func) {
+  static constexpr auto component_text = std::string_view{
+      R"END(
+(component
+    (core module $m
+        (func (export "f") (param $x i32) (param $y i32) (result i32)
+            (local.get $x)
+            (local.get $y)
+            (i32.add)
+        )
+    )
+    (core instance $i (instantiate $m))
+    (func $f (param "x" u32) (param "y" u32) (result u32) (canon lift (core func $i "f")))
+    (export "f" (func $f))
+)
+      )END",
+  };
+  const auto engine = wasm_engine_new();
+  EXPECT_NE(engine, nullptr);
+
+  const auto store = wasmtime_store_new(engine, nullptr, nullptr);
+  const auto context = wasmtime_store_context(store);
+
+  wasmtime_component_t *component = nullptr;
+
+  auto err = wasmtime_component_new(
+      engine, reinterpret_cast<const uint8_t *>(component_text.data()),
+      component_text.size(), &component);
+
+  CHECK_ERR(err);
+
+  const auto f =
+      wasmtime_component_get_export_index(component, nullptr, "f", 1);
+
+  EXPECT_NE(f, nullptr);
+
+  const auto linker = wasmtime_component_linker_new(engine);
+
+  wasmtime_component_instance_t instance = {};
+  err = wasmtime_component_linker_instantiate(linker, context, component,
+                                              &instance);
+  CHECK_ERR(err);
+
+  wasmtime_component_func_t func = {};
+  const auto found =
+      wasmtime_component_instance_get_func(&instance, context, f, &func);
+  EXPECT_TRUE(found);
+
+  const auto params = std::array<wasmtime_component_val_t, 2>{
+      wasmtime_component_val_t{
+          .kind = WASMTIME_COMPONENT_U32,
+          .of = {.u32 = 34},
+      },
+      wasmtime_component_val_t{
+          .kind = WASMTIME_COMPONENT_U32,
+          .of = {.u32 = 35},
+      },
+  };
+
+  auto results = std::array<wasmtime_component_val_t, 1>{};
+
+  err =
+      wasmtime_component_func_call(&func, context, params.data(), params.size(),
+                                   results.data(), results.size());
+  CHECK_ERR(err);
+
+  EXPECT_EQ(results[0].kind, WASMTIME_COMPONENT_U32);
+  EXPECT_EQ(results[0].of.u32, 69);
+
+  wasmtime_component_export_index_delete(f);
+  wasmtime_component_linker_delete(linker);
+
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+}


### PR DESCRIPTION
Only contains primitive values and no docs as of now. Trying to gauge if this is correct way to approach this.

Some things of note:
- `wasmtime_component_valunion_t::boolean` instead of `::bool` because keyword.
- `wasmtime_component_valunion_t::f32` and `WASMTIME_COMPONENT_F32` instead of `float32`, should this be changed to be consistent?
- C++20 needed for syntax used when creating `wasmtime_component_val_t` in the test, so I bumped to 20 only for tests. Is that fine? Could the whole project be bumped to 20?

Also, is there any better way to test all values, other than copying the test for each kind of value?