### PR TITLE
asm: refactor how REX prefixes are emitted

### DIFF
--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -1,6 +1,5 @@
 //! Pure register operands; see [`Gpr`].
 
-use crate::rex::RexFlags;
 use crate::AsReg;
 
 /// A general purpose x64 register (e.g., `%rax`).
@@ -32,12 +31,6 @@ impl<R: AsReg> Gpr<R> {
     /// Return the register name at the given `size`.
     pub fn to_string(&self, size: Size) -> String {
         self.0.to_string(Some(size))
-    }
-
-    /// Proxy on the 8-bit REX flag emission; helpful for simplifying generated
-    /// code.
-    pub(crate) fn always_emit_if_8bit_needed(&self, rex: &mut RexFlags) {
-        rex.always_emit_if_8bit_needed(self.enc());
     }
 }
 

--- a/cranelift/assembler-x64/src/inst.rs
+++ b/cranelift/assembler-x64/src/inst.rs
@@ -7,7 +7,7 @@ use crate::api::{AsReg, CodeSink, KnownOffsetTable, RegisterVisitor, Registers};
 use crate::gpr::{self, Gpr, Size};
 use crate::imm::{Extension, Imm16, Imm32, Imm8, Simm32, Simm8};
 use crate::mem::{emit_modrm_sib_disp, visit_amode, Amode, GprMem, XmmMem};
-use crate::rex::{self, RexFlags};
+use crate::rex::{self, RexPrefix};
 use crate::xmm::Xmm;
 use crate::Fixed;
 

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -84,5 +84,5 @@ pub use imm::{Extension, Imm16, Imm32, Imm8, Simm16, Simm32, Simm8};
 pub use mem::{
     Amode, AmodeOffset, AmodeOffsetPlusKnownOffset, DeferredTarget, GprMem, Scale, XmmMem,
 };
-pub use rex::RexFlags;
+pub use rex::RexPrefix;
 pub use xmm::Xmm;


### PR DESCRIPTION
This does not change functionality; instead, it reorganizes how REX prefixes were encoded by the assembler to simplify code generation. `RexFlags` now becomes the more-correct `RexPrefix` and constructors like `RexPrefix::two_op` build the necessary byte for emission with `RexPrefix::encode`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
