### PR TITLE
fix broken urls in docs; sanitized version of PR #10714

### DIFF
--- a/docs/examples-pre-compiling-wasm.md
+++ b/docs/examples-pre-compiling-wasm.md
@@ -68,6 +68,6 @@ disabled.
   [`wasmtime::Engine::precompile_component`](https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html#method.precompile_component)
 * [`wasmtime::Module::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html#method.deserialize),
   [`wasmtime::Module::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/struct.Module.html#method.deserialize_file),
-  [`wasmtime::Component::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/struct.Component.html#method.deserialize),
+  [`wasmtime::component::Component::deserialize`](https://docs.rs/wasmtime/latest/wasmtime/component/struct.Component.html#method.deserialize),
   and
-  [`wasmtime::Component::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/struct.Component.html#method.deserialize_file)
+  [`wasmtime::component::Component::deserialize_file`](https://docs.rs/wasmtime/latest/wasmtime/component/struct.Component.html#method.deserialize_file)


### PR DESCRIPTION
This commit fixes broken URLs in the pre-compiling-wasm documentation that were causing 404 errors. The URLs for Component::deserialize and Component::deserialize_file were incorrectly pointing to a non-existent path. The fix updates the paths to correctly reflect that the Component struct is in the component module, not in the root namespace.

PR #10714 has a weird branch name with a warning from GitHub I haven't seen before, so rather than merge that lets just land this version where I changed the same typos locally and made a fresh commit, branch, and PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
