### PR TITLE
pulley: Allow disabling SIMD in the interpreter at compile-time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -624,6 +624,9 @@ jobs:
     - run: cargo check -p pulley-interpreter --all-features
       env:
         RUSTFLAGS: "--cfg pulley_tail_calls"
+    - run: cargo check -p pulley-interpreter --all-features
+      env:
+        RUSTFLAGS: "--cfg pulley_disable_interp_simd"
     - run: cargo test -p pulley-interpreter --all-features --release
       env:
         RUSTFLAGS: "--cfg pulley_assume_llvm_makes_tail_calls"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "cranelift-bitset",
  "env_logger 0.11.5",
  "log",
+ "pulley-macros",
  "termcolor",
  "wasmtime-math",
 ]
@@ -2669,6 +2670,15 @@ dependencies = [
  "env_logger 0.11.5",
  "log",
  "pulley-interpreter",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "34.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ level = "warn"
 check-cfg = [
   'cfg(pulley_tail_calls)',
   'cfg(pulley_assume_llvm_makes_tail_calls)',
+  'cfg(pulley_disable_interp_simd)',
 ]
 
 [workspace.lints.clippy]
@@ -261,6 +262,7 @@ wasmtime-test-util = { path = "crates/test-util" }
 
 pulley-interpreter = { path = 'pulley', version = "=34.0.0" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
+pulley-macros = { path = 'pulley/macros', version = "=34.0.0" }
 
 cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.121.0" }
 cranelift-codegen = { path = "cranelift/codegen", version = "0.121.0", default-features = false, features = ["std", "unwind"] }

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -92,6 +92,10 @@ pub enum Trap {
     /// Async-lifted export failed to produce a result by calling `task.return`
     /// before returning `STATUS_DONE` and/or after all host tasks completed.
     NoAsyncResult,
+
+    /// A Pulley opcode was executed at runtime when the opcode was disabled at
+    /// compile time.
+    DisabledOpcode,
     // if adding a variant here be sure to update the `check!` macro below
 }
 
@@ -129,6 +133,7 @@ impl Trap {
             CastFailure
             CannotEnterComponent
             NoAsyncResult
+            DisabledOpcode
         }
 
         None
@@ -160,6 +165,7 @@ impl fmt::Display for Trap {
             CastFailure => "cast failure",
             CannotEnterComponent => "cannot enter component instance",
             NoAsyncResult => "async-lifted export failed to produce a result",
+            DisabledOpcode => "pulley opcode disabled at compile time was executed",
         };
         write!(f, "wasm trap: {desc}")
     }

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -178,6 +178,7 @@ impl InterpreterRef<'_> {
                         TrapKind::DivideByZero => Trap::IntegerDivisionByZero,
                         TrapKind::BadConversionToInteger => Trap::BadConversionToInteger,
                         TrapKind::MemoryOutOfBounds => Trap::MemoryOutOfBounds,
+                        TrapKind::DisabledOpcode => Trap::DisabledOpcode,
                     };
                     s.set_jit_trap(regs, None, trap);
                 }

--- a/docs/examples-pulley.md
+++ b/docs/examples-pulley.md
@@ -94,6 +94,25 @@ modules as Cranelift is an optimizing compiler. Compiling WebAssembly to Pulley
 bytecode should be expected to take about the same time as compiling to native
 platforms.
 
+## Disabling SIMD in Pulley
+
+By default all Pulley opcodes are enabled in the interpreter meaning it's
+possible to execute any Pulley bytecode created by Cranelift and Wasmtime. This
+includes, for example, SIMD opcodes for all of the WebAssembly SIMD proposal.
+Not all WebAssembly modules use these opcodes though nor do all embeddings want
+to enable it, so Pulley supports a custom Rust flag that can be specified at
+compile time to compile-out the SIMD opcodes:
+
+```text
+RUSTFLAGS=--cfg=pulley_disable_interp_simd
+```
+
+When specified the Pulley interpreter will no longer include code to execute
+SIMD opcodes. Instead attempting to execute any opcode will raise a "disabled
+opcode" trap instead. If doing this it's recommended to pair it with
+`Config::wasm_simd(false)` to ensure that SIMD-using modules do not pass
+validation.
+
 ## High-level Design of Pulley
 
 This section is not necessary for users of Pulley but for those interested this

--- a/pulley/Cargo.toml
+++ b/pulley/Cargo.toml
@@ -18,6 +18,7 @@ cranelift-bitset = { workspace = true }
 log = { workspace = true }
 wasmtime-math = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
