### PR TITLE
Make a non-deterministic log message deterministic

### DIFF
--- a/cranelift/assembler-x64/build.rs
+++ b/cranelift/assembler-x64/build.rs
@@ -9,7 +9,11 @@ fn main() {
 
     let out_dir = env::var("OUT_DIR").expect("The OUT_DIR environment variable must be set");
     let out_dir = Path::new(&out_dir);
-    let built_files = [meta::generate_rust_assembler(out_dir, "assembler.rs")];
+    let built_files = [meta::generate_rust_assembler(
+        out_dir,
+        "OUT_DIR",
+        "assembler.rs",
+    )];
 
     // Generating this additional bit of Rust is necessary for listing the
     // generated files.

--- a/cranelift/assembler-x64/meta/src/lib.rs
+++ b/cranelift/assembler-x64/meta/src/lib.rs
@@ -14,11 +14,11 @@ use std::path::{Path, PathBuf};
 /// # Panics
 ///
 /// This function panics if we cannot update the file.
-pub fn generate_rust_assembler<P: AsRef<Path>>(dir: P, file: &str) -> PathBuf {
+pub fn generate_rust_assembler<P: AsRef<Path>>(dir: P, dir_name: &str, file: &str) -> PathBuf {
     let out = dir.as_ref().join(file);
     eprintln!("Generating {}", out.display());
     let mut fmt = Formatter::new(Language::Rust);
     generate::rust_assembler(&mut fmt, &instructions::list());
-    fmt.write(file, dir.as_ref()).unwrap();
+    fmt.write(file, dir.as_ref(), dir_name).unwrap();
     out
 }

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -1210,12 +1210,12 @@ pub(crate) fn generate(
     gen_opcodes(all_inst, &mut fmt);
     fmt.empty_line();
     gen_type_constraints(all_inst, &mut fmt);
-    fmt.write(opcode_filename, out_dir)?;
+    fmt.write(opcode_filename, out_dir, "OUT_DIR")?;
 
     // Instruction builder.
     let mut fmt = Formatter::new(Language::Rust);
     gen_builder(all_inst, &formats, &mut fmt);
-    fmt.write(inst_builder_filename, out_dir)?;
+    fmt.write(inst_builder_filename, out_dir, "OUT_DIR")?;
 
     Ok(())
 }

--- a/cranelift/codegen/meta/src/gen_isle.rs
+++ b/cranelift/codegen/meta/src/gen_isle.rs
@@ -505,12 +505,12 @@ pub(crate) fn generate(
     // ISLE DSL: mid-end ("opt") generated bindings.
     let mut fmt = Formatter::new(Language::Isle);
     gen_opt_isle(&formats, all_inst, &mut fmt);
-    fmt.write(isle_opt_filename, isle_dir)?;
+    fmt.write(isle_opt_filename, isle_dir, "ISLE_DIR")?;
 
     // ISLE DSL: lowering generated bindings.
     let mut fmt = Formatter::new(Language::Isle);
     gen_lower_isle(&formats, all_inst, &mut fmt);
-    fmt.write(isle_lower_filename, isle_dir)?;
+    fmt.write(isle_lower_filename, isle_dir, "ISLE_DIR")?;
 
     Ok(())
 }

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -446,6 +446,6 @@ pub(crate) fn generate(
 ) -> Result<(), error::Error> {
     let mut fmt = Formatter::new(Language::Rust);
     gen_group(settings, parent_group, &mut fmt);
-    fmt.write(filename, out_dir)?;
+    fmt.write(filename, out_dir, "OUT_DIR")?;
     Ok(())
 }

--- a/cranelift/codegen/meta/src/gen_types.rs
+++ b/cranelift/codegen/meta/src/gen_types.rs
@@ -64,6 +64,6 @@ fn emit_types(fmt: &mut Formatter) {
 pub(crate) fn generate(filename: &str, out_dir: &std::path::Path) -> Result<(), error::Error> {
     let mut fmt = Formatter::new(Language::Rust);
     emit_types(&mut fmt);
-    fmt.write(filename, out_dir)?;
+    fmt.write(filename, out_dir, "OUT_DIR")?;
     Ok(())
 }

--- a/cranelift/codegen/meta/src/lib.rs
+++ b/cranelift/codegen/meta/src/lib.rs
@@ -106,7 +106,7 @@ fn generate_isle_for_assembler(
 ) -> Result<(), error::Error> {
     let mut fmt = Formatter::new(Language::Isle);
     gen_asm::generate_isle(&mut fmt, insts);
-    fmt.write("assembler.isle", isle_dir)
+    fmt.write("assembler.isle", isle_dir, "ISLE_DIR")
 }
 
 /// Generate a macro containing builder functions for the assembler's ISLE
@@ -118,7 +118,7 @@ fn generate_rust_macro_for_assembler(
 ) -> Result<(), error::Error> {
     let mut fmt = Formatter::new(Language::Rust);
     gen_asm::generate_rust_macro(&mut fmt, insts);
-    fmt.write("assembler-isle-macro.rs", out_dir)
+    fmt.write("assembler-isle-macro.rs", out_dir, "OUT_DIR")
 }
 
 /// Generates all the source files used in Cranelift from the meta-language.

--- a/cranelift/srcgen/src/lib.rs
+++ b/cranelift/srcgen/src/lib.rs
@@ -232,13 +232,23 @@ impl Formatter {
     }
 
     /// Write `self.lines` to a file.
+    ///
+    /// The `directory_name` should be a deterministic name for the `directory`
+    /// that can be used for logging. The goal here is to prevent
+    /// non-deterministic output which could trigger cache misses in build
+    /// systems.
     pub fn write(
         &self,
         filename: impl AsRef<std::path::Path>,
         directory: &std::path::Path,
+        directory_name: &str,
     ) -> Result<(), error::Error> {
         let path = directory.join(&filename);
-        eprintln!("Writing generated file: {}", path.display());
+        eprintln!(
+            "Writing generated file: {} in {}",
+            filename.as_ref().display(),
+            directory_name
+        );
         let mut f = fs::File::create(path)?;
 
         for l in self.lines.iter().map(|l| l.as_bytes()) {


### PR DESCRIPTION
This resolves the issue from the `eprintln!` line mentioned in https://github.com/bytecodealliance/wasmtime/issues/9553.

When generating a file we currently log the full path to that file which changes depending on where the build is run and can prevent cache hits in build systems like Bazel.

This change instead just prints the file name, along with a deterministic name for the parent directory (e.g. `OUT_DIR` or `ISLE_DIR`) which can be makes the log message deterministic and should still be useful for debugging.

