### PR TITLE
Add plumbing for `error-context` component model feature

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -372,6 +372,9 @@ wasmtime_option_group! {
         /// Component model support for async lifting/lowering: this corresponds
         /// to the 🚟 emoji in the component model specification.
         pub component_model_async_stackful: Option<bool>,
+        /// Component model support for `error-context`: this corresponds
+        /// to the 📝 emoji in the component model specification.
+        pub component_model_error_context: Option<bool>,
         /// Configure support for the function-references proposal.
         pub function_references: Option<bool>,
         /// Configure support for the GC proposal.
@@ -1015,6 +1018,7 @@ impl CommonOptions {
             ("component-model-async", component_model_async, wasm_component_model_async)
             ("component-model-async", component_model_async_builtins, wasm_component_model_async_builtins)
             ("component-model-async", component_model_async_stackful, wasm_component_model_async_stackful)
+            ("component-model", component_model_error_context, wasm_component_model_error_context)
             ("threads", threads, wasm_threads)
             ("gc", gc, wasm_gc)
             ("gc", reference_types, wasm_reference_types)

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -142,6 +142,7 @@ impl Config {
             component_model_async,
             component_model_async_builtins,
             component_model_async_stackful,
+            component_model_error_context,
             simd,
             exceptions,
             legacy_exceptions,
@@ -160,6 +161,8 @@ impl Config {
             component_model_async_builtins.unwrap_or(false);
         self.module_config.component_model_async_stackful =
             component_model_async_stackful.unwrap_or(false);
+        self.module_config.component_model_error_context =
+            component_model_error_context.unwrap_or(false);
         self.module_config.legacy_exceptions = legacy_exceptions.unwrap_or(false);
 
         // Enable/disable proposals that wasm-smith has knobs for which will be
@@ -285,6 +288,8 @@ impl Config {
             Some(self.module_config.component_model_async_builtins);
         cfg.wasm.component_model_async_stackful =
             Some(self.module_config.component_model_async_stackful);
+        cfg.wasm.component_model_error_context =
+            Some(self.module_config.component_model_error_context);
         cfg.wasm.custom_page_sizes = Some(self.module_config.config.custom_page_sizes_enabled);
         cfg.wasm.epoch_interruption = Some(self.wasmtime.epoch_interruption);
         cfg.wasm.extended_const = Some(self.module_config.config.extended_const_enabled);

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -19,6 +19,7 @@ pub struct ModuleConfig {
     pub component_model_async: bool,
     pub component_model_async_builtins: bool,
     pub component_model_async_stackful: bool,
+    pub component_model_error_context: bool,
     pub legacy_exceptions: bool,
 }
 
@@ -68,6 +69,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
             component_model_async: false,
             component_model_async_builtins: false,
             component_model_async_stackful: false,
+            component_model_error_context: false,
             legacy_exceptions: false,
             function_references_enabled: config.gc_enabled,
             config,

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -40,6 +40,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         component_model_async,
         component_model_async_builtins,
         component_model_async_stackful,
+        component_model_error_context,
         nan_canonicalization,
         simd,
         exceptions,
@@ -63,6 +64,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let component_model_async = component_model_async.unwrap_or(false);
     let component_model_async_builtins = component_model_async_builtins.unwrap_or(false);
     let component_model_async_stackful = component_model_async_stackful.unwrap_or(false);
+    let component_model_error_context = component_model_error_context.unwrap_or(false);
     let nan_canonicalization = nan_canonicalization.unwrap_or(false);
     let relaxed_simd = relaxed_simd.unwrap_or(false);
     let exceptions = exceptions.unwrap_or(false);
@@ -94,6 +96,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         .wasm_component_model_async(component_model_async)
         .wasm_component_model_async_builtins(component_model_async_builtins)
         .wasm_component_model_async_stackful(component_model_async_stackful)
+        .wasm_component_model_error_context(component_model_error_context)
         .wasm_exceptions(exceptions)
         .cranelift_nan_canonicalization(nan_canonicalization);
     #[expect(deprecated, reason = "forwarding legacy-exceptions")]

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -243,6 +243,7 @@ macro_rules! foreach_config_option {
             component_model_async
             component_model_async_builtins
             component_model_async_stackful
+            component_model_error_context
             simd
             gc_types
             exceptions

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1159,6 +1159,18 @@ impl Config {
         self
     }
 
+    /// This corresponds to the 📝 emoji in the component model specification.
+    ///
+    /// Please note that Wasmtime's support for this feature is _very_
+    /// incomplete.
+    ///
+    /// [proposal]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Async.md
+    #[cfg(feature = "component-model")]
+    pub fn wasm_component_model_error_context(&mut self, enable: bool) -> &mut Self {
+        self.wasm_feature(WasmFeatures::CM_ERROR_CONTEXT, enable);
+        self
+    }
+
     #[doc(hidden)] // FIXME(#3427) - if/when implemented then un-hide this
     pub fn wasm_exceptions(&mut self, enable: bool) -> &mut Self {
         self.wasm_feature(WasmFeatures::EXCEPTIONS, enable);


### PR DESCRIPTION
This commit adds plumbing in locations for the `error-context` feature of the component model. This is porting some minor changes from the wasip3-prototyping repository back to the main repo.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
