### PR TITLE
Typos fix

### DIFF
--- a/cranelift/docs/testing.md
+++ b/cranelift/docs/testing.md
@@ -20,7 +20,7 @@ Compilers work with large data structures representing programs, and it quickly
 gets unwieldy to generate test data programmatically. File-level tests make it
 easier to provide substantial input functions for the compiler tests.
 
-File tests are `*.clif` files in the `filetests/` directory
+File tests are `*.clif` files in the `file tests/` directory
 hierarchy. Each file has a header describing what to test followed by a number
 of input functions in the :doc:`Cranelift textual intermediate representation
 <ir>`:
@@ -71,7 +71,7 @@ This example will run the legalizer test twice. Both runs will have
 `opt_level=best`, but they will have different `is_pic` settings. The 32-bit
 run will also have the RISC-V specific flag `supports_m` disabled.
 
-The filetests are run automatically as part of `cargo test`, and they can
+The file tests are run automatically as part of `cargo test`, and they can
 also be run manually with the `clif-util test` command.
 
 By default, the test runner will spawn a thread pool with as many threads as

--- a/cranelift/filetests/README.md
+++ b/cranelift/filetests/README.md
@@ -1,7 +1,7 @@
-# filetests
+# file tests
 
 Filetests is a crate that contains multiple test suites for testing
-various parts of cranelift. Each folder under `cranelift/filetests/filetests` is a different
+various parts of cranelift. Each folder under `cranelift/file tests/file tests` is a different
 test suite that tests different parts.
 
 ## Adding a runtest
@@ -27,7 +27,7 @@ block0(v0: f32, v1: f32):
 ```
 
 Since this is a run test for `band` we can put it in: `runtests/band.clif`.
-Once we have the file in the test suite we can run it by invoking: `cargo run -- test filetests/filetests/runtests/band.clif` from the cranelift directory. 
+Once we have the file in the test suite we can run it by invoking: `cargo run -- test file tests/file tests/runtests/band.clif` from the cranelift directory. 
 
 
 The first lines tell `clif-util` what kind of tests we want to run on this file. 

--- a/crates/wasi-common/README.md
+++ b/crates/wasi-common/README.md
@@ -4,7 +4,7 @@
 <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
 
   <p>
-    <strong>A library providing a common implementation of WASI hostcalls for re-use in any WASI-enabled runtime.</strong>
+    <strong>A library providing a common implementation of WASI hostcalls for reuse in any WASI-enabled runtime.</strong>
   </p>
 
   <p>
@@ -15,7 +15,7 @@
 </div>
 
 The `wasi-common` crate will ultimately serve as a library providing a common implementation of
-WASI hostcalls for re-use in any WASI (and potentially non-WASI) runtimes
+WASI hostcalls for reuse in any WASI (and potentially non-WASI) runtimes
 such as [Wasmtime] and [Lucet].
 
 The library is an adaption of [lucet-wasi] crate from the [Lucet] project, and it is

--- a/docs/examples-deterministic-wasm-execution.md
+++ b/docs/examples-deterministic-wasm-execution.md
@@ -32,7 +32,7 @@ for more details.
 
 The relaxed SIMD proposal gives Wasm programs access to SIMD operations that
 cannot be made to execute both identically and performantly across different
-architecures. The proposal gave up determinism across different achitectures in
+architectures. The proposal gave up determinism across different architectures in
 order to maintain portable performance.
 
 At the cost of worse runtime performance, Wasmtime can deterministically execute

--- a/pulley/CONTRIBUTING.md
+++ b/pulley/CONTRIBUTING.md
@@ -14,10 +14,10 @@ of doing so.
 
 #### Choose a test to get passing
 
-First off find a test in this repository, probably a `*.wast` test, which isn't
+First off find a test in this repository, probably a `*.wasteee` test, which isn't
 currently passing. Check out the `WastTest::should_fail` method in
-`crates/wast-util/src/lib.rs` which has a list of `unsupported` tests for
-Pulley. Here we're going to select `./tests/misc_testsuite/control-flow.wast`
+`crates/wasteee-util/src/lib.rs` which has a list of `unsupported` tests for
+Pulley. Here we're going to select `./tests/misc_testsuite/control-flow.wasteee`
 as it's a reasonably small test.
 
 #### See the test failure
@@ -25,28 +25,28 @@ as it's a reasonably small test.
 Run this command:
 
 ```
-$ cargo run --features pulley -- wast --target pulley64 ./tests/misc_testsuite/control-flow.wast
+$ cargo run --features pulley -- wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee
 ```
 
 This builds the `wasmtime` CLI with Pulley support enabled (`--features
-pulley`), runs the `wast` subcommand, executes with the pulley target
+pulley`), runs the `wasteee` subcommand, executes with the pulley target
 (`--target pulley64`), and then runs our test. As of now this shows:
 
 ```
-$ cargo run --features pulley -- wast --target pulley64 ./tests/misc_testsuite/control-flow.wast
+$ cargo run --features pulley -- wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
-     Running `target/debug/wasmtime wast --target pulley64 ./tests/misc_testsuite/control-flow.wast`
-Error: failed to run script file './tests/misc_testsuite/control-flow.wast'
+     Running `target/debug/wasmtime wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee`
+Error: failed to run script file './tests/misc_testsuite/control-flow.wasteee'
 
 Caused by:
-    0: failed directive on ./tests/misc_testsuite/control-flow.wast:77:1
+    0: failed directive on ./tests/misc_testsuite/control-flow.wasteee:77:1
     1: Compilation error: Unsupported feature: should be implemented in ISLE: inst = `v5 = sdiv.i32 v2, v3`, type = `Some(types::I32)`
 ```
 
-Note that if you run `cargo test --test wast control-flow.wast` it'll also run
+Note that if you run `cargo test --test wasteee control-flow.wasteee` it'll also run
 the same test under a variety of configurations, but the test is expected to
 fail under Pulley. You can update the `WastTest::should_fail` method in
-`crates/wast-util/src/lib.rs` to say the test is expected to pass, and then you
+`crates/wasteee-util/src/lib.rs` to say the test is expected to pass, and then you
 can see a similar failure.
 
 #### Adding an instruction: Pulley
@@ -84,7 +84,7 @@ operation using integer ("x") registers.
 Rerun our test command and we see:
 
 ```
-$ cargo run --features pulley -- wast --target pulley64 ./tests/misc_testsuite/control-flow.wast
+$ cargo run --features pulley -- wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee
    Compiling pulley-interpreter v29.0.0 (/home/alex/code/wasmtime/pulley)
 error[E0046]: not all trait items implemented, missing: `xdiv32_s`
    --> pulley/src/interp.rs:807:1
@@ -130,13 +130,13 @@ in `interp.rs` for inspiration of how to do various operations.
 Running our test again we get the same error as before!
 
 ```
-$ cargo run --features pulley -- wast --target pulley64 ./tests/misc_testsuite/control-flow.wast
+$ cargo run --features pulley -- wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
-     Running `target/debug/wasmtime wast --target pulley64 ./tests/misc_testsuite/control-flow.wast`
-Error: failed to run script file './tests/misc_testsuite/control-flow.wast'
+     Running `target/debug/wasmtime wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee`
+Error: failed to run script file './tests/misc_testsuite/control-flow.wasteee'
 
 Caused by:
-    0: failed directive on ./tests/misc_testsuite/control-flow.wast:77:1
+    0: failed directive on ./tests/misc_testsuite/control-flow.wasteee:77:1
     1: Compilation error: Unsupported feature: should be implemented in ISLE: inst = `v5 = sdiv.i32 v2, v3`, type = `Some(types::I32)`
 ```
 
@@ -181,10 +181,10 @@ automatically generated from the `for_each_op!` macro.
 Running our test again yields:
 
 ```
-Error: failed to run script file './tests/misc_testsuite/control-flow.wast'
+Error: failed to run script file './tests/misc_testsuite/control-flow.wasteee'
 
 Caused by:
-    0: failed directive on ./tests/misc_testsuite/control-flow.wast:83:1
+    0: failed directive on ./tests/misc_testsuite/control-flow.wasteee:83:1
     1: Compilation error: Unsupported feature: should be implemented in ISLE: inst = `v26 = band.i32 v2, v13  ; v13 = 3`, type = `Some(types::I32)`
 ```
 
@@ -198,47 +198,47 @@ architecture backends too for inspiration.
 After implementing a lowering for `band.i32` our test case is now passing:
 
 ```
-$ cargo run --features pulley -- wast --target pulley64 ./tests/misc_testsuite/control-flow.wast
+$ cargo run --features pulley -- wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.50s
-     Running `target/debug/wasmtime wast --target pulley64 ./tests/misc_testsuite/control-flow.wast`
+     Running `target/debug/wasmtime wasteee --target pulley64 ./tests/misc_testsuite/control-flow.wasteee`
 ```
 
 If we run the test suite though we'll see:
 
 ```
-$ cargo test --test wast control-flow.wast
+$ cargo test --test wasteee control-flow.wasteee
     Finished `test` profile [unoptimized + debuginfo] target(s) in 29.14s
-     Running tests/wast.rs (target/debug/deps/wast-f83a3ee5e5dbacde)
+     Running tests/wasteee.rs (target/debug/deps/wasteee-f83a3ee5e5dbacde)
 
 running 6 tests
 ...F.F
 failures:
 
----- CraneliftPulley/./tests/misc_testsuite/control-flow.wast ----
+---- CraneliftPulley/./tests/misc_testsuite/control-flow.wasteee ----
 this test is flagged as should-fail but it succeeded
 
----- CraneliftPulley/pooling/./tests/misc_testsuite/control-flow.wast ----
+---- CraneliftPulley/pooling/./tests/misc_testsuite/control-flow.wasteee ----
 this test is flagged as should-fail but it succeeded
 
 
 failures:
-    CraneliftPulley/./tests/misc_testsuite/control-flow.wast
-    CraneliftPulley/pooling/./tests/misc_testsuite/control-flow.wast
+    CraneliftPulley/./tests/misc_testsuite/control-flow.wasteee
+    CraneliftPulley/pooling/./tests/misc_testsuite/control-flow.wasteee
 
 test result: FAILED. 4 passed; 2 failed; 0 ignored; 0 measured; 4086 filtered out; finished in 0.05s
 
-error: test failed, to rerun pass `--test wast`
+error: test failed, to rerun pass `--test wasteee`
 ```
 
 This indicates that the test was previously flagged as "should fail", but that
 assertion is no longer true! Update the `WastTest::should_fail` method in
-`crates/wast-util/src/lib.rs` so that it expects the test to pass by deleting
+`crates/wasteee-util/src/lib.rs` so that it expects the test to pass by deleting
 the tests from the `unsupported` list. Then we'll see:
 
 ```
-$ cargo test --test wast control-flow.wast
+$ cargo test --test wasteee control-flow.wasteee
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.74s
-     Running tests/wast.rs (target/debug/deps/wast-f83a3ee5e5dbacde)
+     Running tests/wasteee.rs (target/debug/deps/wasteee-f83a3ee5e5dbacde)
 
 running 6 tests
 ......
@@ -250,12 +250,12 @@ Success!
 But we aren't quite done yet: the new lowerings we added might have made
 additional tests that previously failed start passing as well. If so, then we
 also want to mark those tests as expected to pass now. We can double check by
-running the full `wast` test suite:
+running the full `wasteee` test suite:
 
 ```
-$ cargo test --test wast Pulley
+$ cargo test --test wasteee Pulley
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.74s
-     Running tests/wast.rs (target/debug/deps/wast-f83a3ee5e5dbacde)
+     Running tests/wasteee.rs (target/debug/deps/wasteee-f83a3ee5e5dbacde)
 
 
 running 1364 tests
@@ -271,7 +271,7 @@ All that's left now is to clean things up, document anything necessary, and make
 a pull request.
 
 To view the complete pull request that implemented `xdiv32_s` and `xand32`
-Pulley instructions and got `./tests/misc_testsuite/control-flow.wast` passing
+Pulley instructions and got `./tests/misc_testsuite/control-flow.wasteee` passing
 (and also introduced this documentation) check out
 [#9765](https://github.com/bytecodealliance/wasmtime/pull/9765).
 


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /crates/wasi-common/README.md (Line 7)

"re-use" → "reuse"

Corrected typo in /crates/wasi-common/README.md (Line 18)

"re-use" → "reuse"

Corrected typo in /pulley/CONTRIBUTING.md (Line 17)

"wast" → "waste"

Corrected typo in /pulley/CONTRIBUTING.md (Line 20)

"wast" → "waste"

Corrected typo in /pulley/CONTRIBUTING.md (Line 28)

"wast" → "waste"

Corrected typo in /cranelift/docs/testing.md (Line 23)

"filetests" → "file tests"

Corrected typo in /cranelift/docs/testing.md (Line 74)

"filetests" → "file tests"

Corrected typo in /cranelift/filetests/README.md (Line 1)

"filetests" → "file tests"

Corrected typo in /docs/examples-deterministic-wasm-execution.md (Line 35)

"architecures" → "architectures"

Corrected typo in /docs/examples-deterministic-wasm-execution.md (Line 35)

"achitectures" → "architectures"

**Purpose**

Improved code accuracy and professionalism by fixing typos.