### PR TITLE
winch: Consolidate branch emission

### DIFF
--- a/tests/disas/winch/x64/block/issue-10613.wat
+++ b/tests/disas/winch/x64/block/issue-10613.wat
@@ -1,0 +1,146 @@
+;;! target = "x86_64"
+;;! test = "winch"
+(module
+  (func (export "e") (result i64 f64)
+    call $a
+    block $block (result i64 f64)
+      call $b
+      i32.const 1
+      br_table $block 1 $block
+      unreachable
+    end
+    unreachable
+  )
+  (func $a (result i64 f64)
+    i64.const 4
+    f64.const 5
+  )
+  (func $b (result i64 f64)
+    i64.const 7
+    f64.const 8
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x40, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x108
+;;   1c: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       subq    $8, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0x110
+;;       addq    $8, %rsp
+;;       movq    0x20(%rsp), %r14
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       subq    $8, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0x180
+;;       addq    $8, %rsp
+;;       movq    0x30(%rsp), %r14
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       movl    $1, %eax
+;;       movsd   (%rsp), %xmm0
+;;       addq    $8, %rsp
+;;       movl    $2, %ecx
+;;       cmpl    %eax, %ecx
+;;       cmovbl  %ecx, %eax
+;;       leaq    0xa(%rip), %r11
+;;       movslq  (%r11, %rax, 4), %rcx
+;;       addq    %rcx, %r11
+;;       jmpq    *%r11
+;;   cd: addb    %al, %es:(%rax)
+;;       addb    %dl, (%rcx)
+;;       addb    %al, (%rax)
+;;       addb    %ah, (%rsi)
+;;       addb    %al, (%rax)
+;;       addb    %ch, %cl
+;;       adcl    $0x4c000000, %eax
+;;       movl    (%rsp), %ebx
+;;       movq    %r11, 0x10(%rsp)
+;;       addq    $0x10, %rsp
+;;       jmp     0xf5
+;;   f3: ud2
+;;       movq    0x10(%rsp), %rax
+;;       popq    %r11
+;;       movq    %r11, (%rax)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  108: ud2
+;;
+;; wasm[0]::function[1]::a:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x28, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x16f
+;;  12c: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       movsd   0x2b(%rip), %xmm0
+;;       subq    $8, %rsp
+;;       movq    $4, (%rsp)
+;;       movq    0x10(%rsp), %rax
+;;       popq    %r11
+;;       movq    %r11, (%rax)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  16f: ud2
+;;  171: addb    %al, (%rax)
+;;  173: addb    %al, (%rax)
+;;  175: addb    %al, (%rax)
+;;  177: addb    %al, (%rax)
+;;  179: addb    %al, (%rax)
+;;  17b: addb    %al, (%rax)
+;;  17d: addb    %dl, (%rax, %rax, 2)
+;;
+;; wasm[0]::function[2]::b:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x28, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x1df
+;;  19c: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       movsd   0x2b(%rip), %xmm0
+;;       subq    $8, %rsp
+;;       movq    $7, (%rsp)
+;;       movq    0x10(%rsp), %rax
+;;       popq    %r11
+;;       movq    %r11, (%rax)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  1df: ud2
+;;  1e1: addb    %al, (%rax)
+;;  1e3: addb    %al, (%rax)
+;;  1e5: addb    %al, (%rax)
+;;  1e7: addb    %al, (%rax)
+;;  1e9: addb    %al, (%rax)
+;;  1eb: addb    %al, (%rax)
+;;  1ed: addb    %ah, (%rax)

--- a/tests/misc_testsuite/winch/issue-10613.wast
+++ b/tests/misc_testsuite/winch/issue-10613.wast
@@ -1,0 +1,22 @@
+(module
+  (func (export "e") (result i64 f64)
+    call $a
+    block $block (result i64 f64)
+      call $b
+      i32.const 1
+      br_table $block 1 $block
+      unreachable
+    end
+    unreachable
+  )
+  (func $a (result i64 f64)
+    i64.const 4
+    f64.const 5
+  )
+  (func $b (result i64 f64)
+    i64.const 7
+    f64.const 8
+  )
+)
+
+(assert_return (invoke "e") (i64.const 7) (f64.const 8))

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -689,7 +689,7 @@ impl ControlStackFrame {
         Self::pop_abi_results_impl(self.results::<M>()?, context, masm, calculate_ret_area)
     }
 
-    /// Shared implementation for poppping the ABI results.
+    /// Shared implementation for popping the ABI results.
     /// This is needed because, in some cases, params must be interpreted and
     /// used as the results of the block. When emitting code at control flow
     /// joins, the block params are interpreted as results, to ensure that they
@@ -1051,5 +1051,14 @@ impl ControlStackFrame {
             Self::Loop { .. } => true,
             _ => false,
         }
+    }
+
+    /// Returns true if the current stack pointer is unbalanced
+    /// relative to the the expected control frame stack pointer
+    /// offset. The stack pointer is considered unbalanced relative
+    /// to the control frame if the stack pointer is greater than the
+    /// the target stack pointer offset expected by the control frame.
+    pub fn unbalanced<M: MacroAssembler>(&self, masm: &mut M) -> Result<bool> {
+        Ok(masm.sp_offset()? > self.stack_state().target_offset)
     }
 }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -45,6 +45,32 @@ pub(crate) use phase::*;
 mod error;
 pub(crate) use error::*;
 
+/// Branch states in the compiler, enabling the derivation of the
+/// reachability state.
+pub(crate) trait BranchState {
+    /// Whether the compiler will enter in an unreachable state after
+    /// the branch is emitted.
+    fn unreachable_state_after_emission() -> bool;
+}
+
+/// A conditional branch state, with a fallthrough.
+pub(crate) struct ConditionalBranch;
+
+impl BranchState for ConditionalBranch {
+    fn unreachable_state_after_emission() -> bool {
+        false
+    }
+}
+
+/// Unconditional branch state.
+pub(crate) struct UnconditionalBranch;
+
+impl BranchState for UnconditionalBranch {
+    fn unreachable_state_after_emission() -> bool {
+        true
+    }
+}
+
 /// Holds metadata about the source code location and the machine code emission.
 /// The fields of this struct are opaque and are not interpreted in any way.
 /// They serve as a mapping between source code and machine code.


### PR DESCRIPTION
This commit fixes https://github.com/bytecodealliance/wasmtime/issues/10613

When emitting some WebAssembly instructions involving branches, like `br_if` stack pointer expectations must be met at jump sites, more importantly when these instructions deal with multiple branches or fall-through cases, the need to reclaim any extra stack space might arise, and when it does, special handling is needed to ensure that value location is respected. Prior to this change, the emission for `br_table`  was incorrectly handling multiple return values on the stack, causing the miscompilation reported in the issue above.

This commit introduces a better mechanism to deal with branch emission, ensuring that all the invariants are applied to the main entry points for branches: `return`, `br` , `br_if`  and `br_table`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
