### PR TITLE
winch: Use innermost frame to emit `br_table`

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -435,6 +435,7 @@ impl WastTest {
                     "misc_testsuite/winch/select.wast",
                     "misc_testsuite/sink-float-but-dont-trap.wast",
                     "misc_testsuite/issue4840.wast",
+		    "misc_testsuite/winch/use-innermost-frame.wast",
                 ];
 
                 return unsupported.iter().any(|part| self.path.ends_with(part));

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -435,7 +435,7 @@ impl WastTest {
                     "misc_testsuite/winch/select.wast",
                     "misc_testsuite/sink-float-but-dont-trap.wast",
                     "misc_testsuite/issue4840.wast",
-		    "misc_testsuite/winch/use-innermost-frame.wast",
+                    "misc_testsuite/winch/use-innermost-frame.wast",
                 ];
 
                 return unsupported.iter().any(|part| self.path.ends_with(part));

--- a/tests/disas/winch/x64/br_table/use-innermost-frame.wat
+++ b/tests/disas/winch/x64/br_table/use-innermost-frame.wat
@@ -1,0 +1,2493 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (type (;0;) (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (type (;1;) (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (func (;0;) (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    unreachable
+  )
+  (func (;1;) (export "main") (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i64)
+    i32.const 0
+    if ;; label = @1
+      unreachable
+    end
+    global.get 2
+    i32.const 1
+    i32.sub
+    global.set 2
+    call 0
+    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @1
+      call 0
+      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @2
+        call 0
+        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @3
+          call 0
+          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @4
+            call 0
+            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @5
+              call 0
+              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @6
+                call 0
+                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @7
+                  call 0
+                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @8
+                    call 0
+                    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @9
+                      call 0
+                      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @10
+                        call 0
+                        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @11
+                          call 0
+                          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @12
+                            call 0
+                            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @13
+                              call 0
+                              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @14
+                                call 0
+                                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @15
+                                  call 0
+                                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @16
+                                    call 0
+                                    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @17
+                                      call 0
+                                      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @18
+                                        call 0
+                                        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @19
+                                          call 0
+                                          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @20
+                                            call 0
+                                            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @21
+                                              call 0
+                                              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @22
+                                                call 0
+                                                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @23
+                                                  call 0
+                                                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @24
+                                                    call 2
+                                                    call 1
+                                                    br_table 0 (;@24;) 1 (;@23;) 2 (;@22;) 3 (;@21;) 4 (;@20;) 5 (;@19;) 6 (;@18;) 7 (;@17;) 8 (;@16;) 9 (;@15;) 10 (;@14;) 11 (;@13;) 12 (;@12;) 13 (;@11;) 14 (;@10;) 15 (;@9;) 16 (;@8;) 17 (;@7;) 18 (;@6;) 19 (;@5;) 20 (;@4;) 21 (;@3;) 22 (;@2;) 23 (;@1;) 24 13 (;@11;)
+                                                    local.set 100
+                                                    block ;; label = @25
+                                                      block ;; label = @26
+                                                        i32.const 1
+                                                        i32.const 0
+                                                        i32.mul
+                                                        i32.const 65120
+                                                        local.get 100
+                                                        i32.add
+                                                        i32.le_u
+                                                        br_if 0 (;@26;)
+                                                        local.get 100
+                                                        br_if 0 (;@26;)
+                                                        i64.const 1
+                                                        local.set 101
+                                                        br 1 (;@25;)
+                                                      end
+                                                      i64.const 0
+                                                      local.set 101
+                                                    end
+                                                    global.get 0
+                                                    global.set 0
+                                                    local.get 101
+                                                    global.set 0
+                                                    i32.const -513
+                                                    i32.const 0
+                                                  else
+                                                    i32.const 8388608
+                                                    i32.const 0
+                                                    i32.const -262145
+                                                    i32.const -513
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                    i32.const 707406591
+                                                    i32.const -262145
+                                                    i32.const 0
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                    i32.const 0
+                                                    i32.const 1
+                                                    i32.const 0
+                                                    i32.const 16843007
+                                                    i32.const 0
+                                                    i32.const 16711684
+                                                    i32.const -524288
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                  end
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                else
+                                                  i32.const 0
+                                                  i32.const 0
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                  i32.const 1862281770
+                                                  i32.const 0
+                                                  i32.const 131071
+                                                  i32.const 65528
+                                                  i32.const 1718513507
+                                                  i32.const 2034180652
+                                                  i32.const -140
+                                                  i32.const -262145
+                                                  i32.const 15
+                                                  i32.const 16842496
+                                                  i32.const -25231360
+                                                  i32.const 1
+                                                  i32.const 0
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                end
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                i32.const 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                              else
+                                                i32.const 1
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                              end
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                            else
+                                              i32.const 0
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                            end
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            i32.const 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            i32.const 0
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                          else
+                                            i32.const 177015437
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                          end
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                        else
+                                          i32.const 0
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const -1275068416
+                                          i32.const 32
+                                          i32.const 32
+                                        end
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                      else
+                                        i32.const 177015437
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                      end
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                    else
+                                      i32.const 0
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                    end
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                  else
+                                    i32.const 1
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                  end
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                else
+                                  i32.const 1
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                end
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                              else
+                                i32.const 32
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 1
+                                i32.const 1
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 0
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 65552
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 0
+                                i32.const -262144
+                              end
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                            else
+                              i32.const 0
+                              i32.const 1
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const 0
+                              i32.const 1850175047
+                              i32.const -262144
+                              i32.const -262145
+                              i32.const 127
+                              i32.const 1198409582
+                            end
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                          else
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const -262144
+                          end
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          i32.const 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                        else
+                          i32.const 1
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -4194304
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                        end
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        i32.const -318947662
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                      else
+                        i32.const 1850175047
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const 0
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const -35638312
+                        i32.const 1073741824
+                        i32.const -589553188
+                        i32.const -594420516
+                        i32.const 1073741824
+                        i32.const 1073741824
+                      end
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      i32.const 0
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                    else
+                      i32.const -587997965
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                    end
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                  else
+                    i32.const 0
+                    i32.const -203623460
+                    i32.const -587997965
+                    i32.const 1073741824
+                    i32.const 131071
+                    i32.const -587997965
+                    i32.const 1073741824
+                    i32.const -9
+                    i32.const -9
+                    i32.const -32769
+                    i32.const -1953794956
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -63772275
+                    i32.const 1073741824
+                  end
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                else
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const -44525566
+                  i32.const 0
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const -262145
+                end
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+              else
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 1431655765
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const -42049289
+                i32.const 0
+              end
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+            else
+              i32.const 1
+              i32.const -32769
+              i32.const 762012513
+              i32.const 926429234
+              i32.const 909719088
+              i32.const 926101809
+              i32.const 875835697
+              i32.const 808472380
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const -707406379
+              i32.const 268435455
+              i32.const 268435455
+              i32.const -262145
+              i32.const 0
+            end
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+          else
+            i32.const 268435455
+            i32.const 268435455
+            i32.const 268435455
+            i32.const 127
+            i32.const 0
+            i32.const 1
+            i32.const 0
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+          end
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+        else
+          i32.const 177015437
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 0
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+        end
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+      else
+        i32.const 177015437
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+      end
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+    else
+      i32.const 177015437
+      i32.const 32
+      i32.const 32
+      i32.const 32
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+    end
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+  )
+  (func (;2;) (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    unreachable
+  )
+  (global (;0;) (mut i64) i64.const 0)
+  (global (;1;) (mut i32) i32.const 0)
+  (global (;2;) (mut i32) i32.const 0)
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x161
+;;   1c: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       ud2
+;;       movq    0x54(%rsp), %rcx
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, (%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 4(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 8(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0xc(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x10(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x14(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x18(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x1c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x20(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x24(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x28(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x2c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x30(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x34(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x38(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x3c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x40(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x44(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x48(%rcx)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  161: ud2
+;;
+;; wasm[0]::function[1]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x980, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4a8b
+;;  18c: movq    %rsi, %r14
+;;       subq    $0x1c0, %rsp
+;;       movq    %rsi, 0x1b8(%rsp)
+;;       movq    %rdx, 0x1b0(%rsp)
+;;       xorq    %r11, %r11
+;;       movq    %r11, 0x1a8(%rsp)
+;;       movq    %r11, 0x1a0(%rsp)
+;;       movq    %r11, 0x198(%rsp)
+;;       movq    %r11, 0x190(%rsp)
+;;       movq    %r11, 0x188(%rsp)
+;;       movq    %r11, 0x180(%rsp)
+;;       movq    %r11, 0x178(%rsp)
+;;       movq    %r11, 0x170(%rsp)
+;;       movq    %r11, 0x168(%rsp)
+;;       movq    %r11, 0x160(%rsp)
+;;       movq    %r11, 0x158(%rsp)
+;;       movq    %r11, 0x150(%rsp)
+;;       movq    %r11, 0x148(%rsp)
+;;       movq    %r11, 0x140(%rsp)
+;;       movq    %r11, 0x138(%rsp)
+;;       movq    %r11, 0x130(%rsp)
+;;       movq    %r11, 0x128(%rsp)
+;;       movq    %r11, 0x120(%rsp)
+;;       movq    %r11, 0x118(%rsp)
+;;       movq    %r11, 0x110(%rsp)
+;;       movq    %r11, 0x108(%rsp)
+;;       movq    %r11, 0x100(%rsp)
+;;       movq    %r11, 0xf8(%rsp)
+;;       movq    %r11, 0xf0(%rsp)
+;;       movq    %r11, 0xe8(%rsp)
+;;       movq    %r11, 0xe0(%rsp)
+;;       movq    %r11, 0xd8(%rsp)
+;;       movq    %r11, 0xd0(%rsp)
+;;       movq    %r11, 0xc8(%rsp)
+;;       movq    %r11, 0xc0(%rsp)
+;;       movq    %r11, 0xb8(%rsp)
+;;       movq    %r11, 0xb0(%rsp)
+;;       movq    %r11, 0xa8(%rsp)
+;;       movq    %r11, 0xa0(%rsp)
+;;       movq    %r11, 0x98(%rsp)
+;;       movq    %r11, 0x90(%rsp)
+;;       movq    %r11, 0x88(%rsp)
+;;       movq    %r11, 0x80(%rsp)
+;;       movq    %r11, 0x78(%rsp)
+;;       movq    %r11, 0x70(%rsp)
+;;       movq    %r11, 0x68(%rsp)
+;;       movq    %r11, 0x60(%rsp)
+;;       movq    %r11, 0x58(%rsp)
+;;       movq    %r11, 0x50(%rsp)
+;;       movq    %r11, 0x48(%rsp)
+;;       movq    %r11, 0x40(%rsp)
+;;       movq    %r11, 0x38(%rsp)
+;;       movq    %r11, 0x30(%rsp)
+;;       movq    %r11, 0x28(%rsp)
+;;       movq    %r11, 0x20(%rsp)
+;;       movq    %r11, 0x18(%rsp)
+;;       movq    %r11, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       movl    $0, %eax
+;;       testl   %eax, %eax
+;;       je      0x333
+;;  331: ud2
+;;       movl    0x60(%r14), %eax
+;;       subl    $1, %eax
+;;       movl    %eax, 0x60(%r14)
+;;       subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x204(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x4836
+;;  376: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x250(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x4612
+;;  3ab: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x29c(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x43ee
+;;  3e0: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x2e8(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x41ca
+;;  406: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x334(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x3fa6
+;;  43b: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x380(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x3d82
+;;  470: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x3cc(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x3b5e
+;;  4a5: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x418(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x393a
+;;  4cb: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x464(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x3716
+;;  500: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x4b0(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x34f2
+;;  535: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x4fc(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x32ce
+;;  56a: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x548(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x30aa
+;;  590: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x594(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x2e86
+;;  5c5: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x5e0(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x2c62
+;;  5fa: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x62c(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x2a3e
+;;  62f: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x678(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x281a
+;;  655: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x6c4(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x25f6
+;;  68a: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x710(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x23d2
+;;  6bf: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x75c(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x21ae
+;;  6f4: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x7a8(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x1f8a
+;;  71a: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0
+;;       addq    $4, %rsp
+;;       movq    0x7f4(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x1d66
+;;  74f: subq    $0x4c, %rsp
+;;       subq    $8, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    8(%rsp), %rdi
+;;       callq   0
+;;       addq    $8, %rsp
+;;       movq    0x840(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x1b42
+;;  784: subq    $0x4c, %rsp
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    0xc(%rsp), %rdi
+;;       callq   0
+;;       addq    $0xc, %rsp
+;;       movq    0x88c(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x191e
+;;  7b9: subq    $0x4c, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    (%rsp), %rdi
+;;       callq   0
+;;       movq    0x8d8(%rsp), %r14
+;;       testl   %eax, %eax
+;;       je      0x176f
+;;  7df: subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0x4a90
+;;       addq    $4, %rsp
+;;       movq    0x924(%rsp), %r14
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $0x4c, %rsp
+;;       subq    $4, %rsp
+;;       movq    %r14, %rsi
+;;       movq    %r14, %rdx
+;;       leaq    4(%rsp), %rdi
+;;       callq   0x170
+;;       addq    $4, %rsp
+;;       movq    0x974(%rsp), %r14
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movl    0x48(%rsp), %r11d
+;;       movl    %r11d, 0x94(%rsp)
+;;       movl    0x44(%rsp), %r11d
+;;       movl    %r11d, 0x90(%rsp)
+;;       movl    0x40(%rsp), %r11d
+;;       movl    %r11d, 0x8c(%rsp)
+;;       movl    0x3c(%rsp), %r11d
+;;       movl    %r11d, 0x88(%rsp)
+;;       movl    0x38(%rsp), %r11d
+;;       movl    %r11d, 0x84(%rsp)
+;;       movl    0x34(%rsp), %r11d
+;;       movl    %r11d, 0x80(%rsp)
+;;       movl    0x30(%rsp), %r11d
+;;       movl    %r11d, 0x7c(%rsp)
+;;       movl    0x2c(%rsp), %r11d
+;;       movl    %r11d, 0x78(%rsp)
+;;       movl    0x28(%rsp), %r11d
+;;       movl    %r11d, 0x74(%rsp)
+;;       movl    0x24(%rsp), %r11d
+;;       movl    %r11d, 0x70(%rsp)
+;;       movl    0x20(%rsp), %r11d
+;;       movl    %r11d, 0x6c(%rsp)
+;;       movl    0x1c(%rsp), %r11d
+;;       movl    %r11d, 0x68(%rsp)
+;;       movl    0x18(%rsp), %r11d
+;;       movl    %r11d, 0x64(%rsp)
+;;       movl    0x14(%rsp), %r11d
+;;       movl    %r11d, 0x60(%rsp)
+;;       movl    0x10(%rsp), %r11d
+;;       movl    %r11d, 0x5c(%rsp)
+;;       movl    0xc(%rsp), %r11d
+;;       movl    %r11d, 0x58(%rsp)
+;;       movl    8(%rsp), %r11d
+;;       movl    %r11d, 0x54(%rsp)
+;;       movl    4(%rsp), %r11d
+;;       movl    %r11d, 0x50(%rsp)
+;;       movl    (%rsp), %r11d
+;;       movl    %r11d, 0x4c(%rsp)
+;;       addq    $0x4c, %rsp
+;;       movl    $0x19, %edx
+;;       cmpl    %ecx, %edx
+;;       cmovbl  %edx, %ecx
+;;       leaq    0xa(%rip), %r11
+;;       movslq  (%r11, %rcx, 4), %rdx
+;;       addq    %rdx, %r11
+;;       jmpq    *%r11
+;;  952: rorb    $0, (%rsi)
+;;       addb    %ch, (%rbp)
+;;       addb    %al, (%rax)
+;;       inl     $0, %eax
+;;       addb    %al, (%rax)
+;;       jb      0x961
+;;  960: addb    %al, (%rax)
+;;       incl    (%rcx)
+;;       addb    %al, (%rax)
+;;       movw    %es, (%rdx)
+;;       addb    %al, (%rax)
+;;       sbbl    %eax, (%rbx)
+;;       addb    %al, (%rax)
+;;       cmpsb   (%rdi), (%rsi)
+;;       addl    (%rax), %eax
+;;       addb    %dh, (%rbx)
+;;       addb    $0, %al
+;;       addb    %al, %al
+;;       addb    $0, %al
+;;       addb    %cl, 5(%rbp)
+;;       addb    %al, (%rax)
+;;       fiaddl  0x6670000(%rip)
+;;       addb    %al, (%rax)
+;;       hlt
+;;
+;; wasm[0]::function[2]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rsi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x4bf1
+;; 4aac: movq    %rsi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rsi, 0x18(%rsp)
+;;       movq    %rdx, 0x10(%rsp)
+;;       movq    %rdi, 8(%rsp)
+;;       ud2
+;;       movq    0x54(%rsp), %rcx
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, (%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 4(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 8(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0xc(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x10(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x14(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x18(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x1c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x20(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x24(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x28(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x2c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x30(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x34(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x38(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x3c(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x40(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x44(%rcx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x48(%rcx)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;; 4bf1: ud2

--- a/tests/misc_testsuite/winch/use-innermost-frame.wast
+++ b/tests/misc_testsuite/winch/use-innermost-frame.wast
@@ -1,0 +1,1944 @@
+(module
+  (type (;0;) (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (type (;1;) (func (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (func (;0;) (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    unreachable
+  )
+  (func (;1;) (export "main") (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    (local i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i64)
+    i32.const 0
+    if ;; label = @1
+      unreachable
+    end
+    global.get 2
+    i32.const 1
+    i32.sub
+    global.set 2
+    call 0
+    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @1
+      call 0
+      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @2
+        call 0
+        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @3
+          call 0
+          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @4
+            call 0
+            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @5
+              call 0
+              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @6
+                call 0
+                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @7
+                  call 0
+                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @8
+                    call 0
+                    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @9
+                      call 0
+                      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @10
+                        call 0
+                        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @11
+                          call 0
+                          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @12
+                            call 0
+                            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @13
+                              call 0
+                              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @14
+                                call 0
+                                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @15
+                                  call 0
+                                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @16
+                                    call 0
+                                    if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @17
+                                      call 0
+                                      if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @18
+                                        call 0
+                                        if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @19
+                                          call 0
+                                          if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @20
+                                            call 0
+                                            if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @21
+                                              call 0
+                                              if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @22
+                                                call 0
+                                                if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @23
+                                                  call 0
+                                                  if (type 0) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32) ;; label = @24
+                                                    call 2
+                                                    call 1
+                                                    br_table 0 (;@24;) 1 (;@23;) 2 (;@22;) 3 (;@21;) 4 (;@20;) 5 (;@19;) 6 (;@18;) 7 (;@17;) 8 (;@16;) 9 (;@15;) 10 (;@14;) 11 (;@13;) 12 (;@12;) 13 (;@11;) 14 (;@10;) 15 (;@9;) 16 (;@8;) 17 (;@7;) 18 (;@6;) 19 (;@5;) 20 (;@4;) 21 (;@3;) 22 (;@2;) 23 (;@1;) 24 13 (;@11;)
+                                                    local.set 100
+                                                    block ;; label = @25
+                                                      block ;; label = @26
+                                                        i32.const 1
+                                                        i32.const 0
+                                                        i32.mul
+                                                        i32.const 65120
+                                                        local.get 100
+                                                        i32.add
+                                                        i32.le_u
+                                                        br_if 0 (;@26;)
+                                                        local.get 100
+                                                        br_if 0 (;@26;)
+                                                        i64.const 1
+                                                        local.set 101
+                                                        br 1 (;@25;)
+                                                      end
+                                                      i64.const 0
+                                                      local.set 101
+                                                    end
+                                                    global.get 0
+                                                    global.set 0
+                                                    local.get 101
+                                                    global.set 0
+                                                    i32.const -513
+                                                    i32.const 0
+                                                  else
+                                                    i32.const 8388608
+                                                    i32.const 0
+                                                    i32.const -262145
+                                                    i32.const -513
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                    i32.const 707406591
+                                                    i32.const -262145
+                                                    i32.const 0
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                    i32.const 0
+                                                    i32.const 1
+                                                    i32.const 0
+                                                    i32.const 16843007
+                                                    i32.const 0
+                                                    i32.const 16711684
+                                                    i32.const -524288
+                                                    i32.const -262145
+                                                    i32.const -262145
+                                                  end
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  global.get 1
+                                                  i32.xor
+                                                  global.set 1
+                                                  drop
+                                                  drop
+                                                else
+                                                  i32.const 0
+                                                  i32.const 0
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                  i32.const 1862281770
+                                                  i32.const 0
+                                                  i32.const 131071
+                                                  i32.const 65528
+                                                  i32.const 1718513507
+                                                  i32.const 2034180652
+                                                  i32.const -140
+                                                  i32.const -262145
+                                                  i32.const 15
+                                                  i32.const 16842496
+                                                  i32.const -25231360
+                                                  i32.const 1
+                                                  i32.const 0
+                                                  i32.const -262145
+                                                  i32.const -262145
+                                                end
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                i32.const 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                                global.get 1
+                                                i32.xor
+                                                global.set 1
+                                              else
+                                                i32.const 1
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                                i32.const 32
+                                              end
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                              global.get 1
+                                              i32.xor
+                                              global.set 1
+                                            else
+                                              i32.const 0
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                              i32.const 32
+                                            end
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            i32.const 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            i32.const 0
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                            global.get 1
+                                            i32.xor
+                                            global.set 1
+                                          else
+                                            i32.const 177015437
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                            i32.const 32
+                                          end
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                          global.get 1
+                                          i32.xor
+                                          global.set 1
+                                        else
+                                          i32.const 0
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const 32
+                                          i32.const -1275068416
+                                          i32.const 32
+                                          i32.const 32
+                                        end
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                        global.get 1
+                                        i32.xor
+                                        global.set 1
+                                      else
+                                        i32.const 177015437
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                        i32.const 32
+                                      end
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                      global.get 1
+                                      i32.xor
+                                      global.set 1
+                                    else
+                                      i32.const 0
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                      i32.const 32
+                                    end
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                    global.get 1
+                                    i32.xor
+                                    global.set 1
+                                  else
+                                    i32.const 1
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                    i32.const 32
+                                  end
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                  global.get 1
+                                  i32.xor
+                                  global.set 1
+                                else
+                                  i32.const 1
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                  i32.const 32
+                                end
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                                global.get 1
+                                i32.xor
+                                global.set 1
+                              else
+                                i32.const 32
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 1
+                                i32.const 1
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 0
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 65552
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const -262144
+                                i32.const 0
+                                i32.const -262144
+                              end
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                              global.get 1
+                              i32.xor
+                              global.set 1
+                            else
+                              i32.const 0
+                              i32.const 1
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const -262144
+                              i32.const 0
+                              i32.const 1850175047
+                              i32.const -262144
+                              i32.const -262145
+                              i32.const 127
+                              i32.const 1198409582
+                            end
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                            global.get 1
+                            i32.xor
+                            global.set 1
+                          else
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const 0
+                            i32.const -262144
+                            i32.const -262144
+                            i32.const -262144
+                          end
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          i32.const 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                          global.get 1
+                          i32.xor
+                          global.set 1
+                        else
+                          i32.const 1
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -4194304
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const -262144
+                          i32.const 0
+                          i32.const -262144
+                          i32.const -262144
+                        end
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        i32.const -318947662
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                        global.get 1
+                        i32.xor
+                        global.set 1
+                      else
+                        i32.const 1850175047
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const 0
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const -262144
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const 2147483647
+                        i32.const -35638312
+                        i32.const 1073741824
+                        i32.const -589553188
+                        i32.const -594420516
+                        i32.const 1073741824
+                        i32.const 1073741824
+                      end
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      i32.const 0
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                      global.get 1
+                      i32.xor
+                      global.set 1
+                    else
+                      i32.const -587997965
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 1073741824
+                      i32.const 0
+                      i32.const 1073741824
+                      i32.const 1073741824
+                    end
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                    global.get 1
+                    i32.xor
+                    global.set 1
+                  else
+                    i32.const 0
+                    i32.const -203623460
+                    i32.const -587997965
+                    i32.const 1073741824
+                    i32.const 131071
+                    i32.const -587997965
+                    i32.const 1073741824
+                    i32.const -9
+                    i32.const -9
+                    i32.const -32769
+                    i32.const -1953794956
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -9
+                    i32.const -63772275
+                    i32.const 1073741824
+                  end
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                  global.get 1
+                  i32.xor
+                  global.set 1
+                else
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const -44525566
+                  i32.const 0
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const 268435455
+                  i32.const -262145
+                end
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+                global.get 1
+                i32.xor
+                global.set 1
+              else
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 1431655765
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const 268435455
+                i32.const -42049289
+                i32.const 0
+              end
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+              global.get 1
+              i32.xor
+              global.set 1
+            else
+              i32.const 1
+              i32.const -32769
+              i32.const 762012513
+              i32.const 926429234
+              i32.const 909719088
+              i32.const 926101809
+              i32.const 875835697
+              i32.const 808472380
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const 0
+              i32.const -707406379
+              i32.const 268435455
+              i32.const 268435455
+              i32.const -262145
+              i32.const 0
+            end
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+            global.get 1
+            i32.xor
+            global.set 1
+          else
+            i32.const 268435455
+            i32.const 268435455
+            i32.const 268435455
+            i32.const 127
+            i32.const 0
+            i32.const 1
+            i32.const 0
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 2147483647
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+            i32.const 32
+          end
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+          global.get 1
+          i32.xor
+          global.set 1
+        else
+          i32.const 177015437
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 0
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+          i32.const 32
+        end
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+        global.get 1
+        i32.xor
+        global.set 1
+      else
+        i32.const 177015437
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+        i32.const 32
+      end
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+      global.get 1
+      i32.xor
+      global.set 1
+    else
+      i32.const 177015437
+      i32.const 32
+      i32.const 32
+      i32.const 32
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+    end
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+    drop
+  )
+  (func (;2;) (type 1) (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)
+    unreachable
+  )
+  (global (;0;) (mut i64) i64.const 0)
+  (global (;1;) (mut i32) i32.const 0)
+  (global (;2;) (mut i32) i32.const 0)
+)
+
+
+(assert_trap (invoke "main") "unreachable")

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2045,23 +2045,23 @@ where
             labels.push(self.masm.get_label()?);
         }
 
-	// Find the innermost target and use it as the relative frame
-	// for result handling below.
-	// 
-	// This approch ensures that
-	// 1. The stack pointer offset is correctly positioned
-	//    according to the expectations of the innermost block end
-	//    sequence.
-	// 2. We meet the jump site invariants introduced by
-	//    `CodegenContext::br`, which take advantage of Wasm
-	//    semantics given that all jumps are "outward".
-	let mut innermost = targets.default();
-	for target in targets.targets()  {
-	    let target = target?;
-	    if target < innermost {
-		innermost = target;
-	    }
-	}
+        // Find the innermost target and use it as the relative frame
+        // for result handling below.
+        //
+        // This approch ensures that
+        // 1. The stack pointer offset is correctly positioned
+        //    according to the expectations of the innermost block end
+        //    sequence.
+        // 2. We meet the jump site invariants introduced by
+        //    `CodegenContext::br`, which take advantage of Wasm
+        //    semantics given that all jumps are "outward".
+        let mut innermost = targets.default();
+        for target in targets.targets() {
+            let target = target?;
+            if target < innermost {
+                innermost = target;
+            }
+        }
 
         let innermost_index = control_index(innermost, self.control_frames.len())?;
         let innermost_frame = &mut self.control_frames[innermost_index];
@@ -2069,7 +2069,7 @@ where
 
         let (index, tmp) = {
             let index_and_tmp = self.context.without::<Result<(TypedReg, _)>, M, _>(
-		innermost_result.regs(),
+                innermost_result.regs(),
                 self.masm,
                 |cx, masm| Ok((cx.pop_to_reg(masm, None)?, cx.any_gpr(masm)?)),
             )??;

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2045,13 +2045,31 @@ where
             labels.push(self.masm.get_label()?);
         }
 
-        let default_index = control_index(targets.default(), self.control_frames.len())?;
-        let default_frame = &mut self.control_frames[default_index];
-        let default_result = default_frame.results::<M>()?;
+	// Find the innermost target and use it as the relative frame
+	// for result handling below.
+	// 
+	// This approch ensures that
+	// 1. The stack pointer offset is correctly positioned
+	//    according to the expectations of the innermost block end
+	//    sequence.
+	// 2. We meet the jump site invariants introduced by
+	//    `CodegenContext::br`, which take advantage of Wasm
+	//    semantics given that all jumps are "outward".
+	let mut innermost = targets.default();
+	for target in targets.targets()  {
+	    let target = target?;
+	    if target < innermost {
+		innermost = target;
+	    }
+	}
+
+        let innermost_index = control_index(innermost, self.control_frames.len())?;
+        let innermost_frame = &mut self.control_frames[innermost_index];
+        let innermost_result = innermost_frame.results::<M>()?;
 
         let (index, tmp) = {
             let index_and_tmp = self.context.without::<Result<(TypedReg, _)>, M, _>(
-                default_result.regs(),
+		innermost_result.regs(),
                 self.masm,
                 |cx, masm| Ok((cx.pop_to_reg(masm, None)?, cx.any_gpr(masm)?)),
             )??;
@@ -2059,7 +2077,7 @@ where
             // Materialize any constants or locals into their result
             // representation, so that when reachability is restored,
             // they are correctly located.  NB: the results are popped
-            // in function of the default branch specified for
+            // in function of the innermost branch specified for
             // `br_table`, which implies that the machine stack will
             // be correctly balanced, by virtue of calling
             // `pop_abi_results`.
@@ -2067,7 +2085,7 @@ where
             // It's possible that we need to balance the stack for the
             // rest of the targets, which will be done before emitting
             // the unconditional jump below.
-            default_frame.pop_abi_results::<M, _>(
+            innermost_frame.pop_abi_results::<M, _>(
                 &mut self.context,
                 self.masm,
                 |results, _, _| Ok(results.ret_area().copied()),


### PR DESCRIPTION
Prior to this commit, the lowering of `br_table` used the default target as the relative reference to pop ABI results. This approach is not ideal, as it leads to a loss of precision regarding the stack pointer position, causing unmet invariants at jump sites for all other branches.

This commit, instead, takes advantage of the fact that all jumps are "outward" and uses the innermost frame to pop ABI results when lowering `br_table`. This ensures two main things:

* The stack pointer offset is correctly positioned according to the expectations of the innermost block's end sequence, which will be handled in the next eventual `end` sequence.
* We meet the jump site invariants introduced by `CodegenContext::br`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
