### PR TITLE
refactor(docs): more conversions of sh to console for copy-paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 The Wasmtime CLI can be installed on Linux and macOS (locally) with a small install
 script:
 
-```sh
+```console
 curl https://wasmtime.dev/install.sh -sSf | bash
 ```
 This script installs into `$WASMTIME_HOME` (defaults to `$HOME/.wasmtime`), and executable is placed in `$WASMTIME_HOME/bin`.
@@ -56,19 +56,31 @@ fn main() {
 }
 ```
 
-and compile/run it with:
+and compile it into a WebAssembly component with:
 
-```sh
-$ rustup target add wasm32-wasip1
-$ rustc hello.rs --target wasm32-wasip1
-$ wasmtime hello.wasm
+```console
+rustup target add wasm32-wasip2
+rustc hello.rs --target wasm32-wasip2
+```
+
+Once compiled, you can can run your component:
+
+```console
+wasmtime hello.wasm
+```
+
+You should see the following output:
+
+```text
 Hello, world!
 ```
 
-(Note: make sure you installed Rust using the `rustup` method in the official
+(Note: make sure you installed Rust using the [`rustup`][rustup] method in the official
 instructions above, and do not have a copy of the Rust toolchain installed on
 your system in some other way as well (e.g. the system package manager). Otherwise, the `rustup target add...`
 command may not install the target for the correct copy of Rust.)
+
+[rustup]: https://rustup.rs
 
 ## Features
 

--- a/cranelift/isle/README.md
+++ b/cranelift/isle/README.md
@@ -39,20 +39,20 @@ Details on ISLE's integration into Cranelift can be found
 
 Build `islec`, the ISLE compiler:
 
-```shell
-$ cargo build --release
+```console
+cargo build --release
 ```
 
 Compile a `.isle` source file into Rust code:
 
-```shell
-$ target/release/islec -i isle_examples/test.isle -o isle_examples/test.rs
+```console
+target/release/islec -i isle_examples/test.isle -o isle_examples/test.rs
 ```
 
 Include that Rust code in your crate and compile it:
 
-```shell
-$ rustc isle_examples/test_main.rs
+```console
+rustc isle_examples/test_main.rs
 ```
 
 ## Tutorial
@@ -132,8 +132,8 @@ variable `c` is bound from the LHS and then reused in the RHS.
 
 Now we can compile this code by running
 
-```shell
-$ islec isle_examples/tutorial.isle
+```console
+islec isle_examples/tutorial.isle
 ```
 
 and we'll get the following output <sup>(ignoring any minor code generation

--- a/crates/wasi-nn/README.md
+++ b/crates/wasi-nn/README.md
@@ -25,8 +25,8 @@ wasmtime_wasi_nn::witx::add_to_linker(...);
 
 ### Build
 
-```sh
-$ cargo build
+```console
+cargo build
 ```
 
 To use the WIT-based ABI, compile with `--features component-model` and use `wasmtime_wasi_nn::wit::add_to_linker`.

--- a/crates/wasi-nn/examples/classification-component-onnx/README.md
+++ b/crates/wasi-nn/examples/classification-component-onnx/README.md
@@ -5,17 +5,20 @@ This example demonstrates how to use the `wasi-nn` crate to run a classification
 
 ## Build
 In this directory, run the following command to build the WebAssembly component:
-```shell
+```console
 cargo component build
 ```
 
 In the Wasmtime root directory, run the following command to build the Wasmtime CLI and run the WebAssembly component:
-```shell
+```sh
 # build wasmtime with component-model and WASI-NN with ONNX runtime support
 cargo build --features component-model,wasi-nn,wasmtime-wasi-nn/onnx
 
 # run the component with wasmtime
-./target/debug/wasmtime run -Snn --dir ./crates/wasi-nn/examples/classification-component-onnx/fixture/::fixture ./crates/wasi-nn/examples/classification-component-onnx/target/wasm32-wasip1/debug/classification-component-onnx.wasm
+./target/debug/wasmtime run \
+    -Snn \
+    --dir ./crates/wasi-nn/examples/classification-component-onnx/fixture/::fixture \
+    ./crates/wasi-nn/examples/classification-component-onnx/target/wasm32-wasip1/debug/classification-component-onnx.wasm
 ```
 
 You should get the following output:

