### PR TITLE
Temporarily disable simd differential fuzzing with wasmi

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -19,6 +19,10 @@ impl WasmiEngine {
         config.exceptions_enabled = false;
         config.gc_enabled = false;
 
+        // FIXME: once the active fuzz bug for wasmi's simd differential fuzzing
+        // has been fixed and we've updated then this should be re-enabled.
+        config.simd_enabled = false;
+
         let mut wasmi_config = wasmi::Config::default();
         wasmi_config
             .consume_fuel(false)


### PR DESCRIPTION
OSS-Fuzz has found a differential execution with wasmi/wasmtime which relates to simd which I've reported, so in the meantime to let the fuzzers keep making progress this disables simd when using wasmi as a differential fuzzer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
