### PR TITLE
x64: convert scalar FP `sqrt` instructions

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/sqrt.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/sqrt.rs
@@ -1,11 +1,13 @@
 use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{align, fmt, inst, r, rex, w};
+use crate::dsl::{align, fmt, inst, r, rex, rw, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
     vec![
         // Vector instructions.
-        inst("sqrtpd", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x51]).r(), _64b | compat | sse2),
+        inst("sqrtss", fmt("A", [rw(xmm), r(xmm_m32)]), rex([0xF3, 0x0F, 0x51]).r(), _64b | compat | sse),
+        inst("sqrtsd", fmt("A", [rw(xmm), r(xmm_m64)]), rex([0xF2, 0x0F, 0x51]).r(), _64b | compat | sse2),
         inst("sqrtps", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x0F, 0x51]).r(), _64b | compat | sse),
+        inst("sqrtpd", fmt("A", [w(xmm), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x51]).r(), _64b | compat | sse2),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -872,10 +872,6 @@
             Roundsd
             Rsqrtss
             Shufps
-            Sqrtps
-            Sqrtpd
-            Sqrtss
-            Sqrtsd
             Ucomiss
             Ucomisd
             Unpcklps
@@ -4637,19 +4633,19 @@
 ;; a data-dependency on the contents of the first register which is modeled
 ;; here.
 (decl x64_sqrtss (Xmm XmmMem) Xmm)
-(rule (x64_sqrtss x y) (xmm_rm_r_unaligned (SseOpcode.Sqrtss) x y))
 (rule 1 (x64_sqrtss x y)
         (if-let true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vsqrtss) x y))
+(rule 0 (x64_sqrtss x y) (x64_sqrtss_a x y))
 
 ;; Helper for creating `sqrtsd` instructions.
 ;;
 ;; NB: see `x64_sqrtss` for explanation of why this has two args.
 (decl x64_sqrtsd (Xmm XmmMem) Xmm)
-(rule (x64_sqrtsd x y) (xmm_rm_r_unaligned (SseOpcode.Sqrtsd) x y))
 (rule 1 (x64_sqrtsd x y)
         (if-let true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vsqrtsd) x y))
+(rule 0 (x64_sqrtsd x y) (x64_sqrtsd_a x y))
 
 ;; Helper for creating `sqrtps` instructions.
 (decl x64_sqrtps (XmmMem) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -913,8 +913,6 @@ pub enum SseOpcode {
     Roundsd,
     Rsqrtss,
     Shufps,
-    Sqrtss,
-    Sqrtsd,
     Ucomiss,
     Ucomisd,
     Unpcklps,
@@ -950,7 +948,6 @@ impl SseOpcode {
             | SseOpcode::Rcpss
             | SseOpcode::Rsqrtss
             | SseOpcode::Shufps
-            | SseOpcode::Sqrtss
             | SseOpcode::Ucomiss
             | SseOpcode::Unpcklps
             | SseOpcode::Unpckhps => SSE,
@@ -994,7 +991,6 @@ impl SseOpcode {
             | SseOpcode::Punpckhwd
             | SseOpcode::Punpcklbw
             | SseOpcode::Punpcklwd
-            | SseOpcode::Sqrtsd
             | SseOpcode::Ucomisd
             | SseOpcode::Punpckldq
             | SseOpcode::Punpckhdq
@@ -1174,8 +1170,6 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Roundsd => "roundsd",
             SseOpcode::Rsqrtss => "rsqrtss",
             SseOpcode::Shufps => "shufps",
-            SseOpcode::Sqrtss => "sqrtss",
-            SseOpcode::Sqrtsd => "sqrtsd",
             SseOpcode::Ucomiss => "ucomiss",
             SseOpcode::Ucomisd => "ucomisd",
             SseOpcode::Unpcklps => "unpcklps",

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1822,8 +1822,6 @@ pub(crate) fn emit(
                 SseOpcode::Unpcklps => (LegacyPrefixes::None, 0x0F14, 2),
                 SseOpcode::Unpckhps => (LegacyPrefixes::None, 0x0F15, 2),
                 SseOpcode::Movss => (LegacyPrefixes::_F3, 0x0F10, 2),
-                SseOpcode::Sqrtss => (LegacyPrefixes::_F3, 0x0F51, 2),
-                SseOpcode::Sqrtsd => (LegacyPrefixes::_F2, 0x0F51, 2),
                 SseOpcode::Unpcklpd => (LegacyPrefixes::_66, 0x0F14, 2),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3011,17 +3011,6 @@ fn test_x64_emit() {
     ));
 
     insns.push((
-        Inst::xmm_rm_r(SseOpcode::Sqrtss, RegMem::reg(xmm7), w_xmm8),
-        "F3440F51C7",
-        "sqrtss  %xmm8, %xmm7, %xmm8",
-    ));
-    insns.push((
-        Inst::xmm_rm_r(SseOpcode::Sqrtsd, RegMem::reg(xmm1), w_xmm2),
-        "F20F51D1",
-        "sqrtsd  %xmm2, %xmm1, %xmm2",
-    ));
-
-    insns.push((
         Inst::xmm_unary_rm_r(SseOpcode::Pabsb, RegMem::reg(xmm2), w_xmm1),
         "660F381CCA",
         "pabsb   %xmm2, %xmm1",

--- a/cranelift/filetests/filetests/isa/x64/fsqrt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fsqrt.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movdqa  %xmm5, %xmm7
-;   sqrtss  %xmm0, %xmm7, %xmm0
+;   sqrtss %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -47,7 +47,7 @@ block0(v0: f64):
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
 ;   movdqa  %xmm5, %xmm7
-;   sqrtsd  %xmm0, %xmm7, %xmm0
+;   sqrtsd %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1642,18 +1642,14 @@ impl Assembler {
     }
 
     pub fn sqrt(&mut self, src: Reg, dst: WritableReg, size: OperandSize) {
-        let op = match size {
-            OperandSize::S32 => SseOpcode::Sqrtss,
-            OperandSize::S64 => SseOpcode::Sqrtsd,
-            OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
+        use OperandSize::*;
+        let dst = pair_xmm(dst);
+        let inst = match size {
+            S32 => asm::inst::sqrtss_a::new(dst, src).into(),
+            S64 => asm::inst::sqrtsd_a::new(dst, src).into(),
+            S8 | S16 | S128 => unimplemented!(),
         };
-
-        self.emit(Inst::XmmRmR {
-            op,
-            src2: Xmm::from(src).into(),
-            src1: dst.to_reg().into(),
-            dst: dst.map(Into::into),
-        })
+        self.emit(Inst::External { inst });
     }
 
     /// Emit a call to an unknown location through a register.


### PR DESCRIPTION
This also cleans up some leftovers from `sqrtp{sd}`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
