### PR TITLE
Add RustSec filing to our advisory process

### DIFF
--- a/docs/security-vulnerability-runbook.md
+++ b/docs/security-vulnerability-runbook.md
@@ -91,6 +91,18 @@ is created these steps are followed:
     looks [like
     this](https://groups.google.com/a/bytecodealliance.org/g/sec-announce/c/7SjEU_qSE4U/m/zjW9fWlcAAAJ).
 
+14. **Add the advisory to the [RustSec
+    database](https://github.com/rustsec/advisory-db)**. We mirror our
+    advisories into the RustSec database for projects using Cargo-based tooling
+    to check for security issue with their dependencies. An example of this is
+    [RUSTSEC-2024-0440]. File a PR with the
+    [RustSec/advisory-db](https://github.com/rustsec/advisory-db) repository
+    adding a new file in the `crates/wasmtime` directory. You'll use the file
+    name `RUSTSEC-0000-0000.md` and can copy metadata from a previous advisory.
+    The description should just point to the GitHub advisory published prior.
+
+[RUSTSEC-2024-0440]: https://github.com/rustsec/advisory-db/blob/4584ad9a5ea16ce196317cf4d3593e974fb4a8a1/crates/wasmtime/RUSTSEC-2024-0440.md
+
 You'll want to pay close attention to CI on release day. There's likely going to
 be CI failures with the fix for the vulnerability for some build configurations
 or platforms and such. It should be easy to fix though so mostly try to stay on


### PR DESCRIPTION
All our historical advisories have now been back-filled and it has been ok'd to have a mostly empty description that points to the GitHub advisories we publish in this repository. Update the runbook process with a final step mentioning RustSec.

Closes #10344

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
