### PR TITLE
Run AArch64 Winch tests on CI

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2047,10 +2047,10 @@ impl Config {
                         // no support for simd on aarch64
                         unsupported |= WasmFeatures::SIMD;
 
-                        // things like multi-table are technically supported on
-                        // winch on aarch64 but this helps gate most spec tests
-                        // by default which otherwise currently cause panics.
-                        unsupported |= WasmFeatures::REFERENCE_TYPES;
+                        // not implemented yet
+                        unsupported |= WasmFeatures::WIDE_ARITHMETIC;
+
+                        // also not implemented yet.
                         unsupported |= WasmFeatures::THREADS
                     }
 

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -111,6 +111,10 @@ For each column in the above tables, this is a further explanation of its meanin
   must pass at least for Cranelift on all [tier 1](./stability-tiers.md)
   platforms, but missing other platforms is otherwise acceptable.
 
+  > For maintainers be sure to audit the `WastTest::should_skip_entirely`
+  > method to ensure that there are no tests which are listed there for this
+  > feature. If so remove them to ensure that the test is run on CI.
+
 * **Finished** - No open questions, design concerns, or serious known bugs. The
   implementation should be complete to the extent that is possible. Support
   must be implemented for all [tier 1](./stability-tiers.md) targets and

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -19,6 +19,10 @@ fn main() {
     let mut trials = Vec::new();
 
     let mut add_trial = |test: &WastTest, config: WastConfig| {
+        if test.should_skip_entirely(&config) {
+            return;
+        }
+
         let trial = Trial::test(
             format!(
                 "{:?}/{}{}{}",

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -387,8 +387,12 @@ impl Masm for MacroAssembler {
         cc: IntCmpKind,
         _size: OperandSize,
     ) -> Result<()> {
-        self.asm.csel(src, dst.to_reg(), dst, Cond::from(cc));
-        Ok(())
+        match (src.class(), dst.to_reg().class()) {
+            (RegClass::Int, RegClass::Int) => {
+                Ok(self.asm.csel(src, dst.to_reg(), dst, Cond::from(cc)))
+            }
+            _ => Err(anyhow!(CodeGenError::invalid_operand_combination())),
+        }
     }
 
     fn add(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {


### PR DESCRIPTION
Most tests pass (yay!), some tests fail, and some tests crash and/or have nondeterministic results. A new `WastTest::should_skip_entirely` helper is added to avoid running crashing or nondeterministic tests in CI and that should enable all other tests to run in CI to ensure we have a ratchet to prevent future regressions. This should also in theory make testing easier locally with `cargo test --test wast`.

Closes #9566

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
