### PR TITLE
x64: convert some SSE `cvt*` instructions

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -2,6 +2,7 @@
 
 mod add;
 mod and;
+mod cvt;
 mod neg;
 mod or;
 mod shift;
@@ -15,6 +16,7 @@ pub fn list() -> Vec<Inst> {
     let mut all = vec![];
     all.extend(add::list());
     all.extend(and::list());
+    all.extend(cvt::list());
     all.extend(neg::list());
     all.extend(or::list());
     all.extend(shift::list());

--- a/cranelift/assembler-x64/meta/src/instructions/cvt.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cvt.rs
@@ -1,0 +1,31 @@
+use crate::dsl::{align, fmt, inst, r, rex, rw, w};
+use crate::dsl::{Feature::*, Inst, Location::*};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        // From 32-bit floating point.
+        inst("cvtps2pd", fmt("A", [w(xmm), r(xmm_m64)]), rex([0x0F, 0x5A]).r(), _64b | compat | sse2),
+        inst("cvttps2dq", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0xF3, 0x0F, 0x5B]).r(), _64b | compat | sse2),
+        inst("cvtss2sd", fmt("A", [rw(xmm), r(xmm_m32)]), rex([0xF3, 0x0F, 0x5A]).r(), _64b | compat | sse2),
+        inst("cvtss2si", fmt("A", [w(r32), r(xmm_m32)]), rex([0xF3, 0x0F, 0x2D]).r(), _64b | compat | sse),
+        inst("cvtss2si", fmt("AQ", [w(r64), r(xmm_m32)]), rex([0xF3, 0x0F, 0x2D]).w().r(), _64b | sse),
+        inst("cvttss2si", fmt("A", [w(r32), r(xmm_m32)]), rex([0xF3, 0x0F, 0x2C]).r(), _64b | compat | sse),
+        inst("cvttss2si", fmt("AQ", [w(r64), r(xmm_m32)]), rex([0xF3, 0x0F, 0x2C]).w().r(), _64b | sse),
+        // From 64-bit floating point.
+        inst("cvtpd2ps", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x5A]).r(), _64b | compat | sse2),
+        inst("cvttpd2dq", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x66, 0x0F, 0xE6]).r(), _64b | compat | sse2),
+        inst("cvtsd2ss", fmt("A", [rw(xmm), r(xmm_m64)]), rex([0xF2, 0x0F, 0x5A]).r(), _64b | compat | sse2),
+        inst("cvtsd2si", fmt("A", [w(r32), r(xmm_m64)]), rex([0xF2, 0x0F, 0x2D]).r(), _64b | compat | sse2),
+        inst("cvtsd2si", fmt("AQ", [w(r64), r(xmm_m64)]), rex([0xF2, 0x0F, 0x2D]).w().r(), _64b | sse2),
+        inst("cvttsd2si", fmt("A", [w(r32), r(xmm_m64)]), rex([0xF2, 0x0F, 0x2C]).r(), _64b | compat | sse2),
+        inst("cvttsd2si", fmt("AQ", [w(r64), r(xmm_m64)]), rex([0xF2, 0x0F, 0x2C]).w().r(), _64b | sse2),
+        // From signed 32-bit integer.
+        inst("cvtdq2ps", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x0F, 0x5B]).r(), _64b | compat | sse2),
+        inst("cvtdq2pd", fmt("A", [w(xmm), r(xmm_m64)]), rex([0xF3, 0x0F, 0xE6]).r(), _64b | compat | sse2),
+        inst("cvtsi2ssl", fmt("A", [rw(xmm), r(rm32)]), rex([0xF3, 0x0F, 0x2A]).r(), _64b | compat | sse),
+        inst("cvtsi2ssq", fmt("A", [rw(xmm), r(rm64)]), rex([0xF3, 0x0F, 0x2A]).w().r(), _64b | sse),
+        inst("cvtsi2sdl", fmt("A", [rw(xmm), r(rm32)]), rex([0xF2, 0x0F, 0x2A]).r(), _64b | compat | sse2),
+        inst("cvtsi2sdq", fmt("A", [rw(xmm), r(rm64)]), rex([0xF2, 0x0F, 0x2A]).w().r(), _64b | sse2),
+    ]
+}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -442,11 +442,6 @@
        ;; Note that this is special in that `src1` is an xmm/float register
        ;; while `src2` is a general purpose register as this is converting an
        ;; integer in a gpr to an equivalent float in an xmm reg.
-       (CvtIntToFloat (op SseOpcode)
-                      (src1 Xmm)
-                      (src2 GprMem)
-                      (dst WritableXmm)
-                      (src2_size OperandSize))
        (CvtIntToFloatVex (op AvxOpcode)
                          (src1 Xmm)
                          (src2 GprMem)
@@ -868,20 +863,6 @@
             Cmppd
             Cmpss
             Cmpsd
-            Cvtdq2ps
-            Cvtdq2pd
-            Cvtpd2ps
-            Cvtps2pd
-            Cvtsd2ss
-            Cvtsd2si
-            Cvtsi2ss
-            Cvtsi2sd
-            Cvtss2si
-            Cvtss2sd
-            Cvttpd2dq
-            Cvttps2dq
-            Cvttss2si
-            Cvttsd2si
             Divps
             Divpd
             Divss
@@ -2210,12 +2191,6 @@
 (rule (unary_rm_r_imm_vex op src size imm)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.UnaryRmRImmVex size op src dst imm))))
-        dst))
-
-(decl cvt_int_to_float (SseOpcode Xmm GprMem OperandSize) Xmm)
-(rule (cvt_int_to_float op src1 src2 size)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.CvtIntToFloat op src1 src2 dst size))))
         dst))
 
 (decl cvt_int_to_float_vex (AvxOpcode Xmm GprMem OperandSize) Xmm)
@@ -4825,79 +4800,77 @@
 ;;
 ;; NB: see `x64_sqrtss` for why this has two args (same reasoning, different op)
 (decl x64_cvtss2sd (Xmm XmmMem) Xmm)
-(rule (x64_cvtss2sd x y) (xmm_rm_r_unaligned (SseOpcode.Cvtss2sd) x y))
 (rule 1 (x64_cvtss2sd x y)
         (if-let true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vcvtss2sd) x y))
+(rule 0 (x64_cvtss2sd x y) (x64_cvtss2sd_a x y))
 
 ;; Helper for creating `cvtsd2ss` instructions.
 ;;
 ;; NB: see `x64_sqrtss` for why this has two args (same reasoning, different op)
 (decl x64_cvtsd2ss (Xmm XmmMem) Xmm)
-(rule (x64_cvtsd2ss x y) (xmm_rm_r_unaligned (SseOpcode.Cvtsd2ss) x y))
 (rule 1 (x64_cvtsd2ss x y)
         (if-let true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vcvtsd2ss) x y))
+(rule 0 (x64_cvtsd2ss x y) (x64_cvtsd2ss_a x y))
 
 ;; Helper for creating `cvtdq2ps` instructions.
 (decl x64_cvtdq2ps (XmmMem) Xmm)
-(rule (x64_cvtdq2ps x) (xmm_unary_rm_r (SseOpcode.Cvtdq2ps) x))
 (rule 1 (x64_cvtdq2ps x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtdq2ps) x))
+(rule (x64_cvtdq2ps x) (x64_cvtdq2ps_a x))
 
 ;; Helper for creating `cvtps2pd` instructions.
 (decl x64_cvtps2pd (XmmMem) Xmm)
-(rule (x64_cvtps2pd x) (xmm_unary_rm_r (SseOpcode.Cvtps2pd) x))
 (rule 1 (x64_cvtps2pd x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtps2pd) x))
+(rule 0 (x64_cvtps2pd x) (x64_cvtps2pd_a x))
 
 ;; Helper for creating `cvtpd2ps` instructions.
 (decl x64_cvtpd2ps (XmmMem) Xmm)
-(rule (x64_cvtpd2ps x) (xmm_unary_rm_r (SseOpcode.Cvtpd2ps) x))
 (rule 1 (x64_cvtpd2ps x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtpd2ps) x))
+(rule 0 (x64_cvtpd2ps x) (x64_cvtpd2ps_a x))
 
 ;; Helper for creating `cvtdq2pd` instructions.
 (decl x64_cvtdq2pd (XmmMem) Xmm)
-(rule (x64_cvtdq2pd x) (xmm_unary_rm_r (SseOpcode.Cvtdq2pd) x))
 (rule 1 (x64_cvtdq2pd x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtdq2pd) x))
+(rule 0 (x64_cvtdq2pd x) (x64_cvtdq2pd_a x))
 
 ;; Helper for creating `cvtsi2ss` instructions.
 (decl x64_cvtsi2ss (Type Xmm GprMem) Xmm)
