### PR TITLE
Inline assembler-x64 `generated_files` in `main.rs`

### DIFF
--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -86,8 +86,3 @@ pub use mem::{
 };
 pub use rex::RexFlags;
 pub use xmm::Xmm;
-
-/// List the files generated to create this assembler.
-pub fn generated_files() -> Vec<std::path::PathBuf> {
-    include!(concat!(env!("OUT_DIR"), "/generated-files.rs"))
-}

--- a/cranelift/assembler-x64/src/main.rs
+++ b/cranelift/assembler-x64/src/main.rs
@@ -1,7 +1,8 @@
 //! Print the path to the generated code.
 
 fn main() {
-    for path in cranelift_assembler_x64::generated_files() {
+    let paths: Vec<std::path::PathBuf> = include!(concat!(env!("OUT_DIR"), "/generated-files.rs"));
+    for path in paths {
         println!("{}", path.display());
     }
 }


### PR DESCRIPTION
The public function `generated_files` in `cranelift-assembler-x64` makes the generated `rlib` non-deterministic because it contains the full paths of generated files. But this function is only used in `main.rs` of the same crate, so this change inlines it there to keep the library artifact deterministic while maintaining the same behavior.
