### PR TITLE
x64: refactor the representation of `*Mem` and `*MemImm`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1553,17 +1553,38 @@
 (type Gpr (primitive Gpr))
 (type WritableGpr (primitive WritableGpr))
 (type OptionWritableGpr (primitive OptionWritableGpr))
-(type GprMem extern (enum))
-(type GprMemImm extern (enum))
+(type GprMem extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))))
+(type GprMemImm extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))
+       (Imm (simm32 u32))))
 (type Imm8Gpr extern (enum))
 
 (type Xmm (primitive Xmm))
 (type WritableXmm (primitive WritableXmm))
 (type OptionWritableXmm (primitive OptionWritableXmm))
-(type XmmMem extern (enum))
-(type XmmMemAligned extern (enum))
-(type XmmMemImm extern (enum))
-(type XmmMemAlignedImm extern (enum))
+(type XmmMem extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))))
+(type XmmMemAligned extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))))
+(type XmmMemImm extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))
+       (Imm (simm32 u32))))
+(type XmmMemAlignedImm extern
+      (enum
+       (Reg (reg Reg))
+       (Mem (addr SyntheticAmode))
+       (Imm (simm32 u32))))
 
 ;; Convert an `Imm8Reg` into an `Imm8Gpr`.
 (decl imm8_reg_to_imm8_gpr (Imm8Reg) Imm8Gpr)


### PR DESCRIPTION
While reflecting on why #10762 is hard, it seemed that the underlying problem to many ISLE matching issues is our inability to actually inspect the variants of the register specific versions of `RegMem` and `RegMemImm`. We had been wrapping instances of these `Reg*` types, but this change pushes the variants down to: `GprMem`, `GprMemImm`, `XmmMem`, `XmmMemAligned`, `XmmMemImm`, and `XmmMemAlignedImm`. With this, it should be possible to match directly on the variants in ISLE. This does not change any functionality.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
