### PR TITLE
Backport to 33.0.0: Cranelift: update to regalloc2 0.12.2; support many return values. (#10747).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987b16639ffa003f99fe9c183ce633c6ba2578f6383b2f04fe9dc669f9aac55a"
+checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.12.1"
+regalloc2 = "0.12.2"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -954,8 +954,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.12.1"
-when = "2025-04-15"
+version = "0.12.2"
+when = "2025-05-07"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"

--- a/tests/disas/many-return-values.wat
+++ b/tests/disas/many-return-values.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+;;! test = "compile"
+
+(module
+  (type $t
+    (func
+      (result
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 10
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 20
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 30
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 40
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 50
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 60
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 70
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 80
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 90
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 100
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 110
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 120
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 130
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 140
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 150
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 160
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 170
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 180
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 190
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 200
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 210
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 220
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 230
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 240
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 250
+        i32 i32 i32 i32                         ;; 254
+      )
+    )
+  )
+  (export "f" (func $f))
+  (func $f (type $t) (unreachable))
+)
+;; wasm[0]::function[0]::f:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       ud2

--- a/tests/misc_testsuite/many-return-values.wast
+++ b/tests/misc_testsuite/many-return-values.wast
@@ -1,0 +1,36 @@
+(module
+  (type $t
+    (func
+      (result
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 10
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 20
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 30
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 40
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 50
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 60
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 70
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 80
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 90
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 100
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 110
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 120
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 130
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 140
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 150
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 160
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 170
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 180
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 190
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 200
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 210
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 220
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 230
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 240
+        i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 ;; 250
+        i32 i32 i32 i32                         ;; 254
+      )
+    )
+  )
+  (export "f" (func $f))
+  (func $f (type $t) (unreachable))
+)


### PR DESCRIPTION
Prior versions of regalloc2 could not support more than 255 operands on an instruction, and together with the integrated return-value loads on call instructions introduced in #10502, this caused issues with calls with many returns. This PR upgrades to a version of RA2 that supports up to `2^16 - 1` operands per instruction (well in excess of the maximum of 1000 return/result values per Wasm's implementation limits, for example).