### PR TITLE
Don't assume a `GcStore` is allocated when creating an `AnyRef` from a raw `i31ref`

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -278,7 +278,11 @@ impl AnyRef {
     // (Not actually memory unsafe since we have indexed GC heaps.)
     pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<Self>> {
         let gc_ref = VMGcRef::from_raw_u32(raw)?;
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = if gc_ref.is_i31() {
+            gc_ref.copy_i31()
+        } else {
+            store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref)
+        };
         Some(Self::from_cloned_gc_ref(store, gc_ref))
     }
 
@@ -331,7 +335,11 @@ impl AnyRef {
 
     pub(crate) unsafe fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+        let raw = if gc_ref.is_i31() {
+            gc_ref.as_raw_non_zero_u32()
+        } else {
+            store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref)
+        };
         Ok(raw.get())
     }
 

--- a/tests/all/i31ref.rs
+++ b/tests/all/i31ref.rs
@@ -19,3 +19,24 @@ fn always_pop_i31ref_lifo_roots() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn i31ref_to_raw_round_trip() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    // Should be able to round trip an `i31ref` to its raw representation and
+    // back again even though we have not forced the allocation of the `GcStore`
+    // yet.
+    let anyref = AnyRef::from_i31(&mut store, I31::wrapping_u32(42));
+    let raw = unsafe { anyref.to_raw(&mut store)? };
+    let anyref = unsafe { AnyRef::from_raw(&mut store, raw).expect("should be non-null") };
+    assert!(anyref.is_i31(&store)?);
+    assert_eq!(anyref.as_i31(&store)?.unwrap().get_u32(), 42);
+
+    Ok(())
+}


### PR DESCRIPTION
And also don't force the allocation of a `GcStore` when converting an `AnyRef` that happens to be an `i31ref` into its raw representation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