+pulley-macros = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/pulley/macros/Cargo.toml
+++ b/pulley/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+description = "Internal pulley macros"
+edition.workspace = true
+rust-version.workspace = true
+license = "Apache-2.0 WITH LLVM-exception"
+name = "pulley-macros"
+repository = "https://github.com/bytecodealliance/wasmtime/tree/main/pulley/macros"
+version.workspace = true
+
+[dependencies]
+syn = { workspace = true, features = ['full'] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+
+[lib]
+proc-macro = true

--- a/pulley/macros/src/interp_disable_if_cfg.rs
+++ b/pulley/macros/src/interp_disable_if_cfg.rs
@@ -1,0 +1,106 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{
+    braced,
+    parse::{Parse, ParseStream},
+    parse_macro_input, token, Attribute, Result, Signature, Visibility,
+};
+
+pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    let mut cfg = None;
+
+    let config_parser = syn::meta::parser(|meta| {
+        cfg = Some(meta.path.require_ident()?.clone());
+        Ok(())
+    });
+
+    parse_macro_input!(attrs with config_parser);
+
+    match expand(cfg.unwrap(), parse_macro_input!(item as Fn)) {
+        Ok(tok) => tok,
+        Err(e) => e.into_compile_error().into(),
+    }
+}
+
+/// Custom function parser.
+/// Parses the function's attributes, visibility and signature, leaving the
+/// block as an opaque [`TokenStream`].
+struct Fn {
+    attrs: Vec<Attribute>,
+    visibility: Visibility,
+    sig: Signature,
+    body: Block,
+}
+
+impl Parse for Fn {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let visibility: Visibility = input.parse()?;
+        let sig: Signature = input.parse()?;
+        let body: Block = input.parse()?;
+
+        Ok(Self {
+            attrs,
+            visibility,
+            sig,
+            body,
+        })
+    }
+}
+
+impl ToTokens for Fn {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        for attr in &self.attrs {
+            attr.to_tokens(tokens);
+        }
+        self.visibility.to_tokens(tokens);
+        self.sig.to_tokens(tokens);
+        self.body.to_tokens(tokens);
+    }
+}
+
+/// A generic function body represented as a braced [`TokenStream`].
+struct Block {
+    brace: token::Brace,
+    rest: proc_macro2::TokenStream,
+}
+
+impl Parse for Block {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content;
+        Ok(Self {
+            brace: braced!(content in input),
+            rest: content.parse()?,
+        })
+    }
+}
+
+impl ToTokens for Block {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.brace.surround(tokens, |tokens| {
+            tokens.append_all(self.rest.clone());
+        });
+    }
+}
+
+fn expand(cfg: syn::Ident, func: Fn) -> Result<TokenStream> {
+    let Fn {
+        attrs,
+        visibility,
+        sig,
+        body: _,
+    } = &func;
+    let name = &sig.ident;
+    Ok(quote! {
+        #[cfg(#cfg)]
+        #(#attrs)*
+        #[allow(unused_variables)]
+        #visibility #sig {
+            self.done_trap_kind::<crate::#name>(Some(TrapKind::DisabledOpcode))
+        }
+
+        #[cfg(not(#cfg))]
+        #func
+    }
+    .into())
+}

--- a/pulley/macros/src/lib.rs
+++ b/pulley/macros/src/lib.rs
@@ -1,0 +1,8 @@
+use proc_macro::TokenStream;
+
+mod interp_disable_if_cfg;
+
+#[proc_macro_attribute]
+pub fn interp_disable_if_cfg(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    interp_disable_if_cfg::run(attrs, item)
+}

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -12,7 +12,9 @@ use core::mem;
 use core::ops::ControlFlow;
 use core::ops::{Index, IndexMut};
 use core::ptr::NonNull;
+use pulley_macros::interp_disable_if_cfg;
 use wasmtime_math::WasmFloat;
+
 mod debug;
 #[cfg(all(not(pulley_tail_calls), not(pulley_assume_llvm_makes_tail_calls)))]
 mod match_loop;
