### PR TITLE
chore: fix typos

### DIFF
--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -49,7 +49,7 @@ impl<R: AsReg> Amode<R> {
         }
     }
 
-    /// Emit the ModR/M, SIB, and displacement suffixes as neeeded for this
+    /// Emit the ModR/M, SIB, and displacement suffixes as needed for this
     /// `Amode`.
     pub(crate) fn encode_rex_suffixes(
         &self,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -969,7 +969,7 @@ pub enum Trampoline {
     /// An intrinisic used by FACT-generated modules to (partially or entirely) transfer
     /// ownership of a `future`.
     ///
-    /// Transfering a `future` can either mean giving away the readable end
+    /// Transferring a `future` can either mean giving away the readable end
     /// while retaining the writable end or only the former, depending on the
     /// ownership status of the `future`.
     FutureTransfer,
@@ -977,7 +977,7 @@ pub enum Trampoline {
     /// An intrinisic used by FACT-generated modules to (partially or entirely) transfer
     /// ownership of a `stream`.
     ///
-    /// Transfering a `stream` can either mean giving away the readable end
+    /// Transferring a `stream` can either mean giving away the readable end
     /// while retaining the writable end or only the former, depending on the
     /// ownership status of the `stream`.
     StreamTransfer,

--- a/crates/environ/src/obj.rs
+++ b/crates/environ/src/obj.rs
@@ -65,7 +65,7 @@ pub const ELF_WASMTIME_ADDRMAP: &str = ".wasmtime.addrmap";
 /// maps).
 ///
 /// This section has a custom binary encoding described in `stack_maps.rs` which
-/// is used to implement the single query we want to satisy of: where are the
+/// is used to implement the single query we want to satisfy of: where are the
 /// live GC references at this pc? Like the addrmap section this has an
 /// alignment of 1 with unaligned reads, and it additionally doesn't support
 /// >=4gb text sections.

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -2003,7 +2003,7 @@ impl Memory {
         }
     }
 
-    /// Returs whether or not the base pointer of this memory is allowed to be
+    /// Returns whether or not the base pointer of this memory is allowed to be
     /// relocated at runtime.
     ///
     /// When this function returns `false` then it means that after the initial


### PR DESCRIPTION
## Description

This pull request fixes several typos in documentation comments across the codebase:

- Fixed `neeeded` to `needed` in `cranelift/assembler-x64/src/mem.rs`
- Fixed `Transfering` to `Transferring` in `crates/environ/src/component/info.rs`
- Fixed `satisy` to `satisfy` in `crates/environ/src/obj.rs`
- Fixed `Returs` to `Returns` in `crates/environ/src/types.rs`

These changes improve the clarity and professionalism of the documentation.

---

## Motivation

Correcting typos helps maintain code quality and ensures that documentation is clear and professional for all contributors and users.

---

## Related Issues

N/A

---

## Checklist

- [x] All changes are documentation/comment only
- [x] No functional code was modified
- [x] Follows the [Wasmtime development process](https://docs.wasmtime.dev/contributing-development-process.html)
- [x] All communication follows the [code of conduct](https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md)