### PR TITLE
winch: move reason for ignoring dead code

### DIFF
--- a/winch/codegen/src/lib.rs
+++ b/winch/codegen/src/lib.rs
@@ -1,10 +1,14 @@
 //! Code generation library for Winch.
 
 // Unless this library is compiled with `all-arch`, the rust compiler
-// is going to emit dead code warnings. This directive is fine as long
-// as we configure to run CI at least once with the `all-arch` feature
-// enabled.
-#![cfg_attr(not(feature = "all-arch"), allow(dead_code))]
+// is going to emit dead code warnings.
+#![cfg_attr(
+    not(feature = "all-arch"),
+    allow(
+        dead_code,
+        reason = "this is fine as long as we run CI at least once with the `all-arch` feature enabled"
+    )
+)]
 
 mod abi;
 pub use codegen::{BuiltinFunctions, FuncEnv};


### PR DESCRIPTION
This removes a clippy warning when running:

```
RUSTFLAGS='-D warnings' cargo clippy --workspace --exclude test-programs
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
