### PR TITLE
x64: enable `select` test

### DIFF
--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -81,7 +81,7 @@ block0(v0: f32, v1: f32):
     v5 = select v2, v3, v4
     return v5
 }
-; runx: %select_le_f32(0x42.42, 0.0) == 0x0.0
+; run: %select_le_f32(0x42.42, 0.0) == 0x0.0
 ; run: %select_le_f32(0.0, 0.0) == 0x1.0
 ; run: %select_le_f32(0x0.0, 0x42.42) == 0x1.0
 ; run: %select_le_f32(0x0.0, NaN) == 0x0.0


### PR DESCRIPTION
I found this while looking around: apparently this test has not been running for several years. This change enables it again.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
