### PR TITLE
[31.0.x]: Migrate run-tests.sh to Python 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -794,8 +794,15 @@ jobs:
       if: matrix.filter == 'linux-x64' && contains(matrix.bucket, 'wasmtime-cli')
       uses: abrown/install-vtune-action@v1
 
-    # Build and test all features
-    - run: ./ci/run-tests.sh --locked ${{ matrix.bucket }}
+    # Build and test all features.
+    #
+    # Note that this uses a different shell, notably not `bash` on Windows. In
+    # the past `bash` would add more items to `PATH` on Windows which would
+    # interfere and cause the `gcc.exe` executable to fail and exit with 1 and
+    # no output. It's believed that `bash` adds things like `/usr/bin` to PATH
+    # which is the wrong DLL or something like that.
+    - run: python3 ./ci/run-tests.py --locked ${{ matrix.bucket }}
+      shell: pwsh
 
     # common logic to cancel the entire run if this job fails
     - uses: ./.github/actions/cancel-on-failure

--- a/ci/run-tests.py
+++ b/ci/run-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
 # Excludes:
 #
@@ -15,12 +15,16 @@
 #
 # - veri_engine: requires an SMT solver (z3)
 
-cargo test \
-      --workspace \
-      --all-features \
-      --exclude test-programs \
-      --exclude wasmtime-wasi-nn \
-      --exclude wasmtime-fuzzing \
-      --exclude wasm-spec-interpreter \
-      --exclude veri_engine \
-      $@
+import subprocess
+import sys
+
+args = ['cargo', 'test', '--workspace', '--all-features']
+args.append('--exclude=test-programs')
+args.append('--exclude=wasmtime-wasi-nn')
+args.append('--exclude=wasmtime-fuzzing')
+args.append('--exclude=wasm-spec-interpreter')
+args.append('--exclude=veri_engine')
+args.extend(sys.argv[1:])
+
+result = subprocess.run(args)
+sys.exit(result.returncode)


### PR DESCRIPTION
Backport #10790 to the 31.0.x branch