### PR TITLE
Fix broken Component API URLs in documentation

### DIFF
--- a/docs/examples-pre-compiling-wasm.md
+++ b/docs/examples-pre-compiling-wasm.md
@@ -68,6 +68,6 @@ disabled.
   [`wasmtime::Engine::precompile_component`](https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html#method.precompile_component)
 * [`wasmtime::Module::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html#method.deserialize),
   [`wasmtime::Module::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html#method.deserialize_file),
-  [`wasmtime::Component::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/struct.Component.html#method.deserialize),
+  [`wasmtime::component::Component::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/component/struct.Component.html#method.deserialize),
   and
-  [`wasmtime::Component::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/struct.Component.html#method.deserialize_file)
+  [`wasmtime::component::Component::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/component/struct.Component.html#method.deserialize_file)


### PR DESCRIPTION
This commit fixes broken URLs in the pre-compiling-wasm documentation that 
were causing 404 errors. The URLs for Component::deserialize and 
Component::deserialize_file were incorrectly pointing to a non-existent 
path. The fix updates the paths to correctly reflect that the Component 
struct is in the component module, not in the root namespace.