### PR TITLE
Duplicate page size determination in `wasmtime-fiber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "libc",
  "rustix 1.0.3",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ http = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["mm", "param", "process"] }
+rustix = { workspace = true, features = ["mm", "process"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
@@ -132,6 +132,9 @@ cranelift-native = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+rustix = { workspace = true, features = ["param"] }
 
 [build-dependencies]
 anyhow = { workspace = true, features = ['std'] }

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -18,7 +18,8 @@ wasmtime-versioned-export-macros = { workspace = true }
 wasmtime-asm-macros = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["mm", "param"] }
+rustix = { workspace = true, features = ["mm"] }
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -36,6 +36,7 @@ use std::cell::Cell;
 use std::io;
 use std::ops::Range;
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub type Error = io::Error;
 
@@ -59,8 +60,26 @@ enum FiberStackStorage {
     Custom(Box<dyn RuntimeFiberStack>),
 }
 
+// FIXME: this is a duplicate copy of what's already in the `wasmtime` crate. If
+// this changes that should change over there, and ideally one day we should
+// probably deduplicate the two.
+fn host_page_size() -> usize {
+    static PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
+
+    return match PAGE_SIZE.load(Ordering::Relaxed) {
+        0 => {
+            let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE).try_into().unwrap() };
+            assert!(size != 0);
+            PAGE_SIZE.store(size, Ordering::Relaxed);
+            size
+        }
+        n => n,
+    };
+}
+
 impl FiberStack {
     pub fn new(size: usize, zeroed: bool) -> io::Result<Self> {
+        let page_size = host_page_size();
         // The anonymous `mmap`s we use for `FiberStackStorage` are alawys
         // zeroed.
         let _ = zeroed;
@@ -70,7 +89,6 @@ impl FiberStack {
         if cfg!(asan) {
             return Self::from_custom(asan::new_fiber_stack(size)?);
         }
-        let page_size = rustix::param::page_size();
         let stack = MmapFiberStack::new(size)?;
 
         // An `MmapFiberStack` allocates a guard page at the bottom of the
@@ -102,7 +120,7 @@ impl FiberStack {
 
     pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
         let range = custom.range();
-        let page_size = rustix::param::page_size();
+        let page_size = host_page_size();
         let start_ptr = range.start as *mut u8;
         assert!(
             start_ptr.align_offset(page_size) == 0,
@@ -153,7 +171,7 @@ impl MmapFiberStack {
     fn new(size: usize) -> io::Result<Self> {
         // Round up our stack size request to the nearest multiple of the
         // page size.
-        let page_size = rustix::param::page_size();
+        let page_size = host_page_size();
         let size = if size == 0 {
             page_size
         } else {
@@ -306,10 +324,9 @@ impl Suspend {
 /// called around every stack switch with some other fiddly bits as well.
 #[cfg(asan)]
 mod asan {
-    use super::{FiberStack, MmapFiberStack, RuntimeFiberStack};
+    use super::{FiberStack, MmapFiberStack, RuntimeFiberStack, host_page_size};
     use alloc::boxed::Box;
     use alloc::vec::Vec;
-    use rustix::param::page_size;
     use std::mem::ManuallyDrop;
     use std::ops::Range;
     use std::sync::Mutex;
@@ -426,7 +443,8 @@ mod asan {
     static FIBER_STACKS: Mutex<Vec<MmapFiberStack>> = Mutex::new(Vec::new());
 
     pub fn new_fiber_stack(size: usize) -> std::io::Result<Box<dyn RuntimeFiberStack>> {
-        let needed_size = size + page_size();
+        let page_size = host_page_size();
+        let needed_size = size + page_size;
         let mut stacks = FIBER_STACKS.lock().unwrap();
 
         let stack = match stacks.iter().position(|i| needed_size <= i.mapping_len) {
@@ -436,7 +454,9 @@ mod asan {
             // ... otherwise allocate a brand new stack.
             None => MmapFiberStack::new(size)?,
         };
-        let stack = AsanFiberStack(ManuallyDrop::new(stack));
+        let stack = AsanFiberStack {
+            mmap: ManuallyDrop::new(stack),
+        };
         Ok(Box::new(stack))
     }
 
@@ -445,27 +465,31 @@ mod asan {
     ///
     /// On drop this stack will return the interior stack to the global
     /// `FIBER_STACKS` list.
-    struct AsanFiberStack(ManuallyDrop<MmapFiberStack>);
+    struct AsanFiberStack {
+        mmap: ManuallyDrop<MmapFiberStack>,
+    }
 
     unsafe impl RuntimeFiberStack for AsanFiberStack {
         fn top(&self) -> *mut u8 {
-            self.0.mapping_base.wrapping_byte_add(self.0.mapping_len)
+            self.mmap
+                .mapping_base
+                .wrapping_byte_add(self.mmap.mapping_len)
         }
 
         fn range(&self) -> Range<usize> {
-            let base = self.0.mapping_base as usize;
-            let end = base + self.0.mapping_len;
-            base + page_size()..end
+            let base = self.mmap.mapping_base as usize;
+            let end = base + self.mmap.mapping_len;
+            base + host_page_size()..end
         }
 
         fn guard_range(&self) -> Range<*mut u8> {
-            self.0.mapping_base..self.0.mapping_base.wrapping_add(page_size())
+            self.mmap.mapping_base..self.mmap.mapping_base.wrapping_add(host_page_size())
         }
     }
 
     impl Drop for AsanFiberStack {
         fn drop(&mut self) {
-            let stack = unsafe { ManuallyDrop::take(&mut self.0) };
+            let stack = unsafe { ManuallyDrop::take(&mut self.mmap) };
             FIBER_STACKS.lock().unwrap().push(stack);
         }
     }

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -23,7 +23,7 @@ object = { workspace = true, optional = true }
 wasmtime-versioned-export-macros = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { workspace = true, features = ["mm", "param", "time"], optional = true }
+rustix = { workspace = true, features = ["mm", "time"], optional = true }
 
 [features]
 gdb_jit_int = []

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -449,6 +449,8 @@ impl ModuleRuntimeInfo {
 /// Returns the host OS page size, in bytes.
 #[cfg(has_virtual_memory)]
 pub fn host_page_size() -> usize {
+    // NB: this function is duplicated in `crates/fiber/src/unix.rs` so if this
+    // changes that should probably get updated as well.
     static PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
 
     return match PAGE_SIZE.load(Ordering::Relaxed) {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(asan), allow(dead_code))]
 
+use crate::PoolConcurrencyLimitError;
 use crate::prelude::*;
-use crate::{PoolConcurrencyLimitError, runtime::vm::PoolingInstanceAllocatorConfig};
+use crate::runtime::vm::PoolingInstanceAllocatorConfig;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A generic implementation of a stack pool.

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -66,6 +66,8 @@ pub unsafe fn decommit_pages(addr: *mut u8, len: usize) -> io::Result<()> {
     Ok(())
 }
 
+// NB: this function is duplicated in `crates/fiber/src/unix.rs` so if this
+// changes that should probably get updated as well.
 pub fn get_page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE).try_into().unwrap() }
 }


### PR DESCRIPTION
Currently Wasmtime has a function `crate::runtime::vm::host_page_size`
but this isn't reachable from the `wasmtime-fiber` crate and instead tha
crate uses `rustix::param::page_size` to determine the host page size.
It looks like this usage of `rustix` is causing a panic in https://github.com/bytecodealliance/wasmtime/issues/10802.
Ideally `wasmtime-fiber` would be able to use the same function but the
crate separation does not currently make that feasible. For now
duplicate the logic of `wasmtime` into `wasmtime-fiber` as it's modest
enough to ensure that this does not panic.

Closes https://github.com/bytecodealliance/wasmtime/issues/10802