### PR TITLE
[24.0.x]: Migrate run-tests.sh to Python 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -678,10 +678,15 @@ jobs:
           echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (\`cargo run --example mpk-available\`)."
         fi
 
-    # Build and test all features
-    - run: ./ci/run-tests.sh --locked ${{ matrix.bucket }}
-      env:
-        RUST_BACKTRACE: 1
+    # Build and test all features.
+    #
+    # Note that this uses a different shell, notably not `bash` on Windows. In
+    # the past `bash` would add more items to `PATH` on Windows which would
+    # interfere and cause the `gcc.exe` executable to fail and exit with 1 and
+    # no output. It's believed that `bash` adds things like `/usr/bin` to PATH
+    # which is the wrong DLL or something like that.
+    - run: python3 ./ci/run-tests.py --locked ${{ matrix.bucket }}
+      shell: pwsh
 
     # NB: the test job here is explicitly lacking in cancellation of this run if
     # something goes wrong. These take the longest anyway and otherwise if

--- a/ci/run-tests.py
+++ b/ci/run-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
 # Excludes:
 #
@@ -13,11 +13,15 @@
 # - wasm-spec-interpreter: brings in OCaml which is a pain to configure for all
 #   targets, tested as part of the wastime-fuzzing CI job.
 
-cargo test \
-      --workspace \
-      --all-features \
-      --exclude test-programs \
-      --exclude wasmtime-wasi-nn \
-      --exclude wasmtime-fuzzing \
-      --exclude wasm-spec-interpreter \
-      $@
+import subprocess
+import sys
+
+args = ['cargo', 'test', '--workspace', '--all-features']
+args.append('--exclude=test-programs')
+args.append('--exclude=wasmtime-wasi-nn')
+args.append('--exclude=wasmtime-fuzzing')
+args.append('--exclude=wasm-spec-interpreter')
+args.extend(sys.argv[1:])
+
+result = subprocess.run(args)
+sys.exit(result.returncode)


### PR DESCRIPTION
Backport of #10790 to the 24.0.x release branch