### PR TITLE
Add a `--generate-dwarf` flag to the `wast` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.7.0",
@@ -4790,6 +4790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8edac03c5fa691551531533928443faf3dc61a44f814a235c7ec5d17b7b34f1"
 dependencies = [
  "bumpalo",
+ "gimli",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime', 'gc', 'async'] }
-wast = { workspace = true }
+wast = { workspace = true, features = ['dwarf'] }
 log = { workspace = true }
 tokio = { workspace = true, features = ['rt'] }
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use std::str;
 use std::thread;
 use wasmtime::*;
+use wast::core::{EncodeOptions, GenerateDwarf};
 use wast::lexer::Lexer;
 use wast::parser::{self, ParseBuffer};
 use wast::{QuoteWat, Wast, WastArg, WastDirective, WastExecute, WastInvoke, WastRet, Wat};
@@ -24,6 +25,7 @@ pub struct WastContext<T: 'static> {
     component_linker: component::Linker<T>,
     pub(crate) store: Store<T>,
     pub(crate) async_runtime: Option<tokio::runtime::Runtime>,
+    generate_dwarf: bool,
 }
 
 enum Outcome<T = Results> {
@@ -118,6 +120,7 @@ where
             } else {
                 None
             },
+            generate_dwarf: true,
         }
     }
 
@@ -187,11 +190,16 @@ where
     }
 
     /// Perform the action portion of a command.
