### PR TITLE
x64: Migrate `SignExtendData` to new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -94,7 +94,7 @@ impl dsl::Format {
         let bits = "w_bit, uses_8bit";
 
         match self.operands_by_kind().as_slice() {
-            [FixedReg(dst), Imm(_)] => {
+            [FixedReg(dst), FixedReg(_)] | [FixedReg(dst)] | [FixedReg(dst), Imm(_)] => {
                 // TODO: don't emit REX byte here.
                 assert_eq!(rex.digit, None);
                 fmtln!(f, "let digit = 0;");
@@ -148,7 +148,7 @@ impl dsl::Format {
         }
 
         match self.operands_by_kind().as_slice() {
-            [FixedReg(_), Imm(_)] => {
+            [FixedReg(_)] | [FixedReg(_), FixedReg(_)] | [FixedReg(_), Imm(_)] => {
                 // No need to emit a ModRM byte: we know the register used.
             }
             [Reg(reg), Imm(_)] => {

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -24,7 +24,7 @@ pub fn list() -> Vec<Inst> {
         inst("popcntl", fmt("RM", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
         inst("popcntq", fmt("RM", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xB8]).r().w(), _64b | popcnt),
 
-        // Note that the intel manual calls has different names for these
+        // Note that the Intel manual calls has different names for these
         // instructions than Capstone gives them:
         //
         // * cbtw => cbw

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -1,5 +1,5 @@
 use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex, w};
+use crate::dsl::{fmt, implicit, inst, r, rex, rw, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -23,5 +23,21 @@ pub fn list() -> Vec<Inst> {
         inst("popcntw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
         inst("popcntl", fmt("RM", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
         inst("popcntq", fmt("RM", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xB8]).r().w(), _64b | popcnt),
+
+        // Note that the intel manual calls has different names for these
+        // instructions than Capstone gives them:
+        //
+        // * cbtw => cbw
+        // * cwtl => cwde
+        // * cltq => cwqe
+        // * cwtd => cwd
+        // * cltd => cdq
+        // * cqto => cqo
+        inst("cbtw", fmt("ZO", [rw(implicit(ax))]), rex([0x66, 0x98]), _64b | compat),
+        inst("cwtl", fmt("ZO", [rw(implicit(eax))]), rex([0x98]), _64b | compat),
+        inst("cltq", fmt("ZO", [rw(implicit(rax))]), rex([0x98]).w(), _64b),
+        inst("cwtd", fmt("ZO", [w(implicit(dx)), r(implicit(ax))]), rex([0x66, 0x99]), _64b | compat),
+        inst("cltd", fmt("ZO", [w(implicit(edx)), r(implicit(eax))]), rex([0x99]), _64b | compat),
+        inst("cqto", fmt("ZO", [w(implicit(rdx)), r(implicit(rax))]), rex([0x99]).w(), _64b),
     ]
 }

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -27,7 +27,7 @@ pub fn roundtrip(inst: &Inst<FuzzRegs>) {
     // off the instruction offset first.
     let expected = expected.split_once(' ').unwrap().1;
     let actual = inst.to_string();
-    if expected != actual && expected != fix_up(&actual) {
+    if expected != actual && expected.trim() != fix_up(&actual) {
         println!("> {inst}");
         println!("  debug: {inst:x?}");
         println!("  assembled: {}", pretty_print_hexadecimal(&assembled));

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -89,12 +89,6 @@
                         (divisor Gpr)
                         (dst WritableGpr))
 
-       ;; Do a sign-extend based on the sign of the value in rax into rdx: (cwd
-       ;; cdq cqo) or al into ah: (cbw)
-       (SignExtendData (size OperandSize) ;; 1, 2, 4, or 8
-                       (src Gpr)
-                       (dst WritableGpr))
-
        ;; Constant materialization: (imm32 imm64) reg.
        ;;
        ;; Either: movl $imm32, %reg32 or movabsq $imm64, %reg32.
@@ -5532,13 +5526,6 @@
 (decl x64_div_remainder (Gpr Gpr GprMem OperandSize DivSignedness TrapCode) ValueRegs)
 (rule (x64_div_remainder dividend_lo dividend_hi divisor size sign trap)
       (value_regs_get (x64_div dividend_lo dividend_hi divisor size sign trap) 1))
-
-;; Helper for creating `SignExtendData` instructions
-(decl x64_sign_extend_data (Gpr OperandSize) Gpr)
-(rule (x64_sign_extend_data src size)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.SignExtendData size src dst))))
-        dst))
 
 ;;;; Pinned Register ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -369,32 +369,6 @@ pub(crate) fn emit(
                 .encode(sink);
         }
 
-        Inst::SignExtendData { size, src, dst } => {
-            let src = src.to_reg();
-            let dst = dst.to_reg().to_reg();
-            debug_assert_eq!(src, regs::rax());
-            if *size == OperandSize::Size8 {
-                debug_assert_eq!(dst, regs::rax());
-            } else {
-                debug_assert_eq!(dst, regs::rdx());
-            }
-            match size {
-                OperandSize::Size8 => {
-                    sink.put1(0x66);
-                    sink.put1(0x98);
-                }
-                OperandSize::Size16 => {
-                    sink.put1(0x66);
-                    sink.put1(0x99);
-                }
-                OperandSize::Size32 => sink.put1(0x99),
-                OperandSize::Size64 => {
-                    sink.put1(0x48);
-                    sink.put1(0x99);
-                }
-            }
-        }
-
         Inst::CheckedSRemSeq { divisor, .. } | Inst::CheckedSRemSeq8 { divisor, .. } => {
             let divisor = divisor.to_reg();
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4409,22 +4409,30 @@
 ;; Rules for `sdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 2 (lower (sdiv a @ (value_type $I8) b))
-        (x64_div8 (x64_sign_extend_data a (OperandSize.Size8))
+        (x64_div8 (x64_cbtw_zo a)
                   (nonzero_sdiv_divisor $I8 b)
                   (DivSignedness.Signed)
                   (TrapCode.INTEGER_OVERFLOW)))
 
 (rule 1 (lower (sdiv a @ (value_type (fits_in_64 ty)) b))
-        (let (
-            (a Gpr a)
-            (size OperandSize (raw_operand_size_of_type ty))
-          )
+        (let ((a Gpr a))
         (x64_div_quotient a
-                          (x64_sign_extend_data a size)
+                          (repeat_sign_bit ty a)
                           (nonzero_sdiv_divisor ty b)
-                          size
+                          (raw_operand_size_of_type ty)
                           (DivSignedness.Signed)
                           (TrapCode.INTEGER_OVERFLOW))))
+
+;; Repeats the sign bit in the provided gpr, which will register-allocate to
+;; %rax, into a destination gpr which will register-allocate to %rdx.
+;;
+;; This is intended to be used before x64 `div` instructions where
+;; left-hand-side (divisor? dividend? I always forget) is double-wide and
+;; present across the rax/rdx registers (sized to the operation in question).
+(decl repeat_sign_bit (Type Gpr) Gpr)
+(rule (repeat_sign_bit $I16 src) (x64_cwtd_zo src))
+(rule (repeat_sign_bit $I32 src) (x64_cltd_zo src))
+(rule (repeat_sign_bit $I64 src) (x64_cqto_zo src))
 
 ;; Checks to make sure that the input `Value` is a non-zero value for `sdiv`.
 ;;
@@ -4474,7 +4482,7 @@
 (rule 3 (lower (srem a @ (value_type $I8) (iconst imm)))
         (if-let n (safe_divisor_from_imm64 $I8 imm))
         (let (
-            (a Gpr (x64_sign_extend_data a (OperandSize.Size8)))
+            (a Gpr (x64_cbtw_zo a))
             (result Gpr (x64_div8 a (imm $I8 n) (DivSignedness.Signed) (TrapCode.INTEGER_DIVISION_BY_ZERO)))
           )
           (x64_shr $I64 result (Imm8Reg.Imm8 8))))
@@ -4487,23 +4495,20 @@
             (size OperandSize (raw_operand_size_of_type ty))
           )
           (x64_div_remainder a
-                             (x64_sign_extend_data a size)
+                             (repeat_sign_bit ty a)
                              (imm ty n)
                              size
                              (DivSignedness.Signed)
                              (TrapCode.INTEGER_DIVISION_BY_ZERO))))
 
 (rule 1 (lower (srem a @ (value_type $I8) b))
-        (let (
-            (a Gpr (x64_sign_extend_data a (OperandSize.Size8)))
-          )
-          (x64_shr $I64 (x64_checked_srem_seq8 a b) (Imm8Reg.Imm8 8))))
+  (x64_shr $I64 (x64_checked_srem_seq8 (x64_cbtw_zo a) b) (Imm8Reg.Imm8 8)))
 
 (rule (lower (srem a @ (value_type ty) b))
       (let (
           (a Gpr a)
           (size OperandSize (raw_operand_size_of_type ty))
-          (hi Gpr (x64_sign_extend_data a size))
+          (hi Gpr (repeat_sign_bit ty a))
           (tmp ValueRegs (x64_checked_srem_seq size a hi b))
         )
         (value_regs_get tmp 1)))

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -152,8 +152,6 @@ pub(crate) fn check(
 
         Inst::CheckedSRemSeq8 { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
 
-        Inst::SignExtendData { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
-
         Inst::Imm { simm64, dst, .. } => {
             check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
                 Ok(Some(Fact::constant(64, simm64)))

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cbw %al, %al
+;   cbtw  ;; implicit: %ax
 ;   checked_srem_seq %al, %sil, %al
 ;   shrq    $8, %rax, %rax
 ;   movq    %rbp, %rsp
@@ -53,7 +53,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cwd %ax, %dx
+;   cwtd  ;; implicit: %dx, %ax
 ;   checked_srem_seq %ax, %dx, %si, %ax, %dx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -89,7 +89,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cdq %eax, %edx
+;   cltd  ;; implicit: %edx, %eax
 ;   checked_srem_seq %eax, %edx, %esi, %eax, %edx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cqo %rax, %rdx
+;   cqto  ;; implicit: %rdx, %rax
 ;   checked_srem_seq %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cbw %al, %al
+;   cbtw  ;; implicit: %ax
 ;   testb   %sil, %sil
 ;   jz #trap=int_divz
 ;   idiv    %al, %sil, %al ; trap=int_ovf
@@ -46,7 +46,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cwd %ax, %dx
+;   cwtd  ;; implicit: %dx, %ax
 ;   testw   %si, %si
 ;   jz #trap=int_divz
 ;   idiv    %ax, %dx, %si, %ax, %dx ; trap=int_ovf
@@ -80,7 +80,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cdq %eax, %edx
+;   cltd  ;; implicit: %edx, %eax
 ;   testl   %esi, %esi
 ;   jz #trap=int_divz
 ;   idiv    %eax, %edx, %esi, %eax, %edx ; trap=int_ovf
@@ -114,7 +114,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cqo %rax, %rdx
+;   cqto  ;; implicit: %rdx, %rax
 ;   testq   %rsi, %rsi
 ;   jz #trap=int_divz
 ;   idiv    %rax, %rdx, %rsi, %rax, %rdx ; trap=int_ovf

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cbw %al, %al
+;   cbtw  ;; implicit: %ax
 ;   checked_srem_seq %al, %sil, %al
 ;   shrq    $8, %rax, %rax
 ;   movq    %rbp, %rsp
@@ -47,7 +47,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cwd %ax, %dx
+;   cwtd  ;; implicit: %dx, %ax
 ;   checked_srem_seq %ax, %dx, %si, %ax, %dx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -82,7 +82,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cdq %eax, %edx
+;   cltd  ;; implicit: %edx, %eax
 ;   checked_srem_seq %eax, %edx, %esi, %eax, %edx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -117,7 +117,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cqo %rax, %rdx
+;   cqto  ;; implicit: %rdx, %rax
 ;   checked_srem_seq %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -153,7 +153,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cbw %al, %al
+;   cbtw  ;; implicit: %ax
 ;   movl    $17, %edx
 ;   idiv    %al, %dl, %al ; trap=int_divz
 ;   shrq    $8, %rax, %rax
@@ -187,7 +187,7 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cwd %ax, %dx
+;   cwtd  ;; implicit: %dx, %ax
 ;   movl    $17, %r8d
 ;   idiv    %ax, %dx, %r8w, %ax, %dx ; trap=int_divz
 ;   movq    %rdx, %rax
@@ -221,7 +221,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cdq %eax, %edx
+;   cltd  ;; implicit: %edx, %eax
 ;   movl    $17, %r8d
 ;   idiv    %eax, %edx, %r8d, %eax, %edx ; trap=int_divz
 ;   movq    %rdx, %rax
@@ -255,7 +255,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   cqo %rax, %rdx
+;   cqto  ;; implicit: %rdx, %rax
 ;   movl    $17, %r8d
 ;   idiv    %rax, %rdx, %r8, %rax, %rdx ; trap=int_divz
 ;   movq    %rdx, %rax


### PR DESCRIPTION
I woke up early today and figure how better to start the day than to frob some assembler instructions. I'd never seen the `SignExtendData` before and it was trickier and more subtle than I thought. The end result of this PR is to remove this pseudo-instruction and replace it with the per-instruction equivalents that it can generate.

The first thing surprising about this instruction is that the Capstone and Intel names disagree. For example what Intel calls `CBW` Capstone calls `cbtw`. This is true for all the various instructions here so the names are all changing subtly.

The second surprising thing was that the behavior of the instruction depended on the operand size. This instruction was tasked with sign-extending data just before a `div` instruction which requires the operand to be in `AX` (sign-extended) for 8-bit division, but otherwise requires `DX:AX` or wider for wider division. That meant that the 8-bit version of `SignExtendData` would read `AL` and write `AX`, but the wider variants would read `AX` and write `DX` for example.

This involved writing a specialized helper in ISLE for handling the 16-bits-or-higher width and otherwise customizing each of the various cases for 8-bit or wider already in ISLE. Winch received appropriate minor updates as well, and in the end we've now got a few more instructions bound which Cranelift doesn't currently used but should be easier to do so in the future.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
