### PR TITLE
winch: Crank the ratchet on tests that can fail

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -409,43 +409,6 @@ impl WastTest {
         spec_proposal_from_path(&self.path)
     }
 
-    /// Returns true for tests that should be ignored (not run) for
-    /// the given config.
-
-    /// The infrastructure for `.wast` tests is designed to enable the
-    /// execution of tests at all times, however, while compiler
-    /// backends are in partial development state, it becomes harder
-    /// to guarantee particular tests will run to completion and
-    /// return a recoverable error, in some cases tests might segfault
-    /// making it challenging to assert a failure status.
-    /// It's recommended to avoid ignoring tests as much as possible, instead
-    /// it's recommended to add tests to `WastTest::should_fail`.
-    pub fn ignore(&self, config: &WastConfig) -> bool {
-        if config.compiler == Compiler::Winch {
-            if cfg!(target_arch = "aarch64") {
-                let unsupported = [
-                    // Segfault
-                    "spec_testsuite/conversions.wast",
-                    "spec_testsuite/float_exprs.wast",
-                    "spec_testsuite/int_exprs.wast",
-                    "spec_testsuite/left-to-right.wast",
-                    "spec_testsuite/i32.wast",
-                    "spec_testsuite/traps.wast",
-                    "spec_testsuite/unreachable.wast",
-                    "spec_testsuite/unreached-valid.wast",
-                    "misc_testsuite/component-model/fused.wast",
-                    "misc_testsuite/component-model/strings.wast",
-                    "misc_testsuite/winch/select.wast",
-                    "misc_testsuite/sink-float-but-dont-trap.wast",
-                    "misc_testsuite/winch/use-innermost-frame.wast",
-                ];
-
-                return unsupported.iter().any(|part| self.path.ends_with(part));
-            }
-        }
-        false
-    }
-
     /// Returns whether this test should fail under the specified extra
     /// configuration.
     pub fn should_fail(&self, config: &WastConfig) -> bool {

--- a/tests/disas/winch/aarch64/call/reg_on_stack.wat
+++ b/tests/disas/winch/aarch64/call/reg_on_stack.wat
@@ -24,7 +24,7 @@
 ;;       movk    x17, #0x24
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0xf0
+;;       b.lo    #0xf8
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -66,12 +66,14 @@
 ;;       b       #0xc8
 ;;   c8: add     x28, x28, #4
 ;;       mov     sp, x28
-;;       b       #0xd8
-;;   d4: .byte   0x1f, 0xc1, 0x00, 0x00
+;;       b       #0xe0
+;;   d4: sub     sp, x28, #4
+;;       .byte   0x1f, 0xc1, 0x00, 0x00
+;;       mov     sp, x28
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   f0: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   f8: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -111,10 +111,6 @@ fn main() {
 fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
     let test_config = test.config.clone();
 
-    if test.ignore(&config) {
-        return Ok(());
-    }
-
     // Determine whether this test is expected to fail or pass. Regardless the
     // test is executed and the result of the execution is asserted to match
     // this expectation. Note that this means that the test can't, for example,

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -840,6 +840,30 @@ impl Assembler {
         });
     }
 
+    /// If the condition is true, `csel` writes rn to rd. If the
+    /// condition is false, it writes rm to rd
+    pub fn fpu_csel(&mut self, rn: Reg, rm: Reg, rd: WritableReg, cond: Cond, size: OperandSize) {
+        match size {
+            OperandSize::S32 => {
+                self.emit(Inst::FpuCSel32 {
+                    rd: rd.map(Into::into),
+                    rn: rn.into(),
+                    rm: rm.into(),
+                    cond,
+                });
+            }
+            OperandSize::S64 => {
+                self.emit(Inst::FpuCSel64 {
+                    rd: rd.map(Into::into),
+                    rn: rn.into(),
+                    rm: rm.into(),
+                    cond,
+                });
+            }
+            _ => todo!(),
+        }
+    }
+
     /// Population count per byte.
     pub fn cnt(&mut self, rd: WritableReg) {
         self.emit(Inst::VecMisc {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1074,8 +1074,10 @@ impl Masm for MacroAssembler {
     }
 
     fn unreachable(&mut self) -> Result<()> {
-        self.asm.udf(wasmtime_cranelift::TRAP_UNREACHABLE);
-        Ok(())
+        self.with_aligned_sp(|masm| {
+            masm.asm.udf(wasmtime_cranelift::TRAP_UNREACHABLE);
+            Ok(())
+        })
     }
 
     fn jmp_table(&mut self, targets: &[MachLabel], index: Reg, tmp: Reg) -> Result<()> {


### PR DESCRIPTION


This commit moves all "ignore these outright" tests for Winch and
AArch64 to "run the test and expect failure" after recent PRs which
removed most of the segfaults/etc which prevented running these tests.
One failure remained which was easy enough to fix here: the `cmov`
implementation only worked on integer registers, not floating-point
registers, leading to a panic. A helper was added for floating-point selects to
resolve this panic and get some tests passing.

After this fix the `ignore` method is no longer necessary as all tests
can be run and be flagged as either pass or fail.

