### PR TITLE
[s390x] Use VCodeConstant literal pool

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -552,21 +552,6 @@
       (rn Reg)
       (rm Reg))
 
-    ;; Load floating-point constant, half-precision (16 bit).
-    (LoadFpuConst16
-      (rd WritableReg)
-      (const_data u16))
-
-    ;; Load floating-point constant, single-precision (32 bit).
-    (LoadFpuConst32
-      (rd WritableReg)
-      (const_data u32))
-
-    ;; Load floating-point constant, double-precision (64 bit).
-    (LoadFpuConst64
-      (rd WritableReg)
-      (const_data u64))
-
     ;; A binary vector operation with two vector register sources.
     (VecRRR
       (op VecBinaryOp)
@@ -765,17 +750,6 @@
       (rn Reg)
       (rm Reg))
 
-    ;; Load 128-bit (big-endian) vector constant.
-    (VecLoadConst
-      (rd WritableReg)
-      (const_data u128))
-
-    ;; Load 128-bit (big-endian) replicated vector constant.
-    (VecLoadConstReplicate
-      (size u32)
-      (rd WritableReg)
-      (const_data u64))
-
     ;; Load vector immediate generated via byte mask.
     (VecImmByteMask
       (rd WritableReg)
@@ -875,6 +849,13 @@
       (size u32)
       (rd WritableReg)
       (ri Reg)
+      (imm i16)
+      (lane_imm u8))
+
+    ;; Same as VecInsertLaneImm, but allow undefined input VR.
+    (VecInsertLaneImmUndef
+      (size u32)
+      (rd WritableReg)
       (imm i16)
       (lane_imm u8))
 
@@ -1787,6 +1768,9 @@
 (decl memarg_got () MemArg)
 (extern constructor memarg_got memarg_got)
 
+(decl memarg_const (VCodeConstant) MemArg)
+(extern constructor memarg_const memarg_const)
+
 ;; Form the sum of two offset values, and check that the result is
 ;; a valid `MemArg::Symbol` offset (i.e. is even and fits into i32).
 (decl pure partial memarg_symbol_offset_sum (i64 i64) i32)
@@ -2544,20 +2528,6 @@
             (_ Unit (emit (MInst.MovToVec128 dst src1 src2))))
         dst))
 
-;; Helper for emitting `MInst.VecLoadConst` instructions.
-(decl vec_load_const (Type u128) Reg)
-(rule (vec_load_const (vr128_ty ty) n)
-      (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.VecLoadConst dst n))))
-        dst))
-
-;; Helper for emitting `MInst.VecLoadConstReplicate` instructions.
-(decl vec_load_const_replicate (Type u64) Reg)
-(rule (vec_load_const_replicate ty @ (multi_lane size _) n)
-      (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.VecLoadConstReplicate size dst n))))
-        dst))
-
 ;; Helper for emitting `MInst.VecImmByteMask` instructions.
 (decl vec_imm_byte_mask (Type u16) Reg)
 (rule (vec_imm_byte_mask (vr128_ty ty) n)
@@ -2643,6 +2613,13 @@
 (rule (vec_insert_lane_imm ty @ (multi_lane size _) src imm lane_imm)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.VecInsertLaneImm size dst src imm lane_imm))))
+        dst))
+
+;; Helper for emitting `MInst.VecInsertLaneImmUndef` instructions.
+(decl vec_insert_lane_imm_undef (Type i16 u8) Reg)
+(rule (vec_insert_lane_imm_undef ty @ (multi_lane size _) imm lane_imm)
+      (let ((dst WritableReg (temp_writable_reg ty))
+            (_ Unit (emit (MInst.VecInsertLaneImmUndef size dst imm lane_imm))))
         dst))
 
 ;; Helper for emitting `MInst.VecReplicateLane` instructions.
@@ -2902,26 +2879,21 @@
             (_ Unit (emit (MInst.Insert64UImm32Shifted dst src n))))
         dst))
 
-;; 16-bit floating-point type, any value.  Loaded from literal pool.
-;; TODO: use LZER to load 0.0
+;; 16-bit floating-point type, any value.
 (rule 8 (imm $F16 n)
-      (let ((dst WritableReg (temp_writable_reg $F16))
-            (_ Unit (emit (MInst.LoadFpuConst16 dst (u64_as_u16 n)))))
-        dst))
+      (vec_insert_lane_imm_undef $F16X8 (u64_as_i16 n) 0))
 
 ;; 32-bit floating-point type, any value.  Loaded from literal pool.
+;; FIXME: This wastes 4 bytes of constant pool space.
 ;; TODO: use LZER to load 0.0
 (rule 8 (imm $F32 n)
-      (let ((dst WritableReg (temp_writable_reg $F32))
-            (_ Unit (emit (MInst.LoadFpuConst32 dst (u64_truncate_to_u32 n)))))
-        dst))
+      (vec_load_lane_undef $F32X4
+        (memarg_const (emit_u64_be_const (u32_pair (u64_truncate_to_u32 n) 0))) 0))
 
 ;; 64-bit floating-point type, any value.  Loaded from literal pool.
 ;; TODO: use LZDR to load 0.0
 (rule 8 (imm $F64 n)
-      (let ((dst WritableReg (temp_writable_reg $F64))
-            (_ Unit (emit (MInst.LoadFpuConst64 dst n))))
-        dst))
+      (vec_load_lane_undef $F64X2 (memarg_const (emit_u64_be_const n)) 0))
 
 ;; Variant used for negative constants.
 (decl imm32 (Type i32) Reg)
@@ -2937,7 +2909,7 @@
 (rule 1 (vec_imm (vr128_ty ty) (u64_pair n n))
       (vec_imm_splat $I64X2 n))
 (rule (vec_imm (vr128_ty ty) n)
-      (vec_load_const ty n))
+      (vec_load ty (memarg_const (emit_u128_be_const n))))
 
 ;; Variant with replicated immediate.
 (decl vec_imm_splat (Type u64) Reg)
@@ -2957,9 +2929,12 @@
       (vec_imm_splat $I16X8 (u16_as_u64 n)))
 (rule 3 (vec_imm_splat (multi_lane 64 _) (u32_pair n n))
       (vec_imm_splat $I32X4 (u32_as_u64 n)))
