### PR TITLE
Update stability docs for the Wasm GC implementation

### DIFF
--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -47,16 +47,21 @@ column is below.
 |  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API |
 |--------------------------|---------|-------|----------|--------|-----|-------|
 | [`function-references`]  | ✅      | ✅    | ❌       | ❌     | ✅  | ❌    |
-| [`gc`] [^6]              | ✅      | ✅    | ❌[^7]   | ❌     | ✅  | ❌    |
+| [`gc`] [^6]              | ✅      | ✅    | ⚠️[^7]   | ⚠️[^8] | ✅  | ❌    |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ❌    |
 
 [^6]: There is also a [tracking
     issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
     GC proposal.
-[^7]: The implementation of GC has [known performance
-    issues](https://github.com/bytecodealliance/wasmtime/issues/9351) which can
-    affect non-GC code when the GC proposal is enabled.
+[^7]: The implementation of Wasm GC is feature complete from a specification
+    perspective, however a number of quality-of-implementation tasks
+    [remain](https://github.com/bytecodealliance/wasmtime/issues/5032), notably
+    a tracing collector that can reclaim garbage cycles.
+[^8]: The GC proposal is lightly fuzzed via `wasm-smith` and our usual
+    whole-module fuzz targets like `differential`, but we would like to
+    additionally [extend the `table_ops` fuzz target to exercise more of the GC
+    proposal](https://github.com/bytecodealliance/wasmtime/issues/10327).
 
 ## Unimplemented proposals
 


### PR DESCRIPTION
Updates the "finished" and "fuzzed" columns to reflect their partial completion.

Removes the footnote about regressing non-GC-using Wasm performance when enabled, as that is not actually true. We only do subtype checks as a fallback when direct equality fails, and for non-GC-using Wasm if direct equality fails then a trap is raised and the program terminates so a subtype check on this branch doesn't matter. When direct equality succeeds, then there is no overhead compared to when the GC proposal is not enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
