### PR TITLE
winch(aarch64): Run wast test in CI

### DIFF
--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -292,7 +292,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
         if wasmtime_test_util::wast::Compiler::#strategy_ident.should_fail(&#test_config) {
             assert!(result.is_err());
         } else {
-            assert!(result.is_ok());
+            result.unwrap();
         }
             }
         };

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -488,42 +488,50 @@ impl WastTest {
 
         // Disable spec tests per target for proposals that Winch does not implement yet.
         if config.compiler == Compiler::Winch {
+            // Common list for tests that fail in all targets supported by Winch.
+            let unsupported = [
+                "extended-const/elem.wast",
+                "extended-const/global.wast",
+                "misc_testsuite/component-model/modules.wast",
+                "misc_testsuite/externref-id-function.wast",
+                "misc_testsuite/externref-segment.wast",
+                "misc_testsuite/externref-segments.wast",
+                "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
+                "misc_testsuite/linking-errors.wast",
+                "misc_testsuite/many_table_gets_lead_to_gc.wast",
+                "misc_testsuite/mutable_externref_globals.wast",
+                "misc_testsuite/no-mixup-stack-maps.wast",
+                "misc_testsuite/no-panic.wast",
+                "misc_testsuite/simple_ref_is_null.wast",
+                "misc_testsuite/table_grow_with_funcref.wast",
+                "spec_testsuite/br_table.wast",
+                "spec_testsuite/global.wast",
+                "spec_testsuite/ref_func.wast",
+                "spec_testsuite/ref_is_null.wast",
+                "spec_testsuite/ref_null.wast",
+                "spec_testsuite/select.wast",
+                "spec_testsuite/table_fill.wast",
+                "spec_testsuite/table_get.wast",
+                "spec_testsuite/table_grow.wast",
+                "spec_testsuite/table_set.wast",
+                "spec_testsuite/table_size.wast",
+                "spec_testsuite/elem.wast",
+                "spec_testsuite/linking.wast",
+            ];
+
+            if unsupported.iter().any(|part| self.path.ends_with(part)) {
+                return true;
+            }
+
             #[cfg(target_arch = "aarch64")]
             {
                 let unsupported = [
                     // Externref / GC related.
-                    "extended-const/elem.wast",
-                    "extended-const/global.wast",
-                    "spec_testsuite/br_table.wast",
-                    "spec_testsuite/global.wast",
-                    "spec_testsuite/linking.wast",
-                    "spec_testsuite/ref_func.wast",
-                    "spec_testsuite/ref_is_null.wast",
-                    "spec_testsuite/ref_null.wast",
-                    "spec_testsuite/select.wast",
-                    "spec_testsuite/table_fill.wast",
-                    "spec_testsuite/table_get.wast",
-                    "spec_testsuite/table_grow.wast",
-                    "spec_testsuite/table_set.wast",
-                    "spec_testsuite/table_size.wast",
-                    "misc_testsuite/table_grow_with_funcref.wast",
-                    "misc_testsuite/component-model/modules.wast",
                     "misc_testsuite/winch/table_get.wast",
                     "misc_testsuite/winch/table_set.wast",
                     "misc_testsuite/winch/table_fill.wast",
-                    "misc_testsuite/linking-errors.wast",
-                    "misc_testsuite/no-panic.wast",
-                    "misc_testsuite/externref-id-function.wast",
-                    "misc_testsuite/simple_ref_is_null.wast",
-                    "misc_testsuite/mutable_externref_globals.wast",
-                    "misc_testsuite/many_table_gets_lead_to_gc.wast",
-                    "misc_testsuite/no-mixup-stack-maps.wast",
-                    "misc_testsuite/externref-segment.wast",
-                    "misc_testsuite/externref-segments.wast",
-                    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
                     // Known bugs that don't cause segfaults.
                     "spec_testsuite/call_indirect.wast",
-                    "spec_testsuite/elem.wast",
                     "spec_testsuite/f32_cmp.wast",
                     "spec_testsuite/f64_cmp.wast",
                     "spec_testsuite/func_ptrs.wast",
@@ -551,34 +559,6 @@ impl WastTest {
             {
                 let unsupported = [
                     // externref/reference-types related
-                    "component-model/modules.wast",
-                    "extended-const/elem.wast",
-                    "extended-const/global.wast",
-                    "misc_testsuite/externref-id-function.wast",
-                    "misc_testsuite/externref-segment.wast",
-                    "misc_testsuite/externref-segments.wast",
-                    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
-                    "misc_testsuite/linking-errors.wast",
-                    "misc_testsuite/many_table_gets_lead_to_gc.wast",
-                    "misc_testsuite/mutable_externref_globals.wast",
-                    "misc_testsuite/no-mixup-stack-maps.wast",
-                    "misc_testsuite/no-panic.wast",
-                    "misc_testsuite/simple_ref_is_null.wast",
-                    "misc_testsuite/table_grow_with_funcref.wast",
-                    "spec_testsuite/br_table.wast",
-                    "spec_testsuite/data-invalid.wast",
-                    "spec_testsuite/elem.wast",
-                    "spec_testsuite/global.wast",
-                    "spec_testsuite/linking.wast",
-                    "spec_testsuite/ref_func.wast",
-                    "spec_testsuite/ref_is_null.wast",
-                    "spec_testsuite/ref_null.wast",
-                    "spec_testsuite/select.wast",
-                    "spec_testsuite/table_fill.wast",
-                    "spec_testsuite/table_get.wast",
-                    "spec_testsuite/table_grow.wast",
-                    "spec_testsuite/table_set.wast",
-                    "spec_testsuite/table_size.wast",
                     // simd-related failures
                     "misc_testsuite/simd/canonicalize-nan.wast",
                 ];

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -341,28 +341,27 @@ impl Compiler {
             Compiler::CraneliftNative => config.legacy_exceptions(),
 
             Compiler::Winch => {
-		let unsupported_base =
-		    config.gc()
-		    || config.tail_call()
-		    || config.function_references()
-		    || config.gc()
-		    || config.relaxed_simd()
-		    || config.gc_types()
-		    || config.exceptions()
-		    || config.legacy_exceptions();
+                let unsupported_base = config.gc()
+                    || config.tail_call()
+                    || config.function_references()
+                    || config.gc()
+                    || config.relaxed_simd()
+                    || config.gc_types()
+                    || config.exceptions()
+                    || config.legacy_exceptions();
 
-		if cfg!(target_arch = "x86_64") {
-		    return unsupported_base;
-		}
+                if cfg!(target_arch = "x86_64") {
+                    return unsupported_base;
+                }
 
-		if cfg!(target_arch = "aarch64") {
-		    return unsupported_base
-			|| config.simd()
-			|| config.wide_arithmetic()
-			|| config.threads()
-		}
+                if cfg!(target_arch = "aarch64") {
+                    return unsupported_base
+                        || config.simd()
+                        || config.wide_arithmetic()
+                        || config.threads();
+                }
 
-		false
+                false
             }
 
             Compiler::CraneliftPulley => config.threads() || config.legacy_exceptions(),
@@ -379,10 +378,7 @@ impl Compiler {
                     || cfg!(target_arch = "riscv64")
                     || cfg!(target_arch = "s390x")
             }
-            Compiler::Winch => {
-                cfg!(target_arch = "x86_64")
-                    || cfg!(target_arch = "aarch64")
-            }
+            Compiler::Winch => cfg!(target_arch = "x86_64") || cfg!(target_arch = "aarch64"),
             Compiler::CraneliftPulley => true,
         }
     }
@@ -419,37 +415,37 @@ impl WastTest {
     /// It's recommended to avoid ignoring tests as much as possible, instead
     /// it's recommended to add tests to `WastTest::should_fail`.
     pub fn ignore(&self, config: &WastConfig) -> bool {
-	if config.compiler == Compiler::Winch {
-	    if cfg!(target_arch = "aarch64") {
-		let unsupported = [
-		    // Missing stack checks (#8321)
-		    "spec_testsuite/call.wast",
-		    "spec_testsuite/fac.wast",
-		    "spec_testsuite/skip-stack-guard-page.wast",
-		    "misc_testsuite/stack_overflow.wast",
-		    // Fails intermittently
-		    "misc_testsuite/table_copy_on_imported_tables.wast",
-		    // Segfault
-		    "spec_testsuite/conversions.wast",
-		    "spec_testsuite/func.wast",
-		    "spec_testsuite/float_exprs.wast",
-		    "spec_testsuite/int_exprs.wast",
-		    "spec_testsuite/left-to-right.wast",
-		    "spec_testsuite/i32.wast",
-		    "spec_testsuite/traps.wast",
-		    "spec_testsuite/unreachable.wast",
-		    "spec_testsuite/unreached-valid.wast",
-		    "misc_testsuite/component-model/fused.wast",
-		    "misc_testsuite/component-model/strings.wast",
-		    "misc_testsuite/winch/select.wast",
-		    "misc_testsuite/sink-float-but-dont-trap.wast",
-		    "misc_testsuite/issue4840.wast",
-		];
+        if config.compiler == Compiler::Winch {
+            if cfg!(target_arch = "aarch64") {
+                let unsupported = [
+                    // Missing stack checks (#8321)
+                    "spec_testsuite/call.wast",
+                    "spec_testsuite/fac.wast",
+                    "spec_testsuite/skip-stack-guard-page.wast",
+                    "misc_testsuite/stack_overflow.wast",
+                    // Fails intermittently
+                    "misc_testsuite/table_copy_on_imported_tables.wast",
+                    // Segfault
+                    "spec_testsuite/conversions.wast",
+                    "spec_testsuite/func.wast",
+                    "spec_testsuite/float_exprs.wast",
+                    "spec_testsuite/int_exprs.wast",
+                    "spec_testsuite/left-to-right.wast",
+                    "spec_testsuite/i32.wast",
+                    "spec_testsuite/traps.wast",
+                    "spec_testsuite/unreachable.wast",
+                    "spec_testsuite/unreached-valid.wast",
+                    "misc_testsuite/component-model/fused.wast",
+                    "misc_testsuite/component-model/strings.wast",
+                    "misc_testsuite/winch/select.wast",
+                    "misc_testsuite/sink-float-but-dont-trap.wast",
+                    "misc_testsuite/issue4840.wast",
+                ];
 
-		return unsupported.iter().any(|part| self.path.ends_with(part));
-	    }
-	}
-	false
+                return unsupported.iter().any(|part| self.path.ends_with(part));
+            }
+        }
+        false
     }
 
     /// Returns whether this test should fail under the specified extra
@@ -492,190 +488,188 @@ impl WastTest {
 
         // Disable spec tests per target for proposals that Winch does not implement yet.
         if config.compiler == Compiler::Winch {
-	    #[cfg(target_arch = "aarch64")]
-	    {
-		let unsupported = [
-		    // Externref / GC related.
-		    "extended-const/elem.wast",
-		    "extended-const/global.wast",
-		    "spec_testsuite/br_table.wast",
-		    "spec_testsuite/global.wast",
-		    "spec_testsuite/linking.wast",
-		    "spec_testsuite/ref_func.wast",
-		    "spec_testsuite/ref_is_null.wast",
-		    "spec_testsuite/ref_null.wast",
-		    "spec_testsuite/select.wast",
-		    "spec_testsuite/table_fill.wast",
-		    "spec_testsuite/table_get.wast",
-		    "spec_testsuite/table_grow.wast",
-		    "spec_testsuite/table_set.wast",
-		    "spec_testsuite/table_size.wast",
-		    "misc_testsuite/table_grow_with_funcref.wast",
-		    "misc_testsuite/component-model/modules.wast",
-		    "misc_testsuite/winch/table_get.wast",
-		    "misc_testsuite/winch/table_set.wast",
-		    "misc_testsuite/winch/table_fill.wast",
-		    "misc_testsuite/linking-errors.wast",
-		    "misc_testsuite/no-panic.wast",
-		    "misc_testsuite/externref-id-function.wast",
-		    "misc_testsuite/simple_ref_is_null.wast",
-		    "misc_testsuite/mutable_externref_globals.wast",
-		    "misc_testsuite/many_table_gets_lead_to_gc.wast",
-		    "misc_testsuite/no-mixup-stack-maps.wast",
-		    "misc_testsuite/externref-segment.wast",
-		    "misc_testsuite/externref-segments.wast",
-		    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
+            #[cfg(target_arch = "aarch64")]
+            {
+                let unsupported = [
+                    // Externref / GC related.
+                    "extended-const/elem.wast",
+                    "extended-const/global.wast",
+                    "spec_testsuite/br_table.wast",
+                    "spec_testsuite/global.wast",
+                    "spec_testsuite/linking.wast",
+                    "spec_testsuite/ref_func.wast",
+                    "spec_testsuite/ref_is_null.wast",
+                    "spec_testsuite/ref_null.wast",
+                    "spec_testsuite/select.wast",
+                    "spec_testsuite/table_fill.wast",
+                    "spec_testsuite/table_get.wast",
+                    "spec_testsuite/table_grow.wast",
+                    "spec_testsuite/table_set.wast",
+                    "spec_testsuite/table_size.wast",
+                    "misc_testsuite/table_grow_with_funcref.wast",
+                    "misc_testsuite/component-model/modules.wast",
+                    "misc_testsuite/winch/table_get.wast",
+                    "misc_testsuite/winch/table_set.wast",
+                    "misc_testsuite/winch/table_fill.wast",
+                    "misc_testsuite/linking-errors.wast",
+                    "misc_testsuite/no-panic.wast",
+                    "misc_testsuite/externref-id-function.wast",
+                    "misc_testsuite/simple_ref_is_null.wast",
+                    "misc_testsuite/mutable_externref_globals.wast",
+                    "misc_testsuite/many_table_gets_lead_to_gc.wast",
+                    "misc_testsuite/no-mixup-stack-maps.wast",
+                    "misc_testsuite/externref-segment.wast",
+                    "misc_testsuite/externref-segments.wast",
+                    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
+                    // Known bugs that don't cause segfaults.
+                    "spec_testsuite/call_indirect.wast",
+                    "spec_testsuite/elem.wast",
+                    "spec_testsuite/f32_cmp.wast",
+                    "spec_testsuite/f64_cmp.wast",
+                    "spec_testsuite/func_ptrs.wast",
+                    "spec_testsuite/i64.wast",
+                    "spec_testsuite/if.wast",
+                    "spec_testsuite/imports.wast",
+                    "spec_testsuite/local_set.wast",
+                    "spec_testsuite/local_tee.wast",
+                    "spec_testsuite/loop.wast",
+                    "spec_testsuite/table_copy.wast",
+                    "spec_testsuite/table_init.wast",
+                    "misc_testsuite/custom-page-sizes/custom-page-sizes.wast",
+                    "misc_testsuite/winch/table_grow.wast",
+                    "spec_testsuite/proposals/custom-page-sizes/custom-page-sizes.wast",
+                    "misc_testsuite/memory64/more-than-4gb.wast",
+                    "misc_testsuite/call_indirect.wast",
+                ];
 
-
-		    // Known bugs that don't cause segfaults.
-		    "spec_testsuite/call_indirect.wast",
-		    "spec_testsuite/elem.wast",
-		    "spec_testsuite/f32_cmp.wast",
-		    "spec_testsuite/f64_cmp.wast",
-		    "spec_testsuite/func_ptrs.wast",
-		    "spec_testsuite/i64.wast",
-		    "spec_testsuite/if.wast",
-		    "spec_testsuite/imports.wast",
-		    "spec_testsuite/local_set.wast",
-		    "spec_testsuite/local_tee.wast",
-		    "spec_testsuite/loop.wast",
-		    "spec_testsuite/table_copy.wast",
-		    "spec_testsuite/table_init.wast",
-		    "misc_testsuite/custom-page-sizes/custom-page-sizes.wast",
-		    "misc_testsuite/winch/table_grow.wast",
-		    "spec_testsuite/proposals/custom-page-sizes/custom-page-sizes.wast",
-		    "misc_testsuite/memory64/more-than-4gb.wast",
-		    "misc_testsuite/call_indirect.wast",
-		];
-
-		if unsupported.iter().any(|part| self.path.ends_with(part)) {
+                if unsupported.iter().any(|part| self.path.ends_with(part)) {
                     return true;
-		}
-	    }
+                }
+            }
 
-	    #[cfg(target_arch = "x86_64")]
-	    {
+            #[cfg(target_arch = "x86_64")]
+            {
+                let unsupported = [
+                    // externref/reference-types related
+                    "component-model/modules.wast",
+                    "extended-const/elem.wast",
+                    "extended-const/global.wast",
+                    "misc_testsuite/externref-id-function.wast",
+                    "misc_testsuite/externref-segment.wast",
+                    "misc_testsuite/externref-segments.wast",
+                    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
+                    "misc_testsuite/linking-errors.wast",
+                    "misc_testsuite/many_table_gets_lead_to_gc.wast",
+                    "misc_testsuite/mutable_externref_globals.wast",
+                    "misc_testsuite/no-mixup-stack-maps.wast",
+                    "misc_testsuite/no-panic.wast",
+                    "misc_testsuite/simple_ref_is_null.wast",
+                    "misc_testsuite/table_grow_with_funcref.wast",
+                    "spec_testsuite/br_table.wast",
+                    "spec_testsuite/data-invalid.wast",
+                    "spec_testsuite/elem.wast",
+                    "spec_testsuite/global.wast",
+                    "spec_testsuite/linking.wast",
+                    "spec_testsuite/ref_func.wast",
+                    "spec_testsuite/ref_is_null.wast",
+                    "spec_testsuite/ref_null.wast",
+                    "spec_testsuite/select.wast",
+                    "spec_testsuite/table_fill.wast",
+                    "spec_testsuite/table_get.wast",
+                    "spec_testsuite/table_grow.wast",
+                    "spec_testsuite/table_set.wast",
+                    "spec_testsuite/table_size.wast",
+                    // simd-related failures
+                    "misc_testsuite/simd/canonicalize-nan.wast",
+                ];
 
-		let unsupported = [
-		    // externref/reference-types related
-		    "component-model/modules.wast",
-		    "extended-const/elem.wast",
-		    "extended-const/global.wast",
-		    "misc_testsuite/externref-id-function.wast",
-		    "misc_testsuite/externref-segment.wast",
-		    "misc_testsuite/externref-segments.wast",
-		    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
-		    "misc_testsuite/linking-errors.wast",
-		    "misc_testsuite/many_table_gets_lead_to_gc.wast",
-		    "misc_testsuite/mutable_externref_globals.wast",
-		    "misc_testsuite/no-mixup-stack-maps.wast",
-		    "misc_testsuite/no-panic.wast",
-		    "misc_testsuite/simple_ref_is_null.wast",
-		    "misc_testsuite/table_grow_with_funcref.wast",
-		    "spec_testsuite/br_table.wast",
-		    "spec_testsuite/data-invalid.wast",
-		    "spec_testsuite/elem.wast",
-		    "spec_testsuite/global.wast",
-		    "spec_testsuite/linking.wast",
-		    "spec_testsuite/ref_func.wast",
-		    "spec_testsuite/ref_is_null.wast",
-		    "spec_testsuite/ref_null.wast",
-		    "spec_testsuite/select.wast",
-		    "spec_testsuite/table_fill.wast",
-		    "spec_testsuite/table_get.wast",
-		    "spec_testsuite/table_grow.wast",
-		    "spec_testsuite/table_set.wast",
-		    "spec_testsuite/table_size.wast",
-		    // simd-related failures
-		    "misc_testsuite/simd/canonicalize-nan.wast",
-		];
-
-		if unsupported.iter().any(|part| self.path.ends_with(part)) {
+                if unsupported.iter().any(|part| self.path.ends_with(part)) {
                     return true;
-		}
+                }
 
-		// SIMD on Winch requires AVX instructions.
-		#[cfg(target_arch = "x86_64")]
-		if !(std::is_x86_feature_detected!("avx") && std::is_x86_feature_detected!("avx2")) {
+                // SIMD on Winch requires AVX instructions.
+                #[cfg(target_arch = "x86_64")]
+                if !(std::is_x86_feature_detected!("avx") && std::is_x86_feature_detected!("avx2"))
+                {
                     let unsupported = [
-			"annotations/simd_lane.wast",
-			"memory64/simd.wast",
-			"misc_testsuite/int-to-float-splat.wast",
-			"misc_testsuite/issue6562.wast",
-			"misc_testsuite/simd/almost-extmul.wast",
-			"misc_testsuite/simd/cvt-from-uint.wast",
-			"misc_testsuite/simd/issue_3327_bnot_lowering.wast",
-			"misc_testsuite/simd/issue6725-no-egraph-panic.wast",
-			"misc_testsuite/simd/replace-lane-preserve.wast",
-			"misc_testsuite/simd/spillslot-size-fuzzbug.wast",
-			"misc_testsuite/winch/issue-10331.wast",
-			"misc_testsuite/winch/replace_lane.wast",
-			"spec_testsuite/simd_align.wast",
-			"spec_testsuite/simd_boolean.wast",
-			"spec_testsuite/simd_conversions.wast",
-			"spec_testsuite/simd_f32x4.wast",
-			"spec_testsuite/simd_f32x4_arith.wast",
-			"spec_testsuite/simd_f32x4_cmp.wast",
-			"spec_testsuite/simd_f32x4_pmin_pmax.wast",
-			"spec_testsuite/simd_f32x4_rounding.wast",
-			"spec_testsuite/simd_f64x2.wast",
-			"spec_testsuite/simd_f64x2_arith.wast",
-			"spec_testsuite/simd_f64x2_cmp.wast",
-			"spec_testsuite/simd_f64x2_pmin_pmax.wast",
-			"spec_testsuite/simd_f64x2_rounding.wast",
-			"spec_testsuite/simd_i16x8_cmp.wast",
-			"spec_testsuite/simd_i32x4_cmp.wast",
-			"spec_testsuite/simd_i64x2_arith2.wast",
-			"spec_testsuite/simd_i64x2_cmp.wast",
-			"spec_testsuite/simd_i8x16_arith2.wast",
-			"spec_testsuite/simd_i8x16_cmp.wast",
-			"spec_testsuite/simd_int_to_int_extend.wast",
-			"spec_testsuite/simd_load.wast",
-			"spec_testsuite/simd_load_extend.wast",
-			"spec_testsuite/simd_load_splat.wast",
-			"spec_testsuite/simd_load_zero.wast",
-			"spec_testsuite/simd_splat.wast",
-			"spec_testsuite/simd_store16_lane.wast",
-			"spec_testsuite/simd_store32_lane.wast",
-			"spec_testsuite/simd_store64_lane.wast",
-			"spec_testsuite/simd_store8_lane.wast",
-			"spec_testsuite/simd_load16_lane.wast",
-			"spec_testsuite/simd_load32_lane.wast",
-			"spec_testsuite/simd_load64_lane.wast",
-			"spec_testsuite/simd_load8_lane.wast",
-			"spec_testsuite/simd_bitwise.wast",
-			"misc_testsuite/simd/load_splat_out_of_bounds.wast",
-			"misc_testsuite/simd/unaligned-load.wast",
-			"multi-memory/simd_memory-multi.wast",
-			"misc_testsuite/simd/issue4807.wast",
-			"spec_testsuite/simd_const.wast",
-			"spec_testsuite/simd_i8x16_sat_arith.wast",
-			"spec_testsuite/simd_i64x2_arith.wast",
-			"spec_testsuite/simd_i16x8_arith.wast",
-			"spec_testsuite/simd_i16x8_arith2.wast",
-			"spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
-			"spec_testsuite/simd_i16x8_sat_arith.wast",
-			"spec_testsuite/simd_i32x4_arith.wast",
-			"spec_testsuite/simd_i32x4_dot_i16x8.wast",
-			"spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
-			"spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
-			"spec_testsuite/simd_i8x16_arith.wast",
-			"spec_testsuite/simd_bit_shift.wast",
-			"spec_testsuite/simd_lane.wast",
-			"spec_testsuite/simd_i16x8_extmul_i8x16.wast",
-			"spec_testsuite/simd_i32x4_extmul_i16x8.wast",
-			"spec_testsuite/simd_i64x2_extmul_i32x4.wast",
-			"spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
-			"spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
-			"spec_testsuite/simd_i32x4_arith2.wast",
+                        "annotations/simd_lane.wast",
+                        "memory64/simd.wast",
+                        "misc_testsuite/int-to-float-splat.wast",
+                        "misc_testsuite/issue6562.wast",
+                        "misc_testsuite/simd/almost-extmul.wast",
+                        "misc_testsuite/simd/cvt-from-uint.wast",
+                        "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
+                        "misc_testsuite/simd/issue6725-no-egraph-panic.wast",
+                        "misc_testsuite/simd/replace-lane-preserve.wast",
+                        "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
+                        "misc_testsuite/winch/issue-10331.wast",
+                        "misc_testsuite/winch/replace_lane.wast",
+                        "spec_testsuite/simd_align.wast",
+                        "spec_testsuite/simd_boolean.wast",
+                        "spec_testsuite/simd_conversions.wast",
+                        "spec_testsuite/simd_f32x4.wast",
+                        "spec_testsuite/simd_f32x4_arith.wast",
+                        "spec_testsuite/simd_f32x4_cmp.wast",
+                        "spec_testsuite/simd_f32x4_pmin_pmax.wast",
+                        "spec_testsuite/simd_f32x4_rounding.wast",
+                        "spec_testsuite/simd_f64x2.wast",
+                        "spec_testsuite/simd_f64x2_arith.wast",
+                        "spec_testsuite/simd_f64x2_cmp.wast",
+                        "spec_testsuite/simd_f64x2_pmin_pmax.wast",
+                        "spec_testsuite/simd_f64x2_rounding.wast",
+                        "spec_testsuite/simd_i16x8_cmp.wast",
+                        "spec_testsuite/simd_i32x4_cmp.wast",
+                        "spec_testsuite/simd_i64x2_arith2.wast",
+                        "spec_testsuite/simd_i64x2_cmp.wast",
+                        "spec_testsuite/simd_i8x16_arith2.wast",
+                        "spec_testsuite/simd_i8x16_cmp.wast",
+                        "spec_testsuite/simd_int_to_int_extend.wast",
+                        "spec_testsuite/simd_load.wast",
+                        "spec_testsuite/simd_load_extend.wast",
+                        "spec_testsuite/simd_load_splat.wast",
+                        "spec_testsuite/simd_load_zero.wast",
+                        "spec_testsuite/simd_splat.wast",
+                        "spec_testsuite/simd_store16_lane.wast",
+                        "spec_testsuite/simd_store32_lane.wast",
+                        "spec_testsuite/simd_store64_lane.wast",
+                        "spec_testsuite/simd_store8_lane.wast",
+                        "spec_testsuite/simd_load16_lane.wast",
+                        "spec_testsuite/simd_load32_lane.wast",
+                        "spec_testsuite/simd_load64_lane.wast",
+                        "spec_testsuite/simd_load8_lane.wast",
+                        "spec_testsuite/simd_bitwise.wast",
+                        "misc_testsuite/simd/load_splat_out_of_bounds.wast",
+                        "misc_testsuite/simd/unaligned-load.wast",
+                        "multi-memory/simd_memory-multi.wast",
+                        "misc_testsuite/simd/issue4807.wast",
+                        "spec_testsuite/simd_const.wast",
+                        "spec_testsuite/simd_i8x16_sat_arith.wast",
+                        "spec_testsuite/simd_i64x2_arith.wast",
+                        "spec_testsuite/simd_i16x8_arith.wast",
+                        "spec_testsuite/simd_i16x8_arith2.wast",
+                        "spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
+                        "spec_testsuite/simd_i16x8_sat_arith.wast",
+                        "spec_testsuite/simd_i32x4_arith.wast",
+                        "spec_testsuite/simd_i32x4_dot_i16x8.wast",
+                        "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
+                        "spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
+                        "spec_testsuite/simd_i8x16_arith.wast",
+                        "spec_testsuite/simd_bit_shift.wast",
+                        "spec_testsuite/simd_lane.wast",
+                        "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
+                        "spec_testsuite/simd_i32x4_extmul_i16x8.wast",
+                        "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
+                        "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
+                        "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
+                        "spec_testsuite/simd_i32x4_arith2.wast",
                     ];
 
                     if unsupported.iter().any(|part| self.path.ends_with(part)) {
-			return true;
+                        return true;
                     }
-		}
-	    }
-	}
+                }
+            }
+        }
 
         // For the exceptions proposal these tests use instructions and such
         // which aren't implemented yet so these are expected to fail.

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -341,14 +341,28 @@ impl Compiler {
             Compiler::CraneliftNative => config.legacy_exceptions(),
 
             Compiler::Winch => {
-                config.gc()
-                    || config.tail_call()
-                    || config.function_references()
-                    || config.gc()
-                    || config.relaxed_simd()
-                    || config.gc_types()
-                    || config.exceptions()
-                    || config.legacy_exceptions()
+		let unsupported_base =
+		    config.gc()
+		    || config.tail_call()
+		    || config.function_references()
+		    || config.gc()
+		    || config.relaxed_simd()
+		    || config.gc_types()
+		    || config.exceptions()
+		    || config.legacy_exceptions();
+
+		if cfg!(target_arch = "x86_64") {
+		    return unsupported_base;
+		}
+
+		if cfg!(target_arch = "aarch64") {
+		    return unsupported_base
+			|| config.simd()
+			|| config.wide_arithmetic()
+			|| config.threads()
+		}
+
+		false
             }
 
             Compiler::CraneliftPulley => config.threads() || config.legacy_exceptions(),
@@ -367,6 +381,7 @@ impl Compiler {
             }
             Compiler::Winch => {
                 cfg!(target_arch = "x86_64")
+                    || cfg!(target_arch = "aarch64")
             }
             Compiler::CraneliftPulley => true,
         }
@@ -390,6 +405,51 @@ impl WastTest {
     /// Returns the optional spec proposal that this test is associated with.
     pub fn spec_proposal(&self) -> Option<&str> {
         spec_proposal_from_path(&self.path)
+    }
+
+    /// Returns true for tests that should be ignored (not run) for
+    /// the given config.
+
+    /// The infrastructure for `.wast` tests is designed to enable the
+    /// execution of tests at all times, however, while compiler
+    /// backends are in partial development state, it becomes harder
+    /// to guarantee particular tests will run to completion and
+    /// return a recoverable error, in some cases tests might segfault
+    /// making it challenging to assert a failure status.
+    /// It's recommended to avoid ignoring tests as much as possible, instead
+    /// it's recommended to add tests to `WastTest::should_fail`.
+    pub fn ignore(&self, config: &WastConfig) -> bool {
+	if config.compiler == Compiler::Winch {
+	    if cfg!(target_arch = "aarch64") {
+		let unsupported = [
+		    // Missing stack checks (#8321)
+		    "spec_testsuite/call.wast",
+		    "spec_testsuite/fac.wast",
+		    "spec_testsuite/skip-stack-guard-page.wast",
+		    "misc_testsuite/stack_overflow.wast",
+		    // Fails intermittently
+		    "misc_testsuite/table_copy_on_imported_tables.wast",
+		    // Segfault
+		    "spec_testsuite/conversions.wast",
+		    "spec_testsuite/func.wast",
+		    "spec_testsuite/float_exprs.wast",
+		    "spec_testsuite/int_exprs.wast",
+		    "spec_testsuite/left-to-right.wast",
+		    "spec_testsuite/i32.wast",
+		    "spec_testsuite/traps.wast",
+		    "spec_testsuite/unreachable.wast",
+		    "spec_testsuite/unreached-valid.wast",
+		    "misc_testsuite/component-model/fused.wast",
+		    "misc_testsuite/component-model/strings.wast",
+		    "misc_testsuite/winch/select.wast",
+		    "misc_testsuite/sink-float-but-dont-trap.wast",
+		    "misc_testsuite/issue4840.wast",
+		];
+
+		return unsupported.iter().any(|part| self.path.ends_with(part));
+	    }
+	}
+	false
     }
 
     /// Returns whether this test should fail under the specified extra
@@ -430,127 +490,192 @@ impl WastTest {
             return true;
         }
 
-        // Disable spec tests for proposals that Winch does not implement yet.
+        // Disable spec tests per target for proposals that Winch does not implement yet.
         if config.compiler == Compiler::Winch {
-            let unsupported = [
-                // externref/reference-types related
-                "component-model/modules.wast",
-                "extended-const/elem.wast",
-                "extended-const/global.wast",
-                "misc_testsuite/externref-id-function.wast",
-                "misc_testsuite/externref-segment.wast",
-                "misc_testsuite/externref-segments.wast",
-                "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
-                "misc_testsuite/linking-errors.wast",
-                "misc_testsuite/many_table_gets_lead_to_gc.wast",
-                "misc_testsuite/mutable_externref_globals.wast",
-                "misc_testsuite/no-mixup-stack-maps.wast",
-                "misc_testsuite/no-panic.wast",
-                "misc_testsuite/simple_ref_is_null.wast",
-                "misc_testsuite/table_grow_with_funcref.wast",
-                "spec_testsuite/br_table.wast",
-                "spec_testsuite/data-invalid.wast",
-                "spec_testsuite/elem.wast",
-                "spec_testsuite/global.wast",
-                "spec_testsuite/linking.wast",
-                "spec_testsuite/ref_func.wast",
-                "spec_testsuite/ref_is_null.wast",
-                "spec_testsuite/ref_null.wast",
-                "spec_testsuite/select.wast",
-                "spec_testsuite/table_fill.wast",
-                "spec_testsuite/table_get.wast",
-                "spec_testsuite/table_grow.wast",
-                "spec_testsuite/table_set.wast",
-                "spec_testsuite/table_size.wast",
-                // simd-related failures
-                "misc_testsuite/simd/canonicalize-nan.wast",
-            ];
+	    #[cfg(target_arch = "aarch64")]
+	    {
+		let unsupported = [
+		    // Externref / GC related.
+		    "extended-const/elem.wast",
+		    "extended-const/global.wast",
+		    "spec_testsuite/br_table.wast",
+		    "spec_testsuite/global.wast",
+		    "spec_testsuite/linking.wast",
+		    "spec_testsuite/ref_func.wast",
+		    "spec_testsuite/ref_is_null.wast",
+		    "spec_testsuite/ref_null.wast",
+		    "spec_testsuite/select.wast",
+		    "spec_testsuite/table_fill.wast",
+		    "spec_testsuite/table_get.wast",
+		    "spec_testsuite/table_grow.wast",
+		    "spec_testsuite/table_set.wast",
+		    "spec_testsuite/table_size.wast",
+		    "misc_testsuite/table_grow_with_funcref.wast",
+		    "misc_testsuite/component-model/modules.wast",
+		    "misc_testsuite/winch/table_get.wast",
+		    "misc_testsuite/winch/table_set.wast",
+		    "misc_testsuite/winch/table_fill.wast",
+		    "misc_testsuite/linking-errors.wast",
+		    "misc_testsuite/no-panic.wast",
+		    "misc_testsuite/externref-id-function.wast",
+		    "misc_testsuite/simple_ref_is_null.wast",
+		    "misc_testsuite/mutable_externref_globals.wast",
+		    "misc_testsuite/many_table_gets_lead_to_gc.wast",
+		    "misc_testsuite/no-mixup-stack-maps.wast",
+		    "misc_testsuite/externref-segment.wast",
+		    "misc_testsuite/externref-segments.wast",
+		    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
 
-            if unsupported.iter().any(|part| self.path.ends_with(part)) {
-                return true;
-            }
 
-            // SIMD on Winch requires AVX instructions.
-            #[cfg(target_arch = "x86_64")]
-            if !(std::is_x86_feature_detected!("avx") && std::is_x86_feature_detected!("avx2")) {
-                let unsupported = [
-                    "annotations/simd_lane.wast",
-                    "memory64/simd.wast",
-                    "misc_testsuite/int-to-float-splat.wast",
-                    "misc_testsuite/issue6562.wast",
-                    "misc_testsuite/simd/almost-extmul.wast",
-                    "misc_testsuite/simd/cvt-from-uint.wast",
-                    "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
-                    "misc_testsuite/simd/issue6725-no-egraph-panic.wast",
-                    "misc_testsuite/simd/replace-lane-preserve.wast",
-                    "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
-                    "misc_testsuite/winch/issue-10331.wast",
-                    "misc_testsuite/winch/replace_lane.wast",
-                    "spec_testsuite/simd_align.wast",
-                    "spec_testsuite/simd_boolean.wast",
-                    "spec_testsuite/simd_conversions.wast",
-                    "spec_testsuite/simd_f32x4.wast",
-                    "spec_testsuite/simd_f32x4_arith.wast",
-                    "spec_testsuite/simd_f32x4_cmp.wast",
-                    "spec_testsuite/simd_f32x4_pmin_pmax.wast",
-                    "spec_testsuite/simd_f32x4_rounding.wast",
-                    "spec_testsuite/simd_f64x2.wast",
-                    "spec_testsuite/simd_f64x2_arith.wast",
-                    "spec_testsuite/simd_f64x2_cmp.wast",
-                    "spec_testsuite/simd_f64x2_pmin_pmax.wast",
-                    "spec_testsuite/simd_f64x2_rounding.wast",
-                    "spec_testsuite/simd_i16x8_cmp.wast",
-                    "spec_testsuite/simd_i32x4_cmp.wast",
-                    "spec_testsuite/simd_i64x2_arith2.wast",
-                    "spec_testsuite/simd_i64x2_cmp.wast",
-                    "spec_testsuite/simd_i8x16_arith2.wast",
-                    "spec_testsuite/simd_i8x16_cmp.wast",
-                    "spec_testsuite/simd_int_to_int_extend.wast",
-                    "spec_testsuite/simd_load.wast",
-                    "spec_testsuite/simd_load_extend.wast",
-                    "spec_testsuite/simd_load_splat.wast",
-                    "spec_testsuite/simd_load_zero.wast",
-                    "spec_testsuite/simd_splat.wast",
-                    "spec_testsuite/simd_store16_lane.wast",
-                    "spec_testsuite/simd_store32_lane.wast",
-                    "spec_testsuite/simd_store64_lane.wast",
-                    "spec_testsuite/simd_store8_lane.wast",
-                    "spec_testsuite/simd_load16_lane.wast",
-                    "spec_testsuite/simd_load32_lane.wast",
-                    "spec_testsuite/simd_load64_lane.wast",
-                    "spec_testsuite/simd_load8_lane.wast",
-                    "spec_testsuite/simd_bitwise.wast",
-                    "misc_testsuite/simd/load_splat_out_of_bounds.wast",
-                    "misc_testsuite/simd/unaligned-load.wast",
-                    "multi-memory/simd_memory-multi.wast",
-                    "misc_testsuite/simd/issue4807.wast",
-                    "spec_testsuite/simd_const.wast",
-                    "spec_testsuite/simd_i8x16_sat_arith.wast",
-                    "spec_testsuite/simd_i64x2_arith.wast",
-                    "spec_testsuite/simd_i16x8_arith.wast",
-                    "spec_testsuite/simd_i16x8_arith2.wast",
-                    "spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
-                    "spec_testsuite/simd_i16x8_sat_arith.wast",
-                    "spec_testsuite/simd_i32x4_arith.wast",
-                    "spec_testsuite/simd_i32x4_dot_i16x8.wast",
-                    "spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
-                    "spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
-                    "spec_testsuite/simd_i8x16_arith.wast",
-                    "spec_testsuite/simd_bit_shift.wast",
-                    "spec_testsuite/simd_lane.wast",
-                    "spec_testsuite/simd_i16x8_extmul_i8x16.wast",
-                    "spec_testsuite/simd_i32x4_extmul_i16x8.wast",
-                    "spec_testsuite/simd_i64x2_extmul_i32x4.wast",
-                    "spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
-                    "spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
-                    "spec_testsuite/simd_i32x4_arith2.wast",
-                ];
+		    // Known bugs that don't cause segfaults.
+		    "spec_testsuite/call_indirect.wast",
+		    "spec_testsuite/elem.wast",
+		    "spec_testsuite/f32_cmp.wast",
+		    "spec_testsuite/f64_cmp.wast",
+		    "spec_testsuite/func_ptrs.wast",
+		    "spec_testsuite/i64.wast",
+		    "spec_testsuite/if.wast",
+		    "spec_testsuite/imports.wast",
+		    "spec_testsuite/local_set.wast",
+		    "spec_testsuite/local_tee.wast",
+		    "spec_testsuite/loop.wast",
+		    "spec_testsuite/table_copy.wast",
+		    "spec_testsuite/table_init.wast",
+		    "misc_testsuite/custom-page-sizes/custom-page-sizes.wast",
+		    "misc_testsuite/winch/table_grow.wast",
+		    "spec_testsuite/proposals/custom-page-sizes/custom-page-sizes.wast",
+		    "misc_testsuite/memory64/more-than-4gb.wast",
+		    "misc_testsuite/call_indirect.wast",
+		];
 
-                if unsupported.iter().any(|part| self.path.ends_with(part)) {
+		if unsupported.iter().any(|part| self.path.ends_with(part)) {
                     return true;
-                }
-            }
-        }
+		}
+	    }
+
+	    #[cfg(target_arch = "x86_64")]
+	    {
+
+		let unsupported = [
+		    // externref/reference-types related
+		    "component-model/modules.wast",
+		    "extended-const/elem.wast",
+		    "extended-const/global.wast",
+		    "misc_testsuite/externref-id-function.wast",
+		    "misc_testsuite/externref-segment.wast",
+		    "misc_testsuite/externref-segments.wast",
+		    "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
+		    "misc_testsuite/linking-errors.wast",
+		    "misc_testsuite/many_table_gets_lead_to_gc.wast",
+		    "misc_testsuite/mutable_externref_globals.wast",
+		    "misc_testsuite/no-mixup-stack-maps.wast",
+		    "misc_testsuite/no-panic.wast",
+		    "misc_testsuite/simple_ref_is_null.wast",
+		    "misc_testsuite/table_grow_with_funcref.wast",
+		    "spec_testsuite/br_table.wast",
+		    "spec_testsuite/data-invalid.wast",
+		    "spec_testsuite/elem.wast",
+		    "spec_testsuite/global.wast",
+		    "spec_testsuite/linking.wast",
+		    "spec_testsuite/ref_func.wast",
+		    "spec_testsuite/ref_is_null.wast",
+		    "spec_testsuite/ref_null.wast",
+		    "spec_testsuite/select.wast",
+		    "spec_testsuite/table_fill.wast",
+		    "spec_testsuite/table_get.wast",
+		    "spec_testsuite/table_grow.wast",
+		    "spec_testsuite/table_set.wast",
+		    "spec_testsuite/table_size.wast",
+		    // simd-related failures
+		    "misc_testsuite/simd/canonicalize-nan.wast",
+		];
+
+		if unsupported.iter().any(|part| self.path.ends_with(part)) {
+                    return true;
+		}
+
+		// SIMD on Winch requires AVX instructions.
+		#[cfg(target_arch = "x86_64")]
+		if !(std::is_x86_feature_detected!("avx") && std::is_x86_feature_detected!("avx2")) {
+                    let unsupported = [
+			"annotations/simd_lane.wast",
+			"memory64/simd.wast",
+			"misc_testsuite/int-to-float-splat.wast",
+			"misc_testsuite/issue6562.wast",
+			"misc_testsuite/simd/almost-extmul.wast",
+			"misc_testsuite/simd/cvt-from-uint.wast",
+			"misc_testsuite/simd/issue_3327_bnot_lowering.wast",
+			"misc_testsuite/simd/issue6725-no-egraph-panic.wast",
+			"misc_testsuite/simd/replace-lane-preserve.wast",
+			"misc_testsuite/simd/spillslot-size-fuzzbug.wast",
+			"misc_testsuite/winch/issue-10331.wast",
+			"misc_testsuite/winch/replace_lane.wast",
+			"spec_testsuite/simd_align.wast",
+			"spec_testsuite/simd_boolean.wast",
+			"spec_testsuite/simd_conversions.wast",
+			"spec_testsuite/simd_f32x4.wast",
+			"spec_testsuite/simd_f32x4_arith.wast",
+			"spec_testsuite/simd_f32x4_cmp.wast",
+			"spec_testsuite/simd_f32x4_pmin_pmax.wast",
+			"spec_testsuite/simd_f32x4_rounding.wast",
+			"spec_testsuite/simd_f64x2.wast",
+			"spec_testsuite/simd_f64x2_arith.wast",
+			"spec_testsuite/simd_f64x2_cmp.wast",
+			"spec_testsuite/simd_f64x2_pmin_pmax.wast",
+			"spec_testsuite/simd_f64x2_rounding.wast",
+			"spec_testsuite/simd_i16x8_cmp.wast",
+			"spec_testsuite/simd_i32x4_cmp.wast",
+			"spec_testsuite/simd_i64x2_arith2.wast",
+			"spec_testsuite/simd_i64x2_cmp.wast",
+			"spec_testsuite/simd_i8x16_arith2.wast",
+			"spec_testsuite/simd_i8x16_cmp.wast",
+			"spec_testsuite/simd_int_to_int_extend.wast",
+			"spec_testsuite/simd_load.wast",
+			"spec_testsuite/simd_load_extend.wast",
+			"spec_testsuite/simd_load_splat.wast",
+			"spec_testsuite/simd_load_zero.wast",
+			"spec_testsuite/simd_splat.wast",
+			"spec_testsuite/simd_store16_lane.wast",
+			"spec_testsuite/simd_store32_lane.wast",
+			"spec_testsuite/simd_store64_lane.wast",
+			"spec_testsuite/simd_store8_lane.wast",
+			"spec_testsuite/simd_load16_lane.wast",
+			"spec_testsuite/simd_load32_lane.wast",
+			"spec_testsuite/simd_load64_lane.wast",
+			"spec_testsuite/simd_load8_lane.wast",
+			"spec_testsuite/simd_bitwise.wast",
+			"misc_testsuite/simd/load_splat_out_of_bounds.wast",
+			"misc_testsuite/simd/unaligned-load.wast",
+			"multi-memory/simd_memory-multi.wast",
+			"misc_testsuite/simd/issue4807.wast",
+			"spec_testsuite/simd_const.wast",
+			"spec_testsuite/simd_i8x16_sat_arith.wast",
+			"spec_testsuite/simd_i64x2_arith.wast",
+			"spec_testsuite/simd_i16x8_arith.wast",
+			"spec_testsuite/simd_i16x8_arith2.wast",
+			"spec_testsuite/simd_i16x8_q15mulr_sat_s.wast",
+			"spec_testsuite/simd_i16x8_sat_arith.wast",
+			"spec_testsuite/simd_i32x4_arith.wast",
+			"spec_testsuite/simd_i32x4_dot_i16x8.wast",
+			"spec_testsuite/simd_i32x4_trunc_sat_f32x4.wast",
+			"spec_testsuite/simd_i32x4_trunc_sat_f64x2.wast",
+			"spec_testsuite/simd_i8x16_arith.wast",
+			"spec_testsuite/simd_bit_shift.wast",
+			"spec_testsuite/simd_lane.wast",
+			"spec_testsuite/simd_i16x8_extmul_i8x16.wast",
+			"spec_testsuite/simd_i32x4_extmul_i16x8.wast",
+			"spec_testsuite/simd_i64x2_extmul_i32x4.wast",
+			"spec_testsuite/simd_i16x8_extadd_pairwise_i8x16.wast",
+			"spec_testsuite/simd_i32x4_extadd_pairwise_i16x8.wast",
+			"spec_testsuite/simd_i32x4_arith2.wast",
+                    ];
+
+                    if unsupported.iter().any(|part| self.path.ends_with(part)) {
+			return true;
+                    }
+		}
+	    }
+	}
 
         // For the exceptions proposal these tests use instructions and such
         // which aren't implemented yet so these are expected to fail.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2044,14 +2044,9 @@ impl Config {
                     | WasmFeatures::LEGACY_EXCEPTIONS;
                 match self.compiler_target().architecture {
                     target_lexicon::Architecture::Aarch64(_) => {
-                        // no support for simd on aarch64
                         unsupported |= WasmFeatures::SIMD;
-
-                        // things like multi-table are technically supported on
-                        // winch on aarch64 but this helps gate most spec tests
-                        // by default which otherwise currently cause panics.
-                        unsupported |= WasmFeatures::REFERENCE_TYPES;
-                        unsupported |= WasmFeatures::THREADS
+                        unsupported |= WasmFeatures::THREADS;
+                        unsupported |= WasmFeatures::WIDE_ARITHMETIC;
                     }
 
                     // Winch doesn't support other non-x64 architectures at this

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -81,7 +81,7 @@ async fn run_and_count_yields_or_trap<F: Fn(Arc<Engine>)>(
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_yield_at_func_entry(config: &mut Config) {
+async fn epoch_yield_at_func_entry(config: &mut Config) -> Result<()> {
     // Should yield at start of call to func $subfunc.
     assert_eq!(
         Some((1, 0)),
@@ -101,10 +101,11 @@ async fn epoch_yield_at_func_entry(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_yield_at_loop_header(config: &mut Config) {
+async fn epoch_yield_at_loop_header(config: &mut Config) -> Result<()> {
     // Should yield at top of loop, once per five iters.
     assert_eq!(
         Some((2, 0)),
@@ -126,10 +127,11 @@ async fn epoch_yield_at_loop_header(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_yield_immediate(config: &mut Config) {
+async fn epoch_yield_immediate(config: &mut Config) -> Result<()> {
     // We should see one yield immediately when the initial deadline
     // is zero.
     assert_eq!(
@@ -147,10 +149,11 @@ async fn epoch_yield_immediate(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_yield_only_once(config: &mut Config) {
+async fn epoch_yield_only_once(config: &mut Config) -> Result<()> {
     // We should yield from the subfunction, and then when we return
     // to the outer function and hit another loop header, we should
     // not yield again (the double-check block will reload the correct
@@ -178,10 +181,11 @@ async fn epoch_yield_only_once(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_interrupt_infinite_loop(config: &mut Config) {
+async fn epoch_interrupt_infinite_loop(config: &mut Config) -> Result<()> {
     assert_eq!(
         None,
         run_and_count_yields_or_trap(
@@ -204,10 +208,11 @@ async fn epoch_interrupt_infinite_loop(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_interrupt_function_entries(config: &mut Config) {
+async fn epoch_interrupt_function_entries(config: &mut Config) -> Result<()> {
     assert_eq!(
         None,
         run_and_count_yields_or_trap(
@@ -327,10 +332,11 @@ async fn epoch_interrupt_function_entries(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_callback_continue(config: &mut Config) {
+async fn epoch_callback_continue(config: &mut Config) -> Result<()> {
     assert_eq!(
         Some((0, 1)),
         run_and_count_yields_or_trap(
@@ -353,10 +359,11 @@ async fn epoch_callback_continue(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_callback_yield(config: &mut Config) {
+async fn epoch_callback_yield(config: &mut Config) -> Result<()> {
     assert_eq!(
         Some((1, 1)),
         run_and_count_yields_or_trap(
@@ -379,10 +386,12 @@ async fn epoch_callback_yield(config: &mut Config) {
         )
         .await
     );
+
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_callback_yield_custom(config: &mut Config) {
+async fn epoch_callback_yield_custom(config: &mut Config) -> Result<()> {
     assert_eq!(
         Some((1, 1)),
         run_and_count_yields_or_trap(
@@ -406,10 +415,11 @@ async fn epoch_callback_yield_custom(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn epoch_callback_trap(config: &mut Config) {
+async fn epoch_callback_trap(config: &mut Config) -> Result<()> {
     assert_eq!(
         None,
         run_and_count_yields_or_trap(
@@ -428,10 +438,11 @@ async fn epoch_callback_trap(config: &mut Config) {
         )
         .await
     );
+    Ok(())
 }
 
 #[wasmtime_test(with = "#[tokio::test]")]
-async fn drop_future_on_epoch_yield(config: &mut Config) {
+async fn drop_future_on_epoch_yield(config: &mut Config) -> Result<()> {
     let wasm = "
     (module
       (import \"\" \"bump_epoch\" (func $bump))
@@ -484,4 +495,5 @@ async fn drop_future_on_epoch_yield(config: &mut Config) {
     let _ = PollOnce::new(Box::pin(f.call_async(&mut store, &[], &mut []))).await;
 
     assert_eq!(true, alive_flag.load(Ordering::Acquire));
+    Ok(())
 }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -127,7 +127,7 @@ fn iloop(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test]
-fn manual_fuel(config: &mut Config) {
+fn manual_fuel(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, ());
@@ -135,11 +135,12 @@ fn manual_fuel(config: &mut Config) {
     assert_eq!(store.get_fuel().ok(), Some(10_000));
     assert_eq!(store.set_fuel(1).ok(), Some(()));
     assert_eq!(store.get_fuel().ok(), Some(1));
+    Ok(())
 }
 
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn host_function_consumes_all(config: &mut Config) {
+fn host_function_consumes_all(config: &mut Config) -> Result<()> {
     const FUEL: u64 = 10_000;
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
@@ -167,20 +168,24 @@ fn host_function_consumes_all(config: &mut Config) {
     let export = instance.get_typed_func::<(), ()>(&mut store, "").unwrap();
     let trap = export.call(&mut store, ()).unwrap_err();
     assert_eq!(trap.downcast::<Trap>().unwrap(), Trap::OutOfFuel);
+    Ok(())
 }
 
 #[wasmtime_test]
-fn manual_edge_cases(config: &mut Config) {
+fn manual_edge_cases(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, ());
     store.set_fuel(u64::MAX).unwrap();
     assert_eq!(store.get_fuel().unwrap(), u64::MAX);
+    Ok(())
 }
 
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping(config: &mut Config) {
+fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping(
+    config: &mut Config,
+) -> Result<()> {
     config.consume_fuel(true);
     config.memory_reservation(0x1_0000);
 
@@ -219,6 +224,7 @@ fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping(config: &m
     // memory access.
     let consumed_fuel = init_fuel - store.get_fuel().unwrap();
     assert!(consumed_fuel > 0);
+    Ok(())
 }
 
 #[wasmtime_test]

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -109,23 +109,10 @@ fn main() {
 // function which actually executes the `wast` test suite given the `strategy`
 // to compile it.
 fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
-    let mut test_config = test.config.clone();
+    let test_config = test.config.clone();
 
-    // FIXME: this is a bit of a hack to get Winch working here for now. Winch
-    // passes some tests on aarch64 so returning `true` from `should_fail`
-    // doesn't work. Winch doesn't pass many tests though as it either panics or
-    // segfaults as AArch64 support isn't finished yet. That means that we can't
-    // have, for example, an allow-list of tests that should pass and assume
-    // everything else fails. In lieu of all of this we feign all tests as
-    // requiring references types which Wasmtime understands that Winch doesn't
-    // support on aarch64 which means that all tests fail quickly in config
-    // validation.
-    //
-    // Ideally the aarch64 backend for Winch would return a normal error on
-    // unsupported opcodes and not segfault, meaning that this would not be
-    // needed.
-    if cfg!(target_arch = "aarch64") && test_config.reference_types.is_none() {
-        test_config.reference_types = Some(true);
+    if test.ignore(&config) {
+        return Ok(());
     }
 
     // Determine whether this test is expected to fail or pass. Regardless the


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/9566

This commit takes inspiration from
https://github.com/bytecodealliance/wasmtime/pull/10738/files

During the 2025-05-07 Cranelift meeting we discussed potential avenues to start running wast tests for winch-aarch64. One potential idea was to declare an allowlist of tests that should be exectued and potentially ignore everyhing else. Although that idea works, I decided to diverge a bit from it, in favor of introducing a very strict classification of the state of tests for aarch64, namely, in this commit tests are classified as:

* Run and expected to pass
* Run and exepected to fail in a recoverable way
* Don't run since it's known that they produce an unrecoverable error e.g., segafault.

This approach is probably more verbose than the one discussed in the meeting, however, I think it's easier to have a global view of that status for aarch64 and potentially other backends in the future.

@alexcrichton curious to see what do you think. 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
