### PR TITLE
Fix name qualification in the `entity_impl` macro.

### DIFF
--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -190,7 +190,7 @@ macro_rules! entity_impl {
     // Include basic `Display` impl using the given display prefix.
     // Display a `Block` reference as "block12".
     ($entity:ident, $display_prefix:expr) => {
-        entity_impl!($entity);
+        $crate::entity_impl!($entity);
 
         impl $crate::__core::fmt::Display for $entity {
             fn fmt(&self, f: &mut $crate::__core::fmt::Formatter) -> $crate::__core::fmt::Result {


### PR DESCRIPTION
Use `$crate` in the `entity_impl` macro for references to itself, so that they resolve even if `entity_impl` isn't imported into the global scope.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
