### PR TITLE
x64: Stringify fixed registers with their runtime value

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/operand.rs
+++ b/cranelift/assembler-x64/meta/src/generate/operand.rs
@@ -40,14 +40,6 @@ impl dsl::Location {
     pub fn generate_to_string(&self, extension: dsl::Extension) -> String {
         use dsl::Location::*;
         match self {
-            al => "\"%al\"".into(),
-            ax => "\"%ax\"".into(),
-            eax => "\"%eax\"".into(),
-            rax => "\"%rax\"".into(),
-            cl => "\"%cl\"".into(),
-            dx => "\"%dx\"".into(),
-            edx => "\"%edx\"".into(),
-            rdx => "\"%rdx\"".into(),
             imm8 | imm16 | imm32 => {
                 if extension.is_sign_extended() {
                     let variant = extension.generate_variant();
@@ -56,7 +48,8 @@ impl dsl::Location {
                     format!("self.{self}.to_string()")
                 }
             }
-            r8 | r16 | r32 | r64 | rm8 | rm16 | rm32 | rm64 => match self.generate_size() {
+            al | ax | eax | rax | cl | dx | edx | rdx | r8 | r16 | r32 | r64 | rm8 | rm16
+            | rm32 | rm64 => match self.generate_size() {
                 Some(size) => format!("self.{self}.to_string({size})"),
                 None => unreachable!(),
             },
@@ -71,11 +64,11 @@ impl dsl::Location {
     fn generate_size(&self) -> Option<&str> {
         use dsl::Location::*;
         match self {
-            al | ax | eax | rax | cl | dx | edx | rdx | imm8 | imm16 | imm32 => None,
-            r8 | rm8 => Some("Size::Byte"),
-            r16 | rm16 => Some("Size::Word"),
-            r32 | rm32 => Some("Size::Doubleword"),
-            r64 | rm64 => Some("Size::Quadword"),
+            imm8 | imm16 | imm32 => None,
+            al | cl | r8 | rm8 => Some("Size::Byte"),
+            ax | dx | r16 | rm16 => Some("Size::Word"),
+            eax | edx | r32 | rm32 => Some("Size::Doubleword"),
+            rax | rdx | r64 | rm64 => Some("Size::Quadword"),
             m8 | m16 | m32 | m64 => {
                 panic!("no need to generate a size for memory-only access")
             }

--- a/cranelift/assembler-x64/src/fixed.rs
+++ b/cranelift/assembler-x64/src/fixed.rs
@@ -1,6 +1,6 @@
 //! Operands with fixed register encodings.
 
-use crate::AsReg;
+use crate::{AsReg, Size};
 
 /// A _fixed_ register.
 ///
@@ -32,6 +32,14 @@ impl<R, const E: u8> Fixed<R, E> {
     /// able to know what this register should encode as.
     pub fn expected_enc(&self) -> u8 {
         E
+    }
+
+    /// Return the register name at the given `size`.
+    pub fn to_string(&self, size: Size) -> String
+    where
+        R: AsReg,
+    {
+        self.0.to_string(Some(size))
     }
 }
 


### PR DESCRIPTION
This commit updates the display implementation of instructions using fixed registers to use the current value of the register rather than the end-result that'll happen after register allocation. That should help ensure that if a virtual register is being used in an instruction that'll get printed instead of the fixed value that should pop out after regalloc. Disassembly shouldn't change though after register allocation because the value of the register should match the fixed encoding.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
