### PR TITLE
x64: Migrate "UnaryRmR" instructions to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -66,6 +66,9 @@ pub enum Feature {
     sse2,
     ssse3,
     sse41,
+    bmi1,
+    lzcnt,
+    popcnt,
 }
 
 /// List all CPU features.
@@ -82,18 +85,14 @@ pub const ALL_FEATURES: &[Feature] = &[
     Feature::sse2,
     Feature::ssse3,
     Feature::sse41,
+    Feature::bmi1,
+    Feature::lzcnt,
+    Feature::popcnt,
 ];
 
 impl fmt::Display for Feature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Feature::_64b => write!(f, "_64b"),
-            Feature::compat => write!(f, "compat"),
-            Feature::sse => write!(f, "sse"),
-            Feature::sse2 => write!(f, "sse2"),
-            Feature::ssse3 => write!(f, "ssse3"),
-            Feature::sse41 => write!(f, "sse41"),
-        }
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -2,6 +2,7 @@
 
 mod add;
 mod and;
+mod bitmanip;
 mod cvt;
 mod mul;
 mod neg;
@@ -17,6 +18,7 @@ pub fn list() -> Vec<Inst> {
     let mut all = vec![];
     all.extend(add::list());
     all.extend(and::list());
+    all.extend(bitmanip::list());
     all.extend(cvt::list());
     all.extend(mul::list());
     all.extend(neg::list());

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -1,0 +1,27 @@
+use crate::dsl::{Feature::*, Inst, Location::*};
+use crate::dsl::{fmt, inst, r, rex, w};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("bsfw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0x0F, 0xBC]).r(), _64b | compat),
+        inst("bsfl", fmt("RM", [w(r32), r(rm32)]), rex([0x0F, 0xBC]).r(), _64b | compat),
+        inst("bsfq", fmt("RM", [w(r64), r(rm64)]), rex([0x0F, 0xBC]).r().w(), _64b),
+
+        inst("bsrw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0x0F, 0xBD]).r(), _64b | compat),
+        inst("bsrl", fmt("RM", [w(r32), r(rm32)]), rex([0x0F, 0xBD]).r(), _64b | compat),
+        inst("bsrq", fmt("RM", [w(r64), r(rm64)]), rex([0x0F, 0xBD]).r().w(), _64b),
+
+        inst("tzcntw", fmt("A", [w(r16), r(rm16)]), rex([0x66, 0xF3, 0x0F, 0xBC]).r(), _64b | compat | bmi1),
+        inst("tzcntl", fmt("A", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xBC]).r(), _64b | compat | bmi1),
+        inst("tzcntq", fmt("A", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xBC]).r().w(), _64b | bmi1),
+
+        inst("lzcntw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0xF3, 0x0F, 0xBD]).r(), _64b | compat | lzcnt),
+        inst("lzcntl", fmt("RM", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xBD]).r(), _64b | compat | lzcnt),
+        inst("lzcntq", fmt("RM", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xBD]).r().w(), _64b | lzcnt),
+
+        inst("popcntw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
+        inst("popcntl", fmt("RM", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
+        inst("popcntq", fmt("RM", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xB8]).r().w(), _64b | popcnt),
+    ]
+}

--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -46,6 +46,12 @@ impl<R: AsReg> AsMut<R> for Gpr<R> {
     }
 }
 
+impl<R: AsReg> From<R> for Gpr<R> {
+    fn from(reg: R) -> Gpr<R> {
+        Gpr(reg)
+    }
+}
+
 /// A single x64 register encoding can access a different number of bits.
 #[derive(Copy, Clone, Debug)]
 pub enum Size {
@@ -93,6 +99,12 @@ impl<R: AsReg> NonRspGpr<R> {
 impl<R: AsReg> AsMut<R> for NonRspGpr<R> {
     fn as_mut(&mut self) -> &mut R {
         &mut self.0
+    }
+}
+
+impl<R: AsReg> From<R> for NonRspGpr<R> {
+    fn from(reg: R) -> NonRspGpr<R> {
+        NonRspGpr(reg)
     }
 }
 

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -300,6 +300,18 @@ impl<R: AsReg, M: AsReg> GprMem<R, M> {
     }
 }
 
+impl<R: AsReg, M: AsReg> From<R> for GprMem<R, M> {
+    fn from(reg: R) -> GprMem<R, M> {
+        GprMem::Gpr(reg)
+    }
+}
+
+impl<R: AsReg, M: AsReg> From<Amode<M>> for GprMem<R, M> {
+    fn from(amode: Amode<M>) -> GprMem<R, M> {
+        GprMem::Mem(amode)
+    }
+}
+
 /// An XMM register or memory operand.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
@@ -346,6 +358,18 @@ impl<R: AsReg, M: AsReg> XmmMem<R, M> {
                 amode.encode_rex_suffixes(sink, offsets, enc_reg, bytes_at_end);
             }
         }
+    }
+}
+
+impl<R: AsReg, M: AsReg> From<R> for XmmMem<R, M> {
+    fn from(reg: R) -> XmmMem<R, M> {
+        XmmMem::Xmm(reg)
+    }
+}
+
+impl<R: AsReg, M: AsReg> From<Amode<M>> for XmmMem<R, M> {
+    fn from(amode: Amode<M>) -> XmmMem<R, M> {
+        XmmMem::Mem(amode)
     }
 }
 

--- a/cranelift/assembler-x64/src/xmm.rs
+++ b/cranelift/assembler-x64/src/xmm.rs
@@ -47,6 +47,12 @@ impl<R: AsReg> AsMut<R> for Xmm<R> {
     }
 }
 
+impl<R: AsReg> From<R> for Xmm<R> {
+    fn from(reg: R) -> Xmm<R> {
+        Xmm(reg)
+    }
+}
+
 /// Encode xmm registers.
 pub mod enc {
     pub const XMM0: u8 = 0;

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -22,13 +22,6 @@
                   (src2 GprMem)
                   (dst WritableGpr))
 
-       ;; Instructions on general-purpose registers that only read src and
-       ;; defines dst (dst is not modified). `bsr`, etc.
-       (UnaryRmR (size OperandSize) ;; 2, 4, or 8
-                 (op UnaryRmROpcode)
-                 (src GprMem)
-                 (dst WritableGpr))
-
        ;; Same as `UnaryRmR` but with the VEX prefix for BMI1 instructions.
        (UnaryRmRVex (size OperandSize)
                     (op UnaryRmRVexOpcode)
@@ -2141,13 +2134,6 @@
 (rule (xmm_rmr_vex3 op src1 src2 src3)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmRVex3 op src1 src2 src3 dst))))
-        dst))
-
-;; Helper for creating `MInst.UnaryRmR` instructions.
-(decl unary_rm_r (UnaryRmROpcode Gpr OperandSize) Gpr)
-(rule (unary_rm_r op src size)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.UnaryRmR size op src dst))))
         dst))
 
 ;; Helper for creating `MInst.UnaryRmRVex` instructions.
@@ -4502,22 +4488,22 @@
       (SideEffectNoResult.Inst (MInst.Hlt)))
 
 ;; Helper for creating `lzcnt` instructions.
-(decl x64_lzcnt (Type Gpr) Gpr)
-(rule (x64_lzcnt ty src)
-      (unary_rm_r (UnaryRmROpcode.Lzcnt) src (operand_size_of_type_32_64 ty)))
+(decl x64_lzcnt (Type GprMem) Gpr)
+(rule (x64_lzcnt $I16 src) (x64_lzcntw_rm src))
+(rule (x64_lzcnt $I32 src) (x64_lzcntl_rm src))
+(rule (x64_lzcnt $I64 src) (x64_lzcntq_rm src))
 
 ;; Helper for creating `tzcnt` instructions.
-(decl x64_tzcnt (Type Gpr) Gpr)
-(rule (x64_tzcnt ty src)
-      (unary_rm_r (UnaryRmROpcode.Tzcnt) src (operand_size_of_type_32_64 ty)))
+(decl x64_tzcnt (Type GprMem) Gpr)
+(rule (x64_tzcnt $I16 src) (x64_tzcntw_a src))
+(rule (x64_tzcnt $I32 src) (x64_tzcntl_a src))
+(rule (x64_tzcnt $I64 src) (x64_tzcntq_a src))
 
 ;; Helper for creating `bsr` instructions.
-(decl x64_bsr (Type Gpr) ProducesFlags)
-(rule (x64_bsr ty src)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (inst MInst (MInst.UnaryRmR size (UnaryRmROpcode.Bsr) src dst)))
-        (ProducesFlags.ProducesFlagsReturnsReg inst dst)))
+(decl x64_bsr (Type GprMem) ProducesFlags)
+(rule (x64_bsr $I16 src) (asm_produce_flags (x64_bsrw_rm_raw src)))
+(rule (x64_bsr $I32 src) (asm_produce_flags (x64_bsrl_rm_raw src)))
+(rule (x64_bsr $I64 src) (asm_produce_flags (x64_bsrq_rm_raw src)))
 
 ;; Helper for creating `bsr + cmov` instruction pairs that produce the
 ;; result of the `bsr`, or `alt` if the input was zero.
@@ -4532,12 +4518,10 @@
         (with_flags_reg (produces_flags_ignore bsr) cmove)))
 
 ;; Helper for creating `bsf` instructions.
-(decl x64_bsf (Type Gpr) ProducesFlags)
-(rule (x64_bsf ty src)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (inst MInst (MInst.UnaryRmR size (UnaryRmROpcode.Bsf) src dst)))
-        (ProducesFlags.ProducesFlagsReturnsReg inst dst)))
+(decl x64_bsf (Type GprMem) ProducesFlags)
+(rule (x64_bsf $I16 src) (asm_produce_flags (x64_bsfw_rm_raw src)))
+(rule (x64_bsf $I32 src) (asm_produce_flags (x64_bsfl_rm_raw src)))
+(rule (x64_bsf $I64 src) (asm_produce_flags (x64_bsfq_rm_raw src)))
 
 ;; Helper for creating `bsf + cmov` instruction pairs that produce the
 ;; result of the `bsf`, or `alt` if the input was zero.
@@ -4590,9 +4574,10 @@
                           imm))
 
 ;; Helper for creating `popcnt` instructions.
-(decl x64_popcnt (Type Gpr) Gpr)
-(rule (x64_popcnt ty src)
-      (unary_rm_r (UnaryRmROpcode.Popcnt) src (operand_size_of_type_32_64 ty)))
+(decl x64_popcnt (Type GprMem) Gpr)
+(rule (x64_popcnt $I16 src) (x64_popcntw_rm src))
+(rule (x64_popcnt $I32 src) (x64_popcntl_rm src))
+(rule (x64_popcnt $I64 src) (x64_popcntq_rm src))
 
 ;; Helper for creating `minss` instructions.
 (decl x64_minss (Xmm XmmMem) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -824,50 +824,6 @@ impl fmt::Display for AluRmROpcode {
     }
 }
 
-#[derive(Clone, PartialEq)]
-/// Unary operations requiring register or memory and register operands.
-pub enum UnaryRmROpcode {
-    /// Bit-scan reverse.
-    Bsr,
-    /// Bit-scan forward.
-    Bsf,
-    /// Counts leading zeroes (Leading Zero CouNT).
-    Lzcnt,
-    /// Counts trailing zeroes (Trailing Zero CouNT).
-    Tzcnt,
-    /// Counts the number of ones (POPulation CouNT).
-    Popcnt,
-}
-
-impl UnaryRmROpcode {
-    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
-        match self {
-            UnaryRmROpcode::Bsr | UnaryRmROpcode::Bsf => smallvec![],
-            UnaryRmROpcode::Lzcnt => smallvec![InstructionSet::Lzcnt],
-            UnaryRmROpcode::Tzcnt => smallvec![InstructionSet::BMI1],
-            UnaryRmROpcode::Popcnt => smallvec![InstructionSet::Popcnt],
-        }
-    }
-}
-
-impl fmt::Debug for UnaryRmROpcode {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            UnaryRmROpcode::Bsr => write!(fmt, "bsr"),
-            UnaryRmROpcode::Bsf => write!(fmt, "bsf"),
-            UnaryRmROpcode::Lzcnt => write!(fmt, "lzcnt"),
-            UnaryRmROpcode::Tzcnt => write!(fmt, "tzcnt"),
-            UnaryRmROpcode::Popcnt => write!(fmt, "popcnt"),
-        }
-    }
-}
-
-impl fmt::Display for UnaryRmROpcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
 pub use crate::isa::x64::lower::isle::generated_code::UnaryRmRVexOpcode;
 
 impl UnaryRmRVexOpcode {

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1082,30 +1082,6 @@ fn test_x64_emit() {
     //
 
     // ========================================================
-    // UnaryRmR
-
-    insns.push((
-        Inst::unary_rm_r(
-            OperandSize::Size32,
-            UnaryRmROpcode::Bsr,
-            RegMem::reg(rsi),
-            w_rdi,
-        ),
-        "0FBDFE",
-        "bsrl    %esi, %edi",
-    ));
-    insns.push((
-        Inst::unary_rm_r(
-            OperandSize::Size64,
-            UnaryRmROpcode::Bsr,
-            RegMem::reg(r15),
-            w_rax,
-        ),
-        "490FBDC7",
-        "bsrq    %r15, %rax",
-    ));
-
-    // ========================================================
     // Div
     insns.push((
         Inst::div(

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -59,13 +59,6 @@ impl From<Writable<Reg>> for asm::GprMem<PairedGpr, Gpr> {
 }
 
 // For ABI ergonomics.
-impl From<Gpr> for asm::GprMem<Gpr, Gpr> {
-    fn from(gpr: Gpr) -> Self {
-        Self::Gpr(gpr)
-    }
-}
-
-// For ABI ergonomics.
 impl From<Reg> for asm::GprMem<Gpr, Gpr> {
     fn from(gpr: Reg) -> Self {
         assert!(gpr.class() == RegClass::Int);
@@ -95,27 +88,6 @@ impl From<Writable<Reg>> for asm::Gpr<WritableGpr> {
         assert!(wgpr.to_reg().class() == RegClass::Int);
         let wgpr = WritableGpr::from_writable_reg(wgpr).unwrap();
         Self::new(wgpr)
-    }
-}
-
-// For Winch ergonomics.
-impl From<PairedGpr> for asm::Gpr<PairedGpr> {
-    fn from(pair: PairedGpr) -> Self {
-        Self::new(pair)
-    }
-}
-
-// For Winch ergonomics.
-impl From<PairedGpr> for asm::GprMem<PairedGpr, Gpr> {
-    fn from(pair: PairedGpr) -> Self {
-        Self::Gpr(pair)
-    }
-}
-
-// For Winch ergonomics.
-impl From<WritableGpr> for asm::Gpr<WritableGpr> {
-    fn from(gpr: WritableGpr) -> Self {
-        Self::new(gpr)
     }
 }
 
@@ -190,13 +162,6 @@ impl From<Reg> for asm::XmmMem<Xmm, Gpr> {
         assert!(xmm.class() == RegClass::Float);
         let xmm = Xmm::unwrap_new(xmm);
         Self::Xmm(xmm)
-    }
-}
-
-// For Winch ergonomics.
-impl From<PairedXmm> for asm::Xmm<PairedXmm> {
-    fn from(pair: PairedXmm) -> Self {
-        Self::new(pair)
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -77,10 +77,7 @@ pub(crate) fn check(
             RegMem::Reg { .. } => undefined_result(ctx, vcode, dst, 64, size.to_bits().into()),
         },
 
-        Inst::UnaryRmR {
-            size, ref src, dst, ..
-        }
-        | Inst::UnaryRmRVex {
+        Inst::UnaryRmRVex {
             size, ref src, dst, ..
         }
         | Inst::UnaryRmRImmVex {

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -13,8 +13,8 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lzcntq  %rsi, %rcx
-;   lzcntq  %rdi, %rax
+;   lzcntq %rsi, %rcx
+;   lzcntq %rdi, %rax
 ;   addq $0x40, %rax
 ;   cmpq    $64, %rcx
 ;   cmovnzq %rcx, %rax, %rax
@@ -49,7 +49,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lzcntq  %rdi, %rax
+;   lzcntq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -74,7 +74,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lzcntl  %edi, %eax
+;   lzcntl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -100,7 +100,7 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzwq  %di, %rax
-;   lzcntq  %rax, %rax
+;   lzcntq %rax, %rax
 ;   subq $0x30, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -129,7 +129,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %rax
-;   lzcntq  %rax, %rax
+;   lzcntq %rax, %rax
 ;   subq $0x38, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -15,12 +15,12 @@ block0(v0: i128):
 ; block0:
 ;   movq    %rdi, %r8
 ;   movabsq $-1, %rcx
-;   bsrq    %rsi, %r9
+;   bsrq %rsi, %r9
 ;   cmovzq  %rcx, %r9, %r9
 ;   movl    $63, %edi
 ;   subq %r9, %rdi
 ;   movabsq $-1, %rdx
-;   bsrq    %r8, %r10
+;   bsrq %r8, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
 ;   subq %r10, %rax
@@ -68,7 +68,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $-1, %rax
-;   bsrq    %rdi, %r8
+;   bsrq %rdi, %r8
 ;   cmovzq  %rax, %r8, %r8
 ;   movl    $63, %eax
 ;   subq %r8, %rax
@@ -101,7 +101,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $-1, %rax
-;   bsrl    %edi, %r8d
+;   bsrl %edi, %r8d
 ;   cmovzl  %eax, %r8d, %r8d
 ;   movl    $31, %eax
 ;   subl %r8d, %eax
@@ -135,7 +135,7 @@ block0(v0: i16):
 ; block0:
 ;   movzwq  %di, %rax
 ;   movabsq $-1, %rdx
-;   bsrq    %rax, %r10
+;   bsrq %rax, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
 ;   subq %r10, %rax
@@ -172,7 +172,7 @@ block0(v0: i8):
 ; block0:
 ;   movzbq  %dil, %rax
 ;   movabsq $-1, %rdx
-;   bsrq    %rax, %r10
+;   bsrq %rax, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
 ;   subq %r10, %rax

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -13,8 +13,8 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   tzcntq  %rdi, %rax
-;   tzcntq  %rsi, %r9
+;   tzcntq %rdi, %rax
+;   tzcntq %rsi, %r9
 ;   addq $0x40, %r9
 ;   cmpq    $64, %rax
 ;   cmovzq  %r9, %rax, %rax
@@ -49,7 +49,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   tzcntq  %rdi, %rax
+;   tzcntq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -74,7 +74,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   tzcntl  %edi, %eax
+;   tzcntl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -101,7 +101,7 @@ block0(v0: i16):
 ; block0:
 ;   movzwl  %di, %ecx
 ;   orl $0x10000, %ecx
-;   tzcntl  %ecx, %eax
+;   tzcntl %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -130,7 +130,7 @@ block0(v0: i8):
 ; block0:
 ;   movzbl  %dil, %ecx
 ;   orl $0x100, %ecx
-;   tzcntl  %ecx, %eax
+;   tzcntl %ecx, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -14,10 +14,10 @@ block0(v0: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $64, %ecx
-;   bsfq    %rdi, %rax
+;   bsfq %rdi, %rax
 ;   cmovzq  %rcx, %rax, %rax
 ;   movl    $64, %edi
-;   bsfq    %rsi, %rdx
+;   bsfq %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   addq $0x40, %rdx
 ;   cmpq    $64, %rax
@@ -58,7 +58,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $64, %ecx
-;   bsfq    %rdi, %rax
+;   bsfq %rdi, %rax
 ;   cmovzq  %rcx, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -87,7 +87,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $32, %ecx
-;   bsfl    %edi, %eax
+;   bsfl %edi, %eax
 ;   cmovzl  %ecx, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -118,7 +118,7 @@ block0(v0: i16):
 ;   movzwl  %di, %ecx
 ;   orl $0x10000, %ecx
 ;   movl    $16, %r9d
-;   bsfl    %ecx, %eax
+;   bsfl %ecx, %eax
 ;   cmovzl  %r9d, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -151,7 +151,7 @@ block0(v0: i8):
 ;   movzbl  %dil, %ecx
 ;   orl $0x100, %ecx
 ;   movl    $8, %r9d
-;   bsfl    %ecx, %eax
+;   bsfl %ecx, %eax
 ;   cmovzl  %r9d, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1342,12 +1342,12 @@ block0(v0: i128):
 ; block0:
 ;   movq    %rdi, %r8
 ;   movabsq $-1, %rcx
-;   bsrq    %rsi, %r9
+;   bsrq %rsi, %r9
 ;   cmovzq  %rcx, %r9, %r9
 ;   movl    $63, %edi
 ;   subq %r9, %rdi
 ;   movabsq $-1, %rdx
-;   bsrq    %r8, %r10
+;   bsrq %r8, %r10
 ;   cmovzq  %rdx, %r10, %r10
 ;   movl    $63, %eax
 ;   subq %r10, %rax
@@ -1395,10 +1395,10 @@ block0(v0: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $64, %ecx
-;   bsfq    %rdi, %rax
+;   bsfq %rdi, %rax
 ;   cmovzq  %rcx, %rax, %rax
 ;   movl    $64, %edi
-;   bsfq    %rsi, %rdx
+;   bsfq %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   addq $0x40, %rdx
 ;   cmpq    $64, %rax

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1006,7 +1006,7 @@ impl Masm for MacroAssembler {
     fn popcnt(&mut self, context: &mut CodeGenContext<Emission>, size: OperandSize) -> Result<()> {
         let src = context.pop_to_reg(self, None)?;
         if self.flags.has_popcnt() && self.flags.has_sse42() {
-            self.asm.popcnt(src.into(), size);
+            self.asm.popcnt(src.into(), writable!(src.into()), size);
             context.stack.push(src.into());
             Ok(())
         } else {


### PR DESCRIPTION
This includes `bsr`, `bsf`, `tzcnt`, `popcnt`, and `lzcnt`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