@@ -111,6 +113,7 @@ impl Vm {
 
         let mut x_args = (0..16).map(|x| unsafe { XReg::new_unchecked(x) });
         let mut f_args = (0..16).map(|f| unsafe { FReg::new_unchecked(f) });
+        #[cfg(not(pulley_disable_interp_simd))]
         let mut v_args = (0..16).map(|v| unsafe { VReg::new_unchecked(v) });
 
         for arg in args {
@@ -123,6 +126,7 @@ impl Vm {
                     Some(reg) => self.state[reg] = *val,
                     None => todo!("stack slots"),
                 },
+                #[cfg(not(pulley_disable_interp_simd))]
                 Val::VReg(val) => match v_args.next() {
                     Some(reg) => self.state[reg] = *val,
                     None => todo!("stack slots"),
@@ -173,6 +177,7 @@ impl Vm {
 
         let mut x_rets = (0..15).map(|x| unsafe { XReg::new_unchecked(x) });
         let mut f_rets = (0..16).map(|f| unsafe { FReg::new_unchecked(f) });
+        #[cfg(not(pulley_disable_interp_simd))]
         let mut v_rets = (0..16).map(|v| unsafe { VReg::new_unchecked(v) });
 
         rets.into_iter().map(move |ty| match ty {
@@ -184,10 +189,13 @@ impl Vm {
                 Some(reg) => Val::FReg(self.state[reg]),
                 None => todo!("stack slots"),
             },
+            #[cfg(not(pulley_disable_interp_simd))]
             RegType::VReg => match v_rets.next() {
                 Some(reg) => Val::VReg(self.state[reg]),
                 None => todo!("stack slots"),
             },
+            #[cfg(pulley_disable_interp_simd)]
+            RegType::VReg => panic!("simd support disabled at compile time"),
         })
     }
 
@@ -252,6 +260,7 @@ pub enum Val {
     FReg(FRegVal),
 
     /// A `v` register value: vectors.
+    #[cfg(not(pulley_disable_interp_simd))]
     VReg(VRegVal),
 }
 
@@ -260,6 +269,7 @@ impl fmt::LowerHex for Val {
         match self {
             Val::XReg(v) => fmt::LowerHex::fmt(v, f),
             Val::FReg(v) => fmt::LowerHex::fmt(v, f),
+            #[cfg(not(pulley_disable_interp_simd))]
             Val::VReg(v) => fmt::LowerHex::fmt(v, f),
         }
     }
@@ -319,6 +329,7 @@ impl From<f32> for Val {
     }
 }
 
+#[cfg(not(pulley_disable_interp_simd))]
 impl From<VRegVal> for Val {
     fn from(value: VRegVal) -> Self {
         Val::VReg(value)
@@ -566,8 +577,10 @@ impl FRegVal {
 
 /// A `v` register value: vectors.
 #[derive(Copy, Clone)]
+#[cfg(not(pulley_disable_interp_simd))]
 pub struct VRegVal(VRegUnion);
 
+#[cfg(not(pulley_disable_interp_simd))]
 impl fmt::Debug for VRegVal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VRegVal")
@@ -576,6 +589,7 @@ impl fmt::Debug for VRegVal {
     }
 }
 
+#[cfg(not(pulley_disable_interp_simd))]
 impl fmt::LowerHex for VRegVal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::LowerHex::fmt(unsafe { &self.0.u128 }, f)
@@ -591,6 +605,7 @@ impl fmt::LowerHex for VRegVal {
 /// vectors works. This union cannot be stored in big-endian.
 #[derive(Copy, Clone)]
 #[repr(align(16))]
+#[cfg(not(pulley_disable_interp_simd))]
 union VRegUnion {
     u128: u128,
     i8x16: [i8; 16],
@@ -608,6 +623,7 @@ union VRegUnion {
     f64x2: [u64; 2],
 }
 
+#[cfg(not(pulley_disable_interp_simd))]
 impl Default for VRegVal {
     fn default() -> Self {
         Self(unsafe { mem::zeroed() })
@@ -615,6 +631,7 @@ impl Default for VRegVal {
 }
 
 #[expect(missing_docs, reason = "self-describing methods")]
+#[cfg(not(pulley_disable_interp_simd))]
 impl VRegVal {
     pub fn new_u128(i: u128) -> Self {
         let mut val = Self::default();
@@ -727,6 +744,7 @@ impl VRegVal {
 pub struct MachineState {
     x_regs: [XRegVal; XReg::RANGE.end as usize],
     f_regs: [FRegVal; FReg::RANGE.end as usize],
+    #[cfg(not(pulley_disable_interp_simd))]
     v_regs: [VRegVal; VReg::RANGE.end as usize],
     fp: *mut u8,
     lr: *mut u8,
@@ -798,6 +816,7 @@ impl fmt::Debug for MachineState {
         let MachineState {
             x_regs,
             f_regs,
+            #[cfg(not(pulley_disable_interp_simd))]
             v_regs,
             stack: _,
             done_reason: _,
@@ -817,20 +836,22 @@ impl fmt::Debug for MachineState {
             }
         }
 
-        f.debug_struct("MachineState")
-            .field(
-                "x_regs",
-                &RegMap(x_regs, |i| XReg::new(i).unwrap().to_string()),
-            )
-            .field(
-                "f_regs",
-                &RegMap(f_regs, |i| FReg::new(i).unwrap().to_string()),
-            )
-            .field(
-                "v_regs",
-                &RegMap(v_regs, |i| VReg::new(i).unwrap().to_string()),
-            )
-            .finish_non_exhaustive()
+        let mut f = f.debug_struct("MachineState");
+
+        f.field(
+            "x_regs",
+            &RegMap(x_regs, |i| XReg::new(i).unwrap().to_string()),
+        )
+        .field(
+            "f_regs",
+            &RegMap(f_regs, |i| FReg::new(i).unwrap().to_string()),
+        );
+        #[cfg(not(pulley_disable_interp_simd))]
+        f.field(
+            "v_regs",
+            &RegMap(v_regs, |i| VReg::new(i).unwrap().to_string()),
+        );
+        f.finish_non_exhaustive()
     }
 }
 
@@ -868,6 +889,7 @@ macro_rules! index_reg {
 
 index_reg!(XReg, XRegVal, x_regs);
 index_reg!(FReg, FRegVal, f_regs);
+#[cfg(not(pulley_disable_interp_simd))]
 index_reg!(VReg, VRegVal, v_regs);
 
 /// Sentinel return address that signals the end of the call stack.
@@ -878,6 +900,7 @@ impl MachineState {
         let mut state = Self {
             x_regs: [Default::default(); XReg::RANGE.end as usize],
             f_regs: Default::default(),
+            #[cfg(not(pulley_disable_interp_simd))]
             v_regs: Default::default(),
             stack: Stack::new(stack_size),
             done_reason: None,
@@ -934,6 +957,7 @@ mod done {
         IntegerOverflow,
         BadConversionToInteger,
         MemoryOutOfBounds,
+        DisabledOpcode,
     }
 
     impl MachineState {
@@ -1119,12 +1143,14 @@ impl Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[cfg(not(pulley_disable_interp_simd))]
     fn get_i128(&self, lo: XReg, hi: XReg) -> i128 {
         let lo = self.state[lo].get_u64();
         let hi = self.state[hi].get_i64();
         i128::from(lo) | (i128::from(hi) << 64)
     }
 
+    #[cfg(not(pulley_disable_interp_simd))]
     fn set_i128(&mut self, lo: XReg, hi: XReg, val: i128) {
         self.state[lo].set_u64(val as u64);
         self.state[hi].set_u64((val >> 64) as u64);
@@ -3044,12 +3070,14 @@ impl ExtendedOpVisitor for Interpreter<'_> {
     // =========================================================================
     // o32 addressing modes for little-endian V-registers
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload128le_o32(&mut self, dst: VReg, addr: AddrO32) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<u128, crate::VLoad128O32>(addr)? };
         self.state[dst].set_u128(u128::from_le(val));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vstore128le_o32(&mut self, addr: AddrO32, src: VReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u128();
         unsafe {
@@ -3061,12 +3089,14 @@ impl ExtendedOpVisitor for Interpreter<'_> {
     // =========================================================================
     // z addressing modes for little-endian V-registers
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload128le_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<u128, crate::VLoad128Z>(addr)? };
         self.state[dst].set_u128(u128::from_le(val));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vstore128le_z(&mut self, addr: AddrZ, src: VReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u128();
         unsafe {
@@ -3078,12 +3108,14 @@ impl ExtendedOpVisitor for Interpreter<'_> {
     // =========================================================================
     // g32 addressing modes for little-endian V-registers
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload128le_g32(&mut self, dst: VReg, addr: AddrG32) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<u128, crate::VLoad128G32>(addr)? };
         self.state[dst].set_u128(u128::from_le(val));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vstore128le_g32(&mut self, addr: AddrG32, src: VReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u128();
         unsafe {
@@ -3110,6 +3142,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmov(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let val = self.state[src];
         self.state[dst] = val;
@@ -3438,6 +3471,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -3455,6 +3489,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmulf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -3472,6 +3507,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vdivf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -3485,6 +3521,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vdivf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -3518,6 +3555,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vtrunc32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3527,6 +3565,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vtrunc64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f64x2();
         for elem in a.iter_mut() {
@@ -3542,6 +3581,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfloor32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3551,6 +3591,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfloor64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f64x2();
         for elem in a.iter_mut() {
@@ -3566,6 +3607,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vceil32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3576,6 +3618,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vceil64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f64x2();
         for elem in a.iter_mut() {
@@ -3592,6 +3635,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnearest32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3601,6 +3645,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnearest64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f64x2();
         for elem in a.iter_mut() {
@@ -3616,6 +3661,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsqrt32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3625,6 +3671,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsqrt64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f64x2();
         for elem in a.iter_mut() {
@@ -3640,6 +3687,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnegf32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let mut a = self.state[src].get_f32x4();
         for elem in a.iter_mut() {
@@ -3739,6 +3787,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -3749,6 +3798,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -3759,6 +3809,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -3769,6 +3820,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -3779,6 +3831,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -3789,6 +3842,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -3799,6 +3853,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi8x16_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -3809,6 +3864,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddu8x16_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -3819,6 +3875,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddi16x8_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -3829,6 +3886,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddu16x8_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -3839,6 +3897,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddpairwisei16x8_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -3852,6 +3911,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vaddpairwisei32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -3864,6 +3924,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshli8x16(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_u32();
@@ -3871,6 +3932,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshli16x8(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_u32();
@@ -3878,6 +3940,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshli32x4(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_u32();
@@ -3885,6 +3948,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshli64x2(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_u32();
@@ -3892,6 +3956,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri8x16_s(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_u32();
@@ -3899,6 +3964,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri16x8_s(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_u32();
@@ -3906,6 +3972,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri32x4_s(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_u32();
@@ -3913,6 +3980,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri64x2_s(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_u32();
@@ -3920,6 +3988,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri8x16_u(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u32();
@@ -3927,6 +3996,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri16x8_u(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u32();
@@ -3934,6 +4004,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri32x4_u(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32();
@@ -3941,6 +4012,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshri64x2_u(&mut self, operands: BinaryOperands<VReg, VReg, XReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u32();
@@ -3948,83 +4020,97 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vconst128(&mut self, dst: VReg, val: u128) -> ControlFlow<Done> {
         self.state[dst].set_u128(val);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatx8(&mut self, dst: VReg, src: XReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u32() as u8;
         self.state[dst].set_u8x16([val; 16]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatx16(&mut self, dst: VReg, src: XReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u32() as u16;
         self.state[dst].set_u16x8([val; 8]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatx32(&mut self, dst: VReg, src: XReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u32();
         self.state[dst].set_u32x4([val; 4]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatx64(&mut self, dst: VReg, src: XReg) -> ControlFlow<Done> {
         let val = self.state[src].get_u64();
         self.state[dst].set_u64x2([val; 2]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatf32(&mut self, dst: VReg, src: FReg) -> ControlFlow<Done> {
         let val = self.state[src].get_f32();
         self.state[dst].set_f32x4([val; 4]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsplatf64(&mut self, dst: VReg, src: FReg) -> ControlFlow<Done> {
         let val = self.state[src].get_f64();
         self.state[dst].set_f64x2([val; 2]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload8x8_s_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[i8; 8], crate::VLoad8x8SZ>(addr)? };
         self.state[dst].set_i16x8(val.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload8x8_u_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[u8; 8], crate::VLoad8x8UZ>(addr)? };
         self.state[dst].set_u16x8(val.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload16x4le_s_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[i16; 4], crate::VLoad16x4LeSZ>(addr)? };
         self.state[dst].set_i32x4(val.map(|i| i16::from_le(i).into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload16x4le_u_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[u16; 4], crate::VLoad16x4LeUZ>(addr)? };
         self.state[dst].set_u32x4(val.map(|i| u16::from_le(i).into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload32x2le_s_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[i32; 2], crate::VLoad32x2LeSZ>(addr)? };
         self.state[dst].set_i64x2(val.map(|i| i32::from_le(i).into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vload32x2le_u_z(&mut self, dst: VReg, addr: AddrZ) -> ControlFlow<Done> {
         let val = unsafe { self.load_ne::<[u32; 2], crate::VLoad32x2LeUZ>(addr)? };
         self.state[dst].set_u64x2(val.map(|i| u32::from_le(i).into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vband128(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u128();
         let b = self.state[operands.src2].get_u128();
@@ -4032,6 +4118,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbor128(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u128();
         let b = self.state[operands.src2].get_u128();
@@ -4039,6 +4126,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbxor128(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u128();
         let b = self.state[operands.src2].get_u128();
@@ -4046,12 +4134,14 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbnot128(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u128();
         self.state[dst].set_u128(!a);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbitselect128(&mut self, dst: VReg, c: VReg, x: VReg, y: VReg) -> ControlFlow<Done> {
         let c = self.state[c].get_u128();
         let x = self.state[x].get_u128();
@@ -4060,6 +4150,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbitmask8x16(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u8x16();
         let mut result = 0;
@@ -4071,6 +4162,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbitmask16x8(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u16x8();
         let mut result = 0;
@@ -4082,6 +4174,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbitmask32x4(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u32x4();
         let mut result = 0;
@@ -4093,6 +4186,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vbitmask64x2(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u64x2();
         let mut result = 0;
@@ -4104,6 +4198,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn valltrue8x16(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u8x16();
         let result = a.iter().all(|a| *a != 0);
@@ -4111,6 +4206,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn valltrue16x8(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u16x8();
         let result = a.iter().all(|a| *a != 0);
@@ -4118,6 +4214,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn valltrue32x4(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u32x4();
         let result = a.iter().all(|a| *a != 0);
@@ -4125,6 +4222,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn valltrue64x2(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u64x2();
         let result = a.iter().all(|a| *a != 0);
@@ -4132,6 +4230,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vanytrue8x16(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u8x16();
         let result = a.iter().any(|a| *a != 0);
@@ -4139,6 +4238,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vanytrue16x8(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u16x8();
         let result = a.iter().any(|a| *a != 0);
@@ -4146,6 +4246,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vanytrue32x4(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u32x4();
         let result = a.iter().any(|a| *a != 0);
@@ -4153,6 +4254,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vanytrue64x2(&mut self, dst: XReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u64x2();
         let result = a.iter().any(|a| *a != 0);
@@ -4160,126 +4262,147 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vf32x4_from_i32x4_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i32x4();
         self.state[dst].set_f32x4(a.map(|i| i as f32));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vf32x4_from_i32x4_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u32x4();
         self.state[dst].set_f32x4(a.map(|i| i as f32));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vf64x2_from_i64x2_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i64x2();
         self.state[dst].set_f64x2(a.map(|i| i as f64));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vf64x2_from_i64x2_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u64x2();
         self.state[dst].set_f64x2(a.map(|i| i as f64));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vi32x4_from_f32x4_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f32x4();
         self.state[dst].set_i32x4(a.map(|f| f as i32));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vi32x4_from_f32x4_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f32x4();
         self.state[dst].set_u32x4(a.map(|f| f as u32));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vi64x2_from_f64x2_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f64x2();
         self.state[dst].set_i64x2(a.map(|f| f as i64));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vi64x2_from_f64x2_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f64x2();
         self.state[dst].set_u64x2(a.map(|f| f as u64));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow8x16_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i8x16().first_chunk().unwrap();
         self.state[dst].set_i16x8(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow8x16_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u8x16().first_chunk().unwrap();
         self.state[dst].set_u16x8(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow16x8_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i16x8().first_chunk().unwrap();
         self.state[dst].set_i32x4(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow16x8_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u16x8().first_chunk().unwrap();
         self.state[dst].set_u32x4(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow32x4_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i32x4().first_chunk().unwrap();
         self.state[dst].set_i64x2(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenlow32x4_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u32x4().first_chunk().unwrap();
         self.state[dst].set_u64x2(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh8x16_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i8x16().last_chunk().unwrap();
         self.state[dst].set_i16x8(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh8x16_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u8x16().last_chunk().unwrap();
         self.state[dst].set_u16x8(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh16x8_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i16x8().last_chunk().unwrap();
         self.state[dst].set_i32x4(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh16x8_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u16x8().last_chunk().unwrap();
         self.state[dst].set_u32x4(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh32x4_s(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_i32x4().last_chunk().unwrap();
         self.state[dst].set_i64x2(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vwidenhigh32x4_u(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = *self.state[src].get_u32x4().last_chunk().unwrap();
         self.state[dst].set_u64x2(a.map(|i| i.into()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow16x8_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4293,6 +4416,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow16x8_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4306,6 +4430,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4319,6 +4444,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow32x4_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4332,6 +4458,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow64x2_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4345,6 +4472,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnarrow64x2_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4358,6 +4486,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vunarrow64x2_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u64x2();
@@ -4369,18 +4498,21 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfpromotelow(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f32x4();
         self.state[dst].set_f64x2([a[0].into(), a[1].into()]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfdemote(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f64x2();
         self.state[dst].set_f32x4([a[0] as f32, a[1] as f32, 0.0, 0.0]);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4391,6 +4523,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4401,6 +4534,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4411,6 +4545,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4421,6 +4556,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi8x16_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4431,6 +4567,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubu8x16_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4441,6 +4578,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubi16x8_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4451,6 +4589,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubu16x8_sat(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4461,6 +4600,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vsubf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -4471,6 +4611,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmuli8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4481,6 +4622,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmuli16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4491,6 +4633,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmuli32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4501,6 +4644,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmuli64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4511,6 +4655,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmulf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -4521,6 +4666,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vqmulrsi16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4534,48 +4680,56 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vpopcnt8x16(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_u8x16();
         self.state[dst].set_u8x16(a.map(|i| i.count_ones() as u8));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xextractv8x16(&mut self, dst: XReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_u8x16().get_unchecked(usize::from(lane)) };
         self.state[dst].set_u32(u32::from(a));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xextractv16x8(&mut self, dst: XReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_u16x8().get_unchecked(usize::from(lane)) };
         self.state[dst].set_u32(u32::from(a));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xextractv32x4(&mut self, dst: XReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_u32x4().get_unchecked(usize::from(lane)) };
         self.state[dst].set_u32(a);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xextractv64x2(&mut self, dst: XReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_u64x2().get_unchecked(usize::from(lane)) };
         self.state[dst].set_u64(a);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn fextractv32x4(&mut self, dst: FReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_f32x4().get_unchecked(usize::from(lane)) };
         self.state[dst].set_f32(a);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn fextractv64x2(&mut self, dst: FReg, src: VReg, lane: u8) -> ControlFlow<Done> {
         let a = unsafe { *self.state[src].get_f64x2().get_unchecked(usize::from(lane)) };
         self.state[dst].set_f64(a);
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertx8(
         &mut self,
         operands: BinaryOperands<VReg, VReg, XReg>,
@@ -4590,6 +4744,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertx16(
         &mut self,
         operands: BinaryOperands<VReg, VReg, XReg>,
@@ -4604,6 +4759,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertx32(
         &mut self,
         operands: BinaryOperands<VReg, VReg, XReg>,
@@ -4618,6 +4774,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertx64(
         &mut self,
         operands: BinaryOperands<VReg, VReg, XReg>,
@@ -4632,6 +4789,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertf32(
         &mut self,
         operands: BinaryOperands<VReg, VReg, FReg>,
@@ -4646,6 +4804,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vinsertf64(
         &mut self,
         operands: BinaryOperands<VReg, VReg, FReg>,
@@ -4660,6 +4819,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veq8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4671,6 +4831,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneq8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4682,6 +4843,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslt8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4693,6 +4855,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslteq8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4704,6 +4867,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vult8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4715,6 +4879,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vulteq8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4726,6 +4891,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veq16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4737,6 +4903,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneq16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4748,6 +4915,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslt16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4759,6 +4927,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslteq16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4770,6 +4939,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vult16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4781,6 +4951,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vulteq16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4792,6 +4963,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veq32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -4803,6 +4975,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneq32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -4814,6 +4987,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslt32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4825,6 +4999,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslteq32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -4836,6 +5011,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vult32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -4847,6 +5023,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vulteq32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -4858,6 +5035,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veq64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u64x2();
@@ -4869,6 +5047,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneq64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u64x2();
@@ -4880,6 +5059,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslt64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4891,6 +5071,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vslteq64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_i64x2();
         let b = self.state[operands.src2].get_i64x2();
@@ -4902,6 +5083,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vult64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u64x2();
@@ -4913,6 +5095,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vulteq64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_u64x2();
         let b = self.state[operands.src2].get_u64x2();
@@ -4924,36 +5107,42 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneg8x16(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i8x16();
         self.state[dst].set_i8x16(a.map(|i| i.wrapping_neg()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneg16x8(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i16x8();
         self.state[dst].set_i16x8(a.map(|i| i.wrapping_neg()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneg32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i32x4();
         self.state[dst].set_i32x4(a.map(|i| i.wrapping_neg()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneg64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i64x2();
         self.state[dst].set_i64x2(a.map(|i| i.wrapping_neg()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vnegf64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f64x2();
         self.state[dst].set_f64x2(a.map(|i| -i));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin8x16_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -4964,6 +5153,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin8x16_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -4974,6 +5164,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin16x8_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -4984,6 +5175,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin16x8_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -4994,6 +5186,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -5004,6 +5197,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmin32x4_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -5014,6 +5208,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax8x16_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i8x16();
         let b = self.state[operands.src2].get_i8x16();
@@ -5024,6 +5219,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax8x16_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -5034,6 +5230,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax16x8_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i16x8();
         let b = self.state[operands.src2].get_i16x8();
@@ -5044,6 +5241,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax16x8_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -5054,6 +5252,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax32x4_s(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_i32x4();
         let b = self.state[operands.src2].get_i32x4();
@@ -5064,6 +5263,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmax32x4_u(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u32x4();
         let b = self.state[operands.src2].get_u32x4();
@@ -5074,42 +5274,49 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabs8x16(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i8x16();
         self.state[dst].set_i8x16(a.map(|i| i.wrapping_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabs16x8(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i16x8();
         self.state[dst].set_i16x8(a.map(|i| i.wrapping_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabs32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i32x4();
         self.state[dst].set_i32x4(a.map(|i| i.wrapping_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabs64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_i64x2();
         self.state[dst].set_i64x2(a.map(|i| i.wrapping_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabsf32x4(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f32x4();
         self.state[dst].set_f32x4(a.map(|i| i.wasm_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vabsf64x2(&mut self, dst: VReg, src: VReg) -> ControlFlow<Done> {
         let a = self.state[src].get_f64x2();
         self.state[dst].set_f64x2(a.map(|i| i.wasm_abs()));
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmaximumf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5120,6 +5327,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vmaximumf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5130,6 +5338,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vminimumf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5140,6 +5349,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vminimumf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5150,6 +5360,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vshuffle(&mut self, dst: VReg, src1: VReg, src2: VReg, mask: u128) -> ControlFlow<Done> {
         let a = self.state[src1].get_u8x16();
         let b = self.state[src2].get_u8x16();
@@ -5164,6 +5375,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vswizzlei8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let src1 = self.state[operands.src1].get_i8x16();
         let src2 = self.state[operands.src2].get_i8x16();
@@ -5179,6 +5391,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vavground8x16(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u8x16();
         let b = self.state[operands.src2].get_u8x16();
@@ -5190,6 +5403,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vavground16x8(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let mut a = self.state[operands.src1].get_u16x8();
         let b = self.state[operands.src2].get_u16x8();
@@ -5201,6 +5415,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5212,6 +5427,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5223,6 +5439,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vltf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5234,6 +5451,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vlteqf32x4(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f32x4();
         let b = self.state[operands.src2].get_f32x4();
@@ -5245,6 +5463,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn veqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5256,6 +5475,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vneqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5267,6 +5487,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vltf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5278,6 +5499,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vlteqf64x2(&mut self, operands: BinaryOperands<VReg>) -> ControlFlow<Done> {
         let a = self.state[operands.src1].get_f64x2();
         let b = self.state[operands.src2].get_f64x2();
@@ -5289,6 +5511,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfma32x4(&mut self, dst: VReg, a: VReg, b: VReg, c: VReg) -> ControlFlow<Done> {
         let mut a = self.state[a].get_f32x4();
         let b = self.state[b].get_f32x4();
@@ -5300,6 +5523,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vfma64x2(&mut self, dst: VReg, a: VReg, b: VReg, c: VReg) -> ControlFlow<Done> {
         let mut a = self.state[a].get_f64x2();
         let b = self.state[b].get_f64x2();
@@ -5311,6 +5535,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn vselect(
         &mut self,
         dst: VReg,
@@ -5327,6 +5552,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xadd128(
         &mut self,
         dst_lo: XReg,
@@ -5343,6 +5569,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xsub128(
         &mut self,
         dst_lo: XReg,
@@ -5359,6 +5586,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xwidemul64_s(
         &mut self,
         dst_lo: XReg,
@@ -5373,6 +5601,7 @@ impl ExtendedOpVisitor for Interpreter<'_> {
         ControlFlow::Continue(())
     }
 
+    #[interp_disable_if_cfg(pulley_disable_interp_simd)]
     fn xwidemul64_u(
         &mut self,
         dst_lo: XReg,

--- a/pulley/src/op.rs
+++ b/pulley/src/op.rs
@@ -91,6 +91,10 @@ macro_rules! define_extended_op {
                 )*
             )? }
 
+            #[doc(hidden)]
+            #[expect(non_camel_case_types, reason = "used in macros as an alternative to camel case")]
+            pub type $snake_name = $name;
+
             impl From<$name> for Op {
                 #[inline]
                 fn from(op: $name) -> Self {

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -20,6 +20,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     // pulley
     "cranelift-bitset",
     "wasmtime-math",
+    "pulley-macros",
     "pulley-interpreter",
     // cranelift
     "cranelift-srcgen",


### PR DESCRIPTION
This commit adds a new feature to Pulley which is used to reduce the compiled code size of the interpreter itself by disabling SIMD opcode interpretation at compile-time. The goal here is to be low-impact on Pulley itself to avoid needing `#[cfg]` all over the place and to additionally avoid the need to redesign Pulley's opcode macro for use in various parts of Wasmtime.

Methods are annotated with a custom macro in the interpreter which registers a `#[cfg]` that either does the listed implementation or switches to an implementation that emits a trap if executed. This means that it's safe to execute mismatched code where SIMD was enabled at compile time but disabled at runtime, it just means the semantics may be a bit surprising to debug.

Note that this SIMD is still enabled by default, and an explicit `--cfg` via `RUSTFLAGS` is required to compile-out the SIMD support. Cargo features aren't a great fit for this sort of feature so an explicit flag is used.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
