### PR TITLE
Refactor call ABI implementation

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -6,7 +6,7 @@ use crate::ir::types::*;
 use crate::ir::MemFlags;
 use crate::ir::{dynamic_to_fixed, ExternalName, LibCall, Signature};
 use crate::isa;
-use crate::isa::aarch64::{inst::*, settings as aarch64_settings, AArch64Backend};
+use crate::isa::aarch64::{inst::*, settings as aarch64_settings};
 use crate::isa::unwind::UnwindInst;
 use crate::isa::winch;
 use crate::machinst::*;
@@ -24,9 +24,6 @@ use std::sync::OnceLock;
 
 /// Support for the AArch64 ABI from the callee side (within a function body).
 pub(crate) type AArch64Callee = Callee<AArch64MachineDeps>;
-
-/// Support for the AArch64 ABI from the caller side (at a callsite).
-pub(crate) type AArch64CallSite = CallSite<AArch64MachineDeps>;
 
 impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
@@ -569,7 +566,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let setup_frame = frame_layout.setup_area_size > 0;
         let mut insts = SmallVec::new();
 
-        match select_api_key(isa_flags, call_conv, setup_frame) {
+        match Self::select_api_key(isa_flags, call_conv, setup_frame) {
             Some(key) => {
                 insts.push(Inst::Paci { key });
                 if flags.unwind_info() {
@@ -675,7 +672,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
     ) -> SmallInstVec<Inst> {
         let setup_frame = frame_layout.setup_area_size > 0;
 
-        match select_api_key(isa_flags, call_conv, setup_frame) {
+        match Self::select_api_key(isa_flags, call_conv, setup_frame) {
             Some(key) => {
                 smallvec![Inst::AuthenticatedRet {
                     key,
@@ -1034,31 +1031,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         insts
     }
 
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Inst; 2]> {
-        let mut insts = SmallVec::new();
-        match dest {
-            CallDest::ExtName(name, RelocDistance::Near) => {
-                let info = Box::new(info.map(|()| name.clone()));
-                insts.push(Inst::Call { info });
-            }
-            CallDest::ExtName(name, RelocDistance::Far) => {
-                insts.push(Inst::LoadExtName {
-                    rd: tmp,
-                    name: Box::new(name.clone()),
-                    offset: 0,
-                });
-                let info = Box::new(info.map(|()| tmp.to_reg()));
-                insts.push(Inst::CallInd { info });
-            }
-            CallDest::Reg(reg) => {
-                let info = Box::new(info.map(|()| *reg));
-                insts.push(Inst::CallInd { info });
-            }
-        }
-
-        insts
-    }
-
     fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         call_conv: isa::CallConv,
         dst: Reg,
@@ -1257,89 +1229,30 @@ impl AArch64MachineDeps {
             step: Imm12::maybe_from_u64(guard_size.into()).unwrap(),
         });
     }
-}
 
-fn select_api_key(
-    isa_flags: &aarch64_settings::Flags,
-    call_conv: isa::CallConv,
-    setup_frame: bool,
-) -> Option<APIKey> {
-    if isa_flags.sign_return_address() && (setup_frame || isa_flags.sign_return_address_all()) {
-        // The `tail` calling convention uses a zero modifier rather than SP
-        // because tail calls may happen with a different stack pointer than
-        // when the function was entered, meaning that it won't be the same when
-        // the return address is decrypted.
-        Some(if isa_flags.sign_return_address_with_bkey() {
-            match call_conv {
-                isa::CallConv::Tail => APIKey::BZ,
-                _ => APIKey::BSP,
-            }
+    pub fn select_api_key(
+        isa_flags: &aarch64_settings::Flags,
+        call_conv: isa::CallConv,
+        setup_frame: bool,
+    ) -> Option<APIKey> {
+        if isa_flags.sign_return_address() && (setup_frame || isa_flags.sign_return_address_all()) {
+            // The `tail` calling convention uses a zero modifier rather than SP
+            // because tail calls may happen with a different stack pointer than
+            // when the function was entered, meaning that it won't be the same when
+            // the return address is decrypted.
+            Some(if isa_flags.sign_return_address_with_bkey() {
+                match call_conv {
+                    isa::CallConv::Tail => APIKey::BZ,
+                    _ => APIKey::BSP,
+                }
+            } else {
+                match call_conv {
+                    isa::CallConv::Tail => APIKey::AZ,
+                    _ => APIKey::ASP,
+                }
+            })
         } else {
-            match call_conv {
-                isa::CallConv::Tail => APIKey::AZ,
-                _ => APIKey::ASP,
-            }
-        })
-    } else {
-        None
-    }
-}
-
-impl AArch64CallSite {
-    pub fn emit_return_call(
-        mut self,
-        ctx: &mut Lower<Inst>,
-        args: isle::ValueSlice,
-        backend: &AArch64Backend,
-    ) {
-        let new_stack_arg_size =
-            u32::try_from(self.sig(ctx.sigs()).sized_stack_arg_space()).unwrap();
-
-        ctx.abi_mut().accumulate_tail_args_size(new_stack_arg_size);
-
-        // Put all arguments in registers and stack slots (within that newly
-        // allocated stack space).
-        self.emit_args(ctx, args);
-        self.emit_stack_ret_arg_for_tail_call(ctx);
-
-        let dest = self.dest().clone();
-        let uses = self.take_uses();
-        let key = select_api_key(&backend.isa_flags, isa::CallConv::Tail, true);
-
-        match dest {
-            CallDest::ExtName(callee, RelocDistance::Near) => {
-                let info = Box::new(ReturnCallInfo {
-                    dest: callee,
-                    uses,
-                    key,
-                    new_stack_arg_size,
-                });
-                ctx.emit(Inst::ReturnCall { info });
-            }
-            CallDest::ExtName(name, RelocDistance::Far) => {
-                let callee = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                ctx.emit(Inst::LoadExtName {
-                    rd: callee,
-                    name: Box::new(name),
-                    offset: 0,
-                });
-                let info = Box::new(ReturnCallInfo {
-                    dest: callee.to_reg(),
-                    uses,
-                    key,
-                    new_stack_arg_size,
-                });
-                ctx.emit(Inst::ReturnCallInd { info });
-            }
-            CallDest::Reg(callee) => {
-                let info = Box::new(ReturnCallInfo {
-                    dest: callee,
-                    uses,
-                    key,
-                    new_stack_arg_size,
-                });
-                ctx.emit(Inst::ReturnCallInd { info });
-            }
+            None
         }
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -4408,17 +4408,37 @@
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl gen_call (SigRef ExternalName RelocDistance ValueSlice) InstOutput)
-(extern constructor gen_call gen_call)
+(decl gen_call_info (Sig ExternalName CallArgList CallRetList OptionTryCallInfo) BoxCallInfo)
+(extern constructor gen_call_info gen_call_info)
 
-(decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
-(extern constructor gen_call_indirect gen_call_indirect)
+(decl gen_call_ind_info (Sig Reg CallArgList CallRetList OptionTryCallInfo) BoxCallIndInfo)
+(extern constructor gen_call_ind_info gen_call_ind_info)
 
-(decl gen_try_call (SigRef ExternalName RelocDistance ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call gen_try_call)
+(decl gen_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
+(extern constructor gen_return_call_info gen_return_call_info)
 
-(decl gen_try_call_indirect (SigRef Value ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call_indirect gen_try_call_indirect)
+(decl gen_return_call_ind_info (Sig Reg CallArgList) BoxReturnCallIndInfo)
+(extern constructor gen_return_call_ind_info gen_return_call_ind_info)
+
+;; Helper for creating `MInst.Call` instructions.
+(decl call_impl (BoxCallInfo) SideEffectNoResult)
+(rule (call_impl info)
+      (SideEffectNoResult.Inst (MInst.Call info)))
+
+;; Helper for creating `MInst.CallInd` instructions.
+(decl call_ind_impl (BoxCallIndInfo) SideEffectNoResult)
+(rule (call_ind_impl info)
+      (SideEffectNoResult.Inst (MInst.CallInd info)))
+
+;; Helper for creating `MInst.ReturnCall` instructions.
+(decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
+(rule (return_call_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnCall info)))
+
+;; Helper for creating `MInst.ReturnCallInd` instructions.
+(decl return_call_ind_impl (BoxReturnCallIndInfo) SideEffectNoResult)
+(rule (return_call_ind_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnCallInd info)))
 
 ;; Helpers for pinned register manipulation.
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2503,20 +2503,71 @@
 (rule (lower (get_return_address))
       (aarch64_link))
 
-;;;; Rules for calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Rules for `call` and `call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (call (func_ref_data sig_ref extname dist) inputs))
-      (gen_call sig_ref extname dist inputs))
+;; Direct call to an in-range function.
+(rule 1 (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl info))))
+        output))
 
-(rule (lower (call_indirect sig_ref val inputs))
-      (gen_call_indirect sig_ref val inputs))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (call (func_ref_data sig_ref name _) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (target Reg (load_ext_name name 0))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_ind_impl info))))
+        output))
 
-(rule (lower_branch (try_call (func_ref_data sig_ref extname dist) inputs et) targets)
-      (gen_try_call sig_ref extname dist et inputs targets))
+;; Indirect call.
+(rule (lower (call_indirect sig_ref ptr args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_ind_impl info))))
+        output))
 
-(rule (lower_branch (try_call_indirect val inputs et) targets)
+;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Direct call to an in-range function.
+(rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi name uses defs trycall)))
+        (emit_side_effect (call_impl info))))
+
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower_branch (try_call (func_ref_data sig_ref name _) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (target Reg (load_ext_name name 0))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_ind_impl info))))
+
+;; Indirect call.
+(rule (lower_branch (try_call_indirect ptr args et) targets)
       (if-let (exception_sig sig_ref) et)
-      (gen_try_call_indirect sig_ref val et inputs targets))
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_ind_impl info))))
 
 ;;;; Rules for `return` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2526,11 +2577,28 @@
 
 ;;;; Rules for `return_call` and `return_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (return_call (func_ref_data sig_ref extname dist) args))
-      (gen_return_call sig_ref extname dist args))
+;; Direct call to an in-range function.
+(rule 1 (lower (return_call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
+        (side_effect (return_call_impl info))))
 
-(rule (lower (return_call_indirect sig_ref callee args))
-      (gen_return_call_indirect sig_ref callee args))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (return_call (func_ref_data sig_ref name _) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (target Reg (load_ext_name name 0))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_ind_impl info))))
+
+;; Indirect call.
+(rule (lower (return_call_indirect sig_ref ptr args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_ind_impl info))))
 
 ;;;; Rules for loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -1,14 +1,14 @@
 //! Implementation of a standard Pulley ABI.
 
 use super::{inst::*, PulleyFlags, PulleyTargetKind};
-use crate::isa::pulley_shared::{PointerWidth, PulleyBackend};
+use crate::isa::pulley_shared::PointerWidth;
 use crate::{
     ir::{self, types::*, MemFlags, Signature},
     isa,
     machinst::*,
     settings, CodegenResult,
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use cranelift_bitset::ScalarBitSet;
 use regalloc2::{MachineEnv, PReg, PRegSet};
@@ -18,9 +18,6 @@ use std::sync::OnceLock;
 
 /// Support for the Pulley ABI from the callee side (within a function body).
 pub(crate) type PulleyCallee<P> = Callee<PulleyMachineDeps<P>>;
-
-/// Support for the Pulley ABI from the caller side (at a callsite).
-pub(crate) type PulleyABICallSite<P> = CallSite<PulleyMachineDeps<P>>;
 
 /// Pulley-specific ABI behavior. This struct just serves as an implementation
 /// point for the trait; it is never actually instantiated.
@@ -446,57 +443,6 @@ where
         SmallVec::new()
     }
 
-    fn gen_call(
-        dest: &CallDest,
-        _tmp: Writable<Reg>,
-        mut info: CallInfo<()>,
-    ) -> SmallVec<[Self::I; 2]> {
-        match dest {
-            // "near" calls are pulley->pulley calls so they use a normal "call"
-            // opcode
-            CallDest::ExtName(name, RelocDistance::Near) => {
-                // The first four integer arguments to a call can be handled via
-                // special pulley call instructions. Assert here that
-                // `info.uses` is sorted in order and then take out x0-x3 if
-                // they're present and move them from `info.uses` to
-                // `info.dest.args` to be handled differently during register
-                // allocation.
-                let mut args = SmallVec::new();
-                info.uses.sort_by_key(|arg| arg.preg);
-                info.uses.retain(|arg| {
-                    if arg.preg != x0() && arg.preg != x1() && arg.preg != x2() && arg.preg != x3()
-                    {
-                        return true;
-                    }
-                    args.push(XReg::new(arg.vreg).unwrap());
-                    false
-                });
-                smallvec![Inst::Call {
-                    info: Box::new(info.map(|()| PulleyCall {
-                        name: name.clone(),
-                        args,
-                    }))
-                }
-                .into()]
-            }
-            // "far" calls are pulley->host calls so they use a different opcode
-            // which is lowered with a special relocation in the backend.
-            CallDest::ExtName(name, RelocDistance::Far) => {
-                smallvec![Inst::IndirectCallHost {
-                    info: Box::new(info.map(|()| name.clone()))
-                }
-                .into()]
-            }
-            // Indirect calls are all assumed to be pulley->pulley calls
-            CallDest::Reg(reg) => {
-                smallvec![Inst::IndirectCall {
-                    info: Box::new(info.map(|()| XReg::new(*reg).unwrap()))
-                }
-                .into()]
-            }
-        }
-    }
-
     fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         _call_conv: isa::CallConv,
         _dst: Reg,
@@ -776,53 +722,6 @@ impl FrameLayout {
             let offset = i32::try_from(offset).unwrap();
             Some((offset, ty, Reg::from(reg.to_reg())))
         })
-    }
-}
-
-impl<P> PulleyABICallSite<P>
-where
-    P: PulleyTargetKind,
-{
-    pub fn emit_return_call(
-        mut self,
-        ctx: &mut Lower<InstAndKind<P>>,
-        args: isle::ValueSlice,
-        _backend: &PulleyBackend<P>,
-    ) {
-        let new_stack_arg_size =
-            u32::try_from(self.sig(ctx.sigs()).sized_stack_arg_space()).unwrap();
-
-        ctx.abi_mut().accumulate_tail_args_size(new_stack_arg_size);
-
-        // Put all arguments in registers and stack slots (within that newly
-        // allocated stack space).
-        self.emit_args(ctx, args);
-        self.emit_stack_ret_arg_for_tail_call(ctx);
-
-        let dest = self.dest().clone();
-        let uses = self.take_uses();
-
-        match dest {
-            CallDest::ExtName(name, RelocDistance::Near) => {
-                let info = Box::new(ReturnCallInfo {
-                    dest: name,
-                    uses,
-                    new_stack_arg_size,
-                });
-                ctx.emit(Inst::ReturnCall { info }.into());
-            }
-            CallDest::ExtName(_name, RelocDistance::Far) => {
-                unimplemented!("return-call of a host function")
-            }
-            CallDest::Reg(callee) => {
-                let info = Box::new(ReturnCallInfo {
-                    dest: XReg::new(callee).unwrap(),
-                    uses,
-                    new_stack_arg_size,
-                });
-                ctx.emit(Inst::ReturnIndirectCall { info }.into());
-            }
-        }
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -708,17 +708,45 @@
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl gen_call (SigRef ExternalName RelocDistance ValueSlice) InstOutput)
-(extern constructor gen_call gen_call)
+(decl gen_call_info (Sig ExternalName CallArgList CallRetList OptionTryCallInfo) BoxCallInfo)
+(extern constructor gen_call_info gen_call_info)
 
-(decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
-(extern constructor gen_call_indirect gen_call_indirect)
+(decl gen_call_ind_info (Sig Reg CallArgList CallRetList OptionTryCallInfo) BoxCallIndInfo)
+(extern constructor gen_call_ind_info gen_call_ind_info)
 
-(decl gen_try_call (SigRef ExternalName RelocDistance ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call gen_try_call)
+(decl gen_call_host_info (Sig ExternalName CallArgList CallRetList OptionTryCallInfo) BoxCallIndirectHostInfo)
+(extern constructor gen_call_host_info gen_call_host_info)
 
-(decl gen_try_call_indirect (SigRef Value ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call_indirect gen_try_call_indirect)
+(decl gen_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
+(extern constructor gen_return_call_info gen_return_call_info)
+
+(decl gen_return_call_ind_info (Sig Reg CallArgList) BoxReturnCallIndInfo)
+(extern constructor gen_return_call_ind_info gen_return_call_ind_info)
+
+;; Helper for creating `MInst.Call` instructions.
+(decl call_impl (BoxCallInfo) SideEffectNoResult)
+(rule (call_impl info)
+      (SideEffectNoResult.Inst (MInst.Call info)))
+
+;; Helper for creating `MInst.IndirectCall` instructions.
+(decl indirect_call_impl (BoxCallIndInfo) SideEffectNoResult)
+(rule (indirect_call_impl info)
+      (SideEffectNoResult.Inst (MInst.IndirectCall info)))
+
+;; Helper for creating `MInst.IndirectCallHost` instructions.
+(decl indirect_call_host_impl (BoxCallIndirectHostInfo) SideEffectNoResult)
+(rule (indirect_call_host_impl info)
+      (SideEffectNoResult.Inst (MInst.IndirectCallHost info)))
+
+;; Helper for creating `MInst.ReturnCall` instructions.
+(decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
+(rule (return_call_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnCall info)))
+
+;; Helper for creating `MInst.ReturnIndirectCall` instructions.
+(decl return_indirect_call_impl (BoxReturnCallIndInfo) SideEffectNoResult)
+(rule (return_indirect_call_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnIndirectCall info)))
 
 ;;;; Helpers for Sign extension ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -138,28 +138,86 @@
 (rule (lower (return args))
       (lower_return args))
 
-;;;; Rules for calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Rules for `call` and `call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (call (func_ref_data sig_ref extname dist) inputs))
-      (gen_call sig_ref extname dist inputs))
+;; Direct call to a pulley function.
+(rule 1 (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl info))))
+        output))
 
-(rule (lower (call_indirect sig_ref val inputs))
-      (gen_call_indirect sig_ref val inputs))
+;; Direct call to a host function.
+(rule (lower (call (func_ref_data sig_ref name _) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallIndirectHostInfo (gen_call_host_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (indirect_call_host_impl info))))
+        output))
 
-(rule (lower_branch (try_call (func_ref_data sig_ref extname dist) inputs et) targets)
-      (gen_try_call sig_ref extname dist et inputs targets))
+;; Indirect call (assumed to be pulley->pulley).
+(rule (lower (call_indirect sig_ref ptr args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (indirect_call_impl info))))
+        output))
 
-(rule (lower_branch (try_call_indirect val inputs et) targets)
+;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Direct call to a pulley function.
+(rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi name uses defs trycall)))
+        (emit_side_effect (call_impl info))))
+
+;; Direct call to a host function.
+(rule (lower_branch (try_call (func_ref_data sig_ref name _) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallIndirectHostInfo (gen_call_host_info abi name uses defs trycall)))
+        (emit_side_effect (indirect_call_host_impl info))))
+
+;; Indirect call (assumed to be pulley->pulley).
+(rule (lower_branch (try_call_indirect ptr args et) targets)
       (if-let (exception_sig sig_ref) et)
-      (gen_try_call_indirect sig_ref val et inputs targets))
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (indirect_call_impl info))))
 
 ;;;; Rules for `return_call` and `return_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (return_call (func_ref_data sig_ref extname dist) args))
-      (gen_return_call sig_ref extname dist args))
+;; Direct call to a pulley function.
+(rule 1 (lower (return_call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
+        (side_effect (return_call_impl info))))
 
-(rule (lower (return_call_indirect sig_ref callee args))
-      (gen_return_call_indirect sig_ref callee args))
+;; Indirect call (assumed to be pulley->pulley).
+(rule (lower (return_call_indirect sig_ref ptr args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_indirect_call_impl info))))
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -8,7 +8,6 @@ use inst::InstAndKind;
 // Types that the generated ISLE code uses via `use super::*`.
 use crate::ir::{condcodes::*, immediates::*, types::*, *};
 use crate::isa::pulley_shared::{
-    abi::*,
     inst::{
         FReg, OperandSize, PulleyCall, ReturnCallInfo, VReg, WritableFReg, WritableVReg,
         WritableXReg, XReg,
@@ -19,11 +18,13 @@ use crate::isa::pulley_shared::{
 use crate::machinst::{
     abi::{ArgPair, RetPair, StackAMode},
     isle::*,
-    CallInfo, IsTailCall, MachInst, Reg, VCodeConstant, VCodeConstantData,
+    CallArgList, CallInfo, CallRetList, MachInst, Reg, VCodeConstant, VCodeConstantData,
 };
 use alloc::boxed::Box;
 use pulley_interpreter::U6;
 use regalloc2::PReg;
+use smallvec::SmallVec;
+
 type Unit = ();
 type VecArgPair = Vec<ArgPair>;
 type VecRetPair = Vec<RetPair>;
@@ -68,7 +69,123 @@ where
     P: PulleyTargetKind,
 {
     crate::isle_lower_prelude_methods!(InstAndKind<P>);
-    crate::isle_prelude_caller_methods!(PulleyABICallSite<P>);
+
+    fn gen_call_info(
+        &mut self,
+        sig: Sig,
+        name: ExternalName,
+        mut uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> BoxCallInfo {
+        let stack_ret_space = self.lower_ctx.sigs()[sig].sized_stack_ret_space();
+        let stack_arg_space = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
+
+        // The first four integer arguments to a call can be handled via
+        // special pulley call instructions. Assert here that
+        // `uses` is sorted in order and then take out x0-x3 if
+        // they're present and move them from `uses` to
+        // `dest.args` to be handled differently during register
+        // allocation.
+        let mut args = SmallVec::new();
+        uses.sort_by_key(|arg| arg.preg);
+        uses.retain(|arg| {
+            if arg.preg != regs::x0()
+                && arg.preg != regs::x1()
+                && arg.preg != regs::x2()
+                && arg.preg != regs::x3()
+            {
+                return true;
+            }
+            args.push(XReg::new(arg.vreg).unwrap());
+            false
+        });
+        let dest = PulleyCall { name, args };
+        Box::new(
+            self.lower_ctx
+                .gen_call_info(sig, dest, uses, defs, try_call_info),
+        )
+    }
+
+    fn gen_call_ind_info(
+        &mut self,
+        sig: Sig,
+        dest: Reg,
+        uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> BoxCallIndInfo {
+        let stack_ret_space = self.lower_ctx.sigs()[sig].sized_stack_ret_space();
+        let stack_arg_space = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
+
+        let dest = XReg::new(dest).unwrap();
+        Box::new(
+            self.lower_ctx
+                .gen_call_info(sig, dest, uses, defs, try_call_info),
+        )
+    }
+
+    fn gen_call_host_info(
+        &mut self,
+        sig: Sig,
+        dest: ExternalName,
+        uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> BoxCallIndirectHostInfo {
+        let stack_ret_space = self.lower_ctx.sigs()[sig].sized_stack_ret_space();
+        let stack_arg_space = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
+
+        Box::new(
+            self.lower_ctx
+                .gen_call_info(sig, dest, uses, defs, try_call_info),
+        )
+    }
+
+    fn gen_return_call_info(
+        &mut self,
+        sig: Sig,
+        dest: ExternalName,
+        uses: CallArgList,
+    ) -> BoxReturnCallInfo {
+        let new_stack_arg_size = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_tail_args_size(new_stack_arg_size);
+
+        Box::new(ReturnCallInfo {
+            dest,
+            uses,
+            new_stack_arg_size,
+        })
+    }
+
+    fn gen_return_call_ind_info(
+        &mut self,
+        sig: Sig,
+        dest: Reg,
+        uses: CallArgList,
+    ) -> BoxReturnCallIndInfo {
+        let new_stack_arg_size = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_tail_args_size(new_stack_arg_size);
+
+        Box::new(ReturnCallInfo {
+            dest: XReg::new(dest).unwrap(),
+            uses,
+            new_stack_arg_size,
+        })
+    }
 
     fn vreg_new(&mut self, r: Reg) -> VReg {
         VReg::new(r).unwrap()

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2944,13 +2944,6 @@
 (rule (lower_branch (br_table index _) targets)
   (lower_br_table index targets))
 
-(rule (lower_branch (try_call (func_ref_data sig_ref extname dist) inputs et) targets)
-      (gen_try_call sig_ref extname dist et inputs targets))
-
-(rule (lower_branch (try_call_indirect val inputs et) targets)
-      (if-let (exception_sig sig_ref) et)
-      (gen_try_call_indirect sig_ref val et inputs targets))
-
 (decl load_ra () Reg)
 (extern constructor load_ra load_ra)
 
@@ -3056,17 +3049,38 @@
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl gen_call (SigRef ExternalName RelocDistance ValueSlice) InstOutput)
-(extern constructor gen_call gen_call)
+(decl gen_call_info (Sig ExternalName CallArgList CallRetList OptionTryCallInfo) BoxCallInfo)
+(extern constructor gen_call_info gen_call_info)
 
-(decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
-(extern constructor gen_call_indirect gen_call_indirect)
+(decl gen_call_ind_info (Sig Reg CallArgList CallRetList OptionTryCallInfo) BoxCallIndInfo)
+(extern constructor gen_call_ind_info gen_call_ind_info)
 
-(decl gen_try_call (SigRef ExternalName RelocDistance ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call gen_try_call)
+(decl gen_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
+(extern constructor gen_return_call_info gen_return_call_info)
 
-(decl gen_try_call_indirect (SigRef Value ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call_indirect gen_try_call_indirect)
+(decl gen_return_call_ind_info (Sig Reg CallArgList) BoxReturnCallIndInfo)
+(extern constructor gen_return_call_ind_info gen_return_call_ind_info)
+
+;; Helper for creating `MInst.Call` instructions.
+(decl call_impl (BoxCallInfo) SideEffectNoResult)
+(rule (call_impl info)
+      (SideEffectNoResult.Inst (MInst.Call info)))
+
+;; Helper for creating `MInst.CallInd` instructions.
+(decl call_ind_impl (BoxCallIndInfo) SideEffectNoResult)
+(rule (call_ind_impl info)
+      (SideEffectNoResult.Inst (MInst.CallInd info)))
+
+;; Helper for creating `MInst.ReturnCall` instructions.
+(decl return_call_impl (BoxReturnCallInfo) SideEffectNoResult)
+(rule (return_call_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnCall info)))
+
+;; Helper for creating `MInst.ReturnCallInd` instructions.
+(decl return_call_ind_impl (BoxReturnCallIndInfo) SideEffectNoResult)
+(rule (return_call_ind_impl info)
+      (SideEffectNoResult.Inst (MInst.ReturnCallInd info)))
+
 
 ;;; this is trying to imitate aarch64 `madd` instruction.
 (decl madd (XReg XReg XReg) XReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -2666,20 +2666,94 @@
 
 ;;;; Rules for calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (call (func_ref_data sig_ref extname dist) inputs))
-  (gen_call sig_ref extname dist inputs))
+;; Direct call to an in-range function.
+(rule 1 (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl info))))
+        output))
 
-(rule (lower (call_indirect sig_ref val inputs))
-  (gen_call_indirect sig_ref val inputs))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (call (func_ref_data sig_ref name _) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (target Reg (load_ext_name name 0))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_ind_impl info))))
+        output))
+
+;; Indirect call.
+(rule (lower (call_indirect sig_ref ptr args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_ind_impl info))))
+        output))
+
+;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Direct call to an in-range function.
+(rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi name uses defs trycall)))
+        (emit_side_effect (call_impl info))))
+
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower_branch (try_call (func_ref_data sig_ref name _) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (target Reg (load_ext_name name 0))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_ind_impl info))))
+
+;; Indirect call.
+(rule (lower_branch (try_call_indirect ptr args et) targets)
+      (if-let (exception_sig sig_ref) et)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_ind_impl info))))
 
 ;;;; Rules for `return_call` and `return_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (return_call (func_ref_data sig_ref extname dist) args))
-      (gen_return_call sig_ref extname dist args))
+;; Direct call to an in-range function.
+(rule 1 (lower (return_call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
+        (side_effect (return_call_impl info))))
 
-(rule (lower (return_call_indirect sig_ref callee args))
-      (gen_return_call_indirect sig_ref callee args))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (return_call (func_ref_data sig_ref name _) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (target Reg (load_ext_name name 0))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_ind_impl info))))
 
+;; Indirect call.
+(rule (lower (return_call_indirect sig_ref ptr args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_ind_impl info))))
 
 ;;;; Rules for `extractlane` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -256,10 +256,11 @@ pub static REG_SAVE_AREA_SIZE: u32 = 160;
 impl Into<MemArg> for StackAMode {
     fn into(self) -> MemArg {
         match self {
-            // Argument area always begins at the initial SP.
-            StackAMode::IncomingArg(off, _) => MemArg::InitialSPOffset { off },
+            StackAMode::IncomingArg(off, stack_args_size) => MemArg::IncomingArgOffset {
+                off: off - stack_args_size as i64,
+            },
             StackAMode::Slot(off) => MemArg::SlotOffset { off },
-            StackAMode::OutgoingArg(off) => MemArg::NominalSPOffset { off },
+            StackAMode::OutgoingArg(off) => MemArg::OutgoingArgOffset { off },
         }
     }
 }
@@ -317,14 +318,6 @@ impl ABIMachineSpec for S390xMachineDeps {
         let mut next_fpr = 0;
         let mut next_vr = 0;
         let mut next_stack: u32 = 0;
-
-        // The bottom of the stack frame holds the register save area.  To simplify
-        // offset computation, include this area as part of the argument area;
-        // however, this does not apply to the tail-call convention, which uses the
-        // callee frame instead to pass arguments.
-        if call_conv != isa::CallConv::Tail && args_or_rets == ArgsOrRets::Args {
-            next_stack = REG_SAVE_AREA_SIZE;
-        }
 
         let ret_area_ptr = if add_ret_area_ptr {
             debug_assert_eq!(args_or_rets, ArgsOrRets::Args);
@@ -471,30 +464,12 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
 
         // With the tail-call convention, arguments are passed in the *callee*'s
-        // frame instead of the caller's frame.  Update all offsets accordingly
-        // (note that resulting offsets will all be negative).
+        // frame instead of the caller's frame.  This means that the register save
+        // area will lie between the incoming arguments and the return buffer.
+        // Include the size of the register area in the argument area size to
+        // match common code expectation that the return buffer resides immediately
+        // above the argument area.
         if call_conv == isa::CallConv::Tail && args_or_rets == ArgsOrRets::Args && next_stack != 0 {
-            for arg in args.args_mut() {
-                match arg {
-                    ABIArg::Slots { slots, .. } => {
-                        for slot in slots {
-                            match slot {
-                                ABIArgSlot::Reg { .. } => {}
-                                ABIArgSlot::Stack { offset, .. } => {
-                                    *offset -= next_stack as i64;
-                                }
-                            }
-                        }
-                    }
-                    ABIArg::StructArg { .. } => unreachable!(),
-                    ABIArg::ImplicitPtrArg { offset, .. } => {
-                        *offset -= next_stack as i64;
-                    }
-                }
-            }
-            // If we have any stack arguments, also allow for a temporary copy
-            // of the register save area.  This is only used until the callee
-            // has finished setting up its own frame.
             next_stack += REG_SAVE_AREA_SIZE;
         }
 
@@ -862,10 +837,6 @@ impl ABIMachineSpec for S390xMachineDeps {
         insts
     }
 
-    fn gen_call(_dest: &CallDest, _tmp: Writable<Reg>, _info: CallInfo<()>) -> SmallVec<[Inst; 2]> {
-        unreachable!();
-    }
-
     fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         _call_conv: isa::CallConv,
         _dst: Reg,
@@ -1063,43 +1034,12 @@ impl S390xMachineDeps {
         // Helper routine to lane-swap a register if needed.
         let lane_swap_if_needed = |insts: &mut SmallInstVec<Inst>, vreg, ty: Type| {
             if LaneOrder::from(info.caller_conv) != LaneOrder::from(info.callee_conv) {
-                if ty.is_vector() {
-                    if ty.lane_count() >= 2 {
-                        insts.push(Inst::VecPermuteDWImm {
-                            rd: vreg,
-                            rn: vreg.to_reg(),
-                            rm: vreg.to_reg(),
-                            idx1: 1,
-                            idx2: 0,
-                        });
-                    }
-                    if ty.lane_count() >= 4 {
-                        insts.push(Inst::VecShiftRR {
-                            shift_op: VecShiftOp::RotL64x2,
-                            rd: vreg,
-                            rn: vreg.to_reg(),
-                            shift_imm: 32,
-                            shift_reg: zero_reg(),
-                        });
-                    }
-                    if ty.lane_count() >= 8 {
-                        insts.push(Inst::VecShiftRR {
-                            shift_op: VecShiftOp::RotL32x4,
-                            rd: vreg,
-                            rn: vreg.to_reg(),
-                            shift_imm: 16,
-                            shift_reg: zero_reg(),
-                        });
-                    }
-                    if ty.lane_count() >= 16 {
-                        insts.push(Inst::VecShiftRR {
-                            shift_op: VecShiftOp::RotL16x8,
-                            rd: vreg,
-                            rn: vreg.to_reg(),
-                            shift_imm: 8,
-                            shift_reg: zero_reg(),
-                        });
-                    }
+                if ty.is_vector() && ty.lane_count() >= 2 {
+                    insts.push(Inst::VecEltRev {
+                        lane_count: ty.lane_count(),
+                        rd: vreg,
+                        rn: vreg.to_reg(),
+                    });
                 }
             }
         };

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -886,6 +886,12 @@
       (rn Reg)
       (lane_imm u8))
 
+    ;; Synthetic instruction to reverse vector elements in-register.
+    (VecEltRev
+      (lane_count u32)
+      (rd WritableReg)
+      (rn Reg))
+
     ;; Allocate stack space for outgoing tail-call arguments.
     (AllocateArgs
       (size u32))
@@ -1013,25 +1019,19 @@
 
 ;; Primitive types used in instruction formats.
 
+(type CallInstDest (primitive CallInstDest))
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
 (type VecMachLabel extern (enum))
 
-;; Information about a call site.
-(type CallSiteInfo (primitive CallSiteInfo))
-(decl call_site_info (BoxCallInfo InstOutput) CallSiteInfo)
-(extern extractor infallible call_site_info call_site_info_split)
+(decl call_inst_dest_direct (ExternalName) CallInstDest)
+(extern constructor call_inst_dest_direct call_inst_dest_direct)
+(convert ExternalName CallInstDest call_inst_dest_direct)
 
-;; The destination of a call instruction.
-(type CallInstDest
-  (enum
-    ;; Direct call.
-    (Direct
-      (name ExternalName))
-    ;; Indirect call.
-    (Indirect
-      (reg Reg))))
+(decl call_inst_dest_indirect (Reg) CallInstDest)
+(extern constructor call_inst_dest_indirect call_inst_dest_indirect)
+(convert Reg CallInstDest call_inst_dest_indirect)
 
 ;; A symbol reference carrying relocation information.
 (type SymbolReloc
@@ -1775,9 +1775,6 @@
 
 (type MemArg extern (enum))
 
-(decl memarg_flags (MemArg) MemFlags)
-(extern constructor memarg_flags memarg_flags)
-
 (decl memarg_reg_plus_reg (Reg Reg u8 MemFlags) MemArg)
 (extern constructor memarg_reg_plus_reg memarg_reg_plus_reg)
 
@@ -1789,10 +1786,6 @@
 
 (decl memarg_got () MemArg)
 (extern constructor memarg_got memarg_got)
-
-;; Add an offset to a virtual MemArg.
-(decl memarg_offset (MemArg i64) MemArg)
-(extern constructor memarg_offset memarg_offset)
 
 ;; Form the sum of two offset values, and check that the result is
 ;; a valid `MemArg::Symbol` offset (i.e. is even and fits into i32).
@@ -2659,6 +2652,13 @@
             (_ Unit (emit (MInst.VecReplicateLane size dst src lane_imm))))
         dst))
 
+;; Helper for emitting `MInst.VecEltRev` instructions.
+(decl vec_elt_rev (Type Reg) Reg)
+(rule (vec_elt_rev ty @ (multi_lane _ lanes) src)
+      (let ((dst WritableReg (temp_writable_reg ty))
+            (_ Unit (emit (MInst.VecEltRev lanes dst src))))
+        dst))
+
 ;; Helper for emitting `MInst.LoadSymbolReloc` instructions.
 (decl load_symbol_reloc (SymbolReloc) Reg)
 (rule (load_symbol_reloc symbol_reloc)
@@ -2833,97 +2833,6 @@
 (decl sp () Reg)
 (rule (sp)
       (mov_preg (preg_stack)))
-
-;; Helpers for accessing argument / return value slots ;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl arg_store (Type Reg MemArg) SideEffectNoResult)
-(rule (arg_store $I8 reg mem) (store8 reg mem))
-(rule (arg_store $I16 reg mem) (store16 reg mem))
-(rule (arg_store $I32 reg mem) (store32 reg mem))
-(rule (arg_store $I64 reg mem) (store64 reg mem))
-(rule (arg_store $F16 reg mem) (vec_store_lane $F16X8 reg mem 0))
-(rule (arg_store $F32 reg mem) (vec_store_lane $F32X4 reg mem 0))
-(rule (arg_store $F64 reg mem) (vec_store_lane $F64X2 reg mem 0))
-(rule -1 (arg_store (vr128_ty ty) reg mem) (vec_store reg mem))
-
-;; Helper to perform a lane swap in register.
-(decl vec_elt_rev (Type Reg) Reg)
-(rule (vec_elt_rev (multi_lane 64 2) reg)
-      (vec_permute_dw_imm $I64X2 reg 1 reg 0))
-(rule (vec_elt_rev (multi_lane 32 4) reg)
-      (let ((rev Reg (vec_permute_dw_imm $I64X2 reg 1 reg 0)))
-        (vec_rot_imm $I64X2 rev 32)))
-(rule (vec_elt_rev (multi_lane 16 8) reg)
-      (let ((rev Reg (vec_permute_dw_imm $I64X2 reg 1 reg 0)))
-        (vec_rot_imm $I32X4 (vec_rot_imm $I64X2 rev 32) 16)))
-(rule (vec_elt_rev (multi_lane 8 16) reg)
-      (let ((rev Reg (vec_permute_dw_imm $I64X2 reg 1 reg 0)))
-        (vec_rot_imm $I16X8 (vec_rot_imm $I32X4 (vec_rot_imm $I64X2 rev 32) 16) 8)))
-
-;; When passing a vector value to a function whose ABI uses a different
-;; lane order than the current function, we need to swap lanes.
-;; The first operand is the lane order used by the callee.
-(decl abi_vec_elt_rev (LaneOrder Type Reg) Reg)
-(rule 5 (abi_vec_elt_rev _ (gpr32_ty ty) reg) reg)
-(rule 4 (abi_vec_elt_rev _ (gpr64_ty ty) reg) reg)
-(rule 3 (abi_vec_elt_rev _ $I128 reg) reg)
-(rule 3 (abi_vec_elt_rev _ $F128 reg) reg)
-(rule 2 (abi_vec_elt_rev _ (ty_scalar_float ty) reg) reg)
-(rule 0 (abi_vec_elt_rev callee_lane_order _ reg)
-      (if-let true (lane_order_equal callee_lane_order (lane_order)))
-      reg)
-(rule 1 (abi_vec_elt_rev callee_lane_order (ty_vec128 ty) reg)
-      (if-let false (lane_order_equal callee_lane_order (lane_order)))
-      (vec_elt_rev ty reg))
-
-;; Prepare a stack copy of a single (oversized) argument.
-(decl copy_to_buffer (MemArg ABIArg Value) InstOutput)
-(rule 2 (copy_to_buffer base (abi_arg_only_slot slot) _) (output_none))
-(rule 0 (copy_to_buffer base (abi_arg_implicit_pointer _ offset ty)
-                      val @ (value_type ty))
-      (side_effect (arg_store ty val (memarg_offset base offset))))
-
-;; Copy a single argument/return value to its slots.
-;; For oversized arguments, set the slot to the buffer address.
-(decl copy_to_arg (CallArgListBuilder LaneOrder MemArg ABIArg Value) InstOutput)
-(rule 2 (copy_to_arg uses lo base (abi_arg_only_slot slot) val)
-      (copy_reg_to_arg_slot uses lo base slot (prepare_arg_val slot val)))
-(rule 0 (copy_to_arg uses lo base (abi_arg_implicit_pointer slot offset _) _)
-      (let ((ptr Reg (load_addr (memarg_offset base offset))))
-        (copy_reg_to_arg_slot uses lo base slot ptr)))
-
-;; Place one component of an argument/return value into a register.
-;; Copy reference values into registers of integer type.
-;; Zero- or sign-extend as required by the ABI.
-(decl prepare_arg_val (ABIArgSlot Value) Reg)
-(rule (prepare_arg_val (ABIArgSlot.Reg _ _ (ArgumentExtension.None)) val)
-      val)
-(rule (prepare_arg_val (ABIArgSlot.Reg _ _ (ArgumentExtension.Uext)) val)
-      (put_in_reg_zext64 val))
-(rule (prepare_arg_val (ABIArgSlot.Reg _ _ (ArgumentExtension.Sext)) val)
-      (put_in_reg_sext64 val))
-(rule (prepare_arg_val (ABIArgSlot.Stack _ _ (ArgumentExtension.None)) val)
-      val)
-(rule (prepare_arg_val (ABIArgSlot.Stack _ _ (ArgumentExtension.Uext)) val)
-      (put_in_reg_zext64 val))
-(rule (prepare_arg_val (ABIArgSlot.Stack _ _ (ArgumentExtension.Sext)) val)
-      (put_in_reg_sext64 val))
-
-;; Copy one component of an argument/return value to its slot, where the
-;; value is already extended and present in a register.
-(decl copy_reg_to_arg_slot (CallArgListBuilder LaneOrder MemArg ABIArgSlot Reg) InstOutput)
-(rule (copy_reg_to_arg_slot uses lo _ (ABIArgSlot.Reg reg ty ext) src)
-      (let ((_ Unit (args_builder_push uses (abi_vec_elt_rev lo ty src) reg)))
-        (output_none)))
-(rule (copy_reg_to_arg_slot _ lo base (ABIArgSlot.Stack offset ty ext) src)
-      (side_effect (arg_store (abi_ext_ty ext ty) (abi_vec_elt_rev lo ty src)
-                              (memarg_offset base offset))))
-
-;; Helper to compute the type of an implicitly extended argument/return value.
-(decl abi_ext_ty (ArgumentExtension Type) Type)
-(rule 0 (abi_ext_ty _ ty) ty)
-(rule 1 (abi_ext_ty (ArgumentExtension.Uext) (gpr32_ty _)) $I64)
-(rule 1 (abi_ext_ty (ArgumentExtension.Sext) (gpr32_ty _)) $I64)
 
 
 ;; Helpers for generating immediate values ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3474,63 +3383,23 @@
 
 ;; Helpers for generating `call` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Partial (mutable) argument list in the process of being created.
-(type CallArgListBuilder extern (enum))
+(decl gen_call_info (Sig CallInstDest CallArgList CallRetList OptionTryCallInfo) BoxCallInfo)
+(extern constructor gen_call_info gen_call_info)
 
-;; Create a new empty instruction sequence builder.
-(decl args_builder_new () CallArgListBuilder)
-(extern constructor args_builder_new args_builder_new)
+(decl gen_return_call_info (Sig CallInstDest CallArgList) BoxReturnCallInfo)
+(extern constructor gen_return_call_info gen_return_call_info)
 
-;; Push an instruction to a sequence under construction.
-(decl args_builder_push (CallArgListBuilder Reg RealReg) Unit)
-(extern constructor args_builder_push args_builder_push)
+(decl abi_emit_call_adjust_stack (Sig) Unit)
+(extern constructor abi_emit_call_adjust_stack abi_emit_call_adjust_stack)
 
-;; Complete the sequence under construction.
-(decl args_builder_finish (CallArgListBuilder) CallArgList)
-(extern constructor args_builder_finish args_builder_finish)
+(decl abi_emit_return_call_adjust_stack (Sig) Unit)
+(extern constructor abi_emit_return_call_adjust_stack abi_emit_return_call_adjust_stack)
 
-(decl abi_sig (SigRef) Sig)
-(extern constructor abi_sig abi_sig)
-
-(decl abi_call_site_info (Sig CallInstDest CallArgList) CallSiteInfo)
-(extern constructor abi_call_site_info abi_call_site_info)
-
-(decl abi_try_call_info (Sig CallInstDest CallArgList ExceptionTable MachLabelSlice) BoxCallInfo)
-(extern constructor abi_try_call_info abi_try_call_info)
-
-(decl abi_return_call_info (Sig CallInstDest CallArgList) BoxReturnCallInfo)
-(extern constructor abi_return_call_info abi_return_call_info)
-
-(decl abi_call_stack_args (Sig) MemArg)
-(extern constructor abi_call_stack_args abi_call_stack_args)
-
-(decl abi_call_stack_rets (Sig) MemArg)
-(extern constructor abi_call_stack_rets abi_call_stack_rets)
-
-(decl abi_return_call_stack_args (Sig) MemArg)
-(extern constructor abi_return_call_stack_args abi_return_call_stack_args)
+(decl abi_prepare_args (Sig ValueSlice) ValueRegsVec)
+(extern constructor abi_prepare_args abi_prepare_args)
 
 (decl writable_link_reg () WritableReg)
 (rule (writable_link_reg) (writable_gpr 14))
-
-(decl abi_call (Sig CallInstDest CallArgList) InstOutput)
-(rule (abi_call abi dest uses)
-      (abi_call_impl (abi_call_site_info abi dest uses)))
-(decl abi_call_impl (CallSiteInfo) InstOutput)
-(rule (abi_call_impl (call_site_info info output))
-      (let ((_ Unit (emit_side_effect (call_impl (writable_link_reg) info))))
-        output))
-
-(decl abi_return_call (Sig CallInstDest CallArgList) SideEffectNoResult)
-(rule (abi_return_call abi dest uses)
-      (return_call_impl (abi_return_call_info abi dest uses)))
-
-(decl abi_try_call (Sig CallInstDest CallArgList ExceptionTable MachLabelSlice) SideEffectNoResult)
-(rule (abi_try_call abi dest uses et targets)
-      (call_impl (writable_link_reg) (abi_try_call_info abi dest uses et targets)))
-
-(decl abi_lane_order (Sig) LaneOrder)
-(extern constructor abi_lane_order abi_lane_order)
 
 
 ;; Helpers for generating vector pack and unpack instructions ;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -1781,6 +1781,12 @@
       (abi_vec_elt_rev (lane_order_from_memflags flags) out_ty
         (abi_vec_elt_rev (lane_order_from_memflags flags) in_ty x)))
 
+(decl abi_vec_elt_rev (LaneOrder Type Reg) Reg)
+(rule 1 (abi_vec_elt_rev callee_lane_order (ty_vec128 ty) reg)
+      (if-let false (lane_order_equal callee_lane_order (lane_order)))
+      (vec_elt_rev ty reg))
+(rule 0 (abi_vec_elt_rev _ _ reg) reg)
+
 
 ;;;; Rules for `insertlane` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3920,33 +3926,38 @@
 
 ;; Direct call to an in-range function.
 (rule 1 (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
-      (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
-        (abi_call abi (CallInstDest.Direct name) uses)))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl (writable_link_reg) info))))
+        output))
 
 ;; Direct call to an out-of-range function (implicitly via pointer).
 (rule (lower (call (func_ref_data sig_ref name _) args))
-      (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args))
-            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0))))
-        (abi_call abi (CallInstDest.Indirect target) uses)))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_call_rets abi output))
+            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
+            (info BoxCallInfo (gen_call_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl (writable_link_reg) info))))
+        output))
 
 ;; Indirect call.
 (rule (lower (call_indirect sig_ref ptr args))
-      (let ((abi Sig (abi_sig sig_ref))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
             (target Reg (put_in_reg ptr))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
-        (abi_call abi (CallInstDest.Indirect target) uses)))
-
-;; Lower function arguments.
-(decl lower_call_args (Sig Range ValueSlice) CallArgList)
-(rule (lower_call_args abi range args)
-      (let ((uses CallArgListBuilder (args_builder_new))
-            (stack MemArg (abi_call_stack_args abi))
-            (_ InstOutput (lower_call_args_buffer abi stack range args))
-            (_ InstOutput (lower_call_args_slots abi uses stack range args))
-            (_ InstOutput (lower_call_ret_arg abi uses stack)))
-        (args_builder_finish uses)))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_impl (writable_link_reg) info))))
+        output))
 
 
 ;;;; Rules for `return_call` and `return_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3954,32 +3965,28 @@
 ;; Direct tail call to an in-range function.
 (rule 1 (lower (return_call (func_ref_data sig_ref name (reloc_distance_near)) args))
       (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_return_call_args abi (range 0 (abi_num_args abi)) args)))
-        (side_effect (abi_return_call abi (CallInstDest.Direct name) uses))))
+            (_ Unit (abi_emit_return_call_adjust_stack abi))
+            (uses CallArgList (gen_return_call_args abi (abi_prepare_args abi args)))
+            (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
+        (side_effect (return_call_impl info))))
 
 ;; Direct tail call to an out-of-range function (implicitly via pointer).
 (rule (lower (return_call (func_ref_data sig_ref name _) args))
       (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_return_call_args abi (range 0 (abi_num_args abi)) args))
-            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0))))
-        (side_effect (abi_return_call abi (CallInstDest.Indirect target) uses))))
+            (_ Unit (abi_emit_return_call_adjust_stack abi))
+            (uses CallArgList (gen_return_call_args abi (abi_prepare_args abi args)))
+            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
+            (info BoxReturnCallInfo (gen_return_call_info abi target uses)))
+        (side_effect (return_call_impl info))))
 
 ;; Indirect tail call.
 (rule (lower (return_call_indirect sig_ref ptr args))
       (let ((abi Sig (abi_sig sig_ref))
             (target Reg (put_in_reg ptr))
-            (uses CallArgList (lower_return_call_args abi (range 0 (abi_num_args abi)) args)))
-        (side_effect (abi_return_call abi (CallInstDest.Indirect target) uses))))
-
-;; Lower tail call function arguments.
-(decl lower_return_call_args (Sig Range ValueSlice) CallArgList)
-(rule (lower_return_call_args abi range args)
-      (let ((uses CallArgListBuilder (args_builder_new))
-            (stack MemArg (abi_return_call_stack_args abi))
-            (_ InstOutput (lower_call_args_buffer abi stack range args))
-            (_ InstOutput (lower_call_args_slots abi uses stack range args))
-            (_ InstOutput (lower_return_call_ret_arg abi uses stack)))
-        (args_builder_finish uses)))
+            (_ Unit (abi_emit_return_call_adjust_stack abi))
+            (uses CallArgList (gen_return_call_args abi (abi_prepare_args abi args)))
+            (info BoxReturnCallInfo (gen_return_call_info abi target uses)))
+        (side_effect (return_call_impl info))))
 
 
 ;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3987,57 +3994,35 @@
 ;; Direct call to an in-range function.
 (rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
       (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
-        (emit_side_effect (abi_try_call abi (CallInstDest.Direct name) uses et targets))))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi name uses defs trycall)))
+        (emit_side_effect (call_impl (writable_link_reg) info))))
 
 ;; Direct call to an out-of-range function (implicitly via pointer).
 (rule (lower_branch (try_call (func_ref_data sig_ref name _) args et) targets)
       (let ((abi Sig (abi_sig sig_ref))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args))
-            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0))))
-        (emit_side_effect (abi_try_call abi (CallInstDest.Indirect target) uses et targets))))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_try_call_rets abi))
+            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
+            (info BoxCallInfo (gen_call_info abi target uses defs trycall)))
+        (emit_side_effect (call_impl (writable_link_reg) info))))
 
 ;; Indirect call.
 (rule (lower_branch (try_call_indirect ptr args et) targets)
       (if-let (exception_sig sig_ref) et)
       (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
             (target Reg (put_in_reg ptr))
-            (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args)))
-        (emit_side_effect (abi_try_call abi (CallInstDest.Indirect target) uses et targets))))
-
-
-;;;; Common helpers for argument lowering ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; Lower function arguments (part 1): prepare buffer copies.
-(decl lower_call_args_buffer (Sig MemArg Range ValueSlice) InstOutput)
-(rule (lower_call_args_buffer abi _ (range_empty) _) (output_none))
-(rule (lower_call_args_buffer abi stack (range_unwrap head tail) args)
-      (let ((_ InstOutput (copy_to_buffer stack (abi_get_arg abi head)
-                                          (value_slice_get args head))))
-        (lower_call_args_buffer abi stack tail args)))
-
-;; Lower function arguments (part 2): set up registers / stack slots.
-(decl lower_call_args_slots (Sig CallArgListBuilder MemArg Range ValueSlice) InstOutput)
-(rule (lower_call_args_slots abi _ _ (range_empty) _) (output_none))
-(rule (lower_call_args_slots abi uses stack (range_unwrap head tail) args)
-      (let ((_ InstOutput (copy_to_arg uses (abi_lane_order abi)
-                                       stack (abi_get_arg abi head)
-                                       (value_slice_get args head))))
-        (lower_call_args_slots abi uses stack tail args)))
-
-;; Lower function arguments (part 3): implicit return-area pointer (call).
-(decl lower_call_ret_arg (Sig CallArgListBuilder MemArg) InstOutput)
-(rule (lower_call_ret_arg (abi_no_ret_arg) _ _) (output_none))
-(rule 1 (lower_call_ret_arg abi @ (abi_ret_arg (abi_arg_only_slot slot)) uses stack)
-      (copy_reg_to_arg_slot uses (abi_lane_order abi)
-                            stack slot (load_addr (abi_call_stack_rets abi))))
-
-;; Lower function arguments (part 3): implicit return-area pointer (return call).
-(decl lower_return_call_ret_arg (Sig CallArgListBuilder MemArg) InstOutput)
-(rule (lower_return_call_ret_arg (abi_no_ret_arg) _ _) (output_none))
-(rule 1 (lower_return_call_ret_arg abi @ (abi_ret_arg (abi_arg_only_slot slot)) uses stack)
-      (copy_reg_to_arg_slot uses (abi_lane_order abi)
-                            stack slot (abi_unwrap_ret_area_ptr)))
+            (_ Unit (abi_emit_call_adjust_stack abi))
+            (uses CallArgList (gen_call_args abi (abi_prepare_args abi args)))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi target uses defs trycall)))
+        (emit_side_effect (call_impl (writable_link_reg) info))))
 
 
 ;;;; Rules for `get_{frame,stack}_pointer` and `get_return_address` ;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2469,17 +2469,38 @@
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl gen_call (SigRef ExternalName RelocDistance ValueSlice) InstOutput)
-(extern constructor gen_call gen_call)
+(decl gen_call_info (Sig ExternalName CallArgList CallRetList OptionTryCallInfo) BoxCallInfo)
+(extern constructor gen_call_info gen_call_info)
 
-(decl gen_call_indirect (SigRef Value ValueSlice) InstOutput)
-(extern constructor gen_call_indirect gen_call_indirect)
+(decl gen_call_ind_info (Sig RegMem CallArgList CallRetList OptionTryCallInfo) BoxCallIndInfo)
+(extern constructor gen_call_ind_info gen_call_ind_info)
 
-(decl gen_try_call (SigRef ExternalName RelocDistance ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call gen_try_call)
+(decl gen_return_call_info (Sig ExternalName CallArgList) BoxReturnCallInfo)
+(extern constructor gen_return_call_info gen_return_call_info)
 
-(decl gen_try_call_indirect (SigRef Value ExceptionTable ValueSlice MachLabelSlice) Unit)
-(extern constructor gen_try_call_indirect gen_try_call_indirect)
+(decl gen_return_call_ind_info (Sig Reg CallArgList) BoxReturnCallIndInfo)
+(extern constructor gen_return_call_ind_info gen_return_call_ind_info)
+
+;; Helper for creating `CallKnown` instructions.
+(decl call_known (BoxCallInfo) SideEffectNoResult)
+(rule (call_known info)
+      (SideEffectNoResult.Inst (MInst.CallKnown info)))
+
+;; Helper for creating `CallUnknown` instructions.
+(decl call_unknown (BoxCallIndInfo) SideEffectNoResult)
+(rule (call_unknown info)
+      (SideEffectNoResult.Inst (MInst.CallUnknown info)))
+
+;; Helper for creating `ReturnCallKnown` instructions.
+(decl return_call_known (BoxReturnCallInfo) SideEffectNoResult)
+(rule (return_call_known info)
+      (SideEffectNoResult.Inst (MInst.ReturnCallKnown info)))
+
+;; Helper for creating `ReturnCallUnknown` instructions.
+(decl return_call_unknown (BoxReturnCallIndInfo) SideEffectNoResult)
+(rule (return_call_unknown info)
+      (SideEffectNoResult.Inst (MInst.ReturnCallUnknown info)))
+
 
 ;;;; Helpers for emitting stack switches ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3468,28 +3468,94 @@
 
 ;; Rules for `call` and `call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (call (func_ref_data sig_ref extname dist) inputs))
-      (gen_call sig_ref extname dist inputs))
+;; Direct call to an in-range function.
+(rule 1 (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallInfo (gen_call_info abi name uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_known info))))
+        output))
 
-(rule (lower (call_indirect sig_ref val inputs))
-      (gen_call_indirect sig_ref val inputs))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (call (func_ref_data sig_ref name dist) args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (target RegMem (RegMem.Reg (load_ext_name name 0 dist)))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_unknown info))))
+        output))
+
+;; Indirect call.
+(rule (lower (call_indirect sig_ref ptr args))
+      (let ((output ValueRegsVec (gen_call_output sig_ref))
+            (abi Sig (abi_sig sig_ref))
+            (target RegMem (RegMem.Reg (put_in_reg ptr)))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_call_rets abi output))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs (try_call_none)))
+            (_ Unit (emit_side_effect (call_unknown info))))
+        output))
 
 ;;;; Rules for `return_call` and `return_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (return_call (func_ref_data sig_ref extname dist) args))
-      (gen_return_call sig_ref extname dist args))
+;; Direct call to an in-range function.
+(rule 1 (lower (return_call (func_ref_data sig_ref name (reloc_distance_near)) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
+        (side_effect (return_call_known info))))
 
-(rule (lower (return_call_indirect sig_ref callee args))
-      (gen_return_call_indirect sig_ref callee args))
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower (return_call (func_ref_data sig_ref name dist) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (target Reg (load_ext_name name 0 dist))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_unknown info))))
+
+;; Indirect call.
+(rule (lower (return_call_indirect sig_ref ptr args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (target Reg (put_in_reg ptr))
+            (uses CallArgList (gen_return_call_args abi args))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_call_unknown info))))
 
 ;;;; Rules for `try_call` and `try_call_indirect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower_branch (try_call (func_ref_data sig_ref extname dist) inputs et) targets)
-      (gen_try_call sig_ref extname dist et inputs targets))
+;; Direct call to an in-range function.
+(rule 1 (lower_branch (try_call (func_ref_data sig_ref name (reloc_distance_near)) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallInfo (gen_call_info abi name uses defs trycall)))
+        (emit_side_effect (call_known info))))
 
-(rule (lower_branch (try_call_indirect val inputs et) targets)
+;; Direct call to an out-of-range function (implicitly via pointer).
+(rule (lower_branch (try_call (func_ref_data sig_ref name dist) args et) targets)
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (target RegMem (RegMem.Reg (load_ext_name name 0 dist)))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_unknown info))))
+
+;; Indirect call.
+(rule (lower_branch (try_call_indirect ptr args et) targets)
       (if-let (exception_sig sig_ref) et)
-      (gen_try_call_indirect sig_ref val et inputs targets))
+      (let ((abi Sig (abi_sig sig_ref))
+            (trycall OptionTryCallInfo (try_call_info et targets))
+            (target RegMem (RegMem.Reg (put_in_reg ptr)))
+            (uses CallArgList (gen_call_args abi args))
+            (defs CallRetList (gen_try_call_rets abi))
+            (info BoxCallIndInfo (gen_call_ind_info abi target uses defs trycall)))
+        (emit_side_effect (call_unknown info))))
 
 ;; Rules for `stack_switch` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -14,7 +14,7 @@ use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
 use crate::settings::Flags;
-use smallvec::{smallvec, SmallVec};
+use std::boxed::Box;
 use target_lexicon::Triple;
 
 //=============================================================================
@@ -150,43 +150,43 @@ fn emit_vm_call(
     flags: &Flags,
     triple: &Triple,
     libcall: LibCall,
-    inputs: &[Reg],
-) -> CodegenResult<SmallVec<[Reg; 1]>> {
+    inputs: &[ValueRegs<Reg>],
+) -> CodegenResult<InstOutput> {
     let extname = ExternalName::LibCall(libcall);
-
-    let dist = if flags.use_colocated_libcalls() {
-        RelocDistance::Near
-    } else {
-        RelocDistance::Far
-    };
 
     // TODO avoid recreating signatures for every single Libcall function.
     let call_conv = CallConv::for_libcall(flags, CallConv::triple_default(triple));
     let sig = libcall.signature(call_conv, types::I64);
-    let caller_conv = ctx.abi().call_conv(ctx.sigs());
+    let outputs = ctx.gen_call_output(&sig);
 
     if !ctx.sigs().have_abi_sig_for_signature(&sig) {
         ctx.sigs_mut()
             .make_abi_sig_from_ir_signature::<X64ABIMachineSpec>(sig.clone(), flags)?;
     }
+    let sig = ctx.sigs().abi_sig_for_signature(&sig);
 
-    let mut abi =
-        X64CallSite::from_libcall(ctx.sigs(), &sig, &extname, dist, caller_conv, flags.clone());
+    let uses = ctx.gen_call_args(sig, inputs);
+    let defs = ctx.gen_call_rets(sig, &outputs);
 
-    assert_eq!(inputs.len(), abi.num_args(ctx.sigs()));
+    let stack_ret_space = ctx.sigs()[sig].sized_stack_ret_space();
+    let stack_arg_space = ctx.sigs()[sig].sized_stack_arg_space();
+    ctx.abi_mut()
+        .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
 
-    for (i, input) in inputs.iter().enumerate() {
-        abi.gen_arg(ctx, i, ValueRegs::one(*input));
+    if flags.use_colocated_libcalls() {
+        let call_info = ctx.gen_call_info(sig, extname, uses, defs, None);
+        ctx.emit(Inst::call_known(Box::new(call_info)));
+    } else {
+        let tmp = ctx.alloc_tmp(types::I64).only_reg().unwrap();
+        ctx.emit(Inst::LoadExtName {
+            dst: tmp,
+            name: Box::new(extname),
+            offset: 0,
+            distance: RelocDistance::Far,
+        });
+        let call_info = ctx.gen_call_info(sig, RegMem::reg(tmp.to_reg()), uses, defs, None);
+        ctx.emit(Inst::call_unknown(Box::new(call_info)));
     }
-
-    let mut outputs: SmallVec<[_; 1]> = smallvec![];
-    for i in 0..ctx.sigs().num_rets(ctx.sigs().abi_sig_for_signature(&sig)) {
-        let retval_regs = abi.gen_retval(ctx, i);
-        outputs.push(retval_regs.only_reg().unwrap());
-    }
-
-    abi.emit_call(ctx, None);
-
     Ok(outputs)
 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -2,7 +2,7 @@
 
 // Pull in the ISLE generated code.
 pub(crate) mod generated_code;
-use crate::{ir::types, ir::AtomicRmwOp, isa};
+use crate::{ir::types, ir::AtomicRmwOp};
 use generated_code::{AssemblerOutputs, Context, MInst, RegisterClass};
 
 // Types that the generated ISLE code uses via `use super::*`.
@@ -14,13 +14,12 @@ use crate::ir::types::*;
 use crate::ir::{
     BlockCall, Inst, InstructionData, LibCall, MemFlags, Opcode, TrapCode, Value, ValueList,
 };
-use crate::isa::x64::abi::X64CallSite;
 use crate::isa::x64::inst::{args::*, regs, ReturnCallInfo};
 use crate::isa::x64::lower::emit_vm_call;
 use crate::isa::x64::X64Backend;
 use crate::machinst::isle::*;
 use crate::machinst::{
-    ArgPair, CallInfo, InsnInput, InstOutput, IsTailCall, MachInst, VCodeConstant,
+    ArgPair, CallArgList, CallInfo, CallRetList, InsnInput, InstOutput, MachInst, VCodeConstant,
     VCodeConstantData,
 };
 use alloc::vec::Vec;
@@ -75,8 +74,85 @@ pub(crate) fn lower_branch(
 
 impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     isle_lower_prelude_methods!();
-    isle_prelude_caller_methods!(X64CallSite);
     isle_assembler_methods!();
+
+    fn gen_call_info(
+        &mut self,
+        sig: Sig,
+        dest: ExternalName,
+        uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> BoxCallInfo {
+        let stack_ret_space = self.lower_ctx.sigs()[sig].sized_stack_ret_space();
+        let stack_arg_space = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
+
+        Box::new(
+            self.lower_ctx
+                .gen_call_info(sig, dest, uses, defs, try_call_info),
+        )
+    }
+
+    fn gen_call_ind_info(
+        &mut self,
+        sig: Sig,
+        dest: &RegMem,
+        uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> BoxCallIndInfo {
+        let stack_ret_space = self.lower_ctx.sigs()[sig].sized_stack_ret_space();
+        let stack_arg_space = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_outgoing_args_size(stack_ret_space + stack_arg_space);
+
+        Box::new(
+            self.lower_ctx
+                .gen_call_info(sig, dest.clone(), uses, defs, try_call_info),
+        )
+    }
+
+    fn gen_return_call_info(
+        &mut self,
+        sig: Sig,
+        dest: ExternalName,
+        uses: CallArgList,
+    ) -> BoxReturnCallInfo {
+        let new_stack_arg_size = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_tail_args_size(new_stack_arg_size);
+
+        Box::new(ReturnCallInfo {
+            dest,
+            uses,
+            tmp: self.lower_ctx.temp_writable_gpr(),
+            new_stack_arg_size,
+        })
+    }
+
+    fn gen_return_call_ind_info(
+        &mut self,
+        sig: Sig,
+        dest: Reg,
+        uses: CallArgList,
+    ) -> BoxReturnCallIndInfo {
+        let new_stack_arg_size = self.lower_ctx.sigs()[sig].sized_stack_arg_space();
+        self.lower_ctx
+            .abi_mut()
+            .accumulate_tail_args_size(new_stack_arg_size);
+
+        Box::new(ReturnCallInfo {
+            dest,
+            uses,
+            tmp: self.lower_ctx.temp_writable_gpr(),
+            new_stack_arg_size,
+        })
+    }
 
     #[inline]
     fn operand_size_of_type_32_64(&mut self, ty: Type) -> OperandSize {
@@ -639,13 +715,13 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             &self.backend.flags,
             &self.backend.triple,
             *libcall,
-            &[a],
+            &[ValueRegs::one(a)],
         )
         .expect("Failed to emit LibCall");
 
         debug_assert_eq!(outputs.len(), 1);
 
-        outputs[0]
+        outputs[0].only_reg().unwrap()
     }
 
     fn libcall_2(&mut self, libcall: &LibCall, a: Reg, b: Reg) -> Reg {
@@ -654,13 +730,13 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             &self.backend.flags,
             &self.backend.triple,
             *libcall,
-            &[a, b],
+            &[ValueRegs::one(a), ValueRegs::one(b)],
         )
         .expect("Failed to emit LibCall");
 
         debug_assert_eq!(outputs.len(), 1);
 
-        outputs[0]
+        outputs[0].only_reg().unwrap()
     }
 
     fn libcall_3(&mut self, libcall: &LibCall, a: Reg, b: Reg, c: Reg) -> Reg {
@@ -669,13 +745,13 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             &self.backend.flags,
             &self.backend.triple,
             *libcall,
-            &[a, b, c],
+            &[ValueRegs::one(a), ValueRegs::one(b), ValueRegs::one(c)],
         )
         .expect("Failed to emit LibCall");
 
         debug_assert_eq!(outputs.len(), 1);
 
-        outputs[0]
+        outputs[0].only_reg().unwrap()
     }
 
     #[inline]

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -845,21 +845,6 @@ macro_rules! isle_common_prelude_methods {
             Offset32::new(offset)
         }
 
-        fn range(&mut self, start: usize, end: usize) -> Range {
-            (start, end)
-        }
-
-        fn range_view(&mut self, (start, end): Range) -> RangeView {
-            if start >= end {
-                RangeView::Empty
-            } else {
-                RangeView::NonEmpty {
-                    index: start,
-                    rest: (start + 1, end),
-                }
-            }
-        }
-
         #[inline]
         fn mem_flags_trusted(&mut self) -> MemFlags {
             MemFlags::trusted()

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -100,7 +100,7 @@
 
 use crate::entity::SecondaryMap;
 use crate::ir::types::*;
-use crate::ir::{ArgumentExtension, ArgumentPurpose, ExceptionTable, ExceptionTag, Signature};
+use crate::ir::{ArgumentExtension, ArgumentPurpose, ExceptionTag, Signature};
 use crate::isa::TargetIsa;
 use crate::settings::ProbestackStrategy;
 use crate::CodegenError;
@@ -113,7 +113,6 @@ use rustc_hash::FxHashMap;
 use smallvec::smallvec;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::mem;
 
 /// A small vector of instructions (with some reasonable size); appropriate for
 /// a small fixed sequence implementing one operation.
@@ -557,10 +556,6 @@ pub trait ABIMachineSpec {
         frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]>;
 
-    /// Generate a call instruction/sequence. This method is provided one
-    /// temporary register to use to synthesize the called address, if needed.
-    fn gen_call(dest: &CallDest, tmp: Writable<Reg>, info: CallInfo<()>) -> SmallVec<[Self::I; 2]>;
-
     /// Generate a memcpy invocation. Used to set up struct
     /// args. Takes `src`, `dst` as read-only inputs and passes a temporary
     /// allocator.
@@ -664,20 +659,6 @@ impl<T> CallInfo<T> {
             try_call_info: None,
         }
     }
-
-    /// Change the `T` payload on this info to `U`.
-    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> CallInfo<U> {
-        CallInfo {
-            dest: f(self.dest),
-            uses: self.uses,
-            defs: self.defs,
-            clobbers: self.clobbers,
-            caller_conv: self.caller_conv,
-            callee_conv: self.callee_conv,
-            callee_pop_size: self.callee_pop_size,
-            try_call_info: self.try_call_info,
-        }
-    }
 }
 
 /// The id of an ABI signature within the `SigSet`.
@@ -739,13 +720,13 @@ pub struct SigData {
 
 impl SigData {
     /// Get total stack space required for arguments.
-    pub fn sized_stack_arg_space(&self) -> i64 {
-        self.sized_stack_arg_space.into()
+    pub fn sized_stack_arg_space(&self) -> u32 {
+        self.sized_stack_arg_space
     }
 
     /// Get total stack space required for return values.
-    pub fn sized_stack_ret_space(&self) -> i64 {
-        self.sized_stack_ret_space.into()
+    pub fn sized_stack_ret_space(&self) -> u32 {
+        self.sized_stack_ret_space
     }
 
     /// Get calling convention used.
@@ -1505,13 +1486,13 @@ impl<M: ABIMachineSpec> Callee<M> {
     }
 
     /// Get the calling convention implemented by this ABI object.
-    pub fn call_conv(&self, sigs: &SigSet) -> isa::CallConv {
-        sigs[self.sig].call_conv
+    pub fn call_conv(&self) -> isa::CallConv {
+        self.call_conv
     }
 
     /// Get the ABI-dependent MachineEnv for managing register allocation.
-    pub fn machine_env(&self, sigs: &SigSet) -> &MachineEnv {
-        M::get_machine_env(&self.flags, self.call_conv(sigs))
+    pub fn machine_env(&self) -> &MachineEnv {
+        M::get_machine_env(&self.flags, self.call_conv)
     }
 
     /// The offsets of all sized stack slots (not spill slots) for debuginfo purposes.
@@ -1751,6 +1732,363 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Generate a return instruction.
     pub fn gen_rets(&self, rets: Vec<RetPair>) -> M::I {
         M::gen_rets(rets)
+    }
+
+    /// Set up arguments values `args` for a call with signature `sig`.
+    /// This will return a series of instructions to be emitted to set
+    /// up all arguments, as well as a `CallArgList` list representing
+    /// the arguments passed in registers.  The latter need to be added
+    /// as constraints to the actual call instruction.
+    pub fn gen_call_args(
+        &self,
+        sigs: &SigSet,
+        sig: Sig,
+        args: &[ValueRegs<Reg>],
+        is_tail_call: bool,
+        flags: &settings::Flags,
+        vregs: &mut VRegAllocator<M::I>,
+    ) -> (CallArgList, SmallInstVec<M::I>) {
+        let mut uses: CallArgList = smallvec![];
+        let mut insts = smallvec![];
+
+        assert_eq!(args.len(), sigs.num_args(sig));
+
+        let call_conv = sigs[sig].call_conv;
+        let stack_arg_space = sigs[sig].sized_stack_arg_space;
+        let stack_arg = |offset| {
+            if is_tail_call {
+                StackAMode::IncomingArg(offset, stack_arg_space)
+            } else {
+                StackAMode::OutgoingArg(offset)
+            }
+        };
+
+        let word_ty = M::word_type();
+        let word_rc = M::word_reg_class();
+        let word_bits = M::word_bits() as usize;
+
+        if is_tail_call {
+            debug_assert_eq!(
+                self.call_conv,
+                isa::CallConv::Tail,
+                "Can only do `return_call`s from within a `tail` calling convention function"
+            );
+        }
+
+        // Helper to process a single argument slot (register or stack slot).
+        // This will either add the register to the `uses` list or write the
+        // value to the stack slot in the outgoing argument area (or for tail
+        // calls, the incoming argument area).
+        let mut process_arg_slot = |insts: &mut SmallInstVec<M::I>, slot, vreg, ty| {
+            match &slot {
+                &ABIArgSlot::Reg { reg, .. } => {
+                    uses.push(CallArgPair {
+                        vreg,
+                        preg: reg.into(),
+                    });
+                }
+                &ABIArgSlot::Stack { offset, .. } => {
+                    insts.push(M::gen_store_stack(stack_arg(offset), vreg, ty));
+                }
+            };
+        };
+
+        // First pass: Handle `StructArg` arguments.  These need to be copied
+        // into their associated stack buffers.  This should happen before any
+        // of the other arguments are processed, as the `memcpy` call might
+        // clobber registers used by other arguments.
+        for (idx, from_regs) in args.iter().enumerate() {
+            match &sigs.args(sig)[idx] {
+                &ABIArg::Slots { .. } | &ABIArg::ImplicitPtrArg { .. } => {}
+                &ABIArg::StructArg { offset, size, .. } => {
+                    let tmp = vregs.alloc_with_deferred_error(word_ty).only_reg().unwrap();
+                    insts.push(M::gen_get_stack_addr(
+                        stack_arg(offset),
+                        Writable::from_reg(tmp),
+                    ));
+                    insts.extend(M::gen_memcpy(
+                        isa::CallConv::for_libcall(flags, call_conv),
+                        tmp,
+                        from_regs.only_reg().unwrap(),
+                        size as usize,
+                        |ty| {
+                            Writable::from_reg(
+                                vregs.alloc_with_deferred_error(ty).only_reg().unwrap(),
+                            )
+                        },
+                    ));
+                }
+            }
+        }
+
+        // Second pass: Handle everything except `StructArg` arguments.
+        for (idx, from_regs) in args.iter().enumerate() {
+            match sigs.args(sig)[idx] {
+                ABIArg::Slots { ref slots, .. } => {
+                    assert_eq!(from_regs.len(), slots.len());
+                    for (slot, from_reg) in slots.iter().zip(from_regs.regs().iter()) {
+                        // Load argument slot value from `from_reg`, and perform any zero-
+                        // or sign-extension that is required by the ABI.
+                        let (ty, extension) = match *slot {
+                            ABIArgSlot::Reg { ty, extension, .. } => (ty, extension),
+                            ABIArgSlot::Stack { ty, extension, .. } => (ty, extension),
+                        };
+                        let ext = M::get_ext_mode(call_conv, extension);
+                        let (vreg, ty) = if ext != ir::ArgumentExtension::None
+                            && ty_bits(ty) < word_bits
+                        {
+                            assert_eq!(word_rc, from_reg.class());
+                            let signed = match ext {
+                                ir::ArgumentExtension::Uext => false,
+                                ir::ArgumentExtension::Sext => true,
+                                _ => unreachable!(),
+                            };
+                            let tmp = vregs.alloc_with_deferred_error(word_ty).only_reg().unwrap();
+                            insts.push(M::gen_extend(
+                                Writable::from_reg(tmp),
+                                *from_reg,
+                                signed,
+                                ty_bits(ty) as u8,
+                                word_bits as u8,
+                            ));
+                            (tmp, word_ty)
+                        } else {
+                            (*from_reg, ty)
+                        };
+                        process_arg_slot(&mut insts, *slot, vreg, ty);
+                    }
+                }
+                ABIArg::ImplicitPtrArg {
+                    offset,
+                    pointer,
+                    ty,
+                    ..
+                } => {
+                    let vreg = from_regs.only_reg().unwrap();
+                    let tmp = vregs.alloc_with_deferred_error(word_ty).only_reg().unwrap();
+                    insts.push(M::gen_get_stack_addr(
+                        stack_arg(offset),
+                        Writable::from_reg(tmp),
+                    ));
+                    insts.push(M::gen_store_base_offset(tmp, 0, vreg, ty));
+                    process_arg_slot(&mut insts, pointer, tmp, word_ty);
+                }
+                ABIArg::StructArg { .. } => {}
+            }
+        }
+
+        // Finally, set the stack-return pointer to the return argument area.
+        // For tail calls, this means forwarding the incoming stack-return pointer.
+        if let Some(ret_arg) = sigs.get_ret_arg(sig) {
+            let ret_area = if is_tail_call {
+                self.ret_area_ptr.expect(
+                    "if the tail callee has a return pointer, then the tail caller must as well",
+                )
+            } else {
+                let tmp = vregs.alloc_with_deferred_error(word_ty).only_reg().unwrap();
+                let amode = StackAMode::OutgoingArg(stack_arg_space.into());
+                insts.push(M::gen_get_stack_addr(amode, Writable::from_reg(tmp)));
+                tmp
+            };
+            match ret_arg {
+                // The return pointer must occupy a single slot.
+                ABIArg::Slots { slots, .. } => {
+                    assert_eq!(slots.len(), 1);
+                    process_arg_slot(&mut insts, slots[0], ret_area, word_ty);
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        (uses, insts)
+    }
+
+    /// Set up return values `outputs` for a call with signature `sig`.
+    /// This does not emit (or return) any instructions, but returns a
+    /// `CallRetList` representing the return value constraints.  This
+    /// needs to be added to the actual call instruction.
+    ///
+    /// If `try_call_payloads` is non-zero, it is expected to hold
+    /// exception payload registers for try_call instructions.  These
+    /// will be added as needed to the `CallRetList` as well.
+    pub fn gen_call_rets(
+        &self,
+        sigs: &SigSet,
+        sig: Sig,
+        outputs: &[ValueRegs<Reg>],
+        try_call_payloads: Option<&[Writable<Reg>]>,
+        vregs: &mut VRegAllocator<M::I>,
+    ) -> CallRetList {
+        let callee_conv = sigs[sig].call_conv;
+        let stack_arg_space = sigs[sig].sized_stack_arg_space;
+
+        let word_ty = M::word_type();
+        let word_bits = M::word_bits() as usize;
+
+        let mut defs: CallRetList = smallvec![];
+        let mut outputs = outputs.into_iter();
+        let num_rets = sigs.num_rets(sig);
+        for idx in 0..num_rets {
+            let ret = sigs.rets(sig)[idx].clone();
+            match ret {
+                ABIArg::Slots {
+                    ref slots, purpose, ..
+                } => {
+                    // We do not use the returned copy of the return buffer pointer,
+                    // so skip any StructReturn returns that may be present.
+                    if purpose == ArgumentPurpose::StructReturn {
+                        continue;
+                    }
+                    let retval_regs = outputs.next().unwrap();
+                    assert_eq!(retval_regs.len(), slots.len());
+                    for (slot, retval_reg) in slots.iter().zip(retval_regs.regs().iter()) {
+                        // We do not perform any extension because we're copying out, not in,
+                        // and we ignore high bits in our own registers by convention.  However,
+                        // we still need to use the proper extended type to access stack slots
+                        // (this is critical on big-endian systems).
+                        let (ty, extension) = match *slot {
+                            ABIArgSlot::Reg { ty, extension, .. } => (ty, extension),
+                            ABIArgSlot::Stack { ty, extension, .. } => (ty, extension),
+                        };
+                        let ext = M::get_ext_mode(callee_conv, extension);
+                        let ty = if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
+                            word_ty
+                        } else {
+                            ty
+                        };
+
+                        match slot {
+                            &ABIArgSlot::Reg { reg, .. } => {
+                                defs.push(CallRetPair {
+                                    vreg: Writable::from_reg(*retval_reg),
+                                    location: RetLocation::Reg(reg.into(), ty),
+                                });
+                            }
+                            &ABIArgSlot::Stack { offset, .. } => {
+                                let amode =
+                                    StackAMode::OutgoingArg(offset + i64::from(stack_arg_space));
+                                defs.push(CallRetPair {
+                                    vreg: Writable::from_reg(*retval_reg),
+                                    location: RetLocation::Stack(amode, ty),
+                                });
+                            }
+                        }
+                    }
+                }
+                ABIArg::StructArg { .. } => {
+                    panic!("StructArg not supported in return position");
+                }
+                ABIArg::ImplicitPtrArg { .. } => {
+                    panic!("ImplicitPtrArg not supported in return position");
+                }
+            }
+        }
+        assert!(outputs.next().is_none());
+
+        if let Some(try_call_payloads) = try_call_payloads {
+            // We need to update `defs` to contain the exception
+            // payload regs as well. We have two sources of info that
+            // we join:
+            //
+            // - The machine-specific ABI implementation `M`, which
+            //   tells us the particular registers that payload values
+            //   must be in
+            // - The passed-in lowering context, which gives us the
+            //   vregs we must define.
+            //
+            // Note that payload values may need to end up in the same
+            // physical registers as ordinary return values; this is
+            // not a conflict, because we either get one or the
+            // other. For regalloc's purposes, we define both starting
+            // here at the callsite, but we can share one def in the
+            // `defs` list and alias one vreg to another. Thus we
+            // handle the two cases below for each payload register:
+            // overlaps a return value (and we alias to it) or not
+            // (and we add a def).
+            let pregs = M::exception_payload_regs(callee_conv);
+            for (i, &preg) in pregs.iter().enumerate() {
+                let vreg = try_call_payloads[i];
+                if let Some(existing) = defs.iter().find(|def| match def.location {
+                    RetLocation::Reg(r, _) => r == preg,
+                    _ => false,
+                }) {
+                    vregs.set_vreg_alias(vreg.to_reg(), existing.vreg.to_reg());
+                } else {
+                    defs.push(CallRetPair {
+                        vreg,
+                        location: RetLocation::Reg(preg, word_ty),
+                    });
+                }
+            }
+        }
+
+        defs
+    }
+
+    /// Populate a `CallInfo` for a call with signature `sig`.
+    ///
+    /// `dest` is the target-specific call destination value
+    /// `uses` is the `CallArgList` describing argument constraints
+    /// `defs` is the `CallRetList` describing return constraints
+    /// `try_call_info` describes exception targets for try_call instructions
+    ///
+    /// The clobber list is computed here from the above data.
+    pub fn gen_call_info<T>(
+        &self,
+        sigs: &SigSet,
+        sig: Sig,
+        dest: T,
+        uses: CallArgList,
+        defs: CallRetList,
+        try_call_info: Option<TryCallInfo>,
+    ) -> CallInfo<T> {
+        let caller_conv = self.call_conv;
+        let callee_conv = sigs[sig].call_conv;
+        let stack_arg_space = sigs[sig].sized_stack_arg_space;
+
+        let clobbers = {
+            // Get clobbers: all caller-saves. These may include return value
+            // regs, which we will remove from the clobber set below.
+            let mut clobbers =
+                <M>::get_regs_clobbered_by_call(callee_conv, try_call_info.is_some());
+
+            // Remove retval regs from clobbers.
+            for def in &defs {
+                if let RetLocation::Reg(preg, _) = def.location {
+                    clobbers.remove(PReg::from(preg.to_real_reg().unwrap()));
+                }
+            }
+
+            clobbers
+        };
+
+        // Any adjustment to SP to account for required outgoing arguments/stack return values must
+        // be done inside of the call pseudo-op, to ensure that SP is always in a consistent
+        // state for all other instructions. For example, if a tail-call abi function is called
+        // here, the reclamation of the outgoing argument area must be done inside of the call
+        // pseudo-op's emission to ensure that SP is consistent at all other points in the lowered
+        // function. (Except the prologue and epilogue, but those are fairly special parts of the
+        // function that establish the SP invariants that are relied on elsewhere and are generated
+        // after the register allocator has run and thus cannot have register allocator-inserted
+        // references to SP offsets.)
+
+        let callee_pop_size = if callee_conv == isa::CallConv::Tail {
+            // The tail calling convention has callees pop stack arguments.
+            stack_arg_space
+        } else {
+            0
+        };
+
+        CallInfo {
+            dest,
+            uses,
+            defs,
+            clobbers,
+            callee_conv,
+            caller_conv,
+            callee_pop_size,
+            try_call_info,
+        }
     }
 
     /// Produce an instruction that computes a sized stackslot address.
@@ -2037,526 +2375,6 @@ pub enum RetLocation {
 
 pub type CallArgList = SmallVec<[CallArgPair; 8]>;
 pub type CallRetList = SmallVec<[CallRetPair; 8]>;
-
-pub enum IsTailCall {
-    Yes,
-    No,
-}
-
-/// ABI object for a callsite.
-pub struct CallSite<M: ABIMachineSpec> {
-    /// The called function's signature.
-    sig: Sig,
-    /// All register uses for the callsite, i.e., function args, with
-    /// VReg and the physical register it is constrained to.
-    uses: CallArgList,
-    /// All defs for the callsite, i.e., return values.
-    defs: CallRetList,
-    /// Call destination.
-    dest: CallDest,
-    is_tail_call: IsTailCall,
-    /// Caller's calling convention.
-    caller_conv: isa::CallConv,
-    /// The settings controlling this compilation.
-    flags: settings::Flags,
-
-    _mach: PhantomData<M>,
-}
-
-/// Destination for a call.
-#[derive(Debug, Clone)]
-pub enum CallDest {
-    /// Call to an ExtName (named function symbol).
-    ExtName(ir::ExternalName, RelocDistance),
-    /// Indirect call to a function pointer in a register.
-    Reg(Reg),
-}
-
-impl<M: ABIMachineSpec> CallSite<M> {
-    /// Create a callsite ABI object for a call directly to the specified function.
-    pub fn from_func(
-        sigs: &SigSet,
-        sig_ref: ir::SigRef,
-        extname: &ir::ExternalName,
-        is_tail_call: IsTailCall,
-        dist: RelocDistance,
-        caller_conv: isa::CallConv,
-        flags: settings::Flags,
-    ) -> CallSite<M> {
-        let sig = sigs.abi_sig_for_sig_ref(sig_ref);
-        CallSite {
-            sig,
-            uses: smallvec![],
-            defs: smallvec![],
-            dest: CallDest::ExtName(extname.clone(), dist),
-            is_tail_call,
-            caller_conv,
-            flags,
-            _mach: PhantomData,
-        }
-    }
-
-    /// Create a callsite ABI object for a call directly to the specified
-    /// libcall.
-    pub fn from_libcall(
-        sigs: &SigSet,
-        sig: &ir::Signature,
-        extname: &ir::ExternalName,
-        dist: RelocDistance,
-        caller_conv: isa::CallConv,
-        flags: settings::Flags,
-    ) -> CallSite<M> {
-        let sig = sigs.abi_sig_for_signature(sig);
-        CallSite {
-            sig,
-            uses: smallvec![],
-            defs: smallvec![],
-            dest: CallDest::ExtName(extname.clone(), dist),
-            is_tail_call: IsTailCall::No,
-            caller_conv,
-            flags,
-            _mach: PhantomData,
-        }
-    }
-
-    /// Create a callsite ABI object for a call to a function pointer with the
-    /// given signature.
-    pub fn from_ptr(
-        sigs: &SigSet,
-        sig_ref: ir::SigRef,
-        ptr: Reg,
-        is_tail_call: IsTailCall,
-        caller_conv: isa::CallConv,
-        flags: settings::Flags,
-    ) -> CallSite<M> {
-        let sig = sigs.abi_sig_for_sig_ref(sig_ref);
-        CallSite {
-            sig,
-            uses: smallvec![],
-            defs: smallvec![],
-            dest: CallDest::Reg(ptr),
-            is_tail_call,
-            caller_conv,
-            flags,
-            _mach: PhantomData,
-        }
-    }
-
-    pub(crate) fn dest(&self) -> &CallDest {
-        &self.dest
-    }
-
-    pub(crate) fn take_uses(self) -> CallArgList {
-        self.uses
-    }
-
-    pub(crate) fn sig<'a>(&self, sigs: &'a SigSet) -> &'a SigData {
-        &sigs[self.sig]
-    }
-
-    pub(crate) fn is_tail_call(&self) -> bool {
-        matches!(self.is_tail_call, IsTailCall::Yes)
-    }
-}
-
-impl<M: ABIMachineSpec> CallSite<M> {
-    /// Get the number of arguments expected.
-    pub fn num_args(&self, sigs: &SigSet) -> usize {
-        sigs.num_args(self.sig)
-    }
-
-    /// Get the number of return values expected.
-    pub fn num_rets(&self, sigs: &SigSet) -> usize {
-        sigs.num_rets(self.sig)
-    }
-
-    /// Emit a copy of a large argument into its associated stack buffer, if
-    /// any.  We must be careful to perform all these copies (as necessary)
-    /// before setting up the argument registers, since we may have to invoke
-    /// memcpy(), which could clobber any registers already set up.  The
-    /// back-end should call this routine for all arguments before calling
-    /// `gen_arg` for all arguments.
-    pub fn emit_copy_regs_to_buffer(
-        &self,
-        ctx: &mut Lower<M::I>,
-        idx: usize,
-        from_regs: ValueRegs<Reg>,
-    ) {
-        match &ctx.sigs().args(self.sig)[idx] {
-            &ABIArg::Slots { .. } | &ABIArg::ImplicitPtrArg { .. } => {}
-            &ABIArg::StructArg { offset, size, .. } => {
-                let src_ptr = from_regs.only_reg().unwrap();
-                let dst_ptr = ctx.alloc_tmp(M::word_type()).only_reg().unwrap();
-                ctx.emit(M::gen_get_stack_addr(
-                    StackAMode::OutgoingArg(offset),
-                    dst_ptr,
-                ));
-                // Emit a memcpy from `src_ptr` to `dst_ptr` of `size` bytes.
-                // N.B.: because we process StructArg params *first*, this is
-                // safe w.r.t. clobbers: we have not yet filled in any other
-                // arg regs.
-                let memcpy_call_conv =
-                    isa::CallConv::for_libcall(&self.flags, ctx.sigs()[self.sig].call_conv);
-                for insn in M::gen_memcpy(
-                    memcpy_call_conv,
-                    dst_ptr.to_reg(),
-                    src_ptr,
-                    size as usize,
-                    |ty| ctx.alloc_tmp(ty).only_reg().unwrap(),
-                )
-                .into_iter()
-                {
-                    ctx.emit(insn);
-                }
-            }
-        }
-    }
-
-    /// Add a constraint for an argument value from a source register.
-    /// For large arguments with associated stack buffer, this may
-    /// load the address of the buffer into the argument register, if
-    /// required by the ABI.
-    pub fn gen_arg(&mut self, ctx: &mut Lower<M::I>, idx: usize, from_regs: ValueRegs<Reg>) {
-        let stack_arg_space = ctx.sigs()[self.sig].sized_stack_arg_space;
-        let stack_arg = if self.is_tail_call() {
-            StackAMode::IncomingArg
-        } else {
-            |offset, _| StackAMode::OutgoingArg(offset)
-        };
-        let word_rc = M::word_reg_class();
-        let word_bits = M::word_bits() as usize;
-
-        match ctx.sigs().args(self.sig)[idx].clone() {
-            ABIArg::Slots { ref slots, .. } => {
-                assert_eq!(from_regs.len(), slots.len());
-                for (slot, from_reg) in slots.iter().zip(from_regs.regs().iter()) {
-                    match slot {
-                        &ABIArgSlot::Reg {
-                            reg, ty, extension, ..
-                        } => {
-                            let ext = M::get_ext_mode(ctx.sigs()[self.sig].call_conv, extension);
-                            let vreg =
-                                if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
-                                    assert_eq!(word_rc, reg.class());
-                                    let signed = match ext {
-                                        ir::ArgumentExtension::Uext => false,
-                                        ir::ArgumentExtension::Sext => true,
-                                        _ => unreachable!(),
-                                    };
-                                    let extend_result =
-                                        ctx.alloc_tmp(M::word_type()).only_reg().unwrap();
-                                    ctx.emit(M::gen_extend(
-                                        extend_result,
-                                        *from_reg,
-                                        signed,
-                                        ty_bits(ty) as u8,
-                                        word_bits as u8,
-                                    ));
-                                    extend_result.to_reg()
-                                } else {
-                                    *from_reg
-                                };
-
-                            let preg = reg.into();
-                            self.uses.push(CallArgPair { vreg, preg });
-                        }
-                        &ABIArgSlot::Stack {
-                            offset,
-                            ty,
-                            extension,
-                            ..
-                        } => {
-                            let ext = M::get_ext_mode(ctx.sigs()[self.sig].call_conv, extension);
-                            let (data, ty) =
-                                if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
-                                    assert_eq!(word_rc, from_reg.class());
-                                    let signed = match ext {
-                                        ir::ArgumentExtension::Uext => false,
-                                        ir::ArgumentExtension::Sext => true,
-                                        _ => unreachable!(),
-                                    };
-                                    let extend_result =
-                                        ctx.alloc_tmp(M::word_type()).only_reg().unwrap();
-                                    ctx.emit(M::gen_extend(
-                                        extend_result,
-                                        *from_reg,
-                                        signed,
-                                        ty_bits(ty) as u8,
-                                        word_bits as u8,
-                                    ));
-                                    // Store the extended version.
-                                    (extend_result.to_reg(), M::word_type())
-                                } else {
-                                    (*from_reg, ty)
-                                };
-                            ctx.emit(M::gen_store_stack(
-                                stack_arg(offset, stack_arg_space),
-                                data,
-                                ty,
-                            ));
-                        }
-                    }
-                }
-            }
-            ABIArg::StructArg { .. } => {
-                // Only supported via ISLE.
-            }
-            ABIArg::ImplicitPtrArg {
-                offset,
-                pointer,
-                ty,
-                purpose: _,
-            } => {
-                assert_eq!(from_regs.len(), 1);
-                let vreg = from_regs.regs()[0];
-                let amode = StackAMode::OutgoingArg(offset);
-                let tmp = ctx.alloc_tmp(M::word_type()).only_reg().unwrap();
-                ctx.emit(M::gen_get_stack_addr(amode, tmp));
-                let tmp = tmp.to_reg();
-                ctx.emit(M::gen_store_base_offset(tmp, 0, vreg, ty));
-                match pointer {
-                    ABIArgSlot::Reg { reg, .. } => self.uses.push(CallArgPair {
-                        vreg: tmp,
-                        preg: reg.into(),
-                    }),
-                    ABIArgSlot::Stack { offset, .. } => ctx.emit(M::gen_store_stack(
-                        stack_arg(offset, stack_arg_space),
-                        tmp,
-                        M::word_type(),
-                    )),
-                }
-            }
-        }
-    }
-
-    /// Call `gen_arg` for each non-hidden argument and emit all instructions
-    /// generated.
-    pub fn emit_args(&mut self, ctx: &mut Lower<M::I>, (inputs, off): isle::ValueSlice) {
-        let num_args = self.num_args(ctx.sigs());
-        assert_eq!(inputs.len(&ctx.dfg().value_lists) - off, num_args);
-
-        let mut arg_value_regs: SmallVec<[_; 16]> = smallvec![];
-        for i in 0..num_args {
-            let input = inputs.get(off + i, &ctx.dfg().value_lists).unwrap();
-            arg_value_regs.push(ctx.put_value_in_regs(input));
-        }
-        for (i, arg_regs) in arg_value_regs.iter().enumerate() {
-            self.emit_copy_regs_to_buffer(ctx, i, *arg_regs);
-        }
-        for (i, value_regs) in arg_value_regs.iter().enumerate() {
-            self.gen_arg(ctx, i, *value_regs);
-        }
-    }
-
-    /// Emit the code to forward a stack-return pointer argument through a tail
-    /// call.
-    pub fn emit_stack_ret_arg_for_tail_call(&mut self, ctx: &mut Lower<M::I>) {
-        if let Some(i) = ctx.sigs()[self.sig].stack_ret_arg() {
-            let ret_area_ptr = ctx.abi().ret_area_ptr.expect(
-                "if the tail callee has a return pointer, then the tail caller \
-                 must as well",
-            );
-            self.gen_arg(ctx, i.into(), ValueRegs::one(ret_area_ptr));
-        }
-    }
-
-    /// Define a return value after the call returns.
-    pub fn gen_retval(&mut self, ctx: &mut Lower<M::I>, idx: usize) -> ValueRegs<Reg> {
-        let mut into_regs: SmallVec<[Reg; 2]> = smallvec![];
-        let ret = ctx.sigs().rets(self.sig)[idx].clone();
-        match ret {
-            ABIArg::Slots { ref slots, .. } => {
-                for slot in slots {
-                    match slot {
-                        // Extension mode doesn't matter because we're copying out, not in,
-                        // and we ignore high bits in our own registers by convention.
-                        &ABIArgSlot::Reg { reg, ty, .. } => {
-                            let into_reg = ctx.alloc_tmp(ty).only_reg().unwrap();
-                            self.defs.push(CallRetPair {
-                                vreg: into_reg,
-                                location: RetLocation::Reg(reg.into(), ty),
-                            });
-                            into_regs.push(into_reg.to_reg());
-                        }
-                        &ABIArgSlot::Stack { offset, ty, .. } => {
-                            let into_reg = ctx.alloc_tmp(ty).only_reg().unwrap();
-                            let sig_data = &ctx.sigs()[self.sig];
-                            // The outgoing argument area must always be restored after a call,
-                            // ensuring that the return values will be in a consistent place after
-                            // any call.
-                            let ret_area_base = sig_data.sized_stack_arg_space();
-                            let amode = StackAMode::OutgoingArg(offset + ret_area_base);
-                            self.defs.push(CallRetPair {
-                                vreg: into_reg,
-                                location: RetLocation::Stack(amode, ty),
-                            });
-                            into_regs.push(into_reg.to_reg());
-                        }
-                    }
-                }
-            }
-            ABIArg::StructArg { .. } => {
-                panic!("StructArg not supported in return position");
-            }
-            ABIArg::ImplicitPtrArg { .. } => {
-                panic!("ImplicitPtrArg not supported in return position");
-            }
-        }
-
-        let value_regs = match *into_regs {
-            [a] => ValueRegs::one(a),
-            [a, b] => ValueRegs::two(a, b),
-            _ => panic!("Expected to see one or two slots only from {ret:?}"),
-        };
-        value_regs
-    }
-
-    /// Emit the call itself.
-    ///
-    /// The returned instruction should have proper use- and def-sets according
-    /// to the argument registers, return-value registers, and clobbered
-    /// registers for this function signature in this ABI.
-    ///
-    /// (Arg registers are uses, and retval registers are defs. Clobbered
-    /// registers are also logically defs, but should never be read; their
-    /// values are "defined" (to the regalloc) but "undefined" in every other
-    /// sense.)
-    ///
-    /// This function should only be called once, as it is allowed to re-use
-    /// parts of the `CallSite` object in emitting instructions.
-    pub fn emit_call(
-        &mut self,
-        ctx: &mut Lower<M::I>,
-        try_call_info: Option<(ExceptionTable, &[MachLabel])>,
-    ) {
-        let word_type = M::word_type();
-        if let Some(i) = ctx.sigs()[self.sig].stack_ret_arg {
-            let rd = ctx.alloc_tmp(word_type).only_reg().unwrap();
-            let ret_area_base = ctx.sigs()[self.sig].sized_stack_arg_space();
-            ctx.emit(M::gen_get_stack_addr(
-                StackAMode::OutgoingArg(ret_area_base),
-                rd,
-            ));
-            self.gen_arg(ctx, i.into(), ValueRegs::one(rd.to_reg()));
-        }
-
-        let uses = mem::take(&mut self.uses);
-        let mut defs = mem::take(&mut self.defs);
-
-        let sig = &ctx.sigs()[self.sig];
-        let callee_pop_size = if sig.call_conv() == isa::CallConv::Tail {
-            // The tail calling convention has callees pop stack arguments.
-            sig.sized_stack_arg_space
-        } else {
-            0
-        };
-
-        let call_conv = sig.call_conv;
-        let ret_space = sig.sized_stack_ret_space;
-        let arg_space = sig.sized_stack_arg_space;
-
-        ctx.abi_mut()
-            .accumulate_outgoing_args_size(ret_space + arg_space);
-
-        let tmp = ctx.alloc_tmp(word_type).only_reg().unwrap();
-
-        let try_call_info = try_call_info.map(|(et, labels)| {
-            let exception_dests = ctx.dfg().exception_tables[et]
-                .catches()
-                .map(|(tag, _)| tag.into())
-                .zip(labels.iter().cloned())
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-
-            // We need to update `defs` to contain the exception
-            // payload regs as well. We have two sources of info that
-            // we join:
-            //
-            // - The machine-specific ABI implementation `M`, which
-            //   tells us the particular registers that payload values
-            //   must be in
-            // - The passed-in lowering context, which gives us the
-            //   vregs we must define.
-            //
-            // Note that payload values may need to end up in the same
-            // physical registers as ordinary return values; this is
-            // not a conflict, because we either get one or the
-            // other. For regalloc's purposes, we define both starting
-            // here at the callsite, but we can share one def in the
-            // `defs` list and alias one vreg to another. Thus we
-            // handle the two cases below for each payload register:
-            // overlaps a return value (and we alias to it) or not
-            // (and we add a def).
-            let pregs = M::exception_payload_regs(call_conv);
-            for (i, &preg) in pregs.iter().enumerate() {
-                let vreg = ctx.try_call_exception_defs(ctx.cur_inst())[i];
-                if let Some(existing) = defs.iter().find(|def| match def.location {
-                    RetLocation::Reg(r, _) => r == preg,
-                    _ => false,
-                }) {
-                    ctx.vregs_mut()
-                        .set_vreg_alias(vreg.to_reg(), existing.vreg.to_reg());
-                } else {
-                    defs.push(CallRetPair {
-                        vreg,
-                        location: RetLocation::Reg(preg, M::word_type()),
-                    });
-                }
-            }
-
-            TryCallInfo {
-                continuation: *labels.last().unwrap(),
-                exception_dests,
-            }
-        });
-
-        let clobbers = {
-            // Get clobbers: all caller-saves. These may include return value
-            // regs, which we will remove from the clobber set below.
-            let mut clobbers = <M>::get_regs_clobbered_by_call(
-                ctx.sigs()[self.sig].call_conv,
-                try_call_info.is_some(),
-            );
-
-            // Remove retval regs from clobbers.
-            for def in &defs {
-                if let RetLocation::Reg(preg, _) = def.location {
-                    clobbers.remove(PReg::from(preg.to_real_reg().unwrap()));
-                }
-            }
-
-            clobbers
-        };
-
-        // Any adjustment to SP to account for required outgoing arguments/stack return values must
-        // be done inside of the call pseudo-op, to ensure that SP is always in a consistent
-        // state for all other instructions. For example, if a tail-call abi function is called
-        // here, the reclamation of the outgoing argument area must be done inside of the call
-        // pseudo-op's emission to ensure that SP is consistent at all other points in the lowered
-        // function. (Except the prologue and epilogue, but those are fairly special parts of the
-        // function that establish the SP invariants that are relied on elsewhere and are generated
-        // after the register allocator has run and thus cannot have register allocator-inserted
-        // references to SP offsets.)
-        for inst in M::gen_call(
-            &self.dest,
-            tmp,
-            CallInfo {
-                dest: (),
-                uses,
-                defs,
-                clobbers,
-                callee_conv: call_conv,
-                caller_conv: self.caller_conv,
-                callee_pop_size,
-                try_call_info,
-            },
-        )
-        .into_iter()
-        {
-            ctx.emit(inst);
-        }
-    }
-}
 
 impl<T> CallInfo<T> {
     /// Emit loads for any stack-carried return values using the call

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -70,7 +70,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
             // (https://github.com/bytecodealliance/regalloc2/issues/217).
         };
 
-        regalloc2::run(&vcode, vcode.machine_env(), &options)
+        regalloc2::run(&vcode, vcode.abi.machine_env(), &options)
             .map_err(|err| {
                 log::error!(
                     "Register allocation error for vcode\n{:?}\nError: {:?}\nCLIF for error:\n{:?}",
@@ -86,7 +86,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     // Run the regalloc checker, if requested.
     if b.flags().regalloc_checker() {
         let _tt = timing::regalloc_checker();
-        let mut checker = regalloc2::checker::Checker::new(&vcode, vcode.machine_env());
+        let mut checker = regalloc2::checker::Checker::new(&vcode, vcode.abi.machine_env());
         checker.prepare(&regalloc_result);
         checker
             .run()

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -2,15 +2,14 @@ use crate::ir::{BlockCall, Value, ValueList};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use smallvec::SmallVec;
-use std::cell::Cell;
 
 pub use super::MachLabel;
 use super::RetPair;
 pub use crate::ir::{condcodes::CondCode, *};
 pub use crate::isa::{unwind::UnwindInst, TargetIsa};
 pub use crate::machinst::{
-    ABIArg, ABIArgSlot, ABIMachineSpec, CallSite, InputSourceInst, Lower, LowerBackend, RealReg,
-    Reg, RelocDistance, Sig, VCodeInst, Writable,
+    ABIArg, ABIArgSlot, ABIMachineSpec, InputSourceInst, Lower, LowerBackend, RealReg, Reg,
+    RelocDistance, Sig, TryCallInfo, VCodeInst, Writable,
 };
 pub use crate::settings::{StackSwitchModel, TlsModel};
 
@@ -24,17 +23,12 @@ pub type VecRetPair = Vec<RetPair>;
 pub type VecMask = Vec<u8>;
 pub type ValueRegs = crate::machinst::ValueRegs<Reg>;
 pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
+pub type ValueRegsVec = SmallVec<[ValueRegs; 2]>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
-pub type InstOutputBuilder = Cell<InstOutput>;
 pub type BoxExternalName = Box<ExternalName>;
-pub type Range = (usize, usize);
 pub type MachLabelSlice = [MachLabel];
 pub type BoxVecMachLabel = Box<Vec<MachLabel>>;
-
-pub enum RangeView {
-    Empty,
-    NonEmpty { index: usize, rest: Range },
-}
+pub type OptionTryCallInfo = Option<TryCallInfo>;
 
 /// Helper macro to define methods in `prelude.isle` within `impl Context for
 /// ...` for each backend. These methods are shared amongst all backends.
