### PR TITLE
[s390x] Add full support for f128

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -552,6 +552,25 @@
       (rn Reg)
       (rm Reg))
 
+    ;; FPU comparison, extended-precision (128 bit).
+    (FpuCmp128
+      (rn Reg)
+      (rm Reg))
+
+    ;; FPU integer to extended-precision conversion using FP reg pair.
+    (FpuConv128FromInt
+      (op FpuConv128Op)
+      (mode FpuRoundMode)
+      (rd WritableRegPair)
+      (rn Reg))
+
+    ;; FPU extended-precision to integer conversion using FP reg pair.
+    (FpuConv128ToInt
+      (op FpuConv128Op)
+      (mode FpuRoundMode)
+      (rd WritableReg)
+      (rn RegPair))
+
     ;; A binary vector operation with two vector register sources.
     (VecRRR
       (op VecBinaryOp)
@@ -1327,22 +1346,27 @@
   (enum
     (Abs32)
     (Abs64)
+    (Abs128)
     (Abs32x4)
     (Abs64x2)
     (Neg32)
     (Neg64)
+    (Neg128)
     (Neg32x4)
     (Neg64x2)
     (NegAbs32)
     (NegAbs64)
+    (NegAbs128)
     (NegAbs32x4)
     (NegAbs64x2)
     (Sqrt32)
     (Sqrt64)
+    (Sqrt128)
     (Sqrt32x4)
     (Sqrt64x2)
     (Cvt32To64)
     (Cvt32x4To64x2)
+    (Cvt64To128)
 ))
 
 ;; A floating-point unit (FPU) operation with two args.
@@ -1350,34 +1374,42 @@
   (enum
     (Add32)
     (Add64)
+    (Add128)
     (Add32x4)
     (Add64x2)
     (Sub32)
     (Sub64)
+    (Sub128)
     (Sub32x4)
     (Sub64x2)
     (Mul32)
     (Mul64)
+    (Mul128)
     (Mul32x4)
     (Mul64x2)
     (Div32)
     (Div64)
+    (Div128)
     (Div32x4)
     (Div64x2)
     (Max32)
     (Max64)
+    (Max128)
     (Max32x4)
     (Max64x2)
     (Min32)
     (Min64)
+    (Min128)
     (Min32x4)
     (Min64x2)
     (MaxPseudo32)
     (MaxPseudo64)
+    (MaxPseudo128)
     (MaxPseudo32x4)
     (MaxPseudo64x2)
     (MinPseudo32)
     (MinPseudo64)
+    (MinPseudo128)
     (MinPseudo32x4)
     (MinPseudo64x2)
 ))
@@ -1387,10 +1419,12 @@
   (enum
     (MAdd32)
     (MAdd64)
+    (MAdd128)
     (MAdd32x4)
     (MAdd64x2)
     (MSub32)
     (MSub64)
+    (MSub128)
     (MSub32x4)
     (MSub64x2)
 ))
@@ -1400,8 +1434,10 @@
   (enum
     (Cvt64To32)
     (Cvt64x2To32x4)
+    (Cvt128To64)
     (Round32)
     (Round64)
+    (Round128)
     (Round32x4)
     (Round64x2)
     (ToSInt32)
@@ -1420,6 +1456,15 @@
     (FromSInt64x2)
     (FromUInt32x4)
     (FromUInt64x2)
+))
+
+;; An extended-precision vs. integer conversion operation.
+(type FpuConv128Op
+  (enum
+    (SInt32)
+    (UInt32)
+    (SInt64)
+    (UInt64)
 ))
 
 ;; Rounding modes for floating-point ops.
@@ -1948,9 +1993,9 @@
 (extern constructor writable_regpair writable_regpair)
 
 ;; Allocate a writable register pair.
-(decl temp_writable_regpair () WritableRegPair)
-(rule (temp_writable_regpair)
-      (writable_regpair (temp_writable_reg $I64) (temp_writable_reg $I64)))
+(decl temp_writable_regpair (Type) WritableRegPair)
+(rule (temp_writable_regpair ty)
+      (writable_regpair (temp_writable_reg ty) (temp_writable_reg ty)))
 
 ;; Retrieve the high word of the writable register pair.
 (decl writable_regpair_hi (WritableRegPair) WritableReg)
@@ -1979,6 +2024,12 @@
 ;; Retrieve the low word of the register pair.
 (decl regpair_lo (RegPair) Reg)
 (extern constructor regpair_lo regpair_lo)
+
+;; Move a $F128 value between a single VR and a pair of FPRs.
+(decl fp_reg_to_regpair (Reg) RegPair)
+(rule (fp_reg_to_regpair x) (regpair x (vec_replicate_lane $I64X2 x 1)))
+(decl fp_regpair_to_reg (RegPair) Reg)
+(rule (fp_regpair_to_reg x) (vec_merge_high $I64X2 (regpair_hi x) (regpair_lo x)))
 
 
 ;; Instruction creation helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2077,42 +2128,42 @@
 ;; Helper for emitting `MInst.SMulWide` instructions.
 (decl smul_wide (Reg Reg) RegPair)
 (rule (smul_wide src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.SMulWide dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.UMulWide` instructions.
 (decl umul_wide (Reg Reg) RegPair)
 (rule (umul_wide src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.UMulWide dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.SDivMod32` instructions.
 (decl sdivmod32 (Reg Reg) RegPair)
 (rule (sdivmod32 src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.SDivMod32 dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.SDivMod64` instructions.
 (decl sdivmod64 (Reg Reg) RegPair)
 (rule (sdivmod64 src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.SDivMod64 dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.UDivMod32` instructions.
 (decl udivmod32 (RegPair Reg) RegPair)
 (rule (udivmod32 src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.UDivMod32 dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.UDivMod64` instructions.
 (decl udivmod64 (RegPair Reg) RegPair)
 (rule (udivmod64 src1 src2)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.UDivMod64 dst src1 src2))))
         dst))
 
@@ -2322,11 +2373,30 @@
 (rule (fpu_cmp64 src1 src2)
       (ProducesFlags.ProducesFlagsSideEffect (MInst.FpuCmp64 src1 src2)))
 
+;; Helper for emitting `MInst.FpuCmp128` instructions.
+(decl fpu_cmp128 (Reg Reg) ProducesFlags)
+(rule (fpu_cmp128 src1 src2)
+      (ProducesFlags.ProducesFlagsSideEffect (MInst.FpuCmp128 src1 src2)))
+
 ;; Helper for emitting `MInst.FpuRound` instructions.
 (decl fpu_round (Type FpuRoundOp FpuRoundMode Reg) Reg)
 (rule (fpu_round ty op mode src)
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.FpuRound op mode dst src))))
+        dst))
+
+;; Helper for emitting `MInst.FpuConv128FromInt` instructions.
+(decl fpu_conv128_from_int (FpuConv128Op FpuRoundMode Reg) RegPair)
+(rule (fpu_conv128_from_int op mode src)
+      (let ((dst WritableRegPair (temp_writable_regpair $F64))
+            (_ Unit (emit (MInst.FpuConv128FromInt op mode dst src))))
+        dst))
+
+;; Helper for emitting `MInst.FpuConv128ToInt` instructions.
+(decl fpu_conv128_to_int (Type FpuConv128Op FpuRoundMode RegPair) Reg)
+(rule (fpu_conv128_to_int ty op mode src)
+      (let ((dst WritableReg (temp_writable_reg ty))
+            (_ Unit (emit (MInst.FpuConv128ToInt op mode dst src))))
         dst))
 
 ;; Helper for emitting `MInst.VecRRR` instructions.
@@ -3559,13 +3629,13 @@
 
 ;; The flogr instruction returns 64 for zero input by default.
 (rule (clz_reg 64 x)
-      (let ((dst WritableRegPair (temp_writable_regpair))
+      (let ((dst WritableRegPair (temp_writable_regpair $I64))
             (_ Unit (emit (MInst.Flogr dst x))))
         (regpair_hi dst)))
 
 ;; If another zero return value was requested, we need to override the flogr result.
 (rule -1 (clz_reg zeroval x)
-      (let ((tmp WritableRegPair (temp_writable_regpair)))
+      (let ((tmp WritableRegPair (temp_writable_regpair $I64)))
         (with_flags_reg
           (ProducesFlags.ProducesFlagsSideEffect (MInst.Flogr tmp x))
           (cmov_imm $I64 (intcc_as_cond (IntCC.Equal)) zeroval (regpair_hi tmp)))))
@@ -4391,6 +4461,7 @@
 (decl fpuop2_add (Type) FPUOp2)
 (rule (fpuop2_add $F32) (FPUOp2.Add32))
 (rule (fpuop2_add $F64) (FPUOp2.Add64))
+(rule (fpuop2_add $F128) (FPUOp2.Add128))
 (rule (fpuop2_add $F32X4) (FPUOp2.Add32x4))
 (rule (fpuop2_add $F64X2) (FPUOp2.Add64x2))
 
@@ -4403,6 +4474,7 @@
 (decl fpuop2_sub (Type) FPUOp2)
 (rule (fpuop2_sub $F32) (FPUOp2.Sub32))
 (rule (fpuop2_sub $F64) (FPUOp2.Sub64))
+(rule (fpuop2_sub $F128) (FPUOp2.Sub128))
 (rule (fpuop2_sub $F32X4) (FPUOp2.Sub32x4))
 (rule (fpuop2_sub $F64X2) (FPUOp2.Sub64x2))
 
@@ -4415,6 +4487,7 @@
 (decl fpuop2_mul (Type) FPUOp2)
 (rule (fpuop2_mul $F32) (FPUOp2.Mul32))
 (rule (fpuop2_mul $F64) (FPUOp2.Mul64))
+(rule (fpuop2_mul $F128) (FPUOp2.Mul128))
 (rule (fpuop2_mul $F32X4) (FPUOp2.Mul32x4))
 (rule (fpuop2_mul $F64X2) (FPUOp2.Mul64x2))
 
@@ -4427,6 +4500,7 @@
 (decl fpuop2_div (Type) FPUOp2)
 (rule (fpuop2_div $F32) (FPUOp2.Div32))
 (rule (fpuop2_div $F64) (FPUOp2.Div64))
+(rule (fpuop2_div $F128) (FPUOp2.Div128))
 (rule (fpuop2_div $F32X4) (FPUOp2.Div32x4))
 (rule (fpuop2_div $F64X2) (FPUOp2.Div64x2))
 
@@ -4439,6 +4513,7 @@
 (decl fpuop2_min (Type) FPUOp2)
 (rule (fpuop2_min $F32) (FPUOp2.Min32))
 (rule (fpuop2_min $F64) (FPUOp2.Min64))
+(rule (fpuop2_min $F128) (FPUOp2.Min128))
 (rule (fpuop2_min $F32X4) (FPUOp2.Min32x4))
 (rule (fpuop2_min $F64X2) (FPUOp2.Min64x2))
 
@@ -4451,6 +4526,7 @@
 (decl fpuop2_max (Type) FPUOp2)
 (rule (fpuop2_max $F32) (FPUOp2.Max32))
 (rule (fpuop2_max $F64) (FPUOp2.Max64))
+(rule (fpuop2_max $F128) (FPUOp2.Max128))
 (rule (fpuop2_max $F32X4) (FPUOp2.Max32x4))
 (rule (fpuop2_max $F64X2) (FPUOp2.Max64x2))
 
@@ -4463,6 +4539,7 @@
 (decl fpuop2_min_pseudo (Type) FPUOp2)
 (rule (fpuop2_min_pseudo $F32) (FPUOp2.MinPseudo32))
 (rule (fpuop2_min_pseudo $F64) (FPUOp2.MinPseudo64))
+(rule (fpuop2_min_pseudo $F128) (FPUOp2.MinPseudo128))
 (rule (fpuop2_min_pseudo $F32X4) (FPUOp2.MinPseudo32x4))
 (rule (fpuop2_min_pseudo $F64X2) (FPUOp2.MinPseudo64x2))
 
@@ -4475,6 +4552,7 @@
 (decl fpuop2_max_pseudo (Type) FPUOp2)
 (rule (fpuop2_max_pseudo $F32) (FPUOp2.MaxPseudo32))
 (rule (fpuop2_max_pseudo $F64) (FPUOp2.MaxPseudo64))
+(rule (fpuop2_max_pseudo $F128) (FPUOp2.MaxPseudo128))
 (rule (fpuop2_max_pseudo $F32X4) (FPUOp2.MaxPseudo32x4))
 (rule (fpuop2_max_pseudo $F64X2) (FPUOp2.MaxPseudo64x2))
 
@@ -4487,6 +4565,7 @@
 (decl fpuop3_fma (Type) FPUOp3)
 (rule (fpuop3_fma $F32) (FPUOp3.MAdd32))
 (rule (fpuop3_fma $F64) (FPUOp3.MAdd64))
+(rule (fpuop3_fma $F128) (FPUOp3.MAdd128))
 (rule (fpuop3_fma $F32X4) (FPUOp3.MAdd32x4))
 (rule (fpuop3_fma $F64X2) (FPUOp3.MAdd64x2))
 
@@ -4499,6 +4578,7 @@
 (decl fpuop1_sqrt (Type) FPUOp1)
 (rule (fpuop1_sqrt $F32) (FPUOp1.Sqrt32))
 (rule (fpuop1_sqrt $F64) (FPUOp1.Sqrt64))
+(rule (fpuop1_sqrt $F128) (FPUOp1.Sqrt128))
 (rule (fpuop1_sqrt $F32X4) (FPUOp1.Sqrt32x4))
 (rule (fpuop1_sqrt $F64X2) (FPUOp1.Sqrt64x2))
 
@@ -4511,6 +4591,7 @@
 (decl fpuop1_neg (Type) FPUOp1)
 (rule (fpuop1_neg $F32) (FPUOp1.Neg32))
 (rule (fpuop1_neg $F64) (FPUOp1.Neg64))
+(rule (fpuop1_neg $F128) (FPUOp1.Neg128))
 (rule (fpuop1_neg $F32X4) (FPUOp1.Neg32x4))
 (rule (fpuop1_neg $F64X2) (FPUOp1.Neg64x2))
 
@@ -4523,6 +4604,7 @@
 (decl fpuop1_abs (Type) FPUOp1)
 (rule (fpuop1_abs $F32) (FPUOp1.Abs32))
 (rule (fpuop1_abs $F64) (FPUOp1.Abs64))
+(rule (fpuop1_abs $F128) (FPUOp1.Abs128))
 (rule (fpuop1_abs $F32X4) (FPUOp1.Abs32x4))
 (rule (fpuop1_abs $F64X2) (FPUOp1.Abs64x2))
 
@@ -4535,6 +4617,7 @@
 (decl fpuroundop_round (Type) FpuRoundOp)
 (rule (fpuroundop_round $F32) (FpuRoundOp.Round32))
 (rule (fpuroundop_round $F64) (FpuRoundOp.Round64))
+(rule (fpuroundop_round $F128) (FpuRoundOp.Round128))
 (rule (fpuroundop_round $F32X4) (FpuRoundOp.Round32x4))
 (rule (fpuroundop_round $F64X2) (FpuRoundOp.Round64x2))
 
@@ -4563,6 +4646,8 @@
       (fpu_rr $F64 (FPUOp1.Cvt32To64) x))
 (rule (fpromote_reg $F64X2 $F32X4 x)
       (fpu_rr $F64 (FPUOp1.Cvt32x4To64x2) x))
+(rule (fpromote_reg $F128 $F64 x)
+      (fpu_rr $F128 (FPUOp1.Cvt64To128) x))
 
 
 ;; Helpers for generating `fdemote` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -4573,32 +4658,42 @@
       (fpu_round $F32 (FpuRoundOp.Cvt64To32) mode x))
 (rule (fdemote_reg $F32X4 $F64X2 mode x)
       (fpu_round $F32X4 (FpuRoundOp.Cvt64x2To32x4) mode x))
+(rule (fdemote_reg $F64 $F128 mode x)
+      (fpu_round $F64 (FpuRoundOp.Cvt128To64) mode x))
 
 
 ;; Helpers for generating `fcvt_from_uint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fcvt_from_uint_reg (Type FpuRoundMode Reg) Reg)
-(rule (fcvt_from_uint_reg $F32 mode x)
+(decl fcvt_from_uint_reg (Type Type FpuRoundMode Reg) Reg)
+(rule (fcvt_from_uint_reg $F32 $I32 mode x)
       (fpu_round $F32 (FpuRoundOp.FromUInt32) mode (vec_insert_lane_undef $I32X4 x 0 (zero_reg))))
-(rule (fcvt_from_uint_reg $F64 mode x)
+(rule (fcvt_from_uint_reg $F64 $I64 mode x)
       (fpu_round $F64 (FpuRoundOp.FromUInt64) mode (vec_insert_lane_undef $I64X2 x 0 (zero_reg))))
-(rule (fcvt_from_uint_reg $F32X4 mode x)
+(rule (fcvt_from_uint_reg $F32X4 $I32X4 mode x)
       (fpu_round $F32X4 (FpuRoundOp.FromUInt32x4) mode x))
-(rule (fcvt_from_uint_reg $F64X2 mode x)
+(rule (fcvt_from_uint_reg $F64X2 $I64X2 mode x)
       (fpu_round $F64X2 (FpuRoundOp.FromUInt64x2) mode x))
+(rule (fcvt_from_uint_reg $F128 $I32 mode x)
+      (fp_regpair_to_reg (fpu_conv128_from_int (FpuConv128Op.UInt32) mode x)))
+(rule (fcvt_from_uint_reg $F128 $I64 mode x)
+      (fp_regpair_to_reg (fpu_conv128_from_int (FpuConv128Op.UInt64) mode x)))
 
 
 ;; Helpers for generating `fcvt_from_sint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fcvt_from_sint_reg (Type FpuRoundMode Reg) Reg)
-(rule (fcvt_from_sint_reg $F32 mode x)
+(decl fcvt_from_sint_reg (Type Type FpuRoundMode Reg) Reg)
+(rule (fcvt_from_sint_reg $F32 $I32 mode x)
       (fpu_round $F32 (FpuRoundOp.FromSInt32) mode (vec_insert_lane_undef $I32X4 x 0 (zero_reg))))
-(rule (fcvt_from_sint_reg $F64 mode x)
+(rule (fcvt_from_sint_reg $F64 $I64 mode x)
       (fpu_round $F64 (FpuRoundOp.FromSInt64) mode (vec_insert_lane_undef $I64X2 x 0 (zero_reg))))
-(rule (fcvt_from_sint_reg $F32X4 mode x)
+(rule (fcvt_from_sint_reg $F32X4 $I32X4 mode x)
       (fpu_round $F32X4 (FpuRoundOp.FromSInt32x4) mode x))
-(rule (fcvt_from_sint_reg $F64X2 mode x)
+(rule (fcvt_from_sint_reg $F64X2 $I64X2 mode x)
       (fpu_round $F64X2 (FpuRoundOp.FromSInt64x2) mode x))
+(rule (fcvt_from_sint_reg $F128 $I32 mode x)
+      (fp_regpair_to_reg (fpu_conv128_from_int (FpuConv128Op.SInt32) mode x)))
+(rule (fcvt_from_sint_reg $F128 $I64 mode x)
+      (fp_regpair_to_reg (fpu_conv128_from_int (FpuConv128Op.SInt64) mode x)))
 
 
 ;; Helpers for generating `fcvt_to_[us]int` instructions ;;;;;;;;;;;;;;;;;;;;;;;
@@ -4607,34 +4702,44 @@
 (rule 1 (fcvt_flt_ty (fits_in_32 ty) (and (vxrs_ext2_enabled) $F32)) $F32)
 (rule (fcvt_flt_ty (fits_in_64 ty) $F32) $F64)
 (rule (fcvt_flt_ty (fits_in_64 ty) $F64) $F64)
+(rule (fcvt_flt_ty (fits_in_64 ty) $F128) $F128)
 
 (decl fcvt_int_ty (Type Type) Type)
 (rule 1 (fcvt_int_ty (fits_in_32 ty) (and (vxrs_ext2_enabled) $F32)) $I32)
 (rule (fcvt_int_ty (fits_in_64 ty) $F32) $I64)
 (rule (fcvt_int_ty (fits_in_64 ty) $F64) $I64)
+(rule 1 (fcvt_int_ty (fits_in_32 ty) $F128) $I32)
+(rule (fcvt_int_ty (fits_in_64 ty) $F128) $I64)
 
 
 ;; Helpers for generating `fcvt_to_uint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fcvt_to_uint_reg (Type FpuRoundMode Reg) Reg)
-(rule (fcvt_to_uint_reg $F32 mode x)
+(decl fcvt_to_uint_reg (Type Type FpuRoundMode Reg) Reg)
+(rule (fcvt_to_uint_reg $I32 $F32 mode x)
       (vec_extract_lane $I32X4 (fpu_round $F32 (FpuRoundOp.ToUInt32) mode x) 0 (zero_reg)))
-(rule (fcvt_to_uint_reg $F64 mode x)
+(rule (fcvt_to_uint_reg $I64 $F64 mode x)
       (vec_extract_lane $I64X2 (fpu_round $F64 (FpuRoundOp.ToUInt64) mode x) 0 (zero_reg)))
-(rule (fcvt_to_uint_reg $F32X4 mode x)
+(rule (fcvt_to_uint_reg $I32X4 $F32X4 mode x)
       (fpu_round $F32X4 (FpuRoundOp.ToUInt32x4) mode x))
-(rule (fcvt_to_uint_reg $F64X2 mode x)
+(rule (fcvt_to_uint_reg $I64X2 $F64X2 mode x)
       (fpu_round $F64X2 (FpuRoundOp.ToUInt64x2) mode x))
+(rule (fcvt_to_uint_reg $I32 $F128 mode x)
+      (fpu_conv128_to_int $I32 (FpuConv128Op.UInt32) mode (fp_reg_to_regpair x)))
+(rule (fcvt_to_uint_reg $I64 $F128 mode x)
+      (fpu_conv128_to_int $I64 (FpuConv128Op.UInt64) mode (fp_reg_to_regpair x)))
 
 (decl fcvt_to_uint_ub (Type Type) Reg)
 (rule (fcvt_to_uint_ub $F32 dst_ty)
       (imm $F32 (fcvt_to_uint_ub32 (ty_bits dst_ty))))
 (rule (fcvt_to_uint_ub $F64 dst_ty)
       (imm $F64 (fcvt_to_uint_ub64 (ty_bits dst_ty))))
+(rule (fcvt_to_uint_ub $F128 dst_ty)
+      (vec_imm $F128 (fcvt_to_uint_ub128 (ty_bits dst_ty))))
 
 (decl fcvt_to_uint_lb (Type) Reg)
 (rule (fcvt_to_uint_lb $F32) (imm $F32 (fcvt_to_uint_lb32)))
 (rule (fcvt_to_uint_lb $F64) (imm $F64 (fcvt_to_uint_lb64)))
+(rule (fcvt_to_uint_lb $F128) (vec_imm $F128 (fcvt_to_uint_lb128)))
 
 (decl fcvt_to_uint_ub32 (u8) u64)
 (extern constructor fcvt_to_uint_ub32 fcvt_to_uint_ub32)
@@ -4644,31 +4749,43 @@
 (extern constructor fcvt_to_uint_ub64 fcvt_to_uint_ub64)
 (decl fcvt_to_uint_lb64 () u64)
 (extern constructor fcvt_to_uint_lb64 fcvt_to_uint_lb64)
+(decl fcvt_to_uint_ub128 (u8) u128)
+(extern constructor fcvt_to_uint_ub128 fcvt_to_uint_ub128)
+(decl fcvt_to_uint_lb128 () u128)
+(extern constructor fcvt_to_uint_lb128 fcvt_to_uint_lb128)
 
 
 ;; Helpers for generating `fcvt_to_sint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fcvt_to_sint_reg (Type FpuRoundMode Reg) Reg)
-(rule (fcvt_to_sint_reg $F32 mode x)
+(decl fcvt_to_sint_reg (Type Type FpuRoundMode Reg) Reg)
+(rule (fcvt_to_sint_reg $I32 $F32 mode x)
       (vec_extract_lane $F32X4 (fpu_round $F32 (FpuRoundOp.ToSInt32) mode x) 0 (zero_reg)))
-(rule (fcvt_to_sint_reg $F64 mode x)
+(rule (fcvt_to_sint_reg $I64 $F64 mode x)
       (vec_extract_lane $F64X2 (fpu_round $F64 (FpuRoundOp.ToSInt64) mode x) 0 (zero_reg)))
-(rule (fcvt_to_sint_reg $F32X4 mode x)
+(rule (fcvt_to_sint_reg $I32X4 $F32X4 mode x)
       (fpu_round $F32X4 (FpuRoundOp.ToSInt32x4) mode x))
-(rule (fcvt_to_sint_reg $F64X2 mode x)
+(rule (fcvt_to_sint_reg $I64X2 $F64X2 mode x)
       (fpu_round $F64X2 (FpuRoundOp.ToSInt64x2) mode x))
+(rule (fcvt_to_sint_reg $I32 $F128 mode x)
+      (fpu_conv128_to_int $I32 (FpuConv128Op.SInt32) mode (fp_reg_to_regpair x)))
+(rule (fcvt_to_sint_reg $I64 $F128 mode x)
+      (fpu_conv128_to_int $I64 (FpuConv128Op.SInt64) mode (fp_reg_to_regpair x)))
 
 (decl fcvt_to_sint_ub (Type Type) Reg)
 (rule (fcvt_to_sint_ub $F32 dst_ty)
       (imm $F32 (fcvt_to_sint_ub32 (ty_bits dst_ty))))
 (rule (fcvt_to_sint_ub $F64 dst_ty)
       (imm $F64 (fcvt_to_sint_ub64 (ty_bits dst_ty))))
+(rule (fcvt_to_sint_ub $F128 dst_ty)
+      (vec_imm $F128 (fcvt_to_sint_ub128 (ty_bits dst_ty))))
 
 (decl fcvt_to_sint_lb (Type Type) Reg)
 (rule (fcvt_to_sint_lb $F32 dst_ty)
       (imm $F32 (fcvt_to_sint_lb32 (ty_bits dst_ty))))
 (rule (fcvt_to_sint_lb $F64 dst_ty)
       (imm $F64 (fcvt_to_sint_lb64 (ty_bits dst_ty))))
+(rule (fcvt_to_sint_lb $F128 dst_ty)
+      (vec_imm $F128 (fcvt_to_sint_lb128 (ty_bits dst_ty))))
 
 (decl fcvt_to_sint_ub32 (u8) u64)
 (extern constructor fcvt_to_sint_ub32 fcvt_to_sint_ub32)
@@ -4678,6 +4795,10 @@
 (extern constructor fcvt_to_sint_ub64 fcvt_to_sint_ub64)
 (decl fcvt_to_sint_lb64 (u8) u64)
 (extern constructor fcvt_to_sint_lb64 fcvt_to_sint_lb64)
+(decl fcvt_to_sint_ub128 (u8) u128)
+(extern constructor fcvt_to_sint_ub128 fcvt_to_sint_ub128)
+(decl fcvt_to_sint_lb128 (u8) u128)
+(extern constructor fcvt_to_sint_lb128 fcvt_to_sint_lb128)
 
 
 ;; Helpers for generating signed `icmp` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -4788,6 +4909,7 @@
 (decl fcmp_reg (Type Reg Reg) ProducesFlags)
 (rule (fcmp_reg $F32 src1 src2) (fpu_cmp32 src1 src2))
 (rule (fcmp_reg $F64 src1 src2) (fpu_cmp64 src1 src2))
+(rule (fcmp_reg $F128 src1 src2) (fpu_cmp128 src1 src2))
 
 
 ;; Helpers for generating vector `fcmp` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7062,6 +7062,15 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Abs128,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C002848CC",
+        "wflpxb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Neg32,
             rd: writable_vr(8),
             rn: vr(12),
@@ -7113,6 +7122,15 @@ fn test_s390x_binemit() {
         },
         "E78C000038CC",
         "vflcdb %v24, %v12",
+    ));
+    insns.push((
+        Inst::FpuRR {
+            fpu_op: FPUOp1::Neg128,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000848CC",
+        "wflcxb %v24, %f12",
     ));
     insns.push((
         Inst::FpuRR {
@@ -7170,6 +7188,15 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::NegAbs128,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001848CC",
+        "wflnxb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Sqrt32,
             rd: writable_vr(8),
             rn: vr(12),
@@ -7224,6 +7251,15 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Sqrt128,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000848CE",
+        "wfsqxb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Cvt32To64,
             rd: writable_vr(8),
             rn: vr(12),
@@ -7248,6 +7284,15 @@ fn test_s390x_binemit() {
         },
         "E78C000028C4",
         "vldeb %v24, %v12",
+    ));
+    insns.push((
+        Inst::FpuRR {
+            fpu_op: FPUOp1::Cvt64To128,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000838C4",
+        "wflld %v24, %f12",
     ));
 
     insns.push((
@@ -7312,6 +7357,16 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Add128,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00848E3",
+        "wfaxb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Sub32,
             rd: writable_vr(8),
             rn: vr(8),
@@ -7369,6 +7424,16 @@ fn test_s390x_binemit() {
         },
         "E748C00038E2",
         "vfsdb %v20, %v8, %v12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Sub128,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00848E2",
+        "wfsxb %v20, %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
@@ -7432,6 +7497,16 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Mul128,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00848E7",
+        "wfmxb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Div32,
             rd: writable_vr(8),
             rn: vr(8),
@@ -7492,6 +7567,16 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Div128,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00848E5",
+        "wfdxb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Max32,
             rd: writable_vr(4),
             rn: vr(6),
@@ -7529,6 +7614,16 @@ fn test_s390x_binemit() {
         },
         "E746801032EF",
         "vfmaxdb %v4, %v6, %v24, 1",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Max128,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(24),
+        },
+        "E746801842EF",
+        "wfmaxxb %f4, %f6, %v24, 1",
     ));
     insns.push((
         Inst::FpuRRR {
@@ -7572,6 +7667,16 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Min128,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+        },
+        "E746801840EE",
+        "wfminxb %f4, %f6, %f8, 1",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::MaxPseudo32,
             rd: writable_vr(4),
             rn: vr(6),
@@ -7612,6 +7717,16 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::MaxPseudo128,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(24),
+        },
+        "E746803842EF",
+        "wfmaxxb %f4, %f6, %v24, 3",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::MinPseudo32,
             rd: writable_vr(4),
             rn: vr(6),
@@ -7649,6 +7764,16 @@ fn test_s390x_binemit() {
         },
         "E746803030EE",
         "vfmindb %v4, %v6, %v8, 3",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::MinPseudo128,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+        },
+        "E746803840EE",
+        "wfminxb %f4, %f6, %f8, 3",
     ));
 
     insns.push((
@@ -7719,6 +7844,17 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuRRRR {
+            fpu_op: FPUOp3::MAdd128,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
+        },
+        "E78CD408418F",
+        "wfmaxb %f8, %f12, %f13, %v20",
+    ));
+    insns.push((
+        Inst::FpuRRRR {
             fpu_op: FPUOp3::MSub32,
             rd: writable_vr(8),
             rn: vr(12),
@@ -7783,6 +7919,17 @@ fn test_s390x_binemit() {
         "E78CD300418E",
         "vfmsdb %v8, %v12, %v13, %v20",
     ));
+    insns.push((
+        Inst::FpuRRRR {
+            fpu_op: FPUOp3::MSub128,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
+        },
+        "E78CD408418E",
+        "wfmsxb %f8, %f12, %f13, %v20",
+    ));
 
     insns.push((
         Inst::FpuCmp32 {
@@ -7816,6 +7963,14 @@ fn test_s390x_binemit() {
         "E78C000038CB",
         "wfcdb %v24, %f12",
     ));
+    insns.push((
+        Inst::FpuCmp128 {
+            rn: vr(24),
+            rm: vr(12),
+        },
+        "E78C000048CB",
+        "wfcxb %v24, %f12",
+    ));
 
     insns.push((
         Inst::FpuRound {
@@ -7846,6 +8001,16 @@ fn test_s390x_binemit() {
         },
         "E78C001038C5",
         "vledb %v24, %v12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Cvt128To64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001848C5",
+        "wflrx %v24, %f12, 0, 1",
     ));
     insns.push((
         Inst::FpuRound {
@@ -7966,6 +8131,16 @@ fn test_s390x_binemit() {
         },
         "E78C001038C7",
         "vfidb %v24, %v12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Round128,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001848C7",
+        "wfixb %v24, %f12, 0, 1",
     ));
     insns.push((
         Inst::FpuRound {
@@ -8126,6 +8301,95 @@ fn test_s390x_binemit() {
         },
         "E78C001038C1",
         "vcdlgb %v24, %v12, 0, 1",
+    ));
+
+    let w_fp_regpair = WritableRegPair {
+        hi: writable_vr(1),
+        lo: writable_vr(3),
+    };
+    let fp_regpair = RegPair {
+        hi: vr(1),
+        lo: vr(3),
+    };
+    insns.push((
+        Inst::FpuConv128FromInt {
+            op: FpuConv128Op::SInt32,
+            mode: FpuRoundMode::ToZero,
+            rd: w_fp_regpair,
+            rn: gpr(8),
+        },
+        "B3965018",
+        "cxfbra %f1, 5, %r8, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128FromInt {
+            op: FpuConv128Op::SInt64,
+            mode: FpuRoundMode::ToZero,
+            rd: w_fp_regpair,
+            rn: gpr(8),
+        },
+        "B3A65018",
+        "cxgbra %f1, 5, %r8, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128FromInt {
+            op: FpuConv128Op::UInt32,
+            mode: FpuRoundMode::ToZero,
+            rd: w_fp_regpair,
+            rn: gpr(8),
+        },
+        "B3925018",
+        "cxlfbr %f1, 5, %r8, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128FromInt {
+            op: FpuConv128Op::UInt64,
+            mode: FpuRoundMode::ToZero,
+            rd: w_fp_regpair,
+            rn: gpr(8),
+        },
+        "B3A25018",
+        "cxlgbr %f1, 5, %r8, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128ToInt {
+            op: FpuConv128Op::SInt32,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_gpr(8),
+            rn: fp_regpair,
+        },
+        "B39A5081",
+        "cfxbra %r8, 5, %f1, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128ToInt {
+            op: FpuConv128Op::SInt64,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_gpr(8),
+            rn: fp_regpair,
+        },
+        "B3AA5081",
+        "cgxbra %r8, 5, %f1, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128ToInt {
+            op: FpuConv128Op::UInt32,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_gpr(8),
+            rn: fp_regpair,
+        },
+        "B39E5081",
+        "clfxbr %r8, 5, %f1, 0",
+    ));
+    insns.push((
+        Inst::FpuConv128ToInt {
+            op: FpuConv128Op::UInt64,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_gpr(8),
+            rn: fp_regpair,
+        },
+        "B3AE5081",
+        "clgxbr %r8, 5, %f1, 0",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -121,6 +121,24 @@ pub fn pretty_print_regpair(pair: RegPair) -> String {
     format!("{}/{}", show_reg(hi), show_reg(lo))
 }
 
+pub fn pretty_print_fp_regpair(pair: RegPair) -> String {
+    let hi = pair.hi;
+    let lo = pair.lo;
+    if let Some(hi_reg) = hi.to_real_reg() {
+        if let Some(lo_reg) = lo.to_real_reg() {
+            assert!(
+                hi_reg.hw_enc() + 2 == lo_reg.hw_enc(),
+                "Invalid regpair: {} {}",
+                show_reg(hi),
+                show_reg(lo)
+            );
+            return maybe_show_fpr(hi).unwrap();
+        }
+    }
+
+    format!("{}/{}", show_reg(hi), show_reg(lo))
+}
+
 pub fn pretty_print_reg_mod(rd: Writable<Reg>, ri: Reg) -> String {
     let output = rd.to_reg();
     let input = ri;

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -1420,6 +1420,9 @@
       (vec_select $F32 x y (imm $F32 2147483647)))
 (rule (lower (has_type $F64 (fcopysign x y)))
       (vec_select $F64 x y (imm $F64 9223372036854775807)))
+(rule (lower (has_type $F128 (fcopysign x y)))
+      (vec_select $F128 x y (vec_imm $F128 (imm8x16 127 255 255 255 255 255 255 255
+                                                    255 255 255 255 255 255 255 255))))
 (rule (lower (has_type $F32X4 (fcopysign x y)))
       (vec_select $F32X4 x y (vec_imm_bit_mask $F32X4 1 31)))
 (rule (lower (has_type $F64X2 (fcopysign x y)))
@@ -1485,8 +1488,11 @@
 ;;;; Rules for `fpromote` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Promote a register.
-(rule (lower (has_type (fits_in_64 dst_ty) (fpromote x @ (value_type src_ty))))
+(rule (lower (has_type dst_ty (fpromote x @ (value_type src_ty))))
       (fpromote_reg dst_ty src_ty x))
+
+(rule 1 (lower (has_type $F128 (fpromote x @ (value_type $F32))))
+      (fpromote_reg $F128 $F64 (fpromote_reg $F64 $F32 x)))
 
 
 ;;;; Rules for `fvpromote_low` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1499,8 +1505,12 @@
 ;;;; Rules for `fdemote` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Demote a register.
-(rule (lower (has_type (fits_in_64 dst_ty) (fdemote x @ (value_type src_ty))))
+(rule (lower (has_type dst_ty (fdemote x @ (value_type src_ty))))
       (fdemote_reg dst_ty src_ty (FpuRoundMode.Current) x))
+
+(rule 1 (lower (has_type $F32 (fdemote x @ (value_type $F128))))
+      (fdemote_reg $F32 $F64 (FpuRoundMode.Current)
+                   (fdemote_reg $F64 $F128 (FpuRoundMode.ShorterPrecision) x)))
 
 
 ;;;; Rules for `fvdemote` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1517,40 +1527,50 @@
 ;; Convert a 32-bit or smaller unsigned integer to $F32 (z15 instruction).
 (rule 1 (lower (has_type $F32
         (fcvt_from_uint x @ (value_type (and (vxrs_ext2_enabled) (fits_in_32 ty))))))
-      (fcvt_from_uint_reg $F32 (FpuRoundMode.ToNearestTiesToEven)
+      (fcvt_from_uint_reg $F32 $I32 (FpuRoundMode.ToNearestTiesToEven)
                           (put_in_reg_zext32 x)))
 
 ;; Convert a 64-bit or smaller unsigned integer to $F32, via an intermediate $F64.
 (rule (lower (has_type $F32 (fcvt_from_uint x @ (value_type (fits_in_64 ty)))))
       (fdemote_reg $F32 $F64 (FpuRoundMode.ToNearestTiesToEven)
-                   (fcvt_from_uint_reg $F64 (FpuRoundMode.ShorterPrecision)
+                   (fcvt_from_uint_reg $F64 $I64 (FpuRoundMode.ShorterPrecision)
                                        (put_in_reg_zext64 x))))
 
 ;; Convert a 64-bit or smaller unsigned integer to $F64.
 (rule (lower (has_type $F64 (fcvt_from_uint x @ (value_type (fits_in_64 ty)))))
-      (fcvt_from_uint_reg $F64 (FpuRoundMode.ToNearestTiesToEven)
+      (fcvt_from_uint_reg $F64 $I64 (FpuRoundMode.ToNearestTiesToEven)
+                          (put_in_reg_zext64 x)))
+
+;; Convert a 32-bit or smaller unsigned integer to $F128.
+(rule 1 (lower (has_type $F128 (fcvt_from_uint x @ (value_type (fits_in_32 ty)))))
+      (fcvt_from_uint_reg $F128 $I32 (FpuRoundMode.ToNearestTiesToEven)
+                          (put_in_reg_zext32 x)))
+
+;; Convert a 64-bit or smaller unsigned integer to $F128.
+(rule (lower (has_type $F128 (fcvt_from_uint x @ (value_type (fits_in_64 ty)))))
+      (fcvt_from_uint_reg $F128 $I64 (FpuRoundMode.ToNearestTiesToEven)
                           (put_in_reg_zext64 x)))
 
 ;; Convert $I32X4 to $F32X4 (z15 instruction).
 (rule 1 (lower (has_type (and (vxrs_ext2_enabled) $F32X4)
                        (fcvt_from_uint x @ (value_type $I32X4))))
-      (fcvt_from_uint_reg $F32X4 (FpuRoundMode.ToNearestTiesToEven) x))
+      (fcvt_from_uint_reg $F32X4 $I32X4 (FpuRoundMode.ToNearestTiesToEven) x))
 
 ;; Convert $I32X4 to $F32X4 (via two $F64X2 on z14).
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F32X4)
                        (fcvt_from_uint x @ (value_type $I32X4))))
       (vec_permute $F32X4
         (fdemote_reg $F32X4 $F64X2 (FpuRoundMode.ToNearestTiesToEven)
-          (fcvt_from_uint_reg $F64X2 (FpuRoundMode.ShorterPrecision)
+          (fcvt_from_uint_reg $F64X2 $I64X2 (FpuRoundMode.ShorterPrecision)
                               (vec_unpacku_high $I32X4 x)))
         (fdemote_reg $F32X4 $F64X2 (FpuRoundMode.ToNearestTiesToEven)
-          (fcvt_from_uint_reg $F64X2 (FpuRoundMode.ShorterPrecision)
+          (fcvt_from_uint_reg $F64X2 $I64X2 (FpuRoundMode.ShorterPrecision)
                               (vec_unpacku_low $I32X4 x)))
         (vec_imm $I8X16 (imm8x16 0 1 2 3 8 9 10 11 16 17 18 19 24 25 26 27))))
 
 ;; Convert $I64X2 to $F64X2.
 (rule (lower (has_type $F64X2 (fcvt_from_uint x @ (value_type $I64X2))))
-      (fcvt_from_uint_reg $F64X2 (FpuRoundMode.ToNearestTiesToEven) x))
+      (fcvt_from_uint_reg $F64X2 $I64X2 (FpuRoundMode.ToNearestTiesToEven) x))
 
 
 ;;;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1558,40 +1578,50 @@
 ;; Convert a 32-bit or smaller signed integer to $F32 (z15 instruction).
 (rule 1 (lower (has_type $F32
         (fcvt_from_sint x @ (value_type (and (vxrs_ext2_enabled) (fits_in_32 ty))))))
-      (fcvt_from_sint_reg $F32 (FpuRoundMode.ToNearestTiesToEven)
+      (fcvt_from_sint_reg $F32 $I32 (FpuRoundMode.ToNearestTiesToEven)
                           (put_in_reg_sext32 x)))
 
 ;; Convert a 64-bit or smaller signed integer to $F32, via an intermediate $F64.
 (rule (lower (has_type $F32 (fcvt_from_sint x @ (value_type (fits_in_64 ty)))))
       (fdemote_reg $F32 $F64 (FpuRoundMode.ToNearestTiesToEven)
-                   (fcvt_from_sint_reg $F64 (FpuRoundMode.ShorterPrecision)
+                   (fcvt_from_sint_reg $F64 $I64 (FpuRoundMode.ShorterPrecision)
                                        (put_in_reg_sext64 x))))
 
 ;; Convert a 64-bit or smaller signed integer to $F64.
 (rule (lower (has_type $F64 (fcvt_from_sint x @ (value_type (fits_in_64 ty)))))
-      (fcvt_from_sint_reg $F64 (FpuRoundMode.ToNearestTiesToEven)
+      (fcvt_from_sint_reg $F64 $I64 (FpuRoundMode.ToNearestTiesToEven)
+                          (put_in_reg_sext64 x)))
+
+;; Convert a 32-bit or smaller signed integer to $F128.
+(rule 1 (lower (has_type $F128 (fcvt_from_sint x @ (value_type (fits_in_32 ty)))))
+      (fcvt_from_sint_reg $F128 $I32 (FpuRoundMode.ToNearestTiesToEven)
+                          (put_in_reg_sext32 x)))
+
+;; Convert a 64-bit or smaller signed integer to $F128.
+(rule (lower (has_type $F128 (fcvt_from_sint x @ (value_type (fits_in_64 ty)))))
+      (fcvt_from_sint_reg $F128 $I64 (FpuRoundMode.ToNearestTiesToEven)
                           (put_in_reg_sext64 x)))
 
 ;; Convert $I32X4 to $F32X4 (z15 instruction).
 (rule 1 (lower (has_type (and (vxrs_ext2_enabled) $F32X4)
                        (fcvt_from_sint x @ (value_type $I32X4))))
-      (fcvt_from_sint_reg $F32X4 (FpuRoundMode.ToNearestTiesToEven) x))
+      (fcvt_from_sint_reg $F32X4 $I32X4 (FpuRoundMode.ToNearestTiesToEven) x))
 
 ;; Convert $I32X4 to $F32X4 (via two $F64X2 on z14).
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F32X4)
                        (fcvt_from_sint x @ (value_type $I32X4))))
       (vec_permute $F32X4
         (fdemote_reg $F32X4 $F64X2 (FpuRoundMode.ToNearestTiesToEven)
-          (fcvt_from_sint_reg $F64X2 (FpuRoundMode.ShorterPrecision)
+          (fcvt_from_sint_reg $F64X2 $I64X2 (FpuRoundMode.ShorterPrecision)
                               (vec_unpacks_high $I32X4 x)))
         (fdemote_reg $F32X4 $F64X2 (FpuRoundMode.ToNearestTiesToEven)
-          (fcvt_from_sint_reg $F64X2 (FpuRoundMode.ShorterPrecision)
+          (fcvt_from_sint_reg $F64X2 $I64X2 (FpuRoundMode.ShorterPrecision)
                               (vec_unpacks_low $I32X4 x)))
         (vec_imm $I8X16 (imm8x16 0 1 2 3 8 9 10 11 16 17 18 19 24 25 26 27))))
 
 ;; Convert $I64X2 to $F64X2.
 (rule (lower (has_type $F64X2 (fcvt_from_sint x @ (value_type $I64X2))))
-      (fcvt_from_sint_reg $F64X2 (FpuRoundMode.ToNearestTiesToEven) x))
+      (fcvt_from_sint_reg $F64X2 $I64X2 (FpuRoundMode.ToNearestTiesToEven) x))
 
 
 ;;;; Rules for `fcvt_to_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1614,8 +1644,9 @@
                             (trap_code_integer_overflow)))
             ;; Perform the conversion using the larger type size.
             (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (int_ty Type (fcvt_int_ty dst_ty src_ty))
             (src_ext Reg (fpromote_reg flt_ty src_ty src)))
-        (fcvt_to_uint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
+        (fcvt_to_uint_reg int_ty flt_ty (FpuRoundMode.ToZero) src_ext)))
 
 
 ;;;; Rules for `fcvt_to_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1638,9 +1669,10 @@
                             (trap_code_integer_overflow)))
             ;; Perform the conversion using the larger type size.
             (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (int_ty Type (fcvt_int_ty dst_ty src_ty))
             (src_ext Reg (fpromote_reg flt_ty src_ty src)))
         ;; Perform the conversion.
-        (fcvt_to_sint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
+        (fcvt_to_sint_reg int_ty flt_ty (FpuRoundMode.ToZero) src_ext)))
 
 
 ;;;; Rules for `fcvt_to_uint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1653,27 +1685,27 @@
             (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
             (int_ty Type (fcvt_int_ty dst_ty src_ty))
             (src_ext Reg (fpromote_reg flt_ty src_ty src))
-            (dst Reg (fcvt_to_uint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
+            (dst Reg (fcvt_to_uint_reg int_ty flt_ty (FpuRoundMode.ToZero) src_ext)))
         ;; Clamp the output to the destination type bounds.
         (uint_sat_reg dst_ty int_ty dst)))
 
 ;; Convert $F32X4 to $I32X4 (z15 instruction).
 (rule 1 (lower (has_type (and (vxrs_ext2_enabled) $I32X4)
                        (fcvt_to_uint_sat x @ (value_type $F32X4))))
-      (fcvt_to_uint_reg $F32X4 (FpuRoundMode.ToZero) x))
+      (fcvt_to_uint_reg $I32X4 $F32X4 (FpuRoundMode.ToZero) x))
 
 ;; Convert $F32X4 to $I32X4 (via two $F64X2 on z14).
 (rule (lower (has_type (and (vxrs_ext2_disabled) $I32X4)
                        (fcvt_to_uint_sat x @ (value_type $F32X4))))
       (vec_pack_usat $I64X2
-        (fcvt_to_uint_reg $F64X2 (FpuRoundMode.ToZero)
+        (fcvt_to_uint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero)
           (fpromote_reg $F64X2 $F32X4 (vec_merge_high $I32X4 x x)))
-        (fcvt_to_uint_reg $F64X2 (FpuRoundMode.ToZero)
+        (fcvt_to_uint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero)
           (fpromote_reg $F64X2 $F32X4 (vec_merge_low $I32X4 x x)))))
 
 ;; Convert $F64X2 to $I64X2.
 (rule (lower (has_type $I64X2 (fcvt_to_uint_sat x @ (value_type $F64X2))))
-      (fcvt_to_uint_reg $F64X2 (FpuRoundMode.ToZero) x))
+      (fcvt_to_uint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero) x))
 
 
 ;;;; Rules for `fcvt_to_sint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1686,7 +1718,7 @@
             (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
             (int_ty Type (fcvt_int_ty dst_ty src_ty))
             (src_ext Reg (fpromote_reg flt_ty src_ty src))
-            (dst Reg (fcvt_to_sint_reg flt_ty (FpuRoundMode.ToZero) src_ext))
+            (dst Reg (fcvt_to_sint_reg int_ty flt_ty (FpuRoundMode.ToZero) src_ext))
             ;; In most special cases, the Z instruction already yields the
             ;; result expected by Cranelift semantics.  The only exception
             ;; it the case where the input was a NaN.  We explicitly check
@@ -1702,7 +1734,7 @@
                        (fcvt_to_sint_sat src @ (value_type $F32X4))))
       ;; See above for why we need to handle NaNs specially.
       (vec_select $I32X4
-        (fcvt_to_sint_reg $F32X4 (FpuRoundMode.ToZero) src)
+        (fcvt_to_sint_reg $I32X4 $F32X4 (FpuRoundMode.ToZero) src)
         (vec_imm $I32X4 0) (vec_fcmpeq $F32X4 src src)))
 
 ;; Convert $F32X4 to $I32X4 (via two $F64X2 on z14).
@@ -1711,9 +1743,9 @@
       ;; See above for why we need to handle NaNs specially.
       (vec_select $I32X4
         (vec_pack_ssat $I64X2
-          (fcvt_to_sint_reg $F64X2 (FpuRoundMode.ToZero)
+          (fcvt_to_sint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero)
             (fpromote_reg $F64X2 $F32X4 (vec_merge_high $I32X4 src src)))
-          (fcvt_to_sint_reg $F64X2 (FpuRoundMode.ToZero)
+          (fcvt_to_sint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero)
             (fpromote_reg $F64X2 $F32X4 (vec_merge_low $I32X4 src src))))
         (vec_imm $I32X4 0) (vec_fcmpeq $F32X4 src src)))
 
@@ -1721,7 +1753,7 @@
 (rule (lower (has_type $I64X2 (fcvt_to_sint_sat src @ (value_type $F64X2))))
       ;; See above for why we need to handle NaNs specially.
       (vec_select $I64X2
-        (fcvt_to_sint_reg $F64X2 (FpuRoundMode.ToZero) src)
+        (fcvt_to_sint_reg $I64X2 $F64X2 (FpuRoundMode.ToZero) src)
         (vec_imm $I64X2 0) (vec_fcmpeq $F64X2 src src)))
 
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -667,6 +667,16 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
+    fn fcvt_to_uint_ub128(&mut self, size: u8) -> u128 {
+        Ieee128::pow2(size).bits()
+    }
+
+    #[inline]
+    fn fcvt_to_uint_lb128(&mut self) -> u128 {
+        (-Ieee128::pow2(0)).bits()
+    }
+
+    #[inline]
     fn fcvt_to_sint_ub32(&mut self, size: u8) -> u64 {
         (2.0_f32).powi((size - 1).into()).to_bits() as u64
     }
@@ -686,6 +696,16 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     fn fcvt_to_sint_lb64(&mut self, size: u8) -> u64 {
         let lb = (-2.0_f64).powi((size - 1).into());
         std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
+    }
+
+    #[inline]
+    fn fcvt_to_sint_ub128(&mut self, size: u8) -> u128 {
+        Ieee128::pow2(size - 1).bits()
+    }
+
+    #[inline]
+    fn fcvt_to_sint_lb128(&mut self, size: u8) -> u128 {
+        Ieee128::fcvt_to_sint_negative_overflow(size).bits()
     }
 
     #[inline]

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -216,6 +216,28 @@ block0(v0: f64, v1: f64):
 ;   adbr %f0, %f2
 ;   br %r14
 
+function %fadd_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fadd v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfaxb %f6, %f1, %f3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfaxb %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+
 function %fsub_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
   v2 = fsub v0, v1
@@ -246,6 +268,28 @@ block0(v0: f64, v1: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sdbr %f0, %f2
+;   br %r14
+
+function %fsub_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fsub v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfsxb %f6, %f1, %f3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfsxb %v6, %v1, %v3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %fmul_f32(f32, f32) -> f32 {
@@ -280,6 +324,28 @@ block0(v0: f64, v1: f64):
 ;   mdbr %f0, %f2
 ;   br %r14
 
+function %fmul_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fmul v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmxb %f6, %f1, %f3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmxb %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+
 function %fdiv_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
   v2 = fdiv v0, v1
@@ -310,6 +376,28 @@ block0(v0: f64, v1: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ddbr %f0, %f2
+;   br %r14
+
+function %fdiv_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fdiv v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfdxb %f6, %f1, %f3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfdxb %v6, %v1, %v3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %fmin_f32(f32, f32) -> f32 {
@@ -344,6 +432,28 @@ block0(v0: f64, v1: f64):
 ;   wfmindb %f0, %f0, %f2, 1
 ;   br %r14
 
+function %fmin_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fmin v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfminxb %f6, %f1, %f3, 1
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfminxb %v6, %v1, %v3, 1
+;   vst %v6, 0(%r2)
+;   br %r14
+
 function %fmax_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
   v2 = fmax v0, v1
@@ -374,6 +484,28 @@ block0(v0: f64, v1: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmaxdb %f0, %f0, %f2, 1
+;   br %r14
+
+function %fmax_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fmax v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmaxxb %f6, %f1, %f3, 1
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmaxxb %v6, %v1, %v3, 1
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %fmin_pseudo_f32(f32, f32) -> f32 {
@@ -410,6 +542,29 @@ block0(v0: f64, v1: f64):
 ;   wfmindb %f0, %f0, %f2, 3
 ;   br %r14
 
+function %fmin_pseudo_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fcmp lt v1, v0
+  v3 = select v2, v1, v0
+  return v3
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfminxb %f6, %f1, %f3, 3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfminxb %v6, %v1, %v3, 3
+;   vst %v6, 0(%r2)
+;   br %r14
+
 function %fmax_pseudo_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):
   v2 = fcmp lt v0, v1
@@ -444,6 +599,29 @@ block0(v0: f64, v1: f64):
 ;   wfmaxdb %f0, %f0, %f2, 3
 ;   br %r14
 
+function %fmax_pseudo_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fcmp lt v0, v1
+  v3 = select v2, v1, v0
+  return v3
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmaxxb %f6, %f1, %f3, 3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   wfmaxxb %v6, %v1, %v3, 3
+;   vst %v6, 0(%r2)
+;   br %r14
+
 function %sqrt_f32(f32) -> f32 {
 block0(v0: f32):
   v1 = sqrt v0
@@ -474,6 +652,26 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqdbr %f0, %f0
+;   br %r14
+
+function %sqrt_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = sqrt v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wfsqxb %f4, %f1
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wfsqxb %v4, %v1
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %fabs_f32(f32) -> f32 {
@@ -508,6 +706,26 @@ block0(v0: f64):
 ;   lpdbr %f0, %f0
 ;   br %r14
 
+function %fabs_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = fabs v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wflpxb %f4, %f1
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wflpxb %v4, %v1
+;   vst %v4, 0(%r2)
+;   br %r14
+
 function %fneg_f32(f32) -> f32 {
 block0(v0: f32):
   v1 = fneg v0
@@ -540,7 +758,27 @@ block0(v0: f64):
 ;   lcdbr %f0, %f0
 ;   br %r14
 
-function %fpromote_f32(f32) -> f64 {
+function %fneg_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = fneg v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wflcxb %f4, %f1
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wflcxb %v4, %v1
+;   vst %v4, 0(%r2)
+;   br %r14
+
+function %fpromote_f32_f64(f32) -> f64 {
 block0(v0: f32):
   v1 = fpromote.f64 v0
   return v1
@@ -556,7 +794,45 @@ block0(v0: f32):
 ;   ldebr %f0, %f0
 ;   br %r14
 
-function %fdemote_f64(f64) -> f32 {
+function %fpromote_f64_f128(f64) -> f128 {
+block0(v0: f64):
+  v1 = fpromote.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   wflld %f3, %f0
+;   vst %v3, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   wflld %v3, %f0
+;   vst %v3, 0(%r2)
+;   br %r14
+
+function %fpromote_f32_f128(f32) -> f128 {
+block0(v0: f32):
+  v1 = fpromote.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   ldebr %f3, %f0
+;   wflld %f5, %f3
+;   vst %v5, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f3, %f0
+;   wflld %v5, %f3
+;   vst %v5, 0(%r2)
+;   br %r14
+
+function %fdemote_f64_f32(f64) -> f32 {
 block0(v0: f64):
   v1 = fdemote.f32 v0
   return v1
@@ -570,6 +846,44 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ledbr %f0, %f0
+;   br %r14
+
+function %fdemote_f128_f64(f128) -> f64 {
+block0(v0: f128):
+  v1 = fdemote.f64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wflrx %f0, %f1, 0, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wflrx %f0, %v1, 0, 0
+;   br %r14
+
+function %fdemote_f128_f32(f128) -> f32 {
+block0(v0: f128):
+  v1 = fdemote.f32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wflrx %f3, %f1, 0, 3
+;   ledbra %f0, 0, %f3, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wflrx %f3, %v1, 0, 3
+;   ledbr %f0, %f3
 ;   br %r14
 
 function %ceil_f32(f32) -> f32 {
@@ -604,6 +918,26 @@ block0(v0: f64):
 ;   fidbr %f0, 6, %f0
 ;   br %r14
 
+function %ceil_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = ceil v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wfixb %f4, %f1, 0, 6
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wfixb %v4, %v1, 0, 6
+;   vst %v4, 0(%r2)
+;   br %r14
+
 function %floor_f32(f32) -> f32 {
 block0(v0: f32):
   v1 = floor v0
@@ -634,6 +968,26 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fidbr %f0, 7, %f0
+;   br %r14
+
+function %floor_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = floor v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wfixb %f4, %f1, 0, 7
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wfixb %v4, %v1, 0, 7
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %trunc_f32(f32) -> f32 {
@@ -668,6 +1022,26 @@ block0(v0: f64):
 ;   fidbr %f0, 5, %f0
 ;   br %r14
 
+function %trunc_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = trunc v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wfixb %f4, %f1, 0, 5
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wfixb %v4, %v1, 0, 5
+;   vst %v4, 0(%r2)
+;   br %r14
+
 function %nearest_f32(f32) -> f32 {
 block0(v0: f32):
   v1 = nearest v0
@@ -700,6 +1074,26 @@ block0(v0: f64):
 ;   fidbr %f0, 4, %f0
 ;   br %r14
 
+function %nearest_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = nearest v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   wfixb %f4, %f1, 0, 4
+;   vst %v4, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   wfixb %v4, %v1, 0, 4
+;   vst %v4, 0(%r2)
+;   br %r14
+
 function %fma_f32(f32, f32, f32) -> f32 {
 block0(v0: f32, v1: f32, v2: f32):
   v3 = fma v0, v1, v2
@@ -730,6 +1124,30 @@ block0(v0: f64, v1: f64, v2: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmadb %f0, %f0, %f2, %f4
+;   br %r14
+
+function %fma_f128(f128, f128, f128) -> f128 {
+block0(v0: f128, v1: f128, v2: f128):
+  v3 = fma v0, v1, v2
+  return v3
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   wfmaxb %v16, %f1, %f3, %f5
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   wfmaxb %v16, %v1, %v3, %v5
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %fcopysign_f32(f32, f32) -> f32 {
@@ -779,6 +1197,43 @@ block0(v0: f64, v1: f64):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   su %f15, 0xfff(%r15, %r15)
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+
+function %fcopysign_f128(f128, f128) -> f128 {
+block0(v0: f128, v1: f128):
+  v2 = fcopysign v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   larl %r1, [const(0)] ; vl %v6, 0(%r1)
+;   vsel %v16, %v1, %v3, %v6
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   larl %r1, 0x30
+;   vl %v6, 0(%r1)
+;   vsel %v16, %v1, %v3, %v6
+;   vst %v16, 0(%r2)
+;   br %r14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   su %f15, 0xfff(%r15, %r15)
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
 ;   .byte 0xff, 0xff
 ;   .byte 0xff, 0xff
 
@@ -1510,6 +1965,426 @@ block0(v0: f64):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x01
 
+function %fcvt_to_uint_f128_i8(f128) -> i8 {
+block0(v0: f128):
+  v1 = fcvt_to_uint.i8 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r0, 0(%r7)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0xf, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_sint_f128_i8(f128) -> i8 {
+block0(v0: f128):
+  v1 = fcvt_to_sint.i8 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r0, 0(%r6)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   xihf %r0, 0x2000000
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_uint_f128_i16(f128) -> i16 {
+block0(v0: f128):
+  v1 = fcvt_to_uint.i16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r0, 0(%r15)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0xf, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_sint_f128_i16(f128) -> i16 {
+block0(v0: f128):
+  v1 = fcvt_to_sint.i16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r0, 0(%r14)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   llihf %r0, 0x20000
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_uint_f128_i32(f128) -> i32 {
+block0(v0: f128):
+  v1 = fcvt_to_uint.i32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r1, 0(%r15)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0xf, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_sint_f128_i32(f128) -> i32 {
+block0(v0: f128):
+  v1 = fcvt_to_sint.i32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r1, 0(%r14)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   llihf %r1, 2
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_uint_f128_i64(f128) -> i64 {
+block0(v0: f128):
+  v1 = fcvt_to_uint.i64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   clgxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   clgxbr %r2, 5, %f1, 0
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r3, 0(%r15)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   icm %r15, 0xf, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
+function %fcvt_to_sint_f128_i64(f128) -> i64 {
+block0(v0: f128):
+  v1 = fcvt_to_sint.i64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   wfcxb %f1, %f1
+;   jgo .+2 # trap=bad_toint
+;   larl %r1, [const(0)] ; vl %v5, 0(%r1)
+;   wfcxb %f1, %f5
+;   jghe .+2 # trap=int_ovf
+;   larl %r1, [const(1)] ; vl %v17, 0(%r1)
+;   wfcxb %f1, %v17
+;   jgle .+2 # trap=int_ovf
+;   vrepg %v3, %v1, 1
+;   cgxbra %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   wfcxb %v1, %v1
+;   jgo 0xe ; trap: bad_toint
+;   larl %r1, 0x50
+;   vl %v5, 0(%r1)
+;   wfcxb %v1, %v5
+;   jghe 0x26 ; trap: int_ovf
+;   larl %r1, 0x60
+;   vl %v17, 0(%r1)
+;   wfcxb %v1, %v17
+;   jgle 0x3e ; trap: int_ovf
+;   vrepg %v3, %v1, 1
+;   cgxbr %r2, 5, %f1
+;   br %r14
+;   .byte 0x00, 0x00
+;   sth %r3, 0(%r14)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   llihf %r3, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+
 function %fcvt_from_uint_i8_f32(i8) -> f32 {
 block0(v0: i8):
   v1 = fcvt_from_uint.f32 v0
@@ -1836,6 +2711,174 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdgb %f0, %f2, 0, 4
+;   br %r14
+
+function %fcvt_from_uint_i8_f128(i8) -> f128 {
+block0(v0: i8):
+  v1 = fcvt_from_uint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   llcr %r5, %r3
+;   cxlfbr %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   llcr %r5, %r3
+;   cxlfbr %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+
+function %fcvt_from_sint_i8_f128(i8) -> f128 {
+block0(v0: i8):
+  v1 = fcvt_from_sint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   lbr %r5, %r3
+;   cxfbra %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lbr %r5, %r3
+;   cxfbra %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+
+function %fcvt_from_uint_i16_f128(i16) -> f128 {
+block0(v0: i16):
+  v1 = fcvt_from_uint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   llhr %r5, %r3
+;   cxlfbr %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r5, %r3
+;   cxlfbr %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+
+function %fcvt_from_sint_i16_f128(i16) -> f128 {
+block0(v0: i16):
+  v1 = fcvt_from_sint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   lhr %r5, %r3
+;   cxfbra %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r5, %r3
+;   cxfbra %f1, 4, %r5, 0
+;   vmrhg %v16, %v1, %v3
+;   vst %v16, 0(%r2)
+;   br %r14
+
+function %fcvt_from_uint_i32_f128(i32) -> f128 {
+block0(v0: i32):
+  v1 = fcvt_from_uint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   cxlfbr %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cxlfbr %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+
+function %fcvt_from_sint_i32_f128(i32) -> f128 {
+block0(v0: i32):
+  v1 = fcvt_from_sint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   cxfbra %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cxfbra %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+
+function %fcvt_from_uint_i64_f128(i64) -> f128 {
+block0(v0: i64):
+  v1 = fcvt_from_uint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   cxlgbr %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cxlgbr %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+
+function %fcvt_from_sint_i64_f128(i64) -> f128 {
+block0(v0: i64):
+  v1 = fcvt_from_sint.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   cxgbra %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cxgbra %f1, 4, %r3, 0
+;   vmrhg %v6, %v1, %v3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %fcvt_to_uint_sat_f32_i8(f32) -> i8 {
@@ -2258,6 +3301,206 @@ block0(v0: f64):
 ;   locghio %r2, 0
 ;   br %r14
 
+function %fcvt_to_uint_sat_f128_i8(f128) -> i8 {
+block0(v0: f128):
+  v1 = fcvt_to_uint_sat.i8 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   clfi %r2, 256
+;   lochih %r2, 255
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   clfi %r2, 0x100
+;   lochih %r2, 0xff
+;   br %r14
+
+function %fcvt_to_sint_sat_f128_i8(f128) -> i8 {
+block0(v0: f128):
+  v1 = fcvt_to_sint_sat.i8 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   wfcxb %f1, %f1
+;   lochio %r2, 0
+;   chi %r2, 127
+;   lochih %r2, 127
+;   chi %r2, -128
+;   lochil %r2, -128
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   wfcxb %v1, %v1
+;   lochio %r2, 0
+;   chi %r2, 0x7f
+;   lochih %r2, 0x7f
+;   chi %r2, -0x80
+;   lochil %r2, -0x80
+;   br %r14
+
+function %fcvt_to_uint_sat_f128_i16(f128) -> i16 {
+block0(v0: f128):
+  v1 = fcvt_to_uint_sat.i16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   clfi %r2, 65535
+;   lochih %r2, -1
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   clfi %r2, 0xffff
+;   lochih %r2, -1
+;   br %r14
+
+function %fcvt_to_sint_sat_f128_i16(f128) -> i16 {
+block0(v0: f128):
+  v1 = fcvt_to_sint_sat.i16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   wfcxb %f1, %f1
+;   lochio %r2, 0
+;   chi %r2, 32767
+;   lochih %r2, 32767
+;   chi %r2, -32768
+;   lochil %r2, -32768
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   wfcxb %v1, %v1
+;   lochio %r2, 0
+;   chi %r2, 0x7fff
+;   lochih %r2, 0x7fff
+;   chi %r2, -0x8000
+;   lochil %r2, -0x8000
+;   br %r14
+
+function %fcvt_to_uint_sat_f128_i32(f128) -> i32 {
+block0(v0: f128):
+  v1 = fcvt_to_uint_sat.i32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clfxbr %r2, 5, %f1, 0
+;   br %r14
+
+function %fcvt_to_sint_sat_f128_i32(f128) -> i32 {
+block0(v0: f128):
+  v1 = fcvt_to_sint_sat.i32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbra %r2, 5, %f1, 0
+;   wfcxb %f1, %f1
+;   lochio %r2, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cfxbr %r2, 5, %f1
+;   wfcxb %v1, %v1
+;   lochio %r2, 0
+;   br %r14
+
+function %fcvt_to_uint_sat_f128_i64(f128) -> i64 {
+block0(v0: f128):
+  v1 = fcvt_to_uint_sat.i64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clgxbr %r2, 5, %f1, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   clgxbr %r2, 5, %f1, 0
+;   br %r14
+
+function %fcvt_to_sint_sat_f128_i64(f128) -> i64 {
+block0(v0: f128):
+  v1 = fcvt_to_sint_sat.i64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cgxbra %r2, 5, %f1, 0
+;   wfcxb %f1, %f1
+;   locghio %r2, 0
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vrepg %v3, %v1, 1
+;   cgxbr %r2, 5, %f1
+;   wfcxb %v1, %v1
+;   locghio %r2, 0
+;   br %r14
+
 function %bitcast_i64_f64(i64) -> f64 {
 block0(v0: i64):
   v1 = bitcast.f64 v0
@@ -2348,5 +3591,59 @@ block0(v0: f64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
+;   br %r14
+
+function %bitcast_f128_f128(f128) -> f128 {
+block0(v0: f128):
+  v1 = bitcast.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+
+function %bitcast_i128_f128(i128) -> f128 {
+block0(v0: i128):
+  v1 = bitcast.f128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+
+function %bitcast_f128_i128(f128) -> i128 {
+block0(v0: f128):
+  v1 = bitcast.i128 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
 ;   br %r14
 


### PR DESCRIPTION
This adds all missing operations to fully support f128 at the same level as f64 and f32 on s390x.  The implementation is mostly a straightfoward extension of existing support, using the same vector instruction set.  The exception is conversion between integer and f128, where we have to use the older floating-point instructions that use FPR register pairs to hold a f128 value.  As regalloc does not support pairs, those registers are hard-coded, just as is done for the few instructions that require GPR register pairs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