--- a/crates/wasi-nn/examples/classification-example-winml/README.md
+++ b/crates/wasi-nn/examples/classification-example-winml/README.md
@@ -14,7 +14,7 @@ To run this example, perform the following steps on Windows 10 v1803 and later:
 
 1. Build Wasmtime according to the [build guide], but enable the `winml`
    feature:
-   ```shell
+   ```console
    cargo build --release --features wasmtime-wasi-nn/winml
    ```
 1. Navigate to this directory from Wasmtime's top-level directory (referred to

--- a/crates/wasi-preview1-component-adapter/README.md
+++ b/crates/wasi-preview1-component-adapter/README.md
@@ -16,8 +16,8 @@ instead.
 
 This adapter can be built with:
 
-```sh
-$ cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --release
+```console
+cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --release
 ```
 
 And the artifact will be located at
@@ -40,7 +40,7 @@ With a `wasi_snapshot_preview1.wasm` file on-hand you can create a component
 from a module that imports WASI functions using the [`wasm-tools`
 CLI](https://github.com/bytecodealliance/wasm-tools)
 
-```sh
+```shell-session
 $ cat foo.rs
 fn main() {
     println!("Hello, world!");

--- a/docs/cli-cache.md
+++ b/docs/cli-cache.md
@@ -2,8 +2,8 @@
 
 The configuration file uses the [toml] format.
 You can create a configuration file at the default location with:
-```sh
-$ wasmtime config new
+```console
+wasmtime config new
 ```
 It will print the location regardless of the success.
 Please refer to the  `--help` message for using a custom location.

--- a/docs/cli-install.md
+++ b/docs/cli-install.md
@@ -7,8 +7,8 @@ you'll want to consult the [embedding documentation](lang.md).
 The easiest way to install the `wasmtime` CLI tool is through our installation
 script. Linux and macOS users can execute the following:
 
-```sh
-$ curl https://wasmtime.dev/install.sh -sSf | bash
+```console
+curl https://wasmtime.dev/install.sh -sSf | bash
 ```
 
 This will download a precompiled version of `wasmtime`, place it in
@@ -23,7 +23,7 @@ to install.
 
 You can confirm your installation works by executing:
 
-```sh
+```shell-session
 $ wasmtime -V
 wasmtime 30.0.0 (ede663c2a 2025-02-19)
 ```

--- a/docs/cli-logging.md
+++ b/docs/cli-logging.md
@@ -9,7 +9,7 @@ To enable logging of WASI system calls, similar to the `strace` command on Linux
 set `WASMTIME_LOG=wasmtime_wasi=trace`. For more information on specifying
 filters, see [tracing-subscriber's EnvFilter docs].
 
-```sh
+```shell-session
 $ WASMTIME_LOG=wasmtime_wasi=trace wasmtime hello.wasm
 [...]
 TRACE wiggle abi{module="wasi_snapshot_preview1" function="fd_write"} wasmtime_wasi::preview1::wasi_snapshot_preview1                     > fd=Fd(1) iovs=*guest 0x14/1

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,15 +8,15 @@ This section will provide a guide to the `wasmtime` CLI and major functionality
 that it contains. In short, however, you can execute a WebAssembly file
 (actually doing work as part of the `start` function) like so:
 
-```sh
-$ wasmtime foo.wasm
+```console
+wasmtime foo.wasm
 ```
 
 Or similarly if you want to invoke a "start" function, such as with WASI
 modules, you can execute
 
-```sh
-$ wasmtime --invoke _start foo.wasm
+```console
+wasmtime --invoke _start foo.wasm
 ```
 
 For more information be sure to check out [how to install the

--- a/docs/contributing-building.md
+++ b/docs/contributing-building.md
@@ -13,7 +13,7 @@ The Wasmtime repository contains a number of git submodules. To build Wasmtime
 and most other crates in the repository, you have to ensure that those are
 initialized with this command:
 
-```shell
+```console
 git submodule update --init
 ```
 
@@ -35,7 +35,7 @@ here.](https://rust-lang.github.io/rust-bindgen/requirements.html#clang)
 To make an unoptimized, debug build of the `wasmtime` CLI tool, go to the root
 of the repository and run this command:
 
-```shell
+```console
 cargo build
 ```
 
@@ -43,7 +43,7 @@ The built executable will be located at `target/debug/wasmtime`.
 
 To make an optimized build, run this command in the root of the repository:
 
-```shell
+```console
 cargo build --release
 ```
 
@@ -64,14 +64,14 @@ You can build any of the Wasmtime crates by appending `-p wasmtime-whatever` to
 the `cargo build` invocation. For example, to build the `wasmtime-environ` crate,
 execute this command:
 
-```shell
+```console
 cargo build -p wasmtime-environ
 ```
 
 Alternatively, you can `cd` into the crate's directory, and run `cargo build`
 there, without needing to supply the `-p` flag:
 
-```shell
+```console
 cd crates/environ/
 cargo build
 ```

--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -11,8 +11,8 @@ be aware of.
 All PRs must be formatted according to rustfmt, and this is checked in the
 continuous integration tests. You can format code locally with:
 
-```sh
-$ cargo fmt
+```console
+cargo fmt
 ```
 
 at the root of the repository. You can find [more information about rustfmt
@@ -82,8 +82,8 @@ crates in the workspace to land the PR in CI.
 
 Clippy can be run locally with:
 
-```shell
-$ cargo clippy --workspace --all-targets
+```console
+cargo clippy --workspace --all-targets
 ```
 
 Contributors are welcome to enable new lints and send PRs for this. Feel free to

--- a/docs/contributing-cross-compiling.md
+++ b/docs/contributing-cross-compiling.md
@@ -23,8 +23,8 @@ hunt for toolchains if you want to compile for Linux or Windows.
 First, use `rustup` to install Rust targets for the other architectures that
 Wasmtime and Cranelift support:
 
-```shell
-$ rustup target add \
+```console
+rustup target add \
     s390x-unknown-linux-gnu \
     riscv64gc-unknown-linux-gnu \
     aarch64-unknown-linux-gnu
@@ -35,8 +35,8 @@ $ rustup target add \
 Next, you'll need to install a `gcc` for each cross-compilation target to serve
 as a linker for `rustc`.
 
-```shell
-$ sudo apt install \
+```console
+sudo apt install \
     gcc-s390x-linux-gnu \
     gcc-riscv64-linux-gnu \
     gcc-aarch64-linux-gnu
@@ -46,8 +46,8 @@ $ sudo apt install \
 
 You will also need to install `qemu` to emulate the cross-compilation targets.
 
-```shell
-$ sudo apt install qemu-user
+```console
+sudo apt install qemu-user
 ```
 
 ## Configure Cargo
@@ -83,18 +83,18 @@ A few examples:
 
 * Build the `wasmtime` binary for `aarch64`:
 
-  ```shell
-  $ cargo build --target aarch64-unknown-linux-gnu
+  ```console
+  cargo build --target aarch64-unknown-linux-gnu
   ```
 
 * Run the tests under `riscv` emulation:
 
-  ```shell
-  $ cargo test --target riscv64gc-unknown-linux-gnu
+  ```console
+  cargo test --target riscv64gc-unknown-linux-gnu
   ```
 
 * Run the `wasmtime` binary under `s390x` emulation:
 
-  ```shell
-  $ cargo run --target s390x-unknown-linux-gnu -- compile example.wasm
+  ```console
+  cargo run --target s390x-unknown-linux-gnu -- compile example.wasm
   ```

--- a/docs/contributing-testing.md
+++ b/docs/contributing-testing.md
@@ -13,7 +13,7 @@ To compile the tests, you'll need the `wasm32-wasip1` and
 [rustup.rs](https://rustup.rs) to manage your Rust versions, can be done as
 follows:
 
-```shell
+```console
 rustup target add wasm32-wasip1 wasm32-unknown-unknown
 ```
 
@@ -37,7 +37,7 @@ At this time not all of the crates in the Wasmtime workspace can be tested, so
 running all tests is a little non-standard. To match what CI does and run all
 tests you'll need to execute
 
-```shell
+```console
 ./ci/run-tests.sh
 ```
 
@@ -47,14 +47,14 @@ You can test a particular Wasmtime crate with `cargo test -p
 wasmtime-whatever`. For example, to test the `wasmtime-environ` crate, execute
 this command:
 
-```shell
+```console
 cargo test -p wasmtime-environ
 ```
 
 Alternatively, you can `cd` into the crate's directory, and run `cargo test`
 there, without needing to supply the `-p` flag:
 
-```shell
+```console
 cd crates/environ/
 cargo test
 ```
@@ -64,7 +64,7 @@ cargo test
 The spec testsuite itself is in a git submodule, so make sure you've
 checked it out and initialized its submodule:
 
-```shell
+```console
 git submodule update --init
 ```
 
@@ -72,7 +72,7 @@ When the submodule is checked out, Wasmtime runs the Wasm spec testsuite as part
 of testing the `wasmtime-cli` crate at the crate root, meaning in the root of
 the repository you can execute:
 
-```shell
+```console
 cargo test --test wast
 ```
 
@@ -80,7 +80,7 @@ You can pass an additional CLI argument to act as a filter on which tests to
 run. For example to only run the spec tests themselves (excluding handwritten
 Wasmtime-specific tests) and only in Cranelift you can run:
 
-```shell
+```console
 cargo test --test wast Cranelift/tests/spec
 ```
 
@@ -95,13 +95,13 @@ WASI integration tests can be run separately from all other tests which
 can be useful when working on the `wasmtime-wasi` crate. This can be done by
 executing this command:
 
-```shell
+```console
 cargo test -p wasmtime-wasi
 ```
 
 Similarly if you're testing HTTP-related functionality you can execute:
 
-```shell
+```console
 cargo test -p wasmtime-wasi-http
 ```
 
@@ -157,7 +157,7 @@ in `tests/misc_testsuite`. Feel free to add new tests to existing
 `tests/misc_testsuite/*.wast` files or create new ones as needed. These tests
 are run from the crate root:
 
-```shell
+```console
 cargo test --test wast
 ```
 

--- a/docs/examples-coredump.md
+++ b/docs/examples-coredump.md
@@ -4,8 +4,8 @@ The following steps describe how to debug using Wasm coredump in Wasmtime:
 
 1. Compile your WebAssembly with debug info enabled; for example:
 
-    ```sh
-    $ rustc foo.rs --target=wasm32-wasip1 -C debuginfo=2
+    ```console
+    rustc foo.rs --target=wasm32-wasip1 -C debuginfo=2
     ```
 
 <details>
@@ -30,7 +30,7 @@ The following steps describe how to debug using Wasm coredump in Wasmtime:
 
 2. Run with Wasmtime and Wasm coredump enabled:
 
-    ```sh
+    ```shell-session
     $ wasmtime -D coredump=/tmp/coredump foo.wasm
 
     thread 'main' panicked at 'attempt to subtract with overflow', foo.rs:10:7
@@ -45,7 +45,7 @@ The following steps describe how to debug using Wasm coredump in Wasmtime:
     ```
 
 3. Use [wasmgdb] to debug:
-    ```sh
+    ```shell-session
     $ wasmgdb foo.wasm /tmp/coredump
 
     wasmgdb> bt

--- a/docs/examples-debugging-core-dumps.md
+++ b/docs/examples-debugging-core-dumps.md
@@ -34,8 +34,8 @@ fn baz(x: u32) {
 
 We can compile it to Wasm with the following command:
 
-```shell-session
-$ rustc --target wasm32-wasip1 -o ./trap.wasm ./trap.rs
+```console
+rustc --target wasm32-wasip1 -o ./trap.wasm ./trap.rs
 ```
 
 Next, we can run it in Wasmtime and capture a core dump when it traps:

--- a/docs/examples-debugging-native-debugger.md
+++ b/docs/examples-debugging-native-debugger.md
@@ -7,7 +7,7 @@ the same time:
 1. Compile your WebAssembly with debug info enabled, usually `-g`; for
    example:
 
-    ```sh
+    ```console
     clang foo.c -g -o foo.wasm
     ```
 
@@ -18,10 +18,10 @@ the same time:
 
 3. Use a supported debugger:
 
-    ```sh
+    ```console
     lldb -- wasmtime run -D debug-info foo.wasm
     ```
-    ```sh
+    ```console
     gdb --args wasmtime run -D debug-info -O opt-level=0 foo.wasm
     ```
 
@@ -34,7 +34,7 @@ If you run into trouble, the following discussions might help:
 - With LLDB, call `__vmctx.set()` to set the current context before calling any
   dereference operators
   ([#1482](https://github.com/bytecodealliance/wasmtime/issues/1482)):
-  ```sh
+  ```text
   (lldb) p __vmctx->set()
   (lldb) p *foo
   ```

--- a/docs/examples-minimal.md
+++ b/docs/examples-minimal.md
@@ -18,7 +18,7 @@ Wasmtime C API `libwasmtime.so`, but to start out let's take a look at
 minimizing the dynamic library as a case study. By default the C API is
 relatively large:
 
-```shell
+```shell-session
 $ cargo build -p wasmtime-c-api
 $ ls -lh ./target/debug/libwasmtime.so
 -rwxrwxr-x 2 alex alex 260M Dec 12 07:46 target/debug/libwasmtime.so
@@ -28,7 +28,7 @@ The easiest size optimization is to compile with optimizations. This will strip
 lots of dead code and additionally generate much less debug information by
 default
 
-```shell
+```shell-session
 $ cargo build -p wasmtime-c-api --release
 $ ls -lh ./target/release/libwasmtime.so
 -rwxrwxr-x 2 alex alex 19M Dec 12 07:46 target/release/libwasmtime.so
@@ -39,7 +39,7 @@ disable the default features of the C API. This will remove all
 optional functionality from the crate and strip it down to the bare bones
 functionality.
 
-```shell
+```shell-session
 $ cargo build -p wasmtime-c-api --release --no-default-features
 $ ls -lh ./target/release/libwasmtime.so
 -rwxrwxr-x 2 alex alex 2.1M Dec 12 07:47 target/release/libwasmtime.so
@@ -60,7 +60,7 @@ Note that for custom embeddings you'd need to replicate the `disable-logging`
 feature which sets the `max_level_off` feature for the `log` and `tracing`
 crate.
 
-```shell
+```shell-session
 $ cargo build -p wasmtime-c-api --release --no-default-features --features disable-logging
 $ ls -lh ./target/release/libwasmtime.so
 -rwxrwxr-x 2 alex alex 2.1M Dec 12 07:49 target/release/libwasmtime.so
@@ -77,7 +77,7 @@ this.
 
 [cargo-env-config]: https://doc.rust-lang.org/cargo/reference/config.html#profile
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ cargo build -p wasmtime-c-api --release --no-default-features --features disable-logging
 $ ls -lh ./target/release/libwasmtime.so
@@ -96,7 +96,7 @@ Rust's "panic=abort" mode where panics translate to process aborts rather than
 unwinding. This removes landing pads from code as well as unwind tables from the
 executable.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ cargo build -p wasmtime-c-api --release --no-default-features --features disable-logging
@@ -110,7 +110,7 @@ deduplicate. Do note that this will take a significantly longer amount of time
 to compile than previously. Here LTO is configured with
 `CARGO_PROFILE_RELEASE_LTO=true`.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -124,7 +124,7 @@ their own single object file instead of multiple by default. This again
 increases compile times. Here that's done with
 `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1`.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -144,7 +144,7 @@ debug information for local crates, but the Rust standard library may have debug
 information still included with it. This is configured via
 `CARGO_PROFILE_RELEASE_STRIP=debuginfo`
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -165,7 +165,7 @@ these commands don't work and we'll update the documentation.
 The first nightly feature we can leverage is to remove filename and line number
 information in panics with `-Zlocation-detail=none`
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -183,7 +183,7 @@ the standard library. This uses the `-Zbuild-std` flag to Cargo. Note that this
 additionally requires `--target` as well which will need to be configured for
 your particular platform.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -202,7 +202,7 @@ environments so the features of the standard library can be disabled with the
 `-Zbuild-std-features=` flag which configures the set of enabled features to be
 empty.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true
@@ -220,7 +220,7 @@ And finally, if you can enable the `panic_immediate_abort` feature of the Rust
 standard library to shrink panics even further. Note that this comes at a cost
 of making bugs/panics very difficult to debug.
 
-```shell
+```shell-session
 $ export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
 $ export CARGO_PROFILE_RELEASE_PANIC=abort
 $ export CARGO_PROFILE_RELEASE_LTO=true

--- a/docs/examples-profiling-perf.md
+++ b/docs/examples-profiling-perf.md
@@ -33,8 +33,8 @@ your application's performance.
 
 For example if you're using the CLI, you'll execute:
 
-```sh
-$ perf record -k mono wasmtime --profile=perfmap foo.wasm
+```console
+perf record -k mono wasmtime --profile=perfmap foo.wasm
 ```
 
 This will create a `perf.data` file as per usual, but it will *also* create a
@@ -43,8 +43,8 @@ specified by `perf` and Wasmtime generates at runtime.
 
 After that you can explore the `perf.data` profile as you usually would, for example with:
 
-```sh
-$ perf report --input perf.data
+```console
+perf report --input perf.data
 ```
 
 You should be able to see time spent in wasm functions, generate flamegraphs based on that, etc..
@@ -81,8 +81,8 @@ your application's performance. You'll need to also be sure to pass the
 
 For example if you're using the CLI, you'll execute:
 
-```sh
-$ perf record -k mono wasmtime --profile=jitdump foo.wasm
+```console
+perf record -k mono wasmtime --profile=jitdump foo.wasm
 ```
 
 This will create a `perf.data` file as per usual, but it will *also* create a
@@ -92,8 +92,8 @@ specified by `perf` and Wasmtime generates at runtime.
 The next thing you need to do is to merge the `*.dump` file into the
 `perf.data` file, which you can do with the `perf inject` command:
 
-```sh
-$ perf inject --jit --input perf.data --output perf.jit.data
+```console
+perf inject --jit --input perf.data --output perf.jit.data
 ```
 
 This will read `perf.data`, automatically pick up the `*.dump` file that's
@@ -105,8 +105,8 @@ created by Wasmtime.
 After that you can explore the `perf.jit.data` profile as you usually would,
 for example with:
 
-```sh
-$ perf report --input perf.jit.data
+```console
+perf report --input perf.jit.data
 ```
 
 You should be able to annotate wasm functions and see their raw assembly. You
@@ -161,7 +161,7 @@ fn fib(n: u32) -> u32 {
 
 To collect perf information for this wasm module we'll execute:
 
-```sh
+```console
 $ rustc --target wasm32-wasip1 fib.rs -O
 $ perf record -k mono wasmtime --profile=jitdump fib.wasm
 fib(42) = 267914296
@@ -175,8 +175,8 @@ example to see that 99% of our runtime (as expected) is spent in our `fib`
 function. Note that the symbol has been demangled to `fib::fib` which is what
 the Rust symbol is:
 
-```sh
-$ perf report --input perf.jit.data
+```console
+perf report --input perf.jit.data
 ```
 
 ![perf report output](assets/perf-report-fib.png)
@@ -184,8 +184,8 @@ $ perf report --input perf.jit.data
 Alternatively we could also use `perf annotate` to take a look at the
 disassembly of the `fib` function, seeing what the JIT generated:
 
-```sh
-$ perf annotate --input perf.jit.data
+```console
+perf annotate --input perf.jit.data
 ```
 
 ![perf annotate output](assets/perf-annotate-fib.png)

--- a/docs/examples-profiling-samply.md
+++ b/docs/examples-profiling-samply.md
@@ -25,8 +25,8 @@ your application's performance.
 
 For example if you're using the CLI, you'll execute:
 
-```sh
-$ samply record wasmtime --profile=perfmap foo.wasm
+```console
+samply record wasmtime --profile=perfmap foo.wasm
 ```
 
 This will record your application's performance and open the Firefox profiler UI to view the

--- a/docs/examples-profiling-vtune.md
+++ b/docs/examples-profiling-vtune.md
@@ -56,9 +56,9 @@ future.
 
 With VTune [properly installed][download], if you are using the CLI execute:
 
-```sh
-$ cargo build
-$ vtune -run-pass-thru=--no-altstack -collect hotspots target/debug/wasmtime --profile=vtune foo.wasm
+```console
+cargo build
+vtune -run-pass-thru=--no-altstack -collect hotspots target/debug/wasmtime --profile=vtune foo.wasm
 ```
 
 This command tells the VTune collector (`vtune`) to collect hot spot
@@ -91,8 +91,8 @@ fn fib(n: u32) -> u32 {
 
 We compile the example to Wasm:
 
-```sh
-$ rustc --target wasm32-wasip1 fib.rs -C opt-level=z -C lto=yes
+```console
+rustc --target wasm32-wasip1 fib.rs -C opt-level=z -C lto=yes
 ```
 
 Then we execute the Wasmtime runtime (built with the `vtune` feature and
@@ -100,7 +100,7 @@ executed with the `--profile=vtune` flag to enable reporting) inside the VTune C
 application, `vtune`, which must already be installed and available on the
 path. To collect hot spot profiling information, we execute:
 
-```sh
+```console
 $ rustc --target wasm32-wasip1 fib.rs -C opt-level=z -C lto=yes
 $ vtune -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --profile=vtune fib.wasm
 fib(45) = 1134903170

--- a/docs/examples-pulley.md
+++ b/docs/examples-pulley.md
@@ -158,7 +158,7 @@ doesn't happen the same in LLVM on all architectures).
 Like when compiling to native the `wasmtime objdump` command can be used to
 inspect compiled bytecode:
 
-```sh
+```shell-session
 $ wasmtime compile --target pulley64 foo.wat
 $ wasmtime objdump foo.cwasm --addresses --bytes
 0x000000: wasm[0]::function[20]:
@@ -194,8 +194,8 @@ it has a performance hit for the interpreter. To collect a profile with the
 `wasmtime` CLI you'll have to build from source and enable the `profile-pulley`
 feature:
 
-```sh
-$ cargo run --features profile-pulley --release run --profile pulley --target pulley64 foo.wat
+```console
+cargo run --features profile-pulley --release run --profile pulley --target pulley64 foo.wat
 ```
 
 This will compile an optimized `wasmtime` executable with the `profile-pulley`
@@ -205,8 +205,8 @@ Cargo feature enabled. The `--profile pulley` flag can then be passed to the
 The command will emit a `pulley-$pid.data` file which contains raw data about
 Pulley opcodes and samples taken. To view this file you can use:
 
-```sh
-$ cargo run -p pulley-interpreter --example profiler-html --all-features ./pulley-$pid.data
+```console
+cargo run -p pulley-interpreter --example profiler-html --all-features ./pulley-$pid.data
 ```
 
 This will load the `pulley-*.data` file, parse it, collate the results, and

--- a/docs/lang-go.md
+++ b/docs/lang-go.md
@@ -11,11 +11,11 @@ Make sure you're using Go 1.12 or later with modules support.
 
 First up you'll want to start a new module:
 
-```sh
-$ mkdir hello-wasm
-$ cd hello-wasm
-$ go mod init hello-wasm
-$ go get github.com/bytecodealliance/wasmtime-go
+```console
+mkdir hello-wasm
+cd hello-wasm
+go mod init hello-wasm
+go get github.com/bytecodealliance/wasmtime-go
 ```
 
 Next, copy this example WebAssembly text module into your project. It exports a
@@ -58,7 +58,7 @@ func check(err error) {
 
 And finally we can build and run it:
 
-```sh
+```console
 $ go run main.go
 gcd(6, 27) = 3
 ```

--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -29,9 +29,9 @@ from Rust.
 
 First up let's create a rust project
 
-```sh
-$ cargo new --bin wasmtime_hello
-$ cd wasmtime_hello
+```console
+cargo new --bin wasmtime_hello
+cd wasmtime_hello
 ```
 
 Next you'll want to add `hello.wat` to the root of your project.
@@ -97,7 +97,7 @@ We can build and execute our example with `cargo run`. Note that by depending on
 `wasmtime` you're depending on a JIT compiler, so it may take a moment to build
 all of its dependencies:
 
-```sh
+```shell-session
 $ cargo run
   Compiling ...
   ...

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -39,7 +39,7 @@ run them in a sandbox with sufficient isolation for your threat model.
 To start fuzzing run the following command, where `$MY_FUZZ_TARGET` is one of
 the [available fuzz targets](#available-fuzz-targets):
 
-```shell
+```console
 cargo fuzz run $MY_FUZZ_TARGET
 ```
 
@@ -76,7 +76,7 @@ At the time of writing, we have the following fuzz targets:
 The canonical list of fuzz targets is the `.rs` files in the `fuzz_targets`
 directory:
 
-```shell
+```console
 ls wasmtime/fuzz/fuzz_targets/
 ```
 
@@ -90,7 +90,7 @@ github](https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus).
 
 You can use our corpora by cloning it and placing it at `wasmtime/fuzz/corpus`:
 
-```shell
+```console
 git clone \
     https://github.com/bytecodealliance/wasmtime-libfuzzer-corpus.git \
     wasmtime/fuzz/corpus
@@ -104,8 +104,8 @@ following steps to reproduce it locally:
 1. Download the test case (either the "Minimized Testcase" or "Unminimized
    Testcase" from OSS-Fuzz will do).
 2. Run the test case in the correct fuzz target:
-    ```shell
-    cargo +nightly fuzz run <target> <test case>
+    ```console
+    cargo +nightly fuzz run $MY_FUZZ_TARGET $MY_TEST_CASE
     ```
     If all goes well, the bug should reproduce and libFuzzer will dump the
     failure stack trace to stdout


### PR DESCRIPTION
This commit udpates more instructions on various READMEs to avoid `$` for easy copy-pasting, and also use `console` where appropriate.

NOTE: this is a re-opening after weird GH behavior on https://github.com/bytecodealliance/wasmtime/pull/10666