### PR TITLE
winch: Fix implementation of `checked_uadd`

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -540,7 +540,6 @@ impl WastTest {
                     "spec_testsuite/table_copy.wast",
                     "spec_testsuite/table_init.wast",
                     "misc_testsuite/winch/table_grow.wast",
-                    "misc_testsuite/memory64/more-than-4gb.wast",
                     "misc_testsuite/call_indirect.wast",
                 ];
 

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -539,9 +539,7 @@ impl WastTest {
                     "spec_testsuite/loop.wast",
                     "spec_testsuite/table_copy.wast",
                     "spec_testsuite/table_init.wast",
-                    "misc_testsuite/custom-page-sizes/custom-page-sizes.wast",
                     "misc_testsuite/winch/table_grow.wast",
-                    "spec_testsuite/proposals/custom-page-sizes/custom-page-sizes.wast",
                     "misc_testsuite/memory64/more-than-4gb.wast",
                     "misc_testsuite/call_indirect.wast",
                 ];

--- a/tests/disas/winch/aarch64/load/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/load/dynamic_heap.wat
@@ -41,7 +41,7 @@
 ;;       ldur    w0, [x28, #0xc]
 ;;       ldur    x1, [x9, #0x48]
 ;;       mov     w2, w0
-;;       add     x2, x2, #4
+;;       adds    x2, x2, #4
 ;;       b.hs    #0x160
 ;;   5c: cmp     x2, x1, uxtx
 ;;       b.hi    #0x164
@@ -55,7 +55,7 @@
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x48]
 ;;       mov     w3, w1
-;;       add     x3, x3, #8
+;;       adds    x3, x3, #8
 ;;       b.hs    #0x168
 ;;   94: cmp     x3, x2, uxtx
 ;;       b.hi    #0x16c
@@ -72,7 +72,7 @@
 ;;       mov     w4, w2
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
-;;       add     x4, x4, x16, uxtx
+;;       adds    x4, x4, x16, uxtx
 ;;       b.hs    #0x170
 ;;   d8: cmp     x4, x3, uxtx
 ;;       b.hi    #0x174

--- a/tests/disas/winch/aarch64/store/dynamic_heap.wat
+++ b/tests/disas/winch/aarch64/store/dynamic_heap.wat
@@ -44,7 +44,7 @@
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x48]
 ;;       mov     w3, w1
-;;       add     x3, x3, #4
+;;       adds    x3, x3, #4
 ;;       b.hs    #0x134
 ;;   68: cmp     x3, x2, uxtx
 ;;       b.hi    #0x138
@@ -59,7 +59,7 @@
 ;;       ldur    w1, [x28, #0xc]
 ;;       ldur    x2, [x9, #0x48]
 ;;       mov     w3, w1
-;;       add     x3, x3, #8
+;;       adds    x3, x3, #8
 ;;       b.hs    #0x13c
 ;;   a4: cmp     x3, x2, uxtx
 ;;       b.hi    #0x140
@@ -77,7 +77,7 @@
 ;;       mov     w3, w1
 ;;       mov     w16, #3
 ;;       movk    w16, #0x10, lsl #16
-;;       add     x3, x3, x16, uxtx
+;;       adds    x3, x3, x16, uxtx
 ;;       b.hs    #0x144
 ;;   ec: cmp     x3, x2, uxtx
 ;;       b.hi    #0x148

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -342,9 +342,22 @@ impl Assembler {
         self.alu_rrr_extend(ALUOp::Add, rm, rn, rd, size);
     }
 
+    /// Add with three registers, setting overflow flags.
+    pub fn adds_rrr(&mut self, rm: Reg, rn: Reg, rd: WritableReg, size: OperandSize) {
+        self.alu_rrr_extend(ALUOp::AddS, rm, rn, rd, size);
+    }
+
     /// Add immediate and register.
     pub fn add_ir(&mut self, imm: u64, rn: Reg, rd: WritableReg, size: OperandSize) {
-        let alu_op = ALUOp::Add;
+        self.alu_ir(ALUOp::Add, imm, rn, rd, size)
+    }
+
+    /// Add immediate and register, setting overflow flags.
+    pub fn adds_ir(&mut self, imm: u64, rn: Reg, rd: WritableReg, size: OperandSize) {
+        self.alu_ir(ALUOp::AddS, imm, rn, rd, size)
+    }
+
+    fn alu_ir(&mut self, alu_op: ALUOp, imm: u64, rn: Reg, rd: WritableReg, size: OperandSize) {
         if let Some(imm) = Imm12::maybe_from_u64(imm) {
             self.alu_rri(alu_op, imm, rn, rd, size);
         } else {


### PR DESCRIPTION
This commit updates the implementation of `checked_uadd` on aarch64 to ensure it uses an `adds` instruction instead of a plain `add` instruction to ensure that overflow flags are appropriately set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
