### PR TITLE
x64: Fix panic compiling 16-bit multiply-with-immediate

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2884,9 +2884,9 @@
 (rule 2 (x64_imul_imm $I16 src1 (i8_try_from_i32 src2))  (x64_imulw_rmi_sxb src1 src2))
 (rule 2 (x64_imul_imm $I32 src1 (i8_try_from_i32 src2))  (x64_imull_rmi_sxb src1 src2))
 (rule 2 (x64_imul_imm $I64 src1 (i8_try_from_i32 src2))  (x64_imulq_rmi_sxb src1 src2))
-(rule 1 (x64_imul_imm $I16 src1 (u16_try_from_i32 src2)) (x64_imulw_rmi src1 src2))
-(rule 1 (x64_imul_imm $I32 src1 (i32_as_u32 src2))       (x64_imull_rmi src1 src2))
-(rule 1 (x64_imul_imm $I64 src1 src2)                    (x64_imulq_rmi_sxl src1 src2))
+(rule 1 (x64_imul_imm $I16 src1 (i16_try_from_i32 src2)) (x64_imulw_rmi src1 (i16_as_u16 src2)))
+(rule 1 (x64_imul_imm $I32 src1 src2) (x64_imull_rmi src1 (i32_as_u32 src2)))
+(rule 1 (x64_imul_imm $I64 src1 src2) (x64_imulq_rmi_sxl src1 src2))
 
 ;; Helper for creating `mul` instructions or `imul` instructions (depending
 ;; on `signed`) for 8-bit operands.

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -59,8 +59,8 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
-        fn i32_as_u32(&mut self, x: i32) -> Option<u32> {
-            Some(x as u32)
+        fn i32_as_u32(&mut self, x: i32) -> u32 {
+            x as u32
         }
 
         #[inline]
@@ -956,6 +956,14 @@ macro_rules! isle_common_prelude_methods {
 
         fn i8_try_from_u64(&mut self, val: u64) -> Option<i8> {
             i8::try_from(val).ok()
+        }
+
+        fn i16_as_u16(&mut self, val: i16) -> u16 {
+            val as u16
+        }
+
+        fn i16_try_from_i32(&mut self, val: i32) -> Option<i16> {
+            i16::try_from(val).ok()
         }
 
         fn i16_try_from_u64(&mut self, val: u64) -> Option<i16> {

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -142,8 +142,14 @@
 (decl pure partial i8_try_from_u64 (u64) i8)
 (extern constructor i8_try_from_u64 i8_try_from_u64)
 
+(decl pure i16_as_u16 (i16) u16)
+(extern constructor i16_as_u16 i16_as_u16)
+
 (decl pure partial i16_try_from_u64 (u64) i16)
 (extern constructor i16_try_from_u64 i16_try_from_u64)
+
+(decl pure partial i16_try_from_i32 (i16) i32)
+(extern extractor i16_try_from_i32 i16_try_from_i32)
 
 (decl pure partial i32_try_from_u64 (u64) i32)
 (extern constructor i32_try_from_u64 i32_try_from_u64)
@@ -152,8 +158,8 @@
 (extern constructor u32_as_u64 u32_as_u64)
 (convert u32 u64 u32_as_u64)
 
-(decl i32_as_u32 (u32) i32)
-(extern extractor i32_as_u32 i32_as_u32)
+(decl i32_as_u32 (i32) u32)
+(extern constructor i32_as_u32 i32_as_u32)
 
 (decl pure i32_as_i64 (i32) i64)
 (extern constructor i32_as_i64 i32_as_i64)

--- a/cranelift/filetests/filetests/isa/x64/mul-with-optimizations.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul-with-optimizations.clif
@@ -1,0 +1,31 @@
+test compile precise-output
+set unwind_info=false
+set opt_level=speed
+target x86_64
+
+function %imul_i16_const_unsigned_but_big(i32) -> i16 {
+block0(v0: i32):
+    v3 = imul_imm v0, 0x81111
+    v4 = ireduce.i16 v3
+    return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   imulw $0x1111, %di, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imulw $0x1111, %di, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/mul.clif
@@ -284,6 +284,81 @@ block0(v0: i16):
 ;   popq %rbp
 ;   retq
 
+function %imul_i16_const_negative(i16) -> i16 {
+block0(v0: i16):
+    v3 = imul_imm v0, -97
+    return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   imulw $0xff9f, %di, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imulw $-0x61, %di, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %imul_i16_const_unsigned_but_big(i16) -> i16 {
+block0(v0: i16):
+    v3 = imul_imm v0, 0x8000
+    return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   imulw $0x8000, %di, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imulw $0x8000, %di, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %imul_i16_const_out_of_bounds(i16) -> i16 {
+block0(v0: i16):
+    v3 = imul_imm v0, 0x80000
+    return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   imulw $0x0, %di, %ax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imulw $0, %di, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
 function %imul_i32_const(i32) -> i32{
 block0(v0: i32):
     v3 = imul_imm v0, 97

--- a/tests/disas/x64-mul16-negative.wat
+++ b/tests/disas/x64-mul16-negative.wat
@@ -1,0 +1,19 @@
+;;! target = 'x86_64'
+;;! test = 'compile'
+
+(module
+  (func (export "mul16") (param i32) (result i32)
+    local.get 0
+    i32.const -7937
+    i32.mul
+    i32.extend16_s
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       imulw   $0xe0ff, %dx, %dx
+;;       movswl  %dx, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq

--- a/tests/misc_testsuite/mul16-negative.wast
+++ b/tests/misc_testsuite/mul16-negative.wast
@@ -1,0 +1,10 @@
+(module
+  (func (export "mul16") (param i32) (result i32)
+    local.get 0
+    i32.const -7937
+    i32.mul
+    i32.extend16_s
+  )
+)
+
+(assert_return (invoke "mul16" (i32.const 100)) (i32.const -7268))


### PR DESCRIPTION
This commit fixes a minor regression from #10782 found via fuzzing. The regression is 16-bit immediates were forced to fit from an `i32` value into a `u16` for 16-bit multiplication. This meant though that negative numbers failed this conversion which meant that ISLE would panic due to the value not being matched. This fixes the logic to first fit the i32 into an i16 and then cast that to a u16 where the first phase should hit all the constants that are possible in Cranelift.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
