### PR TITLE
asm: implement write-only operands

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl.rs
+++ b/cranelift/assembler-x64/meta/src/dsl.rs
@@ -13,7 +13,7 @@ pub use encoding::{
     Encoding, Group1Prefix, Group2Prefix, Group3Prefix, Group4Prefix, Opcodes, Prefixes, Rex,
 };
 pub use features::{Feature, Features, ALL_FEATURES};
-pub use format::{align, fmt, r, rw, sxl, sxq, sxw};
+pub use format::{align, fmt, r, rw, sxl, sxq, sxw, w};
 pub use format::{Extension, Format, Location, Mutability, Operand, OperandKind};
 
 /// Abbreviated constructor for an x64 instruction.

--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -52,6 +52,17 @@ pub fn r(op: impl Into<Operand>) -> Operand {
     op
 }
 
+/// An abbreviated constructor for a "write" operand.
+#[must_use]
+pub fn w(location: Location) -> Operand {
+    Operand {
+        location,
+        mutability: Mutability::Write,
+        extension: Extension::None,
+        align: false,
+    }
+}
+
 /// An abbreviated constructor for a memory operand that requires alignment.
 pub fn align(location: Location) -> Operand {
     assert!(location.uses_memory());
@@ -423,6 +434,7 @@ pub enum OperandKind {
 pub enum Mutability {
     Read,
     ReadWrite,
+    Write,
 }
 
 impl Mutability {
@@ -432,6 +444,7 @@ impl Mutability {
     pub fn is_read(&self) -> bool {
         match self {
             Mutability::Read | Mutability::ReadWrite => true,
+            Mutability::Write => false,
         }
     }
 
@@ -441,7 +454,7 @@ impl Mutability {
     pub fn is_write(&self) -> bool {
         match self {
             Mutability::Read => false,
-            Mutability::ReadWrite => true,
+            Mutability::ReadWrite | Mutability::Write => true,
         }
     }
 }
@@ -457,6 +470,7 @@ impl core::fmt::Display for Mutability {
         match self {
             Self::Read => write!(f, "r"),
             Self::ReadWrite => write!(f, "rw"),
+            Self::Write => write!(f, "w"),
         }
     }
 }

--- a/cranelift/assembler-x64/meta/src/generate/operand.rs
+++ b/cranelift/assembler-x64/meta/src/generate/operand.rs
@@ -88,6 +88,7 @@ impl dsl::Mutability {
         match self {
             dsl::Mutability::Read => "Read",
             dsl::Mutability::ReadWrite => "ReadWrite",
+            dsl::Mutability::Write => "Write",
         }
     }
 
@@ -96,6 +97,7 @@ impl dsl::Mutability {
         match self {
             dsl::Mutability::Read => "read",
             dsl::Mutability::ReadWrite => "read_write",
+            dsl::Mutability::Write => "write",
         }
     }
 }

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -111,11 +111,17 @@ pub trait Registers {
     /// An x64 general purpose register that may be read and written.
     type ReadWriteGpr: AsReg;
 
+    /// An x64 general purpose register that may be written.
+    type WriteGpr: AsReg;
+
     /// An x64 SSE register that may be read.
     type ReadXmm: AsReg;
 
     /// An x64 SSE register that may be read and written.
     type ReadWriteXmm: AsReg;
+
+    /// An x64 SSE register that may be written.
+    type WriteXmm: AsReg;
 }
 
 /// Describe how to interact with an external register type.
@@ -159,20 +165,33 @@ pub trait RegisterVisitor<R: Registers> {
     fn read_gpr(&mut self, reg: &mut R::ReadGpr);
     /// Visit a read-write register.
     fn read_write_gpr(&mut self, reg: &mut R::ReadWriteGpr);
+    /// Visit a write-only register.
+    fn write_gpr(&mut self, reg: &mut R::WriteGpr);
+
     /// Visit a read-only fixed register; this register can be modified in-place
     /// but must emit as the hardware encoding `enc`.
     fn fixed_read_gpr(&mut self, reg: &mut R::ReadGpr, enc: u8);
     /// Visit a read-write fixed register; this register can be modified
     /// in-place but must emit as the hardware encoding `enc`.
     fn fixed_read_write_gpr(&mut self, reg: &mut R::ReadWriteGpr, enc: u8);
+    /// Visit a write-only fixed register; this register can be modified
+    /// in-place but must emit as the hardware encoding `enc`.
+    fn fixed_write_gpr(&mut self, reg: &mut R::WriteGpr, enc: u8);
+
     /// Visit a read-only SSE register.
     fn read_xmm(&mut self, reg: &mut R::ReadXmm);
     /// Visit a read-write SSE register.
     fn read_write_xmm(&mut self, reg: &mut R::ReadWriteXmm);
+    /// Visit a write-only SSE register.
+    fn write_xmm(&mut self, reg: &mut R::WriteXmm);
+
     /// Visit a read-only fixed SSE register; this register can be modified
     /// in-place but must emit as the hardware encoding `enc`.
     fn fixed_read_xmm(&mut self, reg: &mut R::ReadXmm, enc: u8);
     /// Visit a read-write fixed SSE register; this register can be modified
     /// in-place but must emit as the hardware encoding `enc`.
     fn fixed_read_write_xmm(&mut self, reg: &mut R::ReadWriteXmm, enc: u8);
+    /// Visit a read-only fixed SSE register; this register can be modified
+    /// in-place but must emit as the hardware encoding `enc`.
+    fn fixed_write_xmm(&mut self, reg: &mut R::WriteXmm, enc: u8);
 }

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -175,8 +175,10 @@ pub struct FuzzRegs;
 impl Registers for FuzzRegs {
     type ReadGpr = FuzzReg;
     type ReadWriteGpr = FuzzReg;
+    type WriteGpr = FuzzReg;
     type ReadXmm = FuzzReg;
     type ReadWriteXmm = FuzzReg;
+    type WriteXmm = FuzzReg;
 }
 
 /// A simple `u8` register type for fuzzing only.
@@ -240,8 +242,10 @@ pub trait RegistersArbitrary:
     Registers<
     ReadGpr: for<'a> Arbitrary<'a>,
     ReadWriteGpr: for<'a> Arbitrary<'a>,
+    WriteGpr: for<'a> Arbitrary<'a>,
     ReadXmm: for<'a> Arbitrary<'a>,
     ReadWriteXmm: for<'a> Arbitrary<'a>,
+    WriteXmm: for<'a> Arbitrary<'a>,
 >
 {
 }
@@ -251,8 +255,10 @@ where
     R: Registers,
     R::ReadGpr: for<'a> Arbitrary<'a>,
     R::ReadWriteGpr: for<'a> Arbitrary<'a>,
+    R::WriteGpr: for<'a> Arbitrary<'a>,
     R::ReadXmm: for<'a> Arbitrary<'a>,
     R::ReadWriteXmm: for<'a> Arbitrary<'a>,
+    R::WriteXmm: for<'a> Arbitrary<'a>,
 {
 }
 

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -13,8 +13,10 @@
 //! impl Registers for Regs {
 //!     type ReadGpr = u8;
 //!     type ReadWriteGpr = u8;
+//!     type WriteGpr = u8;
 //!     type ReadXmm = u8;
 //!     type ReadWriteXmm = u8;
+//!     type WriteXmm = u8;
 //! }
 //!
 //! // Then, build one of the `AND` instructions; this one operates on an

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -132,7 +132,7 @@ pub fn generate_macro_inst_fn(f: &mut Formatter, inst: &Inst) {
                         OperandKind::Reg(r) => {
                             let ty = r.reg_class().unwrap().to_string();
                             let var = ty.to_lowercase();
-                            fmtln!(f, "let {var} = {r}.as_ref().clone();");
+                            fmtln!(f, "let {var} = {r}.as_ref().to_reg();");
                             fmtln!(f, "AssemblerOutputs::Ret{ty} {{ inst, {var} }}");
                         }
                         _ => unimplemented!(),

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -15,8 +15,10 @@ pub struct CraneliftRegisters;
 impl asm::Registers for CraneliftRegisters {
     type ReadGpr = Gpr;
     type ReadWriteGpr = PairedGpr;
+    type WriteGpr = WritableGpr;
     type ReadXmm = Xmm;
     type ReadWriteXmm = PairedXmm;
+    type WriteXmm = WritableXmm;
 }
 
 /// A pair of registers, one for reading and one for writing.
@@ -288,6 +290,10 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
         self.collector.reg_reuse_def(write, 0);
     }
 
+    fn write_gpr(&mut self, reg: &mut WritableGpr) {
+        self.collector.reg_def(reg);
+    }
+
     fn fixed_read_gpr(&mut self, reg: &mut Gpr, enc: u8) {
         self.collector
             .reg_fixed_use(reg, fixed_reg(enc, RegClass::Int));
@@ -301,6 +307,11 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
             .reg_fixed_def(write, fixed_reg(enc, RegClass::Int));
     }
 
+    fn fixed_write_gpr(&mut self, reg: &mut WritableGpr, enc: u8) {
+        self.collector
+            .reg_fixed_def(reg, fixed_reg(enc, RegClass::Int));
+    }
+
     fn read_xmm(&mut self, reg: &mut Xmm) {
         self.collector.reg_use(reg);
     }
@@ -309,6 +320,10 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
         let PairedXmm { read, write } = reg;
         self.collector.reg_use(read);
         self.collector.reg_reuse_def(write, 0);
+    }
+
+    fn write_xmm(&mut self, reg: &mut WritableXmm) {
+        self.collector.reg_def(reg);
     }
 
     fn fixed_read_xmm(&mut self, reg: &mut Xmm, enc: u8) {
@@ -322,6 +337,11 @@ impl<'a, T: OperandVisitor> asm::RegisterVisitor<CraneliftRegisters> for Regallo
             .reg_fixed_use(read, fixed_reg(enc, RegClass::Float));
         self.collector
             .reg_fixed_def(write, fixed_reg(enc, RegClass::Float));
+    }
+
+    fn fixed_write_xmm(&mut self, reg: &mut WritableXmm, enc: u8) {
+        self.collector
+            .reg_fixed_def(reg, fixed_reg(enc, RegClass::Float));
     }
 }
 

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -225,6 +225,21 @@ impl<T> Writable<T> {
     }
 }
 
+// Proxy on assembler trait to the underlying register type.
+impl<R: cranelift_assembler_x64::AsReg> cranelift_assembler_x64::AsReg for Writable<R> {
+    fn enc(&self) -> u8 {
+        self.reg.enc()
+    }
+
+    fn to_string(&self, size: Option<cranelift_assembler_x64::gpr::Size>) -> String {
+        self.reg.to_string(size)
+    }
+
+    fn new(_: u8) -> Self {
+        panic!("disallow creation of new assembler registers")
+    }
+}
+
 // Conversions between regalloc2 types (VReg, PReg) and our types
 // (VirtualReg, RealReg, Reg).
 


### PR DESCRIPTION
This change adds support to the new assembler for write-only operands. This implementation appeared first in [#10754] but is split out here to unblock implementation of instructions that require it: multiplication, conversions, moves, etc. This starts roughly the same as what was implemented for write-only XMMs in [#10754] but includes support for write-only GPRs as well and generates the temporary registers which are needed.

[#10754]: https://github.com/bytecodealliance/wasmtime/pull/10754

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