@@ -93,20 +87,8 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
-        fn output_builder_new(&mut self) -> InstOutputBuilder {
-            std::cell::Cell::new(InstOutput::new())
-        }
-
-        #[inline]
-        fn output_builder_push(&mut self, builder: &InstOutputBuilder, regs: ValueRegs) -> Unit {
-            let mut vec = builder.take();
-            vec.push(regs);
-            builder.set(vec);
-        }
-
-        #[inline]
-        fn output_builder_finish(&mut self, builder: &InstOutputBuilder) -> InstOutput {
-            builder.take()
+        fn output_vec(&mut self, output: &ValueRegsVec) -> InstOutput {
+            output.clone()
         }
 
         #[inline]
@@ -140,6 +122,16 @@ macro_rules! isle_lower_prelude_methods {
         #[inline]
         fn put_in_regs(&mut self, val: Value) -> ValueRegs {
             self.lower_ctx.put_value_in_regs(val)
+        }
+
+        #[inline]
+        fn put_in_regs_vec(&mut self, (list, off): ValueSlice) -> ValueRegsVec {
+            (off..list.len(&self.lower_ctx.dfg().value_lists))
+                .map(|ix| {
+                    let val = list.get(ix, &self.lower_ctx.dfg().value_lists).unwrap();
+                    self.put_in_regs(val)
+                })
+                .collect()
         }
 
         #[inline]
@@ -442,6 +434,10 @@ macro_rules! isle_lower_prelude_methods {
             regs.regs()[idx]
         }
 
+        fn abi_sig(&mut self, sig_ref: SigRef) -> Sig {
+            self.lower_ctx.sigs().abi_sig_for_sig_ref(sig_ref)
+        }
+
         fn abi_num_args(&mut self, abi: Sig) -> usize {
             self.lower_ctx.sigs().num_args(abi)
         }
@@ -584,14 +580,50 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         /// Generate the return instruction.
-        fn gen_return(&mut self, (list, off): ValueSlice) {
-            let rets = (off..list.len(&self.lower_ctx.dfg().value_lists))
-                .map(|ix| {
-                    let val = list.get(ix, &self.lower_ctx.dfg().value_lists).unwrap();
-                    self.put_in_regs(val)
-                })
-                .collect();
+        fn gen_return(&mut self, rets: &ValueRegsVec) {
             self.lower_ctx.gen_return(rets);
+        }
+
+        fn gen_call_output(&mut self, sig_ref: SigRef) -> ValueRegsVec {
+            self.lower_ctx.gen_call_output_from_sig_ref(sig_ref)
+        }
+
+        fn gen_call_args(&mut self, sig: Sig, inputs: &ValueRegsVec) -> CallArgList {
+            self.lower_ctx.gen_call_args(sig, inputs)
+        }
+
+        fn gen_return_call_args(&mut self, sig: Sig, inputs: &ValueRegsVec) -> CallArgList {
+            self.lower_ctx.gen_return_call_args(sig, inputs)
+        }
+
+        fn gen_call_rets(&mut self, sig: Sig, outputs: &ValueRegsVec) -> CallRetList {
+            self.lower_ctx.gen_call_rets(sig, &outputs)
+        }
+
+        fn gen_try_call_rets(&mut self, sig: Sig) -> CallRetList {
+            self.lower_ctx.gen_try_call_rets(sig)
+        }
+
+        fn try_call_none(&mut self) -> OptionTryCallInfo {
+            None
+        }
+
+        fn try_call_info(
+            &mut self,
+            et: ExceptionTable,
+            labels: &MachLabelSlice,
+        ) -> OptionTryCallInfo {
+            let exception_dests = self.lower_ctx.dfg().exception_tables[et]
+                .catches()
+                .map(|(tag, _)| tag.into())
+                .zip(labels.iter().cloned())
+                .collect::<Vec<_>>()
+                .into_boxed_slice();
+
+            Some(TryCallInfo {
+                continuation: *labels.last().unwrap(),
+                exception_dests,
+            })
         }
 
         /// Same as `shuffle32_from_imm`, but for 64-bit lane shuffles.
@@ -739,260 +771,6 @@ pub fn shuffle_imm_as_le_lane_idx(size: u8, bytes: &[u8]) -> Option<u8> {
     // immediate to specify a lane of `size` bytes. The index, when viewed as
     // `size`-byte immediates, will be the first byte divided by the byte size.
     Some(bytes[0] / size)
-}
-
-/// Helpers specifically for machines that use `abi::CallSite`.
-#[macro_export]
-#[doc(hidden)]
-macro_rules! isle_prelude_caller_methods {
-    ($abicaller:ty) => {
-        fn gen_call(
-            &mut self,
-            sig_ref: SigRef,
-            extname: ExternalName,
-            dist: RelocDistance,
-            args @ (inputs, off): ValueSlice,
-        ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
-            let sig = &self.lower_ctx.dfg().signatures[sig_ref];
-            let num_rets = sig.returns.len();
-            let caller = <$abicaller>::from_func(
-                self.lower_ctx.sigs(),
-                sig_ref,
-                &extname,
-                IsTailCall::No,
-                dist,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-
-            assert_eq!(
-                inputs.len(&self.lower_ctx.dfg().value_lists) - off,
-                sig.params.len()
-            );
-
-            crate::machinst::isle::gen_call_common(
-                &mut self.lower_ctx,
-                num_rets,
-                caller,
-                args,
-                None,
-            )
-        }
-
-        fn gen_call_indirect(
-            &mut self,
-            sig_ref: SigRef,
-            val: Value,
-            args @ (inputs, off): ValueSlice,
-        ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
-            let ptr = self.put_in_reg(val);
-            let sig = &self.lower_ctx.dfg().signatures[sig_ref];
-            let num_rets = sig.returns.len();
-            let caller = <$abicaller>::from_ptr(
-                self.lower_ctx.sigs(),
-                sig_ref,
-                ptr,
-                IsTailCall::No,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-
-            assert_eq!(
-                inputs.len(&self.lower_ctx.dfg().value_lists) - off,
-                sig.params.len()
-            );
-
-            crate::machinst::isle::gen_call_common(
-                &mut self.lower_ctx,
-                num_rets,
-                caller,
-                args,
-                None,
-            )
-        }
-
-        fn gen_return_call(
-            &mut self,
-            callee_sig: SigRef,
-            callee: ExternalName,
-            distance: RelocDistance,
-            args: ValueSlice,
-        ) -> InstOutput {
-            let caller_conv = isa::CallConv::Tail;
-            debug_assert_eq!(
-                self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
-                caller_conv,
-                "Can only do `return_call`s from within a `tail` calling convention function"
-            );
-
-            let call_site = <$abicaller>::from_func(
-                self.lower_ctx.sigs(),
-                callee_sig,
-                &callee,
-                IsTailCall::Yes,
-                distance,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-            call_site.emit_return_call(self.lower_ctx, args, self.backend);
-
-            InstOutput::new()
-        }
-
-        fn gen_return_call_indirect(
-            &mut self,
-            callee_sig: SigRef,
-            callee: Value,
-            args: ValueSlice,
-        ) -> InstOutput {
-            let caller_conv = isa::CallConv::Tail;
-            debug_assert_eq!(
-                self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
-                caller_conv,
-                "Can only do `return_call`s from within a `tail` calling convention function"
-            );
-
-            let callee = self.put_in_reg(callee);
-
-            let call_site = <$abicaller>::from_ptr(
-                self.lower_ctx.sigs(),
-                callee_sig,
-                callee,
-                IsTailCall::Yes,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-            call_site.emit_return_call(self.lower_ctx, args, self.backend);
-
-            InstOutput::new()
-        }
-
-        fn gen_try_call(
-            &mut self,
-            sig_ref: SigRef,
-            extname: ExternalName,
-            dist: RelocDistance,
-            et: ExceptionTable,
-            args: ValueSlice,
-            targets: &MachLabelSlice,
-        ) -> () {
-            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
-            let sigref = self.lower_ctx.dfg().exception_tables[et].signature();
-            let sig = &self.lower_ctx.dfg().signatures[sigref];
-            let num_rets = sig.returns.len();
-            let caller = <$abicaller>::from_func(
-                self.lower_ctx.sigs(),
-                sig_ref,
-                &extname,
-                IsTailCall::No,
-                dist,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-
-            crate::machinst::isle::gen_call_common(
-                &mut self.lower_ctx,
-                num_rets,
-                caller,
-                args,
-                Some((et, targets)),
-            );
-        }
-
-        fn gen_try_call_indirect(
-            &mut self,
-            sigref: SigRef,
-            callee: Value,
-            et: ExceptionTable,
-            args: ValueSlice,
-            targets: &MachLabelSlice,
-        ) -> () {
-            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
-            let sig = &self.lower_ctx.dfg().signatures[sigref];
-            let num_rets = sig.returns.len();
-
-            let callee = self.put_in_reg(callee);
-
-            let caller = <$abicaller>::from_ptr(
-                self.lower_ctx.sigs(),
-                sigref,
-                callee,
-                IsTailCall::No,
-                caller_conv,
-                self.backend.flags().clone(),
-            );
-
-            crate::machinst::isle::gen_call_common(
-                &mut self.lower_ctx,
-                num_rets,
-                caller,
-                args,
-                Some((et, targets)),
-            );
-        }
-    };
-}
-
-fn gen_call_common_args<M: ABIMachineSpec>(
-    ctx: &mut Lower<'_, M::I>,
-    call_site: &mut CallSite<M>,
-    (inputs, off): ValueSlice,
-) {
-    let num_args = call_site.num_args(ctx.sigs());
-
-    assert_eq!(inputs.len(&ctx.dfg().value_lists) - off, num_args);
-    let mut arg_regs = vec![];
-    for i in 0..num_args {
-        let input = inputs.get(off + i, &ctx.dfg().value_lists).unwrap();
-        arg_regs.push(ctx.put_value_in_regs(input));
-    }
-    for (i, arg_regs) in arg_regs.iter().enumerate() {
-        call_site.emit_copy_regs_to_buffer(ctx, i, *arg_regs);
-    }
-    for (i, arg_regs) in arg_regs.iter().enumerate() {
-        call_site.gen_arg(ctx, i, *arg_regs);
-    }
-}
-
-pub fn gen_call_common<M: ABIMachineSpec>(
-    ctx: &mut Lower<'_, M::I>,
-    num_rets: usize,
-    mut caller: CallSite<M>,
-    args: ValueSlice,
-    try_call_info: Option<(ExceptionTable, &MachLabelSlice)>,
-) -> InstOutput {
-    gen_call_common_args(ctx, &mut caller, args);
-
-    // Handle retvals prior to emitting call, so the
-    // constraints are on the call instruction.
-    let mut outputs = InstOutput::new();
-    // We take the *last* `num_rets` returns of the sig:
-    // this skips a StructReturn, if any, that is present.
-    let sigdata_num_rets = caller.num_rets(ctx.sigs());
-    debug_assert!(num_rets <= sigdata_num_rets);
-    for i in (sigdata_num_rets - num_rets)..sigdata_num_rets {
-        let retval_regs = caller.gen_retval(ctx, i);
-        outputs.push(retval_regs);
-    }
-
-    caller.emit_call(ctx, try_call_info);
-
-    // If this is a try-call, alias return value vregs to the ones
-    // already allocated for the block-call arg defs.
-    if try_call_info.is_some() {
-        for i in 0..outputs.len() {
-            let result_regs = outputs[i];
-            let def_regs = ctx.try_call_return_defs(ctx.cur_inst())[i];
-            for (result_reg, def_reg) in result_regs.regs().iter().zip(def_regs.regs().iter()) {
-                ctx.vregs_mut()
-                    .set_vreg_alias(def_reg.to_reg(), *result_reg);
-            }
-        }
-    }
-
-    outputs
 }
 
 /// This structure is used to implement the ISLE-generated `Context` trait and

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -26,7 +26,7 @@ use crate::CodegenError;
 use crate::{machinst::*, trace_log_enabled};
 use crate::{LabelValueLoc, ValueLocRange};
 use regalloc2::{
-    Edit, Function as RegallocFunction, InstOrEdit, InstPosition, InstRange, MachineEnv, Operand,
+    Edit, Function as RegallocFunction, InstOrEdit, InstPosition, InstRange, Operand,
     OperandConstraint, OperandKind, PRegSet, ProgPoint, RegClass,
 };
 use rustc_hash::FxHashMap;
@@ -517,7 +517,7 @@ impl<I: VCodeInst> VCodeBuilder<I> {
     }
 
     fn collect_operands(&mut self, vregs: &VRegAllocator<I>) {
-        let allocatable = PRegSet::from(self.vcode.machine_env());
+        let allocatable = PRegSet::from(self.vcode.abi.machine_env());
         for (i, insn) in self.vcode.insts.iter_mut().enumerate() {
             // Push operands from the instruction onto the operand list.
             //
@@ -663,11 +663,6 @@ impl<I: VCodeInst> VCode<I> {
             facts: vec![],
             log2_min_function_alignment,
         }
-    }
-
-    /// Get the ABI-dependent MachineEnv for managing register allocation.
-    pub fn machine_env(&self) -> &MachineEnv {
-        self.abi.machine_env(&self.sigs)
     }
 
     /// Get the number of blocks. Block indices will be in the range `0 ..

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -19,7 +19,6 @@ use std::marker::PhantomData;
 
 #[allow(dead_code)]
 pub type Unit = ();
-pub type Range = (usize, usize);
 pub type ValueArray2 = [Value; 2];
 pub type ValueArray3 = [Value; 3];
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -779,34 +779,6 @@
 (decl pure trap_code_bad_conversion_to_integer () TrapCode)
 (extern constructor trap_code_bad_conversion_to_integer trap_code_bad_conversion_to_integer)
 
-;;;; Helpers for tail recursion loops ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; A range of integers to loop through.
-(type Range (primitive Range))
-
-;; Create a new range from `start` through `end` (exclusive).
-(decl pure range (usize usize) Range)
-(extern constructor range range)
-
-;; A view on the current state of the range.
-(type RangeView extern
-      (enum
-        (Empty)
-        (NonEmpty (index usize) (rest Range))))
-
-;; View the current state of the range.
-(decl range_view (RangeView) Range)
-(extern extractor infallible range_view range_view)
-
-;; Extractor to test whether a range is empty.
-(decl range_empty () Range)
-(extractor (range_empty) (range_view (RangeView.Empty)))
-
-;; Extractor to return the first value in the range, and a sub-range
-;; containing the remaining values.
-(decl range_unwrap (usize Range) Range)
-(extractor (range_unwrap index rest) (range_view (RangeView.NonEmpty index rest)))
-
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (convert Offset32 i32 offset32_to_i32)

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -8,11 +8,10 @@
 
 (type ValueRegs (primitive ValueRegs))
 (type WritableValueRegs (primitive WritableValueRegs))
+(type ValueRegsVec extern (enum))
 
 ;; Instruction lowering result: a vector of `ValueRegs`.
 (type InstOutput (primitive InstOutput))
-;; (Mutable) builder to incrementally construct an `InstOutput`.
-(type InstOutputBuilder extern (enum))
 
 ;; Type to hold multiple Regs
 (type MultiReg
@@ -86,17 +85,9 @@
 (decl output_value (Value) InstOutput)
 (rule (output_value val) (output (put_in_regs val)))
 
-;; Initially empty `InstOutput` builder.
-(decl output_builder_new () InstOutputBuilder)
-(extern constructor output_builder_new output_builder_new)
-
-;; Append a `ValueRegs` to an `InstOutput` under construction.
-(decl output_builder_push (InstOutputBuilder ValueRegs) Unit)
-(extern constructor output_builder_push output_builder_push)
-
-;; Finish building an `InstOutput` incrementally.
-(decl output_builder_finish (InstOutputBuilder) InstOutput)
-(extern constructor output_builder_finish output_builder_finish)
+;; Construct an `InstOutput` from a vector.
+(decl output_vec (ValueRegsVec) InstOutput)
+(extern constructor output_vec output_vec)
 
 ;; Get a temporary register for writing.
 (decl temp_writable_reg (Type) WritableReg)
@@ -141,6 +132,10 @@
 (decl put_in_regs (Value) ValueRegs)
 (extern constructor put_in_regs put_in_regs)
 
+;; Put a slice of values into a vector of ValueRegs.
+(decl put_in_regs_vec (ValueSlice) ValueRegsVec)
+(extern constructor put_in_regs_vec put_in_regs_vec)
+
 ;; If the given reg is a real register, cause the value in reg to be in a virtual
 ;; reg, by copying it into a new virtual reg.
 (decl ensure_in_vreg (Reg Type) Reg)
@@ -155,10 +150,6 @@
 ;; Get the number of registers in a `ValueRegs`.
 (decl pure value_regs_len (ValueRegs) usize)
 (extern constructor value_regs_len value_regs_len)
-
-;; Get a range for the number of regs in a `ValueRegs`.
-(decl value_regs_range (ValueRegs) Range)
-(rule (value_regs_range regs) (range 0 (value_regs_len regs)))
 
 ;; Put the value into one or more registers and return the first register.
 ;;
@@ -208,7 +199,8 @@
 (type RelocDistance (primitive RelocDistance))
 (type VecArgPair extern (enum))
 (type VecRetPair extern (enum))
-(type CallArgList extern (enum))
+(type CallArgList (primitive CallArgList))
+(type CallRetList (primitive CallRetList))
 (type MachLabelSlice extern (enum))
 (type BoxVecMachLabel extern (enum))
 
@@ -1064,6 +1056,10 @@
     (Uext)
     (Sext)))
 
+;; Create a Sig from a SigRef.
+(decl abi_sig (SigRef) Sig)
+(extern constructor abi_sig abi_sig)
+
 ;; Get the number of arguments expected.
 (decl abi_num_args (Sig) usize)
 (extern constructor abi_num_args abi_num_args)
@@ -1129,14 +1125,29 @@
       (let ((_ Unit (gen_return vals)))
         (output_none)))
 
-(decl gen_return (ValueSlice) Unit)
+(decl gen_return (ValueRegsVec) Unit)
 (extern constructor gen_return gen_return)
 
-(decl gen_return_call (SigRef ExternalName RelocDistance ValueSlice) InstOutput)
-(extern constructor gen_return_call gen_return_call)
+(decl gen_call_output (SigRef) ValueRegsVec)
+(extern constructor gen_call_output gen_call_output)
 
-(decl gen_return_call_indirect (SigRef Value ValueSlice) InstOutput)
-(extern constructor gen_return_call_indirect gen_return_call_indirect)
+(decl gen_call_args (Sig ValueRegsVec) CallArgList)
+(extern constructor gen_call_args gen_call_args)
+
+(decl gen_return_call_args (Sig ValueRegsVec) CallArgList)
+(extern constructor gen_return_call_args gen_return_call_args)
+
+(decl gen_call_rets (Sig ValueRegsVec) CallRetList)
+(extern constructor gen_call_rets gen_call_rets)
+
+(decl gen_try_call_rets (Sig) CallRetList)
+(extern constructor gen_try_call_rets gen_try_call_rets)
+
+(type OptionTryCallInfo (primitive OptionTryCallInfo))
+(decl try_call_info (ExceptionTable MachLabelSlice) OptionTryCallInfo)
+(extern constructor try_call_info try_call_info)
+(decl try_call_none () OptionTryCallInfo)
+(extern constructor try_call_none try_call_none)
 
 ;; Helper for extracting an immediate that's not 0 and not -1 from an imm64.
  (spec (safe_divisor_from_imm64 t x)
@@ -1153,9 +1164,11 @@
 (convert WritableReg WritableValueRegs writable_value_reg)
 (convert Value Reg put_in_reg)
 (convert Value ValueRegs put_in_regs)
+(convert ValueSlice ValueRegsVec put_in_regs_vec)
 (convert WritableReg Reg writable_reg_to_reg)
 (convert ValueRegs InstOutput output)
 (convert Reg InstOutput output_reg)
 (convert Value InstOutput output_value)
+(convert ValueRegsVec InstOutput output_vec)
 (convert ExternalName BoxExternalName box_external_name)
 (convert PReg Reg preg_to_reg)

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -176,8 +176,8 @@ block0(v0: i8):
 ;   sd s1,24(sp)
 ; block0:
 ;   li a7,42
-;   slli a3,a0,56; srai a3,a3,56
-;   sd a3,0(sp)
+;   slli a4,a0,56; srai a4,a4,56
+;   sd a4,0(sp)
 ;   load_sym s1,%g+0
 ;   mv a0,a7
 ;   mv a1,a7
@@ -204,9 +204,9 @@ block0(v0: i8):
 ;   sd s1, 0x18(sp)
 ; block1: ; offset 0x18
 ;   addi a7, zero, 0x2a
-;   slli a3, a0, 0x38
-;   srai a3, a3, 0x38
-;   sd a3, 0(sp)
+;   slli a4, a0, 0x38
+;   srai a4, a4, 0x38
+;   sd a4, 0(sp)
 ;   auipc s1, 0
 ;   ld s1, 0xc(s1)
 ;   j 0xc

--- a/cranelift/filetests/filetests/isa/s390x/call-tail.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call-tail.clif
@@ -17,8 +17,8 @@ block0(v0: i64):
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ; block0:
-;   bras %r1, 12 ; data %g + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   bras %r1, 12 ; data %g + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
 ;
@@ -32,8 +32,8 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -18,8 +18,8 @@ block0(v0: i64):
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ; block0:
-;   bras %r1, 12 ; data %g + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   bras %r1, 12 ; data %g + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
 ;
@@ -33,8 +33,8 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
@@ -438,14 +438,14 @@ block0(v0: f128):
 ; block0:
 ;   lgr %r6, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 160(%r15)
 ;   la %r3, 160(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 176(%r15)
 ;   bras %r1, 12 ; data %g + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4 ; vl %v1, 176(%r15) ; vst %v1, 192(%r15)
 ;   lgr %r2, %r6
-;   vl %v19, 192(%r15)
-;   vst %v19, 0(%r2)
+;   vl %v16, 192(%r15)
+;   vst %v16, 0(%r2)
 ;   lmg %r6, %r15, 256(%r15)
 ;   br %r14
 ;
@@ -456,8 +456,8 @@ block0(v0: f128):
 ; block1: ; offset 0xa
 ;   lgr %r6, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 0xa0(%r15)
 ;   la %r3, 0xa0(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 0xb0(%r15)
 ;   bras %r1, 0x2e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -469,8 +469,8 @@ block0(v0: f128):
 ;   vl %v1, 0xb0(%r15)
 ;   vst %v1, 0xc0(%r15)
 ;   lgr %r2, %r6
-;   vl %v19, 0xc0(%r15)
-;   vst %v19, 0(%r2)
+;   vl %v16, 0xc0(%r15)
+;   vst %v16, 0(%r2)
 ;   lmg %r6, %r15, 0x100(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/return-call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call.clif
@@ -112,9 +112,9 @@ block0(v0: i64):
 ;   stg %r1, 0(%r15)
 ; block0:
 ;   lgr %r9, %r2
-;   bras %r1, 12 ; data %callee_i64 + 0 ; lg %r6, 0(%r1)
+;   bras %r1, 12 ; data %callee_i64 + 0 ; lg %r7, 0(%r1)
 ;   lgr %r2, %r3
-;   basr %r14, %r6
+;   basr %r14, %r7
 ;   bras %r1, 12 ; data %callee_i64_multiret + 0 ; lg %r7, 0(%r1)
 ;   lgr %r3, %r2
 ;   lgr %r2, %r9
@@ -133,9 +133,9 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r6, 0(%r1)
+;   lg %r7, 0(%r1)
 ;   lgr %r2, %r3
-;   basr %r14, %r6
+;   basr %r14, %r7
 ;   bras %r1, 0x3c
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_i64_multiret 0
 ;   .byte 0x00, 0x00

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi-128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi-128.clif
@@ -16,14 +16,14 @@ block0(v0: i128):
 ; block0:
 ;   lgr %r6, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 160(%r15)
 ;   la %r3, 160(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 176(%r15)
 ;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4 ; vl %v1, 176(%r15) ; vst %v1, 192(%r15)
 ;   lgr %r2, %r6
-;   vl %v19, 192(%r15)
-;   vst %v19, 0(%r2)
+;   vl %v16, 192(%r15)
+;   vst %v16, 0(%r2)
 ;   lmg %r6, %r15, 256(%r15)
 ;   br %r14
 ;
@@ -34,8 +34,8 @@ block0(v0: i128):
 ; block1: ; offset 0xa
 ;   lgr %r6, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 0xa0(%r15)
 ;   la %r3, 0xa0(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 0xb0(%r15)
 ;   bras %r1, 0x2e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
@@ -47,8 +47,8 @@ block0(v0: i128):
 ;   vl %v1, 0xb0(%r15)
 ;   vst %v1, 0xc0(%r15)
 ;   lgr %r2, %r6
-;   vl %v19, 0xc0(%r15)
-;   vst %v19, 0(%r2)
+;   vl %v16, 0xc0(%r15)
+;   vst %v16, 0(%r2)
 ;   lmg %r6, %r15, 0x100(%r15)
 ;   br %r14
 
@@ -75,14 +75,14 @@ block0(v0: i128):
 ;   lgr %r8, %r2
 ;   vl %v1, 0(%r3)
 ;   aghi %r15, -176
-;   vst %v1, 160(%r15)
 ;   la %r3, 160(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 336(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4 ; callee_pop_size 176 ; vl %v1, 336(%r15) ; vst %v1, 352(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5 ; callee_pop_size 176 ; vl %v1, 160(%r15) ; vst %v1, 176(%r15)
 ;   lgr %r2, %r8
-;   vl %v20, 176(%r15)
-;   vst %v20, 0(%r2)
+;   vl %v17, 176(%r15)
+;   vst %v17, 0(%r2)
 ;   ld %f8, 192(%r15)
 ;   ld %f9, 200(%r15)
 ;   ld %f10, 208(%r15)
@@ -110,21 +110,21 @@ block0(v0: i128):
 ;   lgr %r8, %r2
 ;   vl %v1, 0(%r3)
 ;   aghi %r15, -0xb0
-;   vst %v1, 0xa0(%r15)
 ;   la %r3, 0xa0(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 0x150(%r15)
 ;   bras %r1, 0x52
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   vl %v1, 0xa0(%r15)
 ;   vst %v1, 0xb0(%r15)
 ;   lgr %r2, %r8
-;   vl %v20, 0xb0(%r15)
-;   vst %v20, 0(%r2)
+;   vl %v17, 0xb0(%r15)
+;   vst %v17, 0(%r2)
 ;   ld %f8, 0xc0(%r15)
 ;   ld %f9, 0xc8(%r15)
 ;   ld %f10, 0xd0(%r15)
@@ -156,16 +156,16 @@ block0(v0: i128):
 ;   std %f14, 256(%r15)
 ;   std %f15, 264(%r15)
 ; block0:
-;   lgr %r6, %r2
+;   lgr %r7, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 160(%r15)
 ;   la %r3, 160(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 176(%r15)
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r5, 0(%r1)
-;   basr %r14, %r5 ; vl %v1, 176(%r15) ; vst %v1, 192(%r15)
-;   lgr %r2, %r6
-;   vl %v19, 192(%r15)
-;   vst %v19, 0(%r2)
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r6, 0(%r1)
+;   basr %r14, %r6 ; vl %v1, 176(%r15) ; vst %v1, 192(%r15)
+;   lgr %r2, %r7
+;   vl %v16, 192(%r15)
+;   vst %v16, 0(%r2)
 ;   ld %f8, 208(%r15)
 ;   ld %f9, 216(%r15)
 ;   ld %f10, 224(%r15)
@@ -191,23 +191,23 @@ block0(v0: i128):
 ;   std %f14, 0x100(%r15)
 ;   std %f15, 0x108(%r15)
 ; block1: ; offset 0x2a
-;   lgr %r6, %r2
+;   lgr %r7, %r2
 ;   vl %v1, 0(%r3)
-;   vst %v1, 0xa0(%r15)
 ;   la %r3, 0xa0(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 0xb0(%r15)
 ;   bras %r1, 0x4e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r5, 0(%r1)
-;   basr %r14, %r5
+;   lg %r6, 0(%r1)
+;   basr %r14, %r6
 ;   vl %v1, 0xb0(%r15)
 ;   vst %v1, 0xc0(%r15)
-;   lgr %r2, %r6
-;   vl %v19, 0xc0(%r15)
-;   vst %v19, 0(%r2)
+;   lgr %r2, %r7
+;   vl %v16, 0xc0(%r15)
+;   vst %v16, 0(%r2)
 ;   ld %f8, 0xd0(%r15)
 ;   ld %f9, 0xd8(%r15)
 ;   ld %f10, 0xe0(%r15)
@@ -235,14 +235,14 @@ block0(v0: i128):
 ;   lgr %r9, %r2
 ;   vl %v1, 0(%r3)
 ;   aghi %r15, -176
-;   vst %v1, 160(%r15)
 ;   la %r3, 160(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 336(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r6, 0(%r1)
-;   basr %r14, %r6 ; callee_pop_size 176 ; vl %v1, 336(%r15) ; vst %v1, 352(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r7, 0(%r1)
+;   basr %r14, %r7 ; callee_pop_size 176 ; vl %v1, 160(%r15) ; vst %v1, 176(%r15)
 ;   lgr %r2, %r9
-;   vl %v20, 176(%r15)
-;   vst %v20, 0(%r2)
+;   vl %v17, 176(%r15)
+;   vst %v17, 0(%r2)
 ;   aghi %r15, 368
 ;   lmg %r9, %r14, 72(%r15)
 ;   br %r14
@@ -255,21 +255,21 @@ block0(v0: i128):
 ;   lgr %r9, %r2
 ;   vl %v1, 0(%r3)
 ;   aghi %r15, -0xb0
-;   vst %v1, 0xa0(%r15)
 ;   la %r3, 0xa0(%r15)
+;   vst %v1, 0(%r3)
 ;   la %r2, 0x150(%r15)
 ;   bras %r1, 0x32
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r6, 0(%r1)
-;   basr %r14, %r6
+;   lg %r7, 0(%r1)
+;   basr %r14, %r7
 ;   vl %v1, 0xa0(%r15)
 ;   vst %v1, 0xb0(%r15)
 ;   lgr %r2, %r9
-;   vl %v20, 0xb0(%r15)
-;   vst %v20, 0(%r2)
+;   vl %v17, 0xb0(%r15)
+;   vst %v17, 0(%r2)
 ;   aghi %r15, 0x170
 ;   lmg %r9, %r14, 0x48(%r15)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -21,8 +21,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vst %v19, 176(%r15)
 ;   vst %v21, 192(%r15)
 ;   vst %v23, 208(%r15)
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r3, 0(%r1)
-;   basr %r14, %r3
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
 ;
@@ -44,8 +44,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r3, 0(%r1)
-;   basr %r14, %r3
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
 ;   lmg %r14, %r15, 0x150(%r15)
 ;   br %r14
 
@@ -75,41 +75,23 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vl %v23, 432(%r15)
 ;   aghi %r15, -224
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v0, %v25, %v25, 4
-;   verllg %v25, %v0, 32
-;   vpdi %v0, %v26, %v26, 4
-;   verllg %v2, %v0, 32
-;   verllf %v26, %v2, 16
-;   vpdi %v6, %v27, %v27, 4
-;   verllg %v16, %v6, 32
-;   verllf %v18, %v16, 16
-;   verllh %v27, %v18, 8
+;   vpdi %v25, %v25, %v25, 4 ; verllg %v25, %v25, 32
+;   vpdi %v26, %v26, %v26, 4 ; verllg %v26, %v26, 32 ; verllf %v26, %v26, 16
+;   vpdi %v27, %v27, %v27, 4 ; verllg %v27, %v27, 32 ; verllf %v27, %v27, 16 ; verllh %v27, %v27, 8
 ;   vpdi %v28, %v28, %v28, 4
-;   vpdi %v29, %v29, %v29, 4
-;   verllg %v29, %v29, 32
-;   vpdi %v30, %v30, %v30, 4
-;   verllg %v30, %v30, 32
-;   verllf %v30, %v30, 16
-;   vpdi %v2, %v31, %v31, 4
-;   verllg %v4, %v2, 32
-;   verllf %v6, %v4, 16
-;   verllh %v31, %v6, 8
-;   vpdi %v18, %v17, %v17, 4
-;   vst %v18, 160(%r15)
-;   vpdi %v22, %v19, %v19, 4
-;   verllg %v0, %v22, 32
-;   vst %v0, 176(%r15)
-;   vpdi %v0, %v21, %v21, 4
-;   verllg %v0, %v0, 32
-;   verllf %v0, %v0, 16
-;   vst %v0, 192(%r15)
-;   vpdi %v1, %v23, %v23, 4
-;   verllg %v3, %v1, 32
-;   verllf %v5, %v3, 16
-;   verllh %v7, %v5, 8
-;   vst %v7, 208(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4 ; callee_pop_size 224 ; vpdi %v24, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vpdi %v29, %v29, %v29, 4 ; verllg %v29, %v29, 32
+;   vpdi %v30, %v30, %v30, 4 ; verllg %v30, %v30, 32 ; verllf %v30, %v30, 16
+;   vpdi %v31, %v31, %v31, 4 ; verllg %v31, %v31, 32 ; verllf %v31, %v31, 16 ; verllh %v31, %v31, 8
+;   vpdi %v20, %v17, %v17, 4
+;   vpdi %v22, %v19, %v19, 4 ; verllg %v19, %v19, 32
+;   vpdi %v1, %v21, %v21, 4 ; verllg %v21, %v21, 32 ; verllf %v21, %v21, 16
+;   vpdi %v0, %v23, %v23, 4 ; verllg %v23, %v23, 32 ; verllf %v23, %v23, 16 ; verllh %v23, %v23, 8
+;   vst %v20, 160(%r15)
+;   vst %v22, 176(%r15)
+;   vst %v1, 192(%r15)
+;   vst %v0, 208(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r5, 0(%r1)
+;   basr %r14, %r5 ; callee_pop_size 224 ; vpdi %v24, %v24, %v24, 4 ; verllg %v24, %v24, 32
 ;   ld %f8, 160(%r15)
 ;   ld %f9, 168(%r15)
 ;   ld %f10, 176(%r15)
@@ -140,46 +122,46 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vl %v23, 0x1b0(%r15)
 ;   aghi %r15, -0xe0
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v0, %v25, %v25, 4
-;   verllg %v25, %v0, 0x20
-;   vpdi %v0, %v26, %v26, 4
-;   verllg %v2, %v0, 0x20
-;   verllf %v26, %v2, 0x10
-;   vpdi %v6, %v27, %v27, 4
-;   verllg %v16, %v6, 0x20
-;   verllf %v18, %v16, 0x10
-;   verllh %v27, %v18, 8
+;   vpdi %v25, %v25, %v25, 4
+;   verllg %v25, %v25, 0x20
+;   vpdi %v26, %v26, %v26, 4
+;   verllg %v26, %v26, 0x20
+;   verllf %v26, %v26, 0x10
+;   vpdi %v27, %v27, %v27, 4
+;   verllg %v27, %v27, 0x20
+;   verllf %v27, %v27, 0x10
+;   verllh %v27, %v27, 8
 ;   vpdi %v28, %v28, %v28, 4
 ;   vpdi %v29, %v29, %v29, 4
 ;   verllg %v29, %v29, 0x20
 ;   vpdi %v30, %v30, %v30, 4
 ;   verllg %v30, %v30, 0x20
 ;   verllf %v30, %v30, 0x10
-;   vpdi %v2, %v31, %v31, 4
-;   verllg %v4, %v2, 0x20
-;   verllf %v6, %v4, 0x10
-;   verllh %v31, %v6, 8
-;   vpdi %v18, %v17, %v17, 4
-;   vst %v18, 0xa0(%r15)
+;   vpdi %v31, %v31, %v31, 4
+;   verllg %v31, %v31, 0x20
+;   verllf %v31, %v31, 0x10
+;   verllh %v31, %v31, 8
+;   vpdi %v20, %v17, %v17, 4
 ;   vpdi %v22, %v19, %v19, 4
-;   verllg %v0, %v22, 0x20
-;   vst %v0, 0xb0(%r15)
-;   vpdi %v0, %v21, %v21, 4
+;   verllg %v22, %v22, 0x20
+;   vpdi %v1, %v21, %v21, 4
+;   verllg %v1, %v1, 0x20
+;   verllf %v1, %v1, 0x10
+;   vpdi %v0, %v23, %v23, 4
 ;   verllg %v0, %v0, 0x20
 ;   verllf %v0, %v0, 0x10
-;   vst %v0, 0xc0(%r15)
-;   vpdi %v1, %v23, %v23, 4
-;   verllg %v3, %v1, 0x20
-;   verllf %v5, %v3, 0x10
-;   verllh %v7, %v5, 8
-;   vst %v7, 0xd0(%r15)
+;   verllh %v0, %v0, 8
+;   vst %v20, 0xa0(%r15)
+;   vst %v22, 0xb0(%r15)
+;   vst %v1, 0xc0(%r15)
+;   vst %v0, 0xd0(%r15)
 ;   bras %r1, 0x11e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
 ;   vpdi %v24, %v24, %v24, 4
 ;   verllg %v24, %v24, 0x20
 ;   ld %f8, 0xa0(%r15)
@@ -218,41 +200,23 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vl %v21, 480(%r15)
 ;   vl %v23, 496(%r15)
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v0, %v25, %v25, 4
-;   verllg %v25, %v0, 32
-;   vpdi %v0, %v26, %v26, 4
-;   verllg %v1, %v0, 32
-;   verllf %v26, %v1, 16
-;   vpdi %v5, %v27, %v27, 4
-;   verllg %v7, %v5, 32
-;   verllf %v18, %v7, 16
-;   verllh %v27, %v18, 8
+;   vpdi %v25, %v25, %v25, 4 ; verllg %v25, %v25, 32
+;   vpdi %v26, %v26, %v26, 4 ; verllg %v26, %v26, 32 ; verllf %v26, %v26, 16
+;   vpdi %v27, %v27, %v27, 4 ; verllg %v27, %v27, 32 ; verllf %v27, %v27, 16 ; verllh %v27, %v27, 8
 ;   vpdi %v28, %v28, %v28, 4
-;   vpdi %v29, %v29, %v29, 4
-;   verllg %v29, %v29, 32
-;   vpdi %v30, %v30, %v30, 4
-;   verllg %v30, %v30, 32
-;   verllf %v30, %v30, 16
-;   vpdi %v1, %v31, %v31, 4
-;   verllg %v3, %v1, 32
-;   verllf %v5, %v3, 16
-;   verllh %v31, %v5, 8
-;   vpdi %v17, %v17, %v17, 4
-;   vst %v17, 160(%r15)
-;   vpdi %v20, %v19, %v19, 4
-;   verllg %v22, %v20, 32
-;   vst %v22, 176(%r15)
-;   vpdi %v0, %v21, %v21, 4
-;   verllg %v0, %v0, 32
-;   verllf %v0, %v0, 16
-;   vst %v0, 192(%r15)
-;   vpdi %v0, %v23, %v23, 4
-;   verllg %v2, %v0, 32
-;   verllf %v4, %v2, 16
-;   verllh %v6, %v4, 8
-;   vst %v6, 208(%r15)
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r5, 0(%r1)
-;   basr %r14, %r5 ; vpdi %v24, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vpdi %v29, %v29, %v29, 4 ; verllg %v29, %v29, 32
+;   vpdi %v30, %v30, %v30, 4 ; verllg %v30, %v30, 32 ; verllf %v30, %v30, 16
+;   vpdi %v31, %v31, %v31, 4 ; verllg %v31, %v31, 32 ; verllf %v31, %v31, 16 ; verllh %v31, %v31, 8
+;   vpdi %v18, %v17, %v17, 4
+;   vpdi %v20, %v19, %v19, 4 ; verllg %v19, %v19, 32
+;   vpdi %v22, %v21, %v21, 4 ; verllg %v21, %v21, 32 ; verllf %v21, %v21, 16
+;   vpdi %v0, %v23, %v23, 4 ; verllg %v23, %v23, 32 ; verllf %v23, %v23, 16 ; verllh %v23, %v23, 8
+;   vst %v18, 160(%r15)
+;   vst %v20, 176(%r15)
+;   vst %v22, 192(%r15)
+;   vst %v0, 208(%r15)
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r6, 0(%r1)
+;   basr %r14, %r6 ; vpdi %v24, %v24, %v24, 4 ; verllg %v24, %v24, 32
 ;   ld %f8, 224(%r15)
 ;   ld %f9, 232(%r15)
 ;   ld %f10, 240(%r15)
@@ -283,46 +247,46 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vl %v21, 0x1e0(%r15)
 ;   vl %v23, 0x1f0(%r15)
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v0, %v25, %v25, 4
-;   verllg %v25, %v0, 0x20
-;   vpdi %v0, %v26, %v26, 4
-;   verllg %v1, %v0, 0x20
-;   verllf %v26, %v1, 0x10
-;   vpdi %v5, %v27, %v27, 4
-;   verllg %v7, %v5, 0x20
-;   verllf %v18, %v7, 0x10
-;   verllh %v27, %v18, 8
+;   vpdi %v25, %v25, %v25, 4
+;   verllg %v25, %v25, 0x20
+;   vpdi %v26, %v26, %v26, 4
+;   verllg %v26, %v26, 0x20
+;   verllf %v26, %v26, 0x10
+;   vpdi %v27, %v27, %v27, 4
+;   verllg %v27, %v27, 0x20
+;   verllf %v27, %v27, 0x10
+;   verllh %v27, %v27, 8
 ;   vpdi %v28, %v28, %v28, 4
 ;   vpdi %v29, %v29, %v29, 4
 ;   verllg %v29, %v29, 0x20
 ;   vpdi %v30, %v30, %v30, 4
 ;   verllg %v30, %v30, 0x20
 ;   verllf %v30, %v30, 0x10
-;   vpdi %v1, %v31, %v31, 4
-;   verllg %v3, %v1, 0x20
-;   verllf %v5, %v3, 0x10
-;   verllh %v31, %v5, 8
-;   vpdi %v17, %v17, %v17, 4
-;   vst %v17, 0xa0(%r15)
+;   vpdi %v31, %v31, %v31, 4
+;   verllg %v31, %v31, 0x20
+;   verllf %v31, %v31, 0x10
+;   verllh %v31, %v31, 8
+;   vpdi %v18, %v17, %v17, 4
 ;   vpdi %v20, %v19, %v19, 4
-;   verllg %v22, %v20, 0x20
-;   vst %v22, 0xb0(%r15)
-;   vpdi %v0, %v21, %v21, 4
+;   verllg %v20, %v20, 0x20
+;   vpdi %v22, %v21, %v21, 4
+;   verllg %v22, %v22, 0x20
+;   verllf %v22, %v22, 0x10
+;   vpdi %v0, %v23, %v23, 4
 ;   verllg %v0, %v0, 0x20
 ;   verllf %v0, %v0, 0x10
-;   vst %v0, 0xc0(%r15)
-;   vpdi %v0, %v23, %v23, 4
-;   verllg %v2, %v0, 0x20
-;   verllf %v4, %v2, 0x10
-;   verllh %v6, %v4, 8
-;   vst %v6, 0xd0(%r15)
+;   verllh %v0, %v0, 8
+;   vst %v18, 0xa0(%r15)
+;   vst %v20, 0xb0(%r15)
+;   vst %v22, 0xc0(%r15)
+;   vst %v0, 0xd0(%r15)
 ;   bras %r1, 0x11a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r5, 0(%r1)
-;   basr %r14, %r5
+;   lg %r6, 0(%r1)
+;   basr %r14, %r6
 ;   vpdi %v24, %v24, %v24, 4
 ;   verllg %v24, %v24, 0x20
 ;   ld %f8, 0xe0(%r15)
@@ -358,8 +322,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   vst %v19, 176(%r15)
 ;   vst %v21, 192(%r15)
 ;   vst %v23, 208(%r15)
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r6, 0(%r1)
-;   basr %r14, %r6 ; callee_pop_size 224
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r7, 0(%r1)
+;   basr %r14, %r7 ; callee_pop_size 224
 ;   aghi %r15, 384
 ;   lmg %r14, %r14, 112(%r15)
 ;   br %r14
@@ -383,8 +347,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   lg %r6, 0(%r1)
-;   basr %r14, %r6
+;   lg %r7, 0(%r1)
+;   basr %r14, %r7
 ;   aghi %r15, 0x180
 ;   lmg %r14, %r14, 0x70(%r15)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
@@ -28,15 +28,14 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   vpdi %v2, %v24, %v24, 4
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 32
+;   vpdi %v24, %v2, %v2, 4 ; verllg %v2, %v2, 32
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v2, %v24, %v24, 4
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 0x20
+;   vpdi %v24, %v2, %v2, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %bitcast_i64x2_i32x4(i64x2) -> i32x4 tail {
@@ -48,15 +47,14 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   vpdi %v2, %v24, %v24, 4
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 32
+;   vpdi %v24, %v2, %v2, 4 ; verllg %v2, %v2, 32
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v2, %v24, %v24, 4
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 0x20
+;   vpdi %v24, %v2, %v2, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %bitcast_i64x2_i32x4(i64x2) -> i32x4 tail {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
@@ -154,17 +154,15 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v6, %v4, 32
-;   verllf %v24, %v6, 16
+;   vpdi %v24, %v2, %v2, 4 ; verllg %v2, %v2, 32 ; verllf %v2, %v2, 16
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2) ; trap: heap_oob
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v6, %v4, 0x20
-;   verllf %v24, %v6, 0x10
+;   vpdi %v24, %v2, %v2, 4
+;   verllg %v24, %v24, 0x20
+;   verllf %v24, %v24, 0x10
 ;   br %r14
 
 function %load_i32x4_big(i64) -> i32x4 tail {
@@ -176,15 +174,14 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 32
+;   vpdi %v24, %v2, %v2, 4 ; verllg %v2, %v2, 32
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2) ; trap: heap_oob
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 0x20
+;   vpdi %v24, %v2, %v2, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %load_i64x2_big(i64) -> i64x2 tail {
@@ -214,15 +211,14 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 32
+;   vpdi %v24, %v2, %v2, 4 ; verllg %v2, %v2, 32
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2) ; trap: heap_oob
-;   vpdi %v4, %v2, %v2, 4
-;   verllg %v24, %v4, 0x20
+;   vpdi %v24, %v2, %v2, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %load_f64x2_big(i64) -> f64x2 tail {
@@ -273,18 +269,16 @@ block0(v0: i16x8, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   verllf %v7, %v5, 16
-;   vst %v7, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32 ; verllf %v24, %v24, 16
+;   vst %v3, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   verllf %v7, %v5, 0x10
-;   vst %v7, 0(%r2) ; trap: heap_oob
+;   verllg %v3, %v3, 0x20
+;   verllf %v3, %v3, 0x10
+;   vst %v3, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
 function %store_i32x4_big(i32x4, i64) tail {
@@ -295,16 +289,15 @@ block0(v0: i32x4, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   vst %v5, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vst %v3, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   vst %v5, 0(%r2) ; trap: heap_oob
+;   verllg %v3, %v3, 0x20
+;   vst %v3, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
 function %store_i64x2_big(i64x2, i64) tail {
@@ -333,16 +326,15 @@ block0(v0: f32x4, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   vst %v5, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vst %v3, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   vst %v5, 0(%r2) ; trap: heap_oob
+;   verllg %v3, %v3, 0x20
+;   vst %v3, 0(%r2) ; trap: heap_oob
 ;   br %r14
 
 function %store_f64x2_big(f64x2, i64) tail {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -485,9 +485,7 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v18, %v16, 32
-;   verllf %v24, %v18, 16
+;   vpdi %v24, %v6, %v6, 4 ; verllg %v6, %v6, 32 ; verllf %v6, %v6, 16
 ;   br %r14
 ;
 ; Disassembled:
@@ -495,9 +493,9 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
 ;   lrvg %r2, 8(%r2) ; trap: heap_oob
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v18, %v16, 0x20
-;   verllf %v24, %v18, 0x10
+;   vpdi %v24, %v6, %v6, 4
+;   verllg %v24, %v24, 0x20
+;   verllf %v24, %v24, 0x10
 ;   br %r14
 
 function %load_i32x4_little(i64) -> i32x4 {
@@ -511,8 +509,7 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v24, %v16, 32
+;   vpdi %v24, %v6, %v6, 4 ; verllg %v6, %v6, 32
 ;   br %r14
 ;
 ; Disassembled:
@@ -520,8 +517,8 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
 ;   lrvg %r2, 8(%r2) ; trap: heap_oob
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v24, %v16, 0x20
+;   vpdi %v24, %v6, %v6, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %load_i64x2_little(i64) -> i64x2 {
@@ -579,8 +576,7 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v24, %v16, 32
+;   vpdi %v24, %v6, %v6, 4 ; verllg %v6, %v6, 32
 ;   br %r14
 ;
 ; Disassembled:
@@ -588,8 +584,8 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2) ; trap: heap_oob
 ;   lrvg %r2, 8(%r2) ; trap: heap_oob
 ;   vlvgp %v6, %r2, %r4
-;   vpdi %v16, %v6, %v6, 4
-;   verllg %v24, %v16, 0x20
+;   vpdi %v24, %v6, %v6, 4
+;   verllg %v24, %v24, 0x20
 ;   br %r14
 
 function %load_f64x2_little(i64) -> f64x2 {
@@ -683,11 +679,9 @@ block0(v0: i16x8, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   verllf %v7, %v5, 16
-;   vlgvg %r3, %v7, 1
-;   lgdr %r5, %f7
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32 ; verllf %v24, %v24, 16
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
 ;   strvg %r3, 0(%r2)
 ;   strvg %r5, 8(%r2)
 ;   br %r14
@@ -695,10 +689,10 @@ block0(v0: i16x8, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   verllf %v7, %v5, 0x10
-;   vlgvg %r3, %v7, 1
-;   lgdr %r5, %f7
+;   verllg %v3, %v3, 0x20
+;   verllf %v3, %v3, 0x10
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
 ;   strvg %r3, 0(%r2) ; trap: heap_oob
 ;   strvg %r5, 8(%r2) ; trap: heap_oob
 ;   br %r14
@@ -711,22 +705,21 @@ block0(v0: i32x4, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   vlgvg %r5, %v5, 1
-;   lgdr %r3, %f5
-;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   vlgvg %r5, %v5, 1
-;   lgdr %r3, %f5
-;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   verllg %v3, %v3, 0x20
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2) ; trap: heap_oob
+;   strvg %r5, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
 function %store_i64x2_little(i64x2, i64) {
@@ -785,22 +778,21 @@ block0(v0: f32x4, v1: i64):
 
 ; VCode:
 ; block0:
-;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 32
-;   vlgvg %r5, %v5, 1
-;   lgdr %r3, %f5
-;   strvg %r5, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4 ; verllg %v24, %v24, 32
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
-;   verllg %v5, %v3, 0x20
-;   vlgvg %r5, %v5, 1
-;   lgdr %r3, %f5
-;   strvg %r5, 0(%r2) ; trap: heap_oob
-;   strvg %r3, 8(%r2) ; trap: heap_oob
+;   verllg %v3, %v3, 0x20
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2) ; trap: heap_oob
+;   strvg %r5, 8(%r2) ; trap: heap_oob
 ;   br %r14
 
 function %store_f64x2_little(f64x2, i64) {

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -77,8 +77,8 @@ block0(v0: i64):
 ;   movq    %rdi, %rsi
 ;   lea     0(%rsp), %rdi
 ;   movl    $64, %edx
-;   load_ext_name %Memcpy+0, %r9
-;   call    *%r9
+;   load_ext_name %Memcpy+0, %r10
+;   call    *%r10
 ;   call    User(userextname0)
 ;   addq $0x40, %rsp
 ;   movq    %rbp, %rsp
@@ -94,8 +94,8 @@ block0(v0: i64):
 ;   movq %rdi, %rsi
 ;   leaq (%rsp), %rdi
 ;   movl $0x40, %edx
-;   movabsq $0, %r9 ; reloc_external Abs8 %Memcpy 0
-;   callq *%r9
+;   movabsq $0, %r10 ; reloc_external Abs8 %Memcpy 0
+;   callq *%r10
 ;   callq 0x26 ; reloc_external CallPCRel4 u0:0 -4
 ;   addq $0x40, %rsp
 ;   movq %rbp, %rsp
@@ -119,8 +119,8 @@ block0(v0: i64, v1: i64):
 ;   movq    %rdi, %r14
 ;   lea     0(%rsp), %rdi
 ;   movl    $64, %edx
-;   load_ext_name %Memcpy+0, %r10
-;   call    *%r10
+;   load_ext_name %Memcpy+0, %r11
+;   call    *%r11
 ;   movq    %r14, %rdi
 ;   call    User(userextname0)
 ;   movq    64(%rsp), %r14
@@ -139,8 +139,8 @@ block0(v0: i64, v1: i64):
 ;   movq %rdi, %r14
 ;   leaq (%rsp), %rdi
 ;   movl $0x40, %edx
-;   movabsq $0, %r10 ; reloc_external Abs8 %Memcpy 0
-;   callq *%r10
+;   movabsq $0, %r11 ; reloc_external Abs8 %Memcpy 0
+;   callq *%r11
 ;   movq %r14, %rdi
 ;   callq 0x2e ; reloc_external CallPCRel4 u0:0 -4
 ;   movq 0x40(%rsp), %r14
@@ -203,13 +203,13 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq    %rdi, %r13
 ;   lea     0(%rsp), %rdi
 ;   movl    $128, %edx
-;   load_ext_name %Memcpy+0, %r11
-;   call    *%r11
+;   load_ext_name %Memcpy+0, %rax
+;   call    *%rax
 ;   lea     128(%rsp), %rdi
 ;   movl    $64, %edx
-;   load_ext_name %Memcpy+0, %r9
+;   load_ext_name %Memcpy+0, %r10
 ;   movq    %rbx, %rsi
-;   call    *%r9
+;   call    *%r10
 ;   movq    %r13, %rdi
 ;   call    User(userextname0)
 ;   movq    192(%rsp), %rbx
@@ -231,15 +231,15 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq %rdi, %r13
 ;   leaq (%rsp), %rdi
 ;   movl $0x80, %edx
-;   movabsq $0, %r11 ; reloc_external Abs8 %Memcpy 0
-;   callq *%r11
+;   movabsq $0, %rax ; reloc_external Abs8 %Memcpy 0
+;   callq *%rax
 ;   leaq 0x80(%rsp), %rdi
 ;   movl $0x40, %edx
-;   movabsq $0, %r9 ; reloc_external Abs8 %Memcpy 0
+;   movabsq $0, %r10 ; reloc_external Abs8 %Memcpy 0
 ;   movq %rbx, %rsi
-;   callq *%r9
+;   callq *%r10
 ;   movq %r13, %rdi
-;   callq 0x5c ; reloc_external CallPCRel4 u0:0 -4
+;   callq 0x5b ; reloc_external CallPCRel4 u0:0 -4
 ;   movq 0xc0(%rsp), %rbx
 ;   movq 0xc8(%rsp), %r13
 ;   addq $0xd0, %rsp


### PR DESCRIPTION
This refactors implementation of call ABI handling across architectures with the goal of bringing s390x in line with other platforms.

The main idea is to
- handle main call instruction selection and generation in ISLE (like s390x but unlike other platforms today)
- handle argument setup mostly outside of ISLE (like other platforms but unlike s390x today)
- handle return value processing as part of the call instructio (like all platforms today)

All platforms now emit the main call instruction directly from ISLE, which e.g. handles selection of the correct ISA instruction depending on the call destination.  This ISLE code calls out to helper routines to handle argument and return value processing.  These helpers are mostly common code and provided by the Callee and/or Lower layers, with some platform-specific additions via ISLE Context routines.

The old CallSite abstraction is no longer needed; most of the differences between call and return_call handling disappear. (There is still a common-code CallInfo vs. a platform-specifc ReturnCallInfo.  At this point, it should be relatively straight- forward to make CallInfo platform-specific as well if desired, but this is not done here.)

Some ISLE infrastructure for iterators / loops, which was only ever used by the s390x argument processing code, has been removed.

s390x now closely matches all other platforms, with only a few special cases (slightly different tail-call ABI requires some differences in stack offset computations; we still need to handle vector lane swaps for cross-ABI calls), which should simplify future maintenance.

FYI @cfallin 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