-(rule 0 (vec_imm_splat (ty_vec128 ty) n)
-      (vec_load_const_replicate ty n))
-
+;; FIXME: This wastes 4 bytes of constant pool space.
+(rule 0 (vec_imm_splat ty @ (multi_lane 32 _) n)
+      (vec_load_replicate ty
+        (memarg_const (emit_u64_be_const (u32_pair (u64_truncate_to_u32 n) 0)))))
+(rule 0 (vec_imm_splat ty @ (multi_lane 64 _) n)
+      (vec_load_replicate ty (memarg_const (emit_u64_be_const n))))
 
 ;; Helpers for generating extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -32,6 +32,9 @@ pub enum MemArg {
     /// PC-relative Reference to a label.
     Label { target: MachLabel },
 
+    /// PC-relative Reference to a constant pool entry.
+    Constant { constant: VCodeConstant },
+
     /// PC-relative Reference to a near symbol.
     Symbol {
         name: Box<ExternalName>,
@@ -103,6 +106,7 @@ impl MemArg {
             MemArg::BXD20 { flags, .. } => *flags,
             MemArg::RegOffset { flags, .. } => *flags,
             MemArg::Label { .. } => MemFlags::trusted(),
+            MemArg::Constant { .. } => MemFlags::trusted(),
             MemArg::Symbol { flags, .. } => *flags,
             MemArg::InitialSPOffset { .. } => MemFlags::trusted(),
             MemArg::IncomingArgOffset { .. } => MemFlags::trusted(),
@@ -226,6 +230,7 @@ impl PrettyPrint for MemArg {
                 }
             }
             &MemArg::Label { target } => target.to_string(),
+            &MemArg::Constant { constant } => format!("[const({})]", constant.as_u32()),
             &MemArg::Symbol {
                 ref name, offset, ..
             } => format!("{} + {}", name.display(None), offset),

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7817,57 +7817,6 @@ fn test_s390x_binemit() {
         "wfcdb %v24, %f12",
     ));
 
-    // FIXME(#8312): Use `1.0_f16.to_bits()` once `f16` is stabilised.
-    let f16_1_0 = 0x3c00;
-    insns.push((
-        Inst::LoadFpuConst16 {
-            rd: writable_vr(8),
-            const_data: f16_1_0,
-        },
-        "A71500033C00E78010000001",
-        "bras %r1, 8 ; data.f16 0x1.000p0 ; vleh %v8, 0(%r1), 0",
-    ));
-    insns.push((
-        Inst::LoadFpuConst16 {
-            rd: writable_vr(24),
-            const_data: f16_1_0,
-        },
-        "A71500033C00E78010000801",
-        "bras %r1, 8 ; data.f16 0x1.000p0 ; vleh %v24, 0(%r1), 0",
-    ));
-    insns.push((
-        Inst::LoadFpuConst32 {
-            rd: writable_vr(8),
-            const_data: 1.0_f32.to_bits(),
-        },
-        "A71500043F80000078801000",
-        "bras %r1, 8 ; data.f32 1 ; le %f8, 0(%r1)",
-    ));
-    insns.push((
-        Inst::LoadFpuConst32 {
-            rd: writable_vr(24),
-            const_data: 1.0_f32.to_bits(),
-        },
-        "A71500043F800000E78010000803",
-        "bras %r1, 8 ; data.f32 1 ; vlef %v24, 0(%r1), 0",
-    ));
-    insns.push((
-        Inst::LoadFpuConst64 {
-            rd: writable_vr(8),
-            const_data: 1.0_f64.to_bits(),
-        },
-        "A71500063FF000000000000068801000",
-        "bras %r1, 12 ; data.f64 1 ; ld %f8, 0(%r1)",
-    ));
-    insns.push((
-        Inst::LoadFpuConst64 {
-            rd: writable_vr(24),
-            const_data: 1.0_f64.to_bits(),
-        },
-        "A71500063FF0000000000000E78010000802",
-        "bras %r1, 12 ; data.f64 1 ; vleg %v24, 0(%r1), 0",
-    ));
-
     insns.push((
         Inst::FpuRound {
             op: FpuRoundOp::Cvt64To32,
@@ -10811,32 +10760,6 @@ fn test_s390x_binemit() {
         "E74560000862",
         "vlvgp %v20, %r5, %r6",
     ));
-    insns.push((
-        Inst::VecLoadConst {
-            rd: writable_vr(24),
-            const_data: 0x0102030405060708090a0b0c0d0e0fu128,
-        },
-        "A715000A000102030405060708090A0B0C0D0E0FE78010000806",
-        "bras %r1, 20 ; data.u128 0x000102030405060708090a0b0c0d0e0f ; vl %v24, 0(%r1)",
-    ));
-    insns.push((
-        Inst::VecLoadConstReplicate {
-            size: 64,
-            rd: writable_vr(24),
-            const_data: 0x01020304050607u64,
-        },
-        "A71500060001020304050607E78010003805",
-        "bras %r1, 12 ; data.u64 0x0001020304050607 ; vlrepg %v24, 0(%r1)",
-    ));
-    insns.push((
-        Inst::VecLoadConstReplicate {
-            size: 32,
-            rd: writable_vr(24),
-            const_data: 0x010203u64,
-        },
-        "A715000400010203E78010002805",
-        "bras %r1, 8 ; data.u32 0x00010203 ; vlrepf %v24, 0(%r1)",
-    ));
 
     insns.push((
         Inst::VecImmByteMask {
@@ -13187,6 +13110,46 @@ fn test_s390x_binemit() {
             size: 64,
             rd: writable_vr(20),
             ri: vr(20),
+            imm: 0x1234,
+            lane_imm: 1,
+        },
+        "E74012341842",
+        "vleig %v20, 4660, 1",
+    ));
+    insns.push((
+        Inst::VecInsertLaneImmUndef {
+            size: 8,
+            rd: writable_vr(20),
+            imm: 0x1234,
+            lane_imm: 15,
+        },
+        "E7401234F840",
+        "vleib %v20, 4660, 15",
+    ));
+    insns.push((
+        Inst::VecInsertLaneImmUndef {
+            size: 16,
+            rd: writable_vr(20),
+            imm: 0x1234,
+            lane_imm: 7,
+        },
+        "E74012347841",
+        "vleih %v20, 4660, 7",
+    ));
+    insns.push((
+        Inst::VecInsertLaneImmUndef {
+            size: 32,
+            rd: writable_vr(20),
+            imm: 0x1234,
+            lane_imm: 3,
+        },
+        "E74012343843",
+        "vleif %v20, 4660, 3",
+    ));
+    insns.push((
+        Inst::VecInsertLaneImmUndef {
+            size: 64,
+            rd: writable_vr(20),
             imm: 0x1234,
             lane_imm: 1,
         },

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -747,6 +747,11 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
+    fn memarg_const(&mut self, constant: VCodeConstant) -> MemArg {
+        MemArg::Constant { constant }
+    }
+
+    #[inline]
     fn memarg_symbol_offset_sum(&mut self, off1: i64, off2: i64) -> Option<i32> {
         let off = i32::try_from(off1 + off2).ok()?;
         if off & 1 == 0 {

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -413,8 +413,20 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         #[inline]
+        fn emit_u64_be_const(&mut self, value: u64) -> VCodeConstant {
+            let data = VCodeConstantData::U64(value.to_be_bytes());
+            self.lower_ctx.use_constant(data)
+        }
+
+        #[inline]
         fn emit_u128_le_const(&mut self, value: u128) -> VCodeConstant {
             let data = VCodeConstantData::Generated(value.to_le_bytes().as_slice().into());
+            self.lower_ctx.use_constant(data)
+        }
+
+        #[inline]
+        fn emit_u128_be_const(&mut self, value: u128) -> VCodeConstant {
+            let data = VCodeConstantData::Generated(value.to_be_bytes().as_slice().into());
             self.lower_ctx.use_constant(data)
         }
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -400,11 +400,23 @@
 (decl emit_u64_le_const (u64) VCodeConstant)
 (extern constructor emit_u64_le_const emit_u64_le_const)
 
+;; Add a u64 big-endian constant to the in-memory constant pool and
+;; return a VCodeConstant index that refers to it. This is
+;; side-effecting but idempotent (constants are deduplicated).
+(decl emit_u64_be_const (u64) VCodeConstant)
+(extern constructor emit_u64_be_const emit_u64_be_const)
+
 ;; Add a u128 little-endian constant to the in-memory constant pool and
 ;; return a VCodeConstant index that refers to it. This is
 ;; side-effecting but idempotent (constants are deduplicated).
 (decl emit_u128_le_const (u128) VCodeConstant)
 (extern constructor emit_u128_le_const emit_u128_le_const)
+
+;; Add a u128 big-endian constant to the in-memory constant pool and
+;; return a VCodeConstant index that refers to it. This is
+;; side-effecting but idempotent (constants are deduplicated).
+(decl emit_u128_be_const (u128) VCodeConstant)
+(extern constructor emit_u128_be_const emit_u128_be_const)
 
 ;; Fetch the VCodeConstant associated with a Constant.
 (decl const_to_vconst (Constant) VCodeConstant)

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -26,7 +26,7 @@ block0(v0: i128):
 ;   vsl %v4, %v30, %v2
 ;   vsrl %v6, %v30, %v2
 ;   vsel %v16, %v4, %v6, %v0
-;   bras %r1, 20 ; data.u128 0x0f0e0d0c0b0a09080706050403020100 ; vl %v18, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v18, 0(%r1)
 ;   vperm %v20, %v16, %v16, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
@@ -49,7 +49,14 @@ block0(v0: i128):
 ;   vsl %v4, %v30, %v2
 ;   vsrl %v6, %v30, %v2
 ;   vsel %v16, %v4, %v6, %v0
-;   bras %r1, 0x74
+;   larl %r1, 0x80
+;   vl %v18, 0(%r1)
+;   vperm %v20, %v16, %v16, %v18
+;   vst %v20, 0(%r2)
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   clcl %r0, %r14
 ;   basr %r0, %r12
 ;   bsm %r0, %r10
@@ -58,10 +65,6 @@ block0(v0: i128):
 ;   balr %r0, %r4
 ;   .byte 0x03, 0x02
 ;   .byte 0x01, 0x00
-;   vl %v18, 0(%r1)
-;   vperm %v20, %v16, %v16, %v18
-;   vst %v20, 0(%r2)
-;   br %r14
 
 function %bitrev_i64(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/s390x/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/exceptions.clif
@@ -32,7 +32,7 @@ function %f0(i32) -> i32, f32, f64 {
 ;   std %f14, 224(%r15)
 ;   std %f15, 232(%r15)
 ; block0:
-;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
+;   larl %r1, [const(1)] ; ld %f2, 0(%r1)
 ;   vst %v2, 160(%r15)
 ;   brasl %r14, %g; jg MachLabel(1); catch [None: MachLabel(2)]
 ; block1:
@@ -51,7 +51,7 @@ function %f0(i32) -> i32, f32, f64 {
 ; block2:
 ;   vl %v2, 160(%r15)
 ;   ahik %r2, %r6, 1
-;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   larl %r1, [const(0)] ; le %f0, 0(%r1)
 ;   ld %f8, 176(%r15)
 ;   ld %f9, 184(%r15)
 ;   ld %f10, 192(%r15)
@@ -76,15 +76,11 @@ function %f0(i32) -> i32, f32, f64 {
 ;   std %f14, 0xe0(%r15)
 ;   std %f15, 0xe8(%r15)
 ; block1: ; offset 0x2a
-;   bras %r1, 0x36
-;   sur %f15, %f0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0xb0
 ;   ld %f2, 0(%r1)
 ;   vst %v2, 0xa0(%r15)
-;   brasl %r14, 0x40 ; reloc_external PLTRel32Dbl %g 2
-; block2: ; offset 0x46
+;   brasl %r14, 0x3a ; reloc_external PLTRel32Dbl %g 2
+; block2: ; offset 0x40
 ;   lhi %r2, 1
 ;   vl %v2, 0xa0(%r15)
 ;   ld %f8, 0xb0(%r15)
@@ -97,12 +93,10 @@ function %f0(i32) -> i32, f32, f64 {
 ;   ld %f15, 0xe8(%r15)
 ;   lmg %r6, %r15, 0x120(%r15)
 ;   br %r14
-; block3: ; offset 0x78
+; block3: ; offset 0x72
 ;   vl %v2, 0xa0(%r15)
 ;   ahik %r2, %r6, 1
-;   bras %r1, 0x8c
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0xb8
 ;   le %f0, 0(%r1)
 ;   ld %f8, 0xb0(%r15)
 ;   ld %f9, 0xb8(%r15)
@@ -114,6 +108,14 @@ function %f0(i32) -> i32, f32, f64 {
 ;   ld %f15, 0xe8(%r15)
 ;   lmg %r6, %r15, 0x120(%r15)
 ;   br %r14
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f2(i32) -> i32, f32, f64 {
     sig0 = (i32) -> f32 tail
@@ -147,7 +149,7 @@ function %f2(i32) -> i32, f32, f64 {
 ;   std %f14, 224(%r15)
 ;   std %f15, 232(%r15)
 ; block0:
-;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
+;   larl %r1, [const(1)] ; ld %f2, 0(%r1)
 ;   vst %v2, 160(%r15)
 ;   bras %r1, 12 ; data %g + 0 ; lg %r5, 0(%r1)
 ;   basr %r14, %r5; jg MachLabel(1); catch [None: MachLabel(2)]
@@ -167,7 +169,7 @@ function %f2(i32) -> i32, f32, f64 {
 ; block2:
 ;   vl %v2, 160(%r15)
 ;   ahik %r2, %r6, 1
-;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   larl %r1, [const(0)] ; le %f0, 0(%r1)
 ;   ld %f8, 176(%r15)
 ;   ld %f9, 184(%r15)
 ;   ld %f10, 192(%r15)
@@ -192,21 +194,17 @@ function %f2(i32) -> i32, f32, f64 {
 ;   std %f14, 0xe0(%r15)
 ;   std %f15, 0xe8(%r15)
 ; block1: ; offset 0x2a
-;   bras %r1, 0x36
-;   sur %f15, %f0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0xc0
 ;   ld %f2, 0(%r1)
 ;   vst %v2, 0xa0(%r15)
-;   bras %r1, 0x4c
+;   bras %r1, 0x46
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   lg %r5, 0(%r1)
 ;   basr %r14, %r5
-; block2: ; offset 0x54
+; block2: ; offset 0x4e
 ;   lhi %r2, 1
 ;   vl %v2, 0xa0(%r15)
 ;   ld %f8, 0xb0(%r15)
@@ -219,12 +217,10 @@ function %f2(i32) -> i32, f32, f64 {
 ;   ld %f15, 0xe8(%r15)
 ;   lmg %r6, %r15, 0x120(%r15)
 ;   br %r14
-; block3: ; offset 0x86
+; block3: ; offset 0x80
 ;   vl %v2, 0xa0(%r15)
 ;   ahik %r2, %r6, 1
-;   bras %r1, 0x9a
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0xc8
 ;   le %f0, 0(%r1)
 ;   ld %f8, 0xb0(%r15)
 ;   ld %f9, 0xb8(%r15)
@@ -236,4 +232,13 @@ function %f2(i32) -> i32, f32, f64 {
 ;   ld %f15, 0xe8(%r15)
 ;   lmg %r6, %r15, 0x120(%r15)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 

--- a/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
@@ -11,10 +11,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 256 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
@@ -25,19 +25,25 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   ic %r8, 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -49,10 +55,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 128 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -129 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
@@ -63,20 +69,26 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   ic %r0, 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   .byte 0xc3, 0x01
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0xc3, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -88,10 +100,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 65536 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
@@ -102,19 +114,25 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   be 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -126,10 +144,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 32768 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -32769 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
@@ -140,20 +158,24 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   bc 0, 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   bpp 0, -0x31dc, 0x100
-;   lpr %r0, %r0
-;   .byte 0x08, 0x03
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
+;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   bc 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   bpp 0, 0x50, 0x100
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -165,10 +187,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 4294967300 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
@@ -179,19 +201,25 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   cvb %r8, 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   cvb %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -203,10 +231,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 2147483600 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -2147484000 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
@@ -217,20 +245,26 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   cvb %r0, 0
+;   larl %r1, 0x48
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   .byte 0xcf, 0x00
-;   .byte 0x00, 0x01
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   cvb %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0xcf, 0x00
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -242,10 +276,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 18446744000000000000 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -257,20 +291,27 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   sl %r8, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sl %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -282,10 +323,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 9223372000000000000 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -9223373000000000000 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -297,21 +338,26 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   sl %r0, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   edmk 1(1), 0x700(%r14)
-;   lpr %r0, %r0
-;   .byte 0x08, 0x03
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
+;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sl %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   edmk 1(1), 0
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -323,10 +369,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 256 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -337,23 +383,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r7, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r7, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -365,10 +413,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 128 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -129 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -379,22 +427,24 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r6, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   larl %r6, 0x40000028
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r6, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   larl %r6, 0x40000050
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -406,10 +456,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 65536 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -420,23 +470,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -448,10 +500,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 32768 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -32769 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -462,22 +514,24 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r14, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   larl %r14, 0x400028
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   larl %r14, 0x400050
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -489,10 +543,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 4294967296 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -503,23 +557,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   la %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   la %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -531,10 +587,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 2147483648 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -2147483649 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -545,24 +601,26 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
+;   larl %r1, 0x48
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jgle 0x32 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   la %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f4, 0(%r1)
-;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
 ;   .byte 0xc1, 0xe0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x20
 ;   .byte 0x00, 0x00
-;   vleg %v16, 0(%r1), 0
-;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
-;   wcgdb %v20, %f0, 0, 5
-;   vlgvg %r2, %v20, 0
-;   br %r14
 
 function %fcvt_to_uint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -574,10 +632,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 18446744073709552000 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -588,23 +646,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   ic %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -616,10 +676,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 9223372036854776000 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -9223372036854778000 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -630,24 +690,26 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
+;   larl %r1, 0x48
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jgle 0x32 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   ic %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f4, 0(%r1)
-;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
 ;   .byte 0xc3, 0xe0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
-;   vleg %v16, 0(%r1), 0
-;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
-;   wcgdb %v20, %f0, 0, 5
-;   vlgvg %r2, %v20, 0
-;   br %r14
 
 function %fcvt_from_uint_i8_f32(i8) -> f32 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -17,14 +17,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.f16 0.0 ; vleh %v0, 0(%r1), 0
+;   vleih %v0, 0, 0
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 6
-;   .byte 0x00, 0x00
-;   vleh %v0, 0(%r1), 0
+;   vleih %v0, 0, 0
 ;   br %r14
 
 function %f32const_zero() -> f32 {
@@ -35,16 +33,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   larl %r1, [const(0)] ; le %f0, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x10
 ;   le %f0, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f64const_zero() -> f64 {
 block0:
@@ -54,18 +56,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f0, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x10
 ;   ld %f0, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f128const_zero() -> f128 {
 block0:
@@ -93,14 +97,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.f16 0x1.000p0 ; vleh %v0, 0(%r1), 0
+;   vleih %v0, 15360, 0
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 6
-;   mder %f0, %f0
-;   vleh %v0, 0(%r1), 0
+;   vleih %v0, 0x3c00, 0
 ;   br %r14
 
 function %f32const_one() -> f32 {
@@ -111,16 +113,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.f32 1 ; le %f0, 0(%r1)
+;   larl %r1, [const(0)] ; le %f0, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   sur %f8, %f0
-;   .byte 0x00, 0x00
+;   larl %r1, 0x10
 ;   le %f0, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sur %f8, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f64const_one() -> f64 {
 block0:
@@ -130,18 +136,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.f64 1 ; ld %f0, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f0, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
+;   larl %r1, 0x10
+;   ld %f0, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   sur %f15, %f0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f0, 0(%r1)
-;   br %r14
 
 function %f128const_one() -> f128 {
 block0:
@@ -151,13 +159,22 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x3fff0000000000000000000000000000 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vst %v2, 0(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vst %v2, 0(%r2)
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   sur %f15, %f15
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -166,9 +183,6 @@ block0:
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   vl %v2, 0(%r1)
-;   vst %v2, 0(%r2)
-;   br %r14
 
 function %fadd_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
@@ -726,17 +740,22 @@ block0(v0: f32, v1: f32):
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.f32 NaN ; le %f3, 0(%r1)
+;   larl %r1, [const(0)] ; le %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   su %f15, 0xfff(%r15, %r15)
+;   larl %r1, 0x18
 ;   le %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f15, 0xfff(%r15, %r15)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcopysign_f64(f64, f64) -> f64 {
 block0(v0: f64, v1: f64):
@@ -746,19 +765,22 @@ block0(v0: f64, v1: f64):
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.f64 NaN ; ld %f3, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   su %f15, 0xfff(%r15, %r15)
-;   .byte 0xff, 0xff
-;   .byte 0xff, 0xff
+;   larl %r1, 0x18
 ;   ld %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f15, 0xfff(%r15, %r15)
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
 
 function %fcvt_to_uint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -770,10 +792,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 256 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -785,20 +807,27 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   ic %r8, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -810,10 +839,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 128 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -129 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -825,21 +854,28 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   ic %r0, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   .byte 0xc3, 0x01
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0xc3, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -851,10 +887,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 65536 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -866,20 +902,27 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   be 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -891,10 +934,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 32768 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -32769 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -906,21 +949,26 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   bc 0, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   bpp 0, -0x31dc, 0x100
-;   lpr %r0, %r0
-;   .byte 0x08, 0x03
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
+;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   bc 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   bpp 0, 0x58, 0x100
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -932,10 +980,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 4294967300 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -947,20 +995,27 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   cvb %r8, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   cvb %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -972,10 +1027,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 2147483600 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -2147484000 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -987,21 +1042,28 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   cvb %r0, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   .byte 0xcf, 0x00
-;   .byte 0x00, 0x01
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   cvb %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0xcf, 0x00
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -1013,10 +1075,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 18446744000000000000 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -1028,20 +1090,27 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   sl %r8, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   icm %r8, 0, 0
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sl %r8, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r8, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -1053,10 +1122,10 @@ block0(v0: f32):
 ; block0:
 ;   cebr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 8 ; data.f32 9223372000000000000 ; le %f4, 0(%r1)
+;   larl %r1, [const(0)] ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 8 ; data.f32 -9223373000000000000 ; vlef %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
@@ -1068,21 +1137,26 @@ block0(v0: f32):
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x12
-;   sl %r0, 0
+;   larl %r1, 0x50
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jghe 0x1c ; trap: int_ovf
-;   bras %r1, 0x28
-;   edmk 1(1), 0x700(%r14)
-;   lpr %r0, %r0
-;   .byte 0x08, 0x03
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x58
+;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jgle 0x36 ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sl %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   edmk 1(1), 0
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -1094,10 +1168,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 256 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -1108,23 +1182,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r7, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r7, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -1136,10 +1212,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 128 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -129 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -1150,22 +1226,24 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r6, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   larl %r6, 0x40000028
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r6, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   larl %r6, 0x40000050
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -1177,10 +1255,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 65536 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -1191,23 +1269,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -1219,10 +1299,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 32768 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -32769 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -1233,22 +1313,24 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   sth %r14, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   larl %r14, 0x400028
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   larl %r14, 0x400050
+;   .byte 0x00, 0x00
 
 function %fcvt_to_uint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -1260,10 +1342,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 4294967296 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -1274,23 +1356,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   la %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   la %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -1302,10 +1386,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 2147483648 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -2147483649 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -1316,24 +1400,26 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
+;   larl %r1, 0x48
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jgle 0x32 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   la %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f4, 0(%r1)
-;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
 ;   .byte 0xc1, 0xe0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x20
 ;   .byte 0x00, 0x00
-;   vleg %v16, 0(%r1), 0
-;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
-;   wcgdb %v20, %f0, 0, 5
-;   vlgvg %r2, %v20, 0
-;   br %r14
 
 function %fcvt_to_uint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -1345,10 +1431,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 18446744073709552000 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
@@ -1359,23 +1445,25 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
-;   ic %r15, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x48
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
-;   icm %r15, 0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
+;   jgle 0x32 ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ic %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %fcvt_to_sint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -1387,10 +1475,10 @@ block0(v0: f64):
 ; block0:
 ;   cdbr %f0, %f0
 ;   jgo .+2 # trap=bad_toint
-;   bras %r1, 12 ; data.f64 9223372036854776000 ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
 ;   jghe .+2 # trap=int_ovf
-;   bras %r1, 12 ; data.f64 -9223372036854778000 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(1)] ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
 ;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
@@ -1401,24 +1489,26 @@ block0(v0: f64):
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
 ;   jgo 6 ; trap: bad_toint
-;   bras %r1, 0x16
+;   larl %r1, 0x48
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jghe 0x1a ; trap: int_ovf
+;   larl %r1, 0x50
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jgle 0x32 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   ic %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f4, 0(%r1)
-;   cdbr %f0, %f4
-;   jghe 0x20 ; trap: int_ovf
-;   bras %r1, 0x30
 ;   .byte 0xc3, 0xe0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
-;   vleg %v16, 0(%r1), 0
-;   wfcdb %f0, %v16
-;   jgle 0x3e ; trap: int_ovf
-;   wcgdb %v20, %f0, 0, 5
-;   vlgvg %r2, %v20, 0
-;   br %r14
 
 function %fcvt_from_uint_i8_f32(i8) -> f32 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -80,37 +80,40 @@ block1:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
-;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
-;   bras %r1, 12 ; data.f64 2 ; ld %f4, 0(%r1)
-;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
+;   larl %r1, [const(3)] ; ld %f0, 0(%r1)
+;   larl %r1, [const(2)] ; ld %f2, 0(%r1)
+;   larl %r1, [const(1)] ; ld %f4, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f6, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x30
 ;   ld %f0, 0(%r1)
-;   bras %r1, 0x1c
+;   larl %r1, 0x38
+;   ld %f2, 0(%r1)
+;   larl %r1, 0x40
+;   ld %f4, 0(%r1)
+;   larl %r1, 0x48
+;   ld %f6, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   sur %f15, %f0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f2, 0(%r1)
-;   bras %r1, 0x2c
 ;   sth %r0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f4, 0(%r1)
-;   bras %r1, 0x3c
 ;   sth %r0, 0(%r8)
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   ld %f6, 0(%r1)
-;   br %r14
 
 function %f4() -> f64, f64, f64, f64, f64, f64 {
 block1:
@@ -125,51 +128,54 @@ block1:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
-;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
-;   bras %r1, 12 ; data.f64 2 ; ld %f4, 0(%r1)
-;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
-;   bras %r1, 12 ; data.f64 4 ; ld %f7, 0(%r1)
-;   bras %r1, 12 ; data.f64 5 ; vleg %v16, 0(%r1), 0
+;   larl %r1, [const(5)] ; ld %f0, 0(%r1)
+;   larl %r1, [const(4)] ; ld %f2, 0(%r1)
+;   larl %r1, [const(3)] ; ld %f4, 0(%r1)
+;   larl %r1, [const(2)] ; ld %f6, 0(%r1)
+;   larl %r1, [const(1)] ; ld %f7, 0(%r1)
+;   larl %r1, [const(0)] ; vleg %v16, 0(%r1), 0
 ;   std %f7, 0(%r2)
 ;   vsteg %v16, 8(%r2), 0
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x50
 ;   ld %f0, 0(%r1)
-;   bras %r1, 0x1c
-;   sur %f15, %f0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x58
 ;   ld %f2, 0(%r1)
-;   bras %r1, 0x2c
-;   sth %r0, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x60
 ;   ld %f4, 0(%r1)
-;   bras %r1, 0x3c
-;   sth %r0, 0(%r8)
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x68
 ;   ld %f6, 0(%r1)
-;   bras %r1, 0x4c
-;   sth %r1, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x70
 ;   ld %f7, 0(%r1)
-;   bras %r1, 0x5c
-;   sth %r1, 0(%r4)
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x78
 ;   vleg %v16, 0(%r1), 0
 ;   std %f7, 0(%r2)
 ;   vsteg %v16, 8(%r2), 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r0, 0(%r8)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r1, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r1, 0(%r4)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 

--- a/cranelift/filetests/filetests/isa/s390x/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/s390x/nan-canonicalization.clif
@@ -11,7 +11,7 @@ block0(v0: f32x4, v1: f32x4):
 ; VCode:
 ; block0:
 ;   vfasb %v17, %v24, %v25
-;   bras %r1, 8 ; data.f32 NaN ; vlef %v18, 0(%r1), 0
+;   larl %r1, [const(0)] ; vlef %v18, 0(%r1), 0
 ;   vrepf %v18, %v18, 0
 ;   vfchesb %v7, %v17, %v17
 ;   vfchesb %v19, %v17, %v17
@@ -22,8 +22,7 @@ block0(v0: f32x4, v1: f32x4):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfasb %v17, %v24, %v25
-;   bras %r1, 0xe
-;   su %f12, 0
+;   larl %r1, 0x38
 ;   vlef %v18, 0(%r1), 0
 ;   vrepf %v18, %v18, 0
 ;   vfchesb %v7, %v17, %v17
@@ -31,6 +30,12 @@ block0(v0: f32x4, v1: f32x4):
 ;   vno %v19, %v7, %v19
 ;   vsel %v24, %v18, %v17, %v19
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f12, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f1(f64, f64) -> f64 {
 block0(v0: f64, v1: f64):
@@ -41,7 +46,7 @@ block0(v0: f64, v1: f64):
 ; VCode:
 ; block0:
 ;   wfadb %v21, %f0, %f2
-;   bras %r1, 12 ; data.f64 NaN ; vleg %v22, 0(%r1), 0
+;   larl %r1, [const(0)] ; vleg %v22, 0(%r1), 0
 ;   vgbm %v20, 0
 ;   vpdi %v22, %v22, %v20, 0
 ;   vgbm %v20, 0
@@ -56,10 +61,7 @@ block0(v0: f64, v1: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfadb %v21, %f0, %f2
-;   bras %r1, 0x12
-;   su %f15, 0(%r8)
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x50
 ;   vleg %v22, 0(%r1), 0
 ;   vzero %v20
 ;   vpdi %v22, %v22, %v20, 0
@@ -71,6 +73,12 @@ block0(v0: f64, v1: f64):
 ;   vsel %v21, %v22, %v23, %v24
 ;   vrepg %v0, %v21, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f15, 0(%r8)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %f1(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
@@ -81,7 +89,7 @@ block0(v0: f32, v1: f32):
 ; VCode:
 ; block0:
 ;   wfasb %v21, %f0, %f2
-;   bras %r1, 8 ; data.f32 NaN ; vlef %v22, 0(%r1), 0
+;   larl %r1, [const(0)] ; vlef %v22, 0(%r1), 0
 ;   vgbm %v20, 61440
 ;   vn %v22, %v22, %v20
 ;   vgbm %v20, 61440
@@ -96,8 +104,7 @@ block0(v0: f32, v1: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfasb %v21, %f0, %f2
-;   bras %r1, 0xe
-;   su %f12, 0
+;   larl %r1, 0x50
 ;   vlef %v22, 0(%r1), 0
 ;   vgbm %v20, 0xf000
 ;   vn %v22, %v22, %v20
@@ -109,4 +116,10 @@ block0(v0: f32, v1: f32):
 ;   vsel %v21, %v22, %v23, %v24
 ;   vrepf %v0, %v21, 0
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f12, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 

--- a/cranelift/filetests/filetests/isa/s390x/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call-indirect.clif
@@ -111,7 +111,7 @@ block0(v0: f64):
 ;   aghi %r15, -160
 ;   stg %r1, 0(%r15)
 ; block0:
-;   bras %r1, 12 ; data.f64 16 ; ld %f3, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f3, 0(%r1)
 ;   adbr %f0, %f3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
@@ -123,14 +123,17 @@ block0(v0: f64):
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
 ; block1: ; offset 0x14
-;   bras %r1, 0x20
-;   sth %r3, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x30
 ;   ld %f3, 0(%r1)
 ;   adbr %f0, %f3
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r3, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %call_f64(f64) -> f64 tail {
     sig0 = (f64) -> f64 tail

--- a/cranelift/filetests/filetests/isa/s390x/return-call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/return-call.clif
@@ -189,7 +189,7 @@ block0(v0: f64):
 ;   aghi %r15, -160
 ;   stg %r1, 0(%r15)
 ; block0:
-;   bras %r1, 12 ; data.f64 16 ; ld %f3, 0(%r1)
+;   larl %r1, [const(0)] ; ld %f3, 0(%r1)
 ;   adbr %f0, %f3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
@@ -201,14 +201,17 @@ block0(v0: f64):
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
 ; block1: ; offset 0x14
-;   bras %r1, 0x20
-;   sth %r3, 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
+;   larl %r1, 0x30
 ;   ld %f3, 0(%r1)
 ;   adbr %f0, %f3
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r3, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 
 function %call_f64(f64) -> f64 tail {
     fn0 = %callee_f64(f64) -> f64 tail

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
@@ -57,19 +57,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   ssm 0x780(%r14)
-;   lpr %r0, %r0
-;   ler %f0, %f5
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x80, 0x00
 
 function %vconst_i64x2_splat4() -> i64x2 tail {
 block0:
@@ -79,19 +79,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0xff, 0xff
-;   .byte 0xff, 0xff
-;   .byte 0xff, 0xff
-;   su %f15, 0x780(%r15, %r14)
-;   lpr %r0, %r0
-;   ler %f0, %f5
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0x7f, 0xff
 
 function %vconst_i64x2_mixed() -> i64x2 tail {
 block0:
@@ -101,12 +101,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00000000000000020000000000000001 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -115,8 +118,6 @@ block0:
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i32x4_zero() -> i32x4 tail {
 block0:
@@ -174,17 +175,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepf %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   .byte 0x00, 0x00
-;   ssm 0x780(%r14)
-;   lpr %r0, %r0
-;   ldr %f0, %f5
+;   larl %r1, 0x10
+;   vlrepf %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ssm 0
+;   .byte 0x00, 0x00
 
 function %vconst_i32x4_splat4() -> i32x4 tail {
 block0:
@@ -194,17 +196,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepf %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   .byte 0xff, 0xff
-;   su %f15, 0x780(%r15, %r14)
-;   lpr %r0, %r0
-;   ldr %f0, %f5
+;   larl %r1, 0x10
+;   vlrepf %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0xff, 0xff
+;   su %f15, 0(%r15)
+;   .byte 0x00, 0x00
 
 function %vconst_i32x4_splat_i64() -> i32x4 tail {
 block0:
@@ -214,18 +217,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0x0000000200000001 ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x02
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
-;   vlrepg %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i32x4_mixed() -> i32x4 tail {
 block0:
@@ -235,12 +239,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00000004000000030000000200000001 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x04
 ;   .byte 0x00, 0x00
@@ -249,8 +256,6 @@ block0:
 ;   .byte 0x00, 0x02
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i16x8_zero() -> i16x8 tail {
 block0:
@@ -308,12 +313,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00080007000600050004000300020001 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x08
 ;   .byte 0x00, 0x07
 ;   .byte 0x00, 0x06
@@ -322,8 +330,6 @@ block0:
 ;   .byte 0x00, 0x03
 ;   .byte 0x00, 0x02
 ;   .byte 0x00, 0x01
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i8x16_zero() -> i8x16 tail {
 block0:
@@ -381,12 +387,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x100f0e0d0c0b0a090807060504030201 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   lpr %r0, %r15
 ;   .byte 0x0e, 0x0d
 ;   bassm %r0, %r11
@@ -395,6 +404,4 @@ block0:
 ;   bctr %r0, %r5
 ;   .byte 0x04, 0x03
 ;   .byte 0x02, 0x01
-;   vl %v24, 0(%r1)
-;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
@@ -57,19 +57,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   ssm 0x780(%r14)
-;   lpr %r0, %r0
-;   ler %f0, %f5
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x80, 0x00
 
 function %vconst_i64x2_splat4() -> i64x2 {
 block0:
@@ -79,19 +79,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
-;   .byte 0xff, 0xff
-;   .byte 0xff, 0xff
-;   .byte 0xff, 0xff
-;   su %f15, 0x780(%r15, %r14)
-;   lpr %r0, %r0
-;   ler %f0, %f5
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0x7f, 0xff
 
 function %vconst_i64x2_mixed() -> i64x2 {
 block0:
@@ -101,12 +101,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00000000000000010000000000000002 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -115,8 +118,6 @@ block0:
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x02
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i32x4_zero() -> i32x4 {
 block0:
@@ -174,17 +175,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepf %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   .byte 0x00, 0x00
-;   ssm 0x780(%r14)
-;   lpr %r0, %r0
-;   ldr %f0, %f5
+;   larl %r1, 0x10
+;   vlrepf %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ssm 0
+;   .byte 0x00, 0x00
 
 function %vconst_i32x4_splat4() -> i32x4 {
 block0:
@@ -194,17 +196,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepf %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 8
-;   .byte 0xff, 0xff
-;   su %f15, 0x780(%r15, %r14)
-;   lpr %r0, %r0
-;   ldr %f0, %f5
+;   larl %r1, 0x10
+;   vlrepf %v24, 0(%r1)
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0xff, 0xff
+;   su %f15, 0(%r15)
+;   .byte 0x00, 0x00
 
 function %vconst_i32x4_splat_i64() -> i32x4 {
 block0:
@@ -214,18 +217,19 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 12 ; data.u64 0x0000000100000002 ; vlrepg %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vlrepg %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0xc
+;   larl %r1, 0x10
+;   vlrepg %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x02
-;   vlrepg %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i32x4_mixed() -> i32x4 {
 block0:
@@ -235,12 +239,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00000001000000020000000300000004 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 ;   .byte 0x00, 0x00
@@ -249,8 +256,6 @@ block0:
 ;   .byte 0x00, 0x03
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x04
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i16x8_zero() -> i16x8 {
 block0:
@@ -308,12 +313,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00010002000300040005000600070008 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 ;   .byte 0x00, 0x02
 ;   .byte 0x00, 0x03
@@ -322,8 +330,6 @@ block0:
 ;   .byte 0x00, 0x06
 ;   .byte 0x00, 0x07
 ;   .byte 0x00, 0x08
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_i8x16_zero() -> i8x16 {
 block0:
@@ -381,12 +387,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x0102030405060708090a0b0c0d0e0f10 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   upt
 ;   .byte 0x03, 0x04
 ;   balr %r0, %r6
@@ -395,6 +404,4 @@ block0:
 ;   bsm %r0, %r12
 ;   basr %r0, %r14
 ;   .byte 0x0f, 0x10
-;   vl %v24, 0(%r1)
-;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
@@ -41,19 +41,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x3f800000400000004040000040800000 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   sur %f8, %f0
 ;   .byte 0x00, 0x00
 ;   sth %r0, 0
 ;   sth %r4, 0
 ;   sth %r8, 0
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_f32x4_mixed_le() -> f32x4 tail {
 block0:
@@ -63,19 +64,20 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x4080000040400000400000003f800000 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   sth %r8, 0
 ;   sth %r4, 0
 ;   sth %r0, 0
 ;   sur %f8, %f0
 ;   .byte 0x00, 0x00
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_f64x2_mixed_be() -> f64x2 {
 block0:
@@ -85,12 +87,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x3ff00000000000004000000000000000 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   sur %f15, %f0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -98,8 +103,6 @@ block0:
 ;   sth %r0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %vconst_f64x2_mixed_le() -> f64x2 tail {
 block0:
@@ -109,12 +112,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x40000000000000003ff0000000000000 ; vl %v24, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v24, 0(%r1)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x10
+;   vl %v24, 0(%r1)
+;   br %r14
+;   .byte 0x00, 0x00
 ;   sth %r0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -122,8 +128,6 @@ block0:
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
-;   vl %v24, 0(%r1)
-;   br %r14
 
 function %fadd_f32x4(f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4):
@@ -775,7 +779,7 @@ block0(v0: i32x4):
 ;   vupllf %v16, %v24
 ;   vcdlgb %v18, %v16, 0, 3
 ;   vledb %v20, %v18, 0, 4
-;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
 ;
@@ -787,7 +791,14 @@ block0(v0: i32x4):
 ;   vupllf %v16, %v24
 ;   vcdlgb %v18, %v16, 0, 3
 ;   vledb %v20, %v18, 0, 4
-;   bras %r1, 0x38
+;   larl %r1, 0x40
+;   vl %v22, 0(%r1)
+;   vperm %v24, %v6, %v20, %v22
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 ;   .byte 0x02, 0x03
 ;   .byte 0x08, 0x09
@@ -796,9 +807,6 @@ block0(v0: i32x4):
 ;   ltr %r1, %r3
 ;   lr %r1, %r9
 ;   ar %r1, %r11
-;   vl %v22, 0(%r1)
-;   vperm %v24, %v6, %v20, %v22
-;   br %r14
 
 function %fcvt_from_sint_i32x4_f32x4(i32x4) -> f32x4 {
 block0(v0: i32x4):
@@ -814,7 +822,7 @@ block0(v0: i32x4):
 ;   vuplf %v16, %v24
 ;   vcdgb %v18, %v16, 0, 3
 ;   vledb %v20, %v18, 0, 4
-;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
 ;
@@ -826,7 +834,14 @@ block0(v0: i32x4):
 ;   vuplf %v16, %v24
 ;   vcdgb %v18, %v16, 0, 3
 ;   vledb %v20, %v18, 0, 4
-;   bras %r1, 0x38
+;   larl %r1, 0x40
+;   vl %v22, 0(%r1)
+;   vperm %v24, %v6, %v20, %v22
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 ;   .byte 0x02, 0x03
 ;   .byte 0x08, 0x09
@@ -835,9 +850,6 @@ block0(v0: i32x4):
 ;   ltr %r1, %r3
 ;   lr %r1, %r9
 ;   ar %r1, %r11
-;   vl %v22, 0(%r1)
-;   vperm %v24, %v6, %v20, %v22
-;   br %r14
 
 function %fcvt_from_uint_i64x2_f64x2(i64x2) -> f64x2 {
 block0(v0: i64x2):

--- a/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
@@ -1025,27 +1025,30 @@ block0(v0: i64x2):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080808080808080804000 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   .byte 0x80, 0x80
-;   sth %r0, 0x720(%r14)
-;   lpr %r0, %r0
-;   .byte 0x00, 0x06
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x40, 0x00
 
 function %vhigh_bits_be(i32x4) -> i64 {
 block0(v0: i32x4):
@@ -1055,14 +1058,22 @@ block0(v0: i32x4):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080808080808060402000 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
@@ -1070,10 +1081,6 @@ block0(v0: i32x4):
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   std %f4, 0(%r2)
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 
 function %vhigh_bits_be(i16x8) -> i64 {
 block0(v0: i16x8):
@@ -1083,14 +1090,22 @@ block0(v0: i16x8):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080807060504030201000 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
@@ -1098,10 +1113,6 @@ block0(v0: i16x8):
 ;   ste %f6, 0x40(%r5)
 ;   lper %f2, %f0
 ;   lpr %r0, %r0
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 
 function %vhigh_bits_be(i8x16) -> i64 {
 block0(v0: i8x16):
@@ -1111,24 +1122,28 @@ block0(v0: i8x16):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x78706860585048403830282018100800 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   le %f7, 0x860(%r6)
 ;   l %r5, 0x840(%r4)
 ;   ler %f3, %f0
 ;   ldr %f2, %f0
 ;   lr %r1, %r0
 ;   .byte 0x08, 0x00
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 
 function %vhigh_bits_le(i64x2) -> i64 tail {
 block0(v0: i64x2):
@@ -1138,14 +1153,22 @@ block0(v0: i64x2):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080808080808080800040 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
@@ -1154,10 +1177,6 @@ block0(v0: i64x2):
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x00, 0x40
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 
 function %vhigh_bits_le(i32x4) -> i64 tail {
 block0(v0: i32x4):
@@ -1167,14 +1186,22 @@ block0(v0: i32x4):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080808080808000204060 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
@@ -1182,12 +1209,7 @@ block0(v0: i32x4):
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x00, 0x20
-;   sth %r6, 0x720(%r14)
-;   lpr %r0, %r0
-;   .byte 0x00, 0x06
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
+;   .byte 0x40, 0x60
 
 function %vhigh_bits_le(i16x8) -> i64 tail {
 block0(v0: i16x8):
@@ -1197,14 +1219,22 @@ block0(v0: i16x8):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x80808080808080800010203040506070 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
 ;   .byte 0x80, 0x80
@@ -1212,10 +1242,6 @@ block0(v0: i16x8):
 ;   .byte 0x00, 0x10
 ;   lpdr %f3, %f0
 ;   sth %r5, 0x70(%r6)
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 
 function %vhigh_bits_le(i8x16) -> i64 tail {
 block0(v0: i8x16):
@@ -1225,22 +1251,26 @@ block0(v0: i8x16):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x00081018202830384048505860687078 ; vl %v2, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x08
 ;   lpr %r1, %r8
 ;   lpdr %f2, %f8
 ;   lper %f3, %f8
 ;   sth %r4, 0x58(%r8, %r5)
 ;   std %f6, 0x78(%r8, %r7)
-;   vl %v2, 0(%r1)
-;   vbperm %v4, %v24, %v2
-;   lgdr %r2, %f4
-;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -51,13 +51,22 @@ block0(v0: i8x16, v1: i8x16):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x0a1e000d0b1702180403090b15100f0c ; vl %v3, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v3, 0(%r1)
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   svc 0x1e
 ;   .byte 0x00, 0x0d
 ;   bsm %r1, %r7
@@ -66,9 +75,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   .byte 0x09, 0x0b
 ;   clr %r1, %r0
 ;   clcl %r0, %r12
-;   vl %v3, 0(%r1)
-;   vperm %v24, %v24, %v25, %v3
-;   br %r14
 
 function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 tail {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
@@ -49,13 +49,22 @@ block0(v0: i8x16, v1: i8x16):
 
 ; VCode:
 ; block0:
-;   bras %r1, 20 ; data.u128 0x03001f1a04060c0b170d1804020f1105 ; vl %v3, 0(%r1)
+;   larl %r1, [const(0)] ; vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bras %r1, 0x14
+;   larl %r1, 0x20
+;   vl %v3, 0(%r1)
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
 ;   .byte 0x03, 0x00
 ;   slr %r1, %r10
 ;   .byte 0x04, 0x06
@@ -64,9 +73,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   lr %r0, %r4
 ;   .byte 0x02, 0x0f
 ;   lnr %r0, %r5
-;   vl %v3, 0(%r1)
-;   vperm %v24, %v24, %v25, %v3
-;   br %r14
 
 function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):


### PR DESCRIPTION
This switches s390x to use the common-code VCodeConstant literal pool instead of constants inlined into the instruction stream.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
