### PR TITLE
Cranelift: fix invalid regalloc constraints on try-call with empty handler list.

### DIFF
--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -173,12 +173,19 @@ impl BlockLoweringOrder {
                 }
             });
 
-            // Ensure that blocks terminated by br_table instructions with an empty jump table are
-            // still treated like conditional blocks from the point of view of critical edge
-            // splitting.
+            // Ensure that blocks terminated by br_table instructions
+            // with an empty jump table are still treated like
+            // conditional blocks from the point of view of critical
+            // edge splitting. Also do the same for TryCall and
+            // TryCallIndirect: we cannot have edge moves before the
+            // branch, even if they have empty handler tables and thus
+            // would otherwise have only one successor.
             if let Some(inst) = f.layout.last_inst(block) {
-                if Opcode::BrTable == f.dfg.insts[inst].opcode() {
-                    block_out_count[block] = block_out_count[block].max(2);
+                match f.dfg.insts[inst].opcode() {
+                    Opcode::BrTable | Opcode::TryCall | Opcode::TryCallIndirect => {
+                        block_out_count[block] = block_out_count[block].max(2);
+                    }
+                    _ => {}
                 }
             }
 

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -368,3 +368,40 @@ function %f2(i32) -> i32, f32, f64 {
 ;   popq %rbp
 ;   retq
 
+function %f3() system_v {
+    sig0 = () system_v
+    fn0 = u0:1 sig0
+
+block0:
+    jump block1
+
+block1:
+    try_call fn0(), sig0, block2, []
+
+block2:
+    jump block2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   jmp     label1
+; block1:
+;   load_ext_name userextname0+0, %rcx
+;   call    *%rcx; jmp MachLabel(2); catch []
+; block2:
+;   jmp     label3
+; block3:
+;   jmp     label3
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 u0:1 0
+;   callq *%rcx
+; block2: ; offset 0x10
+;   jmp 0x10
+


### PR DESCRIPTION
(Reported by bjorn3 -- thanks!)

We handle edge splitting for regalloc moves in a way that is designed to split minimally (for compiler performance and codegen quality): we only split edges that are truly critical, i.e., come from a block with more than one successor and go to a block with more than one predecessor. In all other cases, there is always a place for these moves to go: if a block only has one successor, then edge-moves can go before its jump; and if a block only has one predecessor, then edge-moves can go at the beginning of that block (before the blockparams' parallel-move). The former case -- before the branch -- works because of a restriction that regalloc2 imposes: branches with only one target (that is, unconditional branches) cannot have any arguments. Otherwise, those uses would occur after the edge-moves have already shuffled the register state into a state suitable for the next block. Violating this constraint leads to a panic.

With ordinary unconditional branches, this is no problem. With `try_call`s with at least one handler listed, this is also no problem: such a terminator is seen as a branch with (at least) two targets by regalloc, so no edge-moves are placed before it, so it's allowed to have arguments, such as the arguments to the call itself. However, a `try_call` with *no* handler clauses, though pathological, appears to regalloc as an unconditional branch and so should not have any arguments. The included test-case triggers this issue with such a `try_call` together with a normal-return target branch that has more than one incoming edge, forcing the location for the moves into the `try_call`'s block. (The lack of actual edge-moves doesn't matter -- RA2 performs the check on the IR restriction first.) The result is a panic at compile time.

This PR fixes the issue by extending a similar fix for `br_table`s (which can trigger a very similar bug if they have only the default case, i.e., one target) to `try_call{,_indirect}` as well: the lowered-block order computation, where edge-splits are determined, pretends that they always have at least two successors. This ensures that edges will be split as necessary, satisfying the no-arguments-to-unconditional-terminators restriction.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
