### PR TITLE
mpk: fix example CLI argument

### DIFF
--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -66,7 +66,7 @@ struct Args {
     /// The maximum number of bytes for each WebAssembly linear memory in the
     /// pool.
     #[arg(long, default_value = "128MiB", value_parser = parse_byte_size)]
-    memory_size: usize,
+    memory_size: u64,
 
     /// The maximum number of bytes a memory is considered static; see
     /// `Config::memory_reservation` for more details and the default
@@ -185,8 +185,10 @@ impl ExponentialSearch {
 fn build_engine(args: &Args, num_memories: u32, enable_mpk: MpkEnabled) -> Result<usize> {
     // Configure the memory pool.
     let mut pool = PoolingAllocationConfig::default();
-    pool.max_memory_size(args.memory_size);
-    pool.total_memories(num_memories)
+    let max_memory_size =
+        usize::try_from(args.memory_size).expect("memory size should fit in `usize`");
+    pool.max_memory_size(max_memory_size)
+        .total_memories(num_memories)
         .memory_protection_keys(enable_mpk);
 
     // Configure the engine itself.


### PR DESCRIPTION
The `--memory-size` argument caused failures when running the `mpk.rs` example. This was due to some `clap`-related conversions that no longer worked as when this was written:

```
thread 'main' panicked at examples/mpk.rs:69:18:
Mismatch between definition and access of `memory_size`. Could not
downcast to usize, need to downcast to u64
```

This change explicitly uses `u64` for the CLI argument, fixing the failure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
