### PR TITLE
Use `Waker::noop` from Rust 1.85

### DIFF
--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU64;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 use std::{ptr, str};
 use wasmtime::{
     AsContextMut, Func, Instance, Result, RootScope, StackCreator, StackMemory, Trap, Val,
@@ -199,8 +199,11 @@ pub extern "C" fn wasmtime_call_future_delete(_future: Box<wasmtime_call_future_
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_call_future_poll(future: &mut wasmtime_call_future_t) -> bool {
-    let w = futures::task::noop_waker_ref();
-    match future.underlying.as_mut().poll(&mut Context::from_waker(w)) {
+    match future
+        .underlying
+        .as_mut()
+        .poll(&mut Context::from_waker(Waker::noop()))
+    {
         Poll::Ready(()) => true,
         Poll::Pending => false,
     }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -29,7 +29,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use std::sync::{Arc, Condvar, Mutex};
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 use wasmtime::*;
 use wasmtime_wast::WastContext;
@@ -1320,7 +1320,7 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
 
     fn run<F: Future>(future: F) -> F::Output {
         let mut f = Box::pin(future);
-        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+        let mut cx = Context::from_waker(Waker::noop());
         loop {
             match f.as_mut().poll(&mut cx) {
                 Poll::Ready(val) => break val,

--- a/crates/wasi-tls/src/lib.rs
+++ b/crates/wasi-tls/src/lib.rs
@@ -676,6 +676,7 @@ fn try_lock_for_stream<TlsWriter>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::task::Waker;
     use tokio::sync::oneshot;
 
     #[tokio::test]
@@ -689,7 +690,7 @@ mod tests {
 
         let mut fut = future_streams.ready();
 
-        let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+        let mut cx = std::task::Context::from_waker(Waker::noop());
         assert!(fut.as_mut().poll(&mut cx).is_pending());
 
         //cancel the readiness check

--- a/crates/wasi/src/p2/tcp.rs
+++ b/crates/wasi/src/p2/tcp.rs
@@ -18,7 +18,7 @@ use std::mem;
 use std::net::{Shutdown, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Poll;
+use std::task::{Poll, Waker};
 use tokio::sync::Mutex;
 
 /// The state of a TCP socket.
@@ -265,7 +265,7 @@ impl TcpSocket {
         let result = match previous_state {
             TcpState::ConnectReady(result) => result,
             TcpState::Connecting(mut future) => {
-                let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+                let mut cx = std::task::Context::from_waker(Waker::noop());
                 match with_ambient_tokio_runtime(|| future.as_mut().poll(&mut cx)) {
                     Poll::Ready(result) => result,
                     Poll::Pending => {
@@ -369,7 +369,7 @@ impl TcpSocket {
         let result = match pending_accept.take() {
             Some(result) => result,
             None => {
-                let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+                let mut cx = std::task::Context::from_waker(Waker::noop());
                 match with_ambient_tokio_runtime(|| listener.poll_accept(&mut cx))
                     .map_ok(|(stream, _)| stream)
                 {

--- a/crates/wasi/src/runtime.rs
+++ b/crates/wasi/src/runtime.rs
@@ -22,7 +22,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::LazyLock;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
 pub(crate) static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
@@ -181,7 +181,7 @@ pub fn poll_noop<F>(future: Pin<&mut F>) -> Option<F::Output>
 where
     F: Future,
 {
-    let mut task = Context::from_waker(futures::task::noop_waker_ref());
+    let mut task = Context::from_waker(Waker::noop());
     match future.poll(&mut task) {
         Poll::Ready(result) => Some(result),
         Poll::Pending => None,

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::task::{Context, Poll, Waker};
 use wasmtime::*;
 
 fn async_store() -> Store<()> {
@@ -206,7 +206,7 @@ async fn suspend_while_suspending() {
             let mut future = Box::pin(async_thunk.call_async(&mut caller, &[], &mut []));
             let poll = future
                 .as_mut()
-                .poll(&mut Context::from_waker(&noop_waker()));
+                .poll(&mut Context::from_waker(Waker::noop()));
             assert!(poll.is_ready());
             Ok(())
         });
@@ -593,7 +593,7 @@ async fn resume_separate_thread3() {
         let mut future = Box::pin(f);
         let poll = future
             .as_mut()
-            .poll(&mut Context::from_waker(&noop_waker()));
+            .poll(&mut Context::from_waker(Waker::noop()));
         assert!(poll.is_pending());
 
         // ... so at this point our call into wasm is suspended. The call into
@@ -778,13 +778,6 @@ where
             Poll::Ready(val) => Poll::Ready(Ok(val)),
         }
     }
-}
-
-fn noop_waker() -> Waker {
-    const VTABLE: RawWakerVTable =
-        RawWakerVTable::new(|ptr| RawWaker::new(ptr, &VTABLE), |_| {}, |_| {}, |_| {});
-    const RAW: RawWaker = RawWaker::new(0 as *const (), &VTABLE);
-    unsafe { Waker::from_raw(RAW) }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Now possible after #10785

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
