### PR TITLE
Make debugtrap generate `brk #0xf000` on aarch64 so debuggers recognize it

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2966,7 +2966,7 @@
 (rule (csdb)
       (SideEffectNoResult.Inst (MInst.Csdb)))
 
-;; Helper for generating `brk` instructions.
+;; Helper for generating `brk` instructions, hinted as being debug traps.
 (decl brk () SideEffectNoResult)
 (rule (brk)
       (SideEffectNoResult.Inst (MInst.Brk)))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3119,7 +3119,7 @@ impl MachInstEmit for Inst {
                 sink.put4(0xd503201f);
             }
             &Inst::Brk => {
-                sink.put4(0xd4200000);
+                sink.put4(0xd43e0000);
             }
             &Inst::Udf { trap_code } => {
                 sink.add_trap(trap_code);

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6082,7 +6082,7 @@ fn test_aarch64_binemit() {
         "br x3",
     ));
 
-    insns.push((Inst::Brk, "000020D4", "brk #0"));
+    insns.push((Inst::Brk, "00003ED4", "brk #0xf000"));
 
     insns.push((
         Inst::Adr {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2680,7 +2680,7 @@ impl Inst {
                 let rn = pretty_print_reg(rn);
                 format!("br {rn}")
             }
-            &Inst::Brk => "brk #0".to_string(),
+            &Inst::Brk => "brk #0xf000".to_string(),
             &Inst::Udf { .. } => "udf #0xc11f".to_string(),
             &Inst::TrapIf {
                 ref kind,


### PR DESCRIPTION
Debuggers treat `brk #0xf000` as a software breakpoint, so that they
know to skip over it when attempting to resume.

Fixes: https://github.com/bytecodealliance/wasmtime/issues/9726