-(rule (x64_cvtsi2ss ty x y)
-      (cvt_int_to_float (SseOpcode.Cvtsi2ss) x y (raw_operand_size_of_type ty)))
-(rule 1 (x64_cvtsi2ss ty x y)
+(rule 2 (x64_cvtsi2ss ty x y)
         (if-let true (use_avx))
         (cvt_int_to_float_vex (AvxOpcode.Vcvtsi2ss) x y (raw_operand_size_of_type ty)))
+(rule 1 (x64_cvtsi2ss $I32 x y) (x64_cvtsi2ssl_a x y))
+(rule 0 (x64_cvtsi2ss $I64 x y) (x64_cvtsi2ssq_a x y))
 
 ;; Helper for creating `cvtsi2sd` instructions.
 (decl x64_cvtsi2sd (Type Xmm GprMem) Xmm)
-(rule (x64_cvtsi2sd ty x y)
-      (cvt_int_to_float (SseOpcode.Cvtsi2sd) x y (raw_operand_size_of_type ty)))
-(rule 1 (x64_cvtsi2sd ty x y)
+(rule 2 (x64_cvtsi2sd ty x y)
         (if-let true (use_avx))
         (cvt_int_to_float_vex (AvxOpcode.Vcvtsi2sd) x y (raw_operand_size_of_type ty)))
+(rule 1 (x64_cvtsi2sd $I32 x y) (x64_cvtsi2sdl_a x y))
+(rule 0 (x64_cvtsi2sd $I64 x y) (x64_cvtsi2sdq_a x y))
 
 ;; Helper for creating `cvttps2dq` instructions.
 (decl x64_cvttps2dq (XmmMem) Xmm)
-(rule (x64_cvttps2dq x)
-      (xmm_unary_rm_r (SseOpcode.Cvttps2dq) x))
 (rule 1 (x64_cvttps2dq x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvttps2dq) x))
+(rule 0 (x64_cvttps2dq x) (x64_cvttps2dq_a x))
 
 ;; Helper for creating `cvttpd2dq` instructions.
 (decl x64_cvttpd2dq (XmmMem) Xmm)
-(rule (x64_cvttpd2dq x)
-      (xmm_unary_rm_r (SseOpcode.Cvttpd2dq) x))
 (rule 1 (x64_cvttpd2dq x)
         (if-let true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvttpd2dq) x))
