### PR TITLE
Publicly expose `wasmtime::component::Instance::instance_pre`

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -363,7 +363,7 @@ impl Instance {
         ))
     }
 
-    #[doc(hidden)]
+    /// Returns the [`InstancePre`] that was used to create this instance.
     pub fn instance_pre<T>(&self, store: &impl AsContext<Data = T>) -> InstancePre<T> {
         // This indexing operation asserts the Store owns the Instance.
         // Therefore, the InstancePre<T> must match the Store<T>.


### PR DESCRIPTION
I ended up needing this in Spin, and it's already needed in Wasmtime's generated bindings, so let's commit to exposing this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
