### PR TITLE
Update MSRV to 1.85.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2025-04-03" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2025-05-16" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.84.0"
+rust-version = "1.85.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -114,7 +114,7 @@ impl TestFileCompiler {
             unsafe extern "C" {
                 safe fn cosf(f: f32) -> f32;
             }
-            let f = 1.2_f32;
+            let f = std::hint::black_box(1.2_f32);
             assert_eq!(f.cos(), cosf(f));
         }
 

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -757,7 +757,7 @@ impl AsyncCx {
     /// which represents that the asynchronous computation was cancelled. It is
     /// not recommended to catch the trap and try to keep executing wasm, so
     /// we've tried to liberally document this.
-    pub unsafe fn block_on<F>(&self, mut future: F) -> Result<F::Output>
+    pub unsafe fn block_on<F>(&self, future: F) -> Result<F::Output>
     where
         F: Future + Send,
     {


### PR DESCRIPTION
This makes us eligible to update to the 2024 Rust edition but I'm planning on deferring that to a separate follow-up change.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
