### PR TITLE
Skip a test with threads on ASAN

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -552,8 +552,12 @@ fn run_cwasm_from_stdin() -> Result<()> {
 #[cfg(feature = "wasi-threads")]
 #[test]
 fn run_threads() -> Result<()> {
-    // Skip this test on platforms that don't support threads.
-    if crate::threads::engine().is_none() {
+    // Only run threaded tests on platforms that support threads. Also skip
+    // these tests with ASAN as it, rightfully, complains about a memory leak.
+    // The memory leak at this time is that child threads aren't joined with the
+    // main thread, meaning that allocations done on child threads are indeed
+    // leaked.
+    if crate::threads::engine().is_none() || cfg!(asan) {
         return Ok(());
     }
     let wasm = build_wasm("tests/all/cli_tests/threads.wat")?;


### PR DESCRIPTION
It's expected that this has memory leaks, there's no clean shutdown in the CLI right now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