-    fn perform_execute(&mut self, exec: WastExecute<'_>) -> Result<Outcome> {
+    fn perform_execute(
+        &mut self,
+        exec: WastExecute<'_>,
+        filename: &str,
+        wast: &str,
+    ) -> Result<Outcome> {
         match exec {
             WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
-            WastExecute::Wat(module) => {
-                Ok(match self.module_definition(QuoteWat::Wat(module))? {
+            WastExecute::Wat(module) => Ok(
+                match self.module_definition(QuoteWat::Wat(module), filename, wast)? {
                     (_, ModuleKind::Core(module)) => self
                         .instantiate_module(&module)?
                         .map(|_| Results::Core(Vec::new())),
@@ -199,8 +207,8 @@ where
                     (_, ModuleKind::Component(component)) => self
                         .instantiate_component(&component)?
                         .map(|_| Results::Component(Vec::new())),
-                })
-            }
+                },
+            ),
             WastExecute::Get { module, global, .. } => self.get(module.map(|s| s.name()), global),
         }
     }
@@ -325,6 +333,8 @@ where
     fn module_definition<'a>(
         &mut self,
         mut wat: QuoteWat<'a>,
+        filename: &str,
+        wast: &str,
     ) -> Result<(Option<&'a str>, ModuleKind)> {
         let (is_module, name) = match &wat {
             QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
@@ -332,7 +342,16 @@ where
             QuoteWat::Wat(Wat::Component(m)) => (false, m.id),
             QuoteWat::QuoteComponent(..) => (false, None),
         };
-        let bytes = wat.encode()?;
+        let bytes = match &mut wat {
+            QuoteWat::Wat(wat) => {
+                let mut opts = EncodeOptions::new();
+                if self.generate_dwarf {
+                    opts.dwarf(filename.as_ref(), wast, GenerateDwarf::Lines);
+                }
+                opts.encode_wat(wat)?
+            }
+            _ => wat.encode()?,
+        };
         if is_module {
             let module = Module::new(self.store.engine(), &bytes)?;
             Ok((name.map(|n| n.name()), ModuleKind::Core(module)))
@@ -451,7 +470,8 @@ where
 
         let mut lexer = Lexer::new(wast);
         lexer.allow_confusing_unicode(filename.ends_with("names.wast"));
-        let buf = ParseBuffer::new_with_lexer(lexer).map_err(adjust_wast)?;
+        let mut buf = ParseBuffer::new_with_lexer(lexer).map_err(adjust_wast)?;
+        buf.track_instr_spans(self.generate_dwarf);
         let ast = parser::parse::<Wast>(&buf).map_err(adjust_wast)?;
 
         self.run_directives(ast.directives, filename, wast)
@@ -506,11 +526,11 @@ where
 
         match directive {
             Module(module) => {
-                let (name, module) = self.module_definition(module)?;
+                let (name, module) = self.module_definition(module, filename, wast)?;
                 self.module(name, &module)?;
             }
             ModuleDefinition(module) => {
-                let (name, module) = self.module_definition(module)?;
+                let (name, module) = self.module_definition(module, filename, wast)?;
                 if let Some(name) = name {
                     self.modules.insert(name.to_string(), module.clone());
                 }
@@ -541,7 +561,7 @@ where
                 exec,
                 results,
             } => {
-                let result = self.perform_execute(exec)?;
+                let result = self.perform_execute(exec, filename, wast)?;
                 self.assert_return(result, &results)?;
             }
             AssertTrap {
@@ -549,7 +569,7 @@ where
                 exec,
                 message,
             } => {
-                let result = self.perform_execute(exec)?;
+                let result = self.perform_execute(exec, filename, wast)?;
                 self.assert_trap(result, message)?;
             }
             AssertExhaustion {
@@ -565,7 +585,7 @@ where
                 module,
                 message,
             } => {
-                let err = match self.module_definition(module) {
+                let err = match self.module_definition(module, filename, wast) {
                     Ok(_) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
@@ -583,7 +603,7 @@ where
                 span: _,
                 message: _,
             } => {
-                if let Ok(_) = self.module_definition(module) {
+                if let Ok(_) = self.module_definition(module, filename, wast) {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
@@ -592,7 +612,8 @@ where
                 module,
                 message,
             } => {
-                let (name, module) = self.module_definition(QuoteWat::Wat(module))?;
+                let (name, module) =
+                    self.module_definition(QuoteWat::Wat(module), filename, wast)?;
                 let err = match self.module(name, &module) {
                     Ok(_) => bail!("expected module to fail to link"),
                     Err(e) => e,
@@ -632,6 +653,7 @@ where
                             .build()
                             .unwrap()
                     }),
+                    generate_dwarf: self.generate_dwarf,
                 };
                 let name = thread.name.name();
                 let child =
@@ -661,6 +683,13 @@ where
         let bytes =
             std::fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))?;
         self.run_buffer(path.to_str().unwrap(), &bytes)
+    }
+
+    /// Whether or not to generate DWARF debugging information in custom
+    /// sections in modules being tested.
+    pub fn generate_dwarf(&mut self, enable: bool) -> &mut Self {
+        self.generate_dwarf = enable;
+        self
     }
 }
 

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -16,6 +16,11 @@ pub struct WastCommand {
     /// The path of the WebAssembly test script to run
     #[arg(required = true, value_name = "SCRIPT_FILE")]
     scripts: Vec<PathBuf>,
+
+    /// Whether or not to generate DWARF debugging information in text-to-binary
+    /// transformations to show line numbers in backtraces.
+    #[arg(long, require_equals = true, value_name = "true|false")]
+    generate_dwarf: Option<Option<bool>>,
 }
 
 impl WastCommand {
@@ -35,6 +40,7 @@ impl WastCommand {
         }
         let mut wast_context = WastContext::new(store, wasmtime_wast::Async::Yes);
 
+        wast_context.generate_dwarf(optional_flag_with_default(self.generate_dwarf, true));
         wast_context
             .register_spectest(&SpectestConfig {
                 use_shared_memory: true,
@@ -49,5 +55,13 @@ impl WastCommand {
         }
 
         Ok(())
+    }
+}
+
+fn optional_flag_with_default(flag: Option<Option<bool>>, default: bool) -> bool {
+    match flag {
+        None => default,
+        Some(None) => true,
+        Some(Some(val)) => val,
     }
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2012,6 +2012,12 @@ criteria = "safe-to-deploy"
 delta = "0.29.0 -> 0.31.0"
 notes = "Various updates here and there, nothing too major, what you'd expect from a DWARF parsing crate."
 
+[[audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.31.0 -> 0.31.1"
+notes = "No fundmanetally new `unsafe` code, some small refactoring of existing code. Lots of changes in tests, not as many changes in the rest of the crate. More dwarf!"
+
 [[audits.glob]]
 who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -316,10 +316,6 @@ criteria = "safe-to-deploy"
 version = "0.2.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.gimli]]
-version = "0.26.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.h2]]
 version = "0.4.4"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2507,6 +2507,23 @@ documentation.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.gimli]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.30.0"
+notes = """
+Unsafe code blocks are sound. Minimal dependencies used. No use of
+side-effectful std functions.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.gimli]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.30.0 -> 0.29.0"
+notes = "No unsafe code, mostly algorithms and parsing. Very unlikely to cause security issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.half]]
 who = "John M. Schanck <jschanck@mozilla.com>"
 criteria = "safe-to-deploy"

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -242,6 +242,7 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
         let result = engine.and_then(|engine| {
             let store = Store::new(&engine, ());
             let mut wast_context = WastContext::new(store, Async::Yes);
+            wast_context.generate_dwarf(true);
             wast_context.register_spectest(&SpectestConfig {
                 use_shared_memory: true,
                 suppress_prints: true,


### PR DESCRIPTION
This commit adds support for the `wast` subcommand to generate DWARF debugging information for the text-to-binary translation that happens. This leans on the support within the `wast` crate already and enables more easily seeing where a trap is happening during development of tests due to the fact that line numbers are available as opposed to just having binary offsets with a stack trace.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