+(rule 0 (x64_cvttpd2dq x) (x64_cvttpd2dq_a x))
 
 ;; Helpers for creating `pcmpeq*` instructions.
 (decl x64_pcmpeq (Type Xmm XmmMem) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -949,20 +949,6 @@ pub enum SseOpcode {
     Cmppd,
     Cmpss,
     Cmpsd,
-    Cvtdq2ps,
-    Cvtdq2pd,
-    Cvtpd2ps,
-    Cvtps2pd,
-    Cvtsd2ss,
-    Cvtsd2si,
-    Cvtsi2ss,
-    Cvtsi2sd,
-    Cvtss2si,
-    Cvtss2sd,
-    Cvttpd2dq,
-    Cvttps2dq,
-    Cvttss2si,
-    Cvttsd2si,
     Divps,
     Divpd,
     Divss,
@@ -1094,9 +1080,6 @@ impl SseOpcode {
             SseOpcode::Comiss
             | SseOpcode::Cmpps
             | SseOpcode::Cmpss
-            | SseOpcode::Cvtsi2ss
-            | SseOpcode::Cvtss2si
-            | SseOpcode::Cvttss2si
             | SseOpcode::Divps
             | SseOpcode::Divss
             | SseOpcode::Maxps
@@ -1122,17 +1105,6 @@ impl SseOpcode {
             SseOpcode::Cmppd
             | SseOpcode::Cmpsd
             | SseOpcode::Comisd
-            | SseOpcode::Cvtdq2ps
-            | SseOpcode::Cvtdq2pd
-            | SseOpcode::Cvtpd2ps
-            | SseOpcode::Cvtps2pd
-            | SseOpcode::Cvtsd2ss
-            | SseOpcode::Cvtsd2si
-            | SseOpcode::Cvtsi2sd
-            | SseOpcode::Cvtss2sd
-            | SseOpcode::Cvttpd2dq
-            | SseOpcode::Cvttps2dq
-            | SseOpcode::Cvttsd2si
             | SseOpcode::Divpd
             | SseOpcode::Divsd
             | SseOpcode::Maxpd
@@ -1281,20 +1253,6 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Cmpsd => "cmpsd",
             SseOpcode::Comiss => "comiss",
             SseOpcode::Comisd => "comisd",
-            SseOpcode::Cvtdq2ps => "cvtdq2ps",
-            SseOpcode::Cvtdq2pd => "cvtdq2pd",
-            SseOpcode::Cvtpd2ps => "cvtpd2ps",
-            SseOpcode::Cvtps2pd => "cvtps2pd",
-            SseOpcode::Cvtsd2ss => "cvtsd2ss",
-            SseOpcode::Cvtsd2si => "cvtsd2si",
-            SseOpcode::Cvtsi2ss => "cvtsi2ss",
-            SseOpcode::Cvtsi2sd => "cvtsi2sd",
-            SseOpcode::Cvtss2si => "cvtss2si",
-            SseOpcode::Cvtss2sd => "cvtss2sd",
-            SseOpcode::Cvttpd2dq => "cvttpd2dq",
-            SseOpcode::Cvttps2dq => "cvttps2dq",
-            SseOpcode::Cvttss2si => "cvttss2si",
-            SseOpcode::Cvttsd2si => "cvttsd2si",
             SseOpcode::Divps => "divps",
             SseOpcode::Divpd => "divpd",
             SseOpcode::Divss => "divss",

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3399,23 +3399,6 @@ fn test_x64_emit() {
 
     // ========================================================
     // XMM_RM_R: Integer Conversion
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvtdq2ps, RegMem::reg(xmm1), w_xmm8),
-        "440F5BC1",
-        "cvtdq2ps %xmm1, %xmm8",
-    ));
-
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvttpd2dq, RegMem::reg(xmm15), w_xmm7),
-        "66410FE6FF",
-        "cvttpd2dq %xmm15, %xmm7",
-    ));
-
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvttps2dq, RegMem::reg(xmm9), w_xmm8),
-        "F3450F5BC1",
-        "cvttps2dq %xmm9, %xmm8",
-    ));
 
     // XMM_Mov_R_M: float stores
     insns.push((
@@ -3549,17 +3532,6 @@ fn test_x64_emit() {
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvtss2sd, RegMem::reg(xmm0), w_xmm1),
-        "F30F5AC8",
-        "cvtss2sd %xmm1, %xmm0, %xmm1",
-    ));
-    insns.push((
-        Inst::xmm_rm_r(SseOpcode::Cvtsd2ss, RegMem::reg(xmm1), w_xmm0),
-        "F20F5AC1",
-        "cvtsd2ss %xmm0, %xmm1, %xmm0",
-    ));
-
-    insns.push((
         Inst::xmm_unary_rm_r(SseOpcode::Pabsb, RegMem::reg(xmm2), w_xmm1),
         "660F381CCA",
         "pabsb   %xmm2, %xmm1",
@@ -3573,12 +3545,6 @@ fn test_x64_emit() {
         Inst::xmm_unary_rm_r(SseOpcode::Pabsd, RegMem::reg(xmm10), w_xmm11),
         "66450F381EDA",
         "pabsd   %xmm10, %xmm11",
-    ));
-
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvtdq2pd, RegMem::reg(xmm2), w_xmm8),
-        "F3440FE6C2",
-        "cvtdq2pd %xmm2, %xmm8",
     ));
 
     insns.push((
@@ -3599,18 +3565,6 @@ fn test_x64_emit() {
         "vpopcntb %xmm2, %xmm8",
     ));
 
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvtpd2ps, RegMem::reg(xmm7), w_xmm7),
-        "660F5AFF",
-        "cvtpd2ps %xmm7, %xmm7",
-    ));
-
-    insns.push((
-        Inst::xmm_unary_rm_r(SseOpcode::Cvtps2pd, RegMem::reg(xmm11), w_xmm9),
-        "450F5ACB",
-        "cvtps2pd %xmm11, %xmm9",
-    ));
-
     // Xmm to int conversions, and conversely.
 
     insns.push((
@@ -3622,26 +3576,6 @@ fn test_x64_emit() {
         Inst::xmm_to_gpr(SseOpcode::Movq, xmm2, w_rdi, OperandSize::Size64),
         "66480F7ED7",
         "movq    %xmm2, %rdi",
-    ));
-    insns.push((
-        Inst::xmm_to_gpr(SseOpcode::Cvttss2si, xmm0, w_rsi, OperandSize::Size32),
-        "F30F2CF0",
-        "cvttss2si %xmm0, %esi",
-    ));
-    insns.push((
-        Inst::xmm_to_gpr(SseOpcode::Cvttss2si, xmm0, w_rdi, OperandSize::Size64),
-        "F3480F2CF8",
-        "cvttss2si %xmm0, %rdi",
-    ));
-    insns.push((
-        Inst::xmm_to_gpr(SseOpcode::Cvttsd2si, xmm0, w_rax, OperandSize::Size32),
-        "F20F2CC0",
-        "cvttsd2si %xmm0, %eax",
-    ));
-    insns.push((
-        Inst::xmm_to_gpr(SseOpcode::Cvttsd2si, xmm0, w_r15, OperandSize::Size64),
-        "F24C0F2CF8",
-        "cvttsd2si %xmm0, %r15",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -90,6 +90,14 @@ impl From<Writable<Reg>> for asm::Gpr<PairedGpr> {
     }
 }
 
+impl From<Writable<Reg>> for asm::Gpr<WritableGpr> {
+    fn from(wgpr: Writable<Reg>) -> Self {
+        assert!(wgpr.to_reg().class() == RegClass::Int);
+        let wgpr = WritableGpr::from_writable_reg(wgpr).unwrap();
+        Self::new(wgpr)
+    }
+}
+
 // For Winch ergonomics.
 impl From<PairedGpr> for asm::Gpr<PairedGpr> {
     fn from(pair: PairedGpr) -> Self {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -164,8 +164,7 @@ impl Inst {
             | Inst::XmmToGprImm { op, .. }
             | Inst::XmmUnaryRmRImm { op, .. }
             | Inst::XmmUnaryRmRUnaligned { op, .. }
-            | Inst::XmmUnaryRmR { op, .. }
-            | Inst::CvtIntToFloat { op, .. } => smallvec![op.available_from()],
+            | Inst::XmmUnaryRmR { op, .. } => smallvec![op.available_from()],
 
             Inst::XmmUnaryRmREvex { op, .. }
             | Inst::XmmRmREvex { op, .. }
@@ -364,6 +363,7 @@ impl Inst {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn xmm_to_gpr(
         op: SseOpcode,
         src: Reg,
@@ -1272,20 +1272,6 @@ impl PrettyPrint for Inst {
                 let src2 = src2.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src2}, {src1}")
-            }
-
-            Inst::CvtIntToFloat {
-                op,
-                src1,
-                src2,
-                dst,
-                src2_size,
-            } => {
-                let src1 = pretty_print_reg(src1.to_reg(), 8);
-                let dst = pretty_print_reg(*dst.to_reg(), 8);
-                let src2 = src2.pretty_print(src2_size.to_bytes());
-                let op = ljustify(op.to_string());
-                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::CvtIntToFloatVex {
@@ -2254,13 +2240,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         Inst::GprToXmm { src, dst, .. } | Inst::GprToXmmVex { src, dst, .. } => {
             collector.reg_def(dst);
             src.get_operands(collector);
-        }
-        Inst::CvtIntToFloat {
-            src1, src2, dst, ..
-        } => {
-            collector.reg_use(src1);
-            collector.reg_reuse_def(dst, 0);
-            src2.get_operands(collector);
         }
         Inst::CvtIntToFloatVex {
             src1, src2, dst, ..

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -597,8 +597,7 @@ pub(crate) fn check(
             undefined_result(ctx, vcode, dst, 64, 64)
         }
 
-        Inst::CvtIntToFloat { dst, ref src2, .. }
-        | Inst::CvtIntToFloatVex { dst, ref src2, .. } => {
+        Inst::CvtIntToFloatVex { dst, ref src2, .. } => {
             match <&RegMem>::from(src2) {
                 RegMem::Mem { addr } => {
                     check_load(ctx, None, addr, vcode, I64, 64)?;

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -242,7 +242,7 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm3
 ;   xorpd %xmm3, %xmm3
-;   cvtsi2sd %xmm3, %rcx, %xmm3
+;   cvtsi2sdq %rcx, %xmm3
 ;   movq    %rcx, 32(%rsp)
 ;   movq    %rcx, 40(%rsp)
 ;   load_ext_name %g+0, %r11

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movsbl  %dil, %r9d
-;   cvtsi2ss %xmm0, %r9d, %xmm0
+;   cvtsi2ssl %r9d, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -44,7 +44,7 @@ block0(v0: i16):
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movswl  %di, %r9d
-;   cvtsi2ss %xmm0, %r9d, %xmm0
+;   cvtsi2ssl %r9d, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -73,7 +73,7 @@ block0(v0: i32):
 ; block0:
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
-;   cvtsi2ss %xmm0, %edi, %xmm0
+;   cvtsi2ssl %edi, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -101,7 +101,7 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
-;   cvtsi2ss %xmm0, %rdi, %xmm0
+;   cvtsi2ssq %rdi, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -130,7 +130,7 @@ block0(v0: i8):
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
 ;   movsbl  %dil, %r9d
-;   cvtsi2sd %xmm0, %r9d, %xmm0
+;   cvtsi2sdl %r9d, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -160,7 +160,7 @@ block0(v0: i16):
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
 ;   movswl  %di, %r9d
-;   cvtsi2sd %xmm0, %r9d, %xmm0
+;   cvtsi2sdl %r9d, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -189,7 +189,7 @@ block0(v0: i32):
 ; block0:
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
-;   cvtsi2sd %xmm0, %edi, %xmm0
+;   cvtsi2sdl %edi, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -217,7 +217,7 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
-;   cvtsi2sd %xmm0, %rdi, %xmm0
+;   cvtsi2sdq %rdi, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -278,15 +278,15 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movzbq  %dil, %r8
-;   cvtsi2ss %xmm0, %r8, %xmm0
+;   cvtsi2ssq %r8, %xmm0
 ;   uninit  %xmm6
 ;   xorps %xmm6, %xmm6
 ;   movzwq  %si, %r8
-;   cvtsi2ss %xmm6, %r8, %xmm6
+;   cvtsi2ssq %r8, %xmm6
 ;   uninit  %xmm7
 ;   xorps %xmm7, %xmm7
 ;   movl    %edx, %r8d
-;   cvtsi2ss %xmm7, %r8, %xmm7
+;   cvtsi2ssq %r8, %xmm7
 ;   u64_to_f32_seq %rcx, %xmm4, %r8, %rdx
 ;   addss %xmm6, %xmm0
 ;   addss %xmm7, %xmm0
@@ -1211,10 +1211,10 @@ block0(v0: i64x2):
 ;   movdqa  %xmm0, %xmm6
 ;   movq    %xmm6, %r9
 ;   movdqa  %xmm1, %xmm0
-;   cvtsi2sd %xmm0, %r9, %xmm0
+;   cvtsi2sdq %r9, %xmm0
 ;   pshufd  $238, %xmm6, %xmm2
 ;   movq    %xmm2, %rcx
-;   cvtsi2sd %xmm1, %rcx, %xmm1
+;   cvtsi2sdq %rcx, %xmm1
 ;   unpcklpd %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
 ;   movdqa  %xmm5, %xmm7
-;   cvtss2sd %xmm0, %xmm7, %xmm0
+;   cvtss2sd %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -53,7 +53,7 @@ block0(v1: i64, v2: f32):
 ;   movss   %xmm0, 0(%r8)
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
-;   cvtss2sd %xmm0, 0(%r8), %xmm0
+;   cvtss2sd (%r8), %xmm0
 ;   addq $0x10, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -88,7 +88,7 @@ block0(v0: f64):
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movdqa  %xmm5, %xmm7
-;   cvtsd2ss %xmm0, %xmm7, %xmm0
+;   cvtsd2ss %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -126,7 +126,7 @@ block0(v1: i64, v2: f64):
 ;   movsd   %xmm0, 0(%r8)
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
-;   cvtsd2ss %xmm0, 0(%r8), %xmm0
+;   cvtsd2ss (%r8), %xmm0
 ;   addq $0x10, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
x86 CPUs have a set of conversions of the form: `cvt{from}2{to}`, where `from` and `to` can be various XMM-held types (e.g., `ss`, `ps, `si`, etc.). These also have their truncating versions, `cvtt*`. This change defines all of the instructions Cranelift needs (there are a few more) and wires them up in ISLE and in various emitted sequences. For these sequences, this chooses to factor out the choice of instruction into a closure since we no longer can pass around an opcode.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
