### PR TITLE
winch: Fine-tune assertions for branch emission

### DIFF
--- a/tests/misc_testsuite/winch/issue-10751.wast
+++ b/tests/misc_testsuite/winch/issue-10751.wast
@@ -1,0 +1,35 @@
+(module
+  (type (;0;) (func (result i32 i32)))
+  (func (;0;) (export "main") (type 0) (result i32 i32)
+    loop (result i32) ;; label = @1
+      i32.const 0
+      i32.const 1
+      i32.const 0
+      i32.const 1
+      br_if 1
+      br_if 0 (;@1;)
+      block (result i32) ;; label = @2
+        call 0
+        drop
+        loop (type 0) (result i32 i32) ;; label = @3
+          i32.const 0
+          i32.const 1
+          block (type 0) (result i32 i32) ;; label = @4
+            call 0
+            i32.const 0
+            br_table 0 (;@4;) 4
+          end
+          drop
+          drop
+        end
+        drop
+        drop
+      end
+      drop
+      drop
+    end
+    i32.const 0
+  )
+)
+
+(assert_return (invoke "main") (i32.const 1) (i32.const 0))


### PR DESCRIPTION
This commit is a follow-up to
https://github.com/bytecodealliance/wasmtime/pull/10730 and closes https://github.com/bytecodealliance/wasmtime/issues/10751.

In https://github.com/bytecodealliance/wasmtime/issues/10751, I forgot to update the branch emission heuristic checks.

Typically, branch-emitting code, such as br, will handle the results in the maybe_pop_results callback. In this case, we can safely assert that the stack pointer should be greater than or equal to the target base stack pointer offset before calling the callback. However, for certain cases, like `br_table`, result handling must occur before invoking `CodeContext::br`, which can lead to assertion failures.

To maintain the invariant check while accommodating both scenarios, this commit moves the assertion to occur after the callback is invoked.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
