### PR TITLE
asm: fix SSE2 feature detection for existing operations

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -55,6 +55,7 @@ pub enum Feature {
     _64b,
     compat,
     sse,
+    sse2,
 }
 
 /// List all CPU features.
@@ -64,7 +65,7 @@ pub enum Feature {
 /// transcribe each variant to an `enum` available in the generated layer above.
 /// If this list is incomplete, we will (fortunately) see compile errors for
 /// generated functions that use the missing variants.
-pub const ALL_FEATURES: &[Feature] = &[Feature::_64b, Feature::compat, Feature::sse];
+pub const ALL_FEATURES: &[Feature] = &[Feature::_64b, Feature::compat, Feature::sse, Feature::sse2];
 
 impl fmt::Display for Feature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -72,6 +73,7 @@ impl fmt::Display for Feature {
             Feature::_64b => write!(f, "_64b"),
             Feature::compat => write!(f, "compat"),
             Feature::sse => write!(f, "sse"),
+            Feature::sse2 => write!(f, "sse2"),
         }
     }
 }

--- a/cranelift/assembler-x64/meta/src/instructions/add.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/add.rs
@@ -63,6 +63,6 @@ pub fn list() -> Vec<Inst> {
         inst("lock_adcq", fmt("MR", [rw(m64), r(r64)]), rex([0xf0, 0x11]).w().r(), _64b),
         // Vector instructions.
         inst("addps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x58]).r(), _64b | compat | sse),
-        inst("addpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x58]).r(), _64b | compat | sse),
+        inst("addpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x58]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/and.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/and.rs
@@ -41,6 +41,6 @@ pub fn list() -> Vec<Inst> {
         inst("lock_andq", fmt("MR", [rw(m64), r(r64)]), rex([0xf0, 0x21]).w().r(), _64b),
         // Vector instructions.
         inst("andps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x54]).r(), _64b | compat | sse),
-        inst("andpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x54]).r(), _64b | compat | sse),
+        inst("andpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x54]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/or.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/or.rs
@@ -34,6 +34,6 @@ pub fn list() -> Vec<Inst> {
         inst("lock_orq", fmt("MR", [rw(m64), r(r64)]), rex([0xf0, 0x09]).w().r(), _64b),
         // Vector instructions.
         inst("orps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x56]).r(), _64b | compat | sse),
-        inst("orpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x56]).r(), _64b | compat | sse),
+        inst("orpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x56]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/sub.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/sub.rs
@@ -63,6 +63,6 @@ pub fn list() -> Vec<Inst> {
         inst("lock_sbbq", fmt("MR", [rw(m64), r(r64)]), rex([0xf0, 0x19]).w().r(), _64b),
         // Vector instructions.
         inst("subps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x5C]).r(), _64b | compat | sse),
-        inst("subpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x5C]).r(), _64b | compat | sse),
+        inst("subpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x5C]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/xor.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/xor.rs
@@ -34,6 +34,6 @@ pub fn list() -> Vec<Inst> {
         inst("lock_xorq", fmt("MR", [rw(m64), r(r64)]), rex([0xf0, 0x31]).w().r(), _64b),
         // Vector instructions.
         inst("xorps", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x0F, 0x57]).r(), _64b | compat | sse),
-        inst("xorpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x57]).r(), _64b | compat | sse),
+        inst("xorpd", fmt("A", [rw(xmm), r(align(rm128))]), rex([0x66, 0x0F, 0x57]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -199,6 +199,7 @@ impl Inst {
                     match f {
                         _64b | compat => {}
                         sse => features.push(InstructionSet::SSE),
+                        sse2 => features.push(InstructionSet::SSE2),
                     }
                 }
                 features


### PR DESCRIPTION
Previously, these `*pd` vector operations had been classified as SSE when in fact they are SSE2. This is not the most critical bug fix, since SSE2 was released in 2000 and all x86 CPUs past that date should have both SSE and SSE2 present. But this corrects the record and illustrates how to add new features.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
