### PR TITLE
x64: Migrate `bswap` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -140,18 +140,18 @@ impl dsl::Format {
                 fmtln!(f, "let dst = self.{dst}.enc();");
                 fmtln!(f, "let rex = RexPrefix::with_digit(digit, dst, {bits});");
             }
-            [Reg(dst), Imm(_)] | [Reg(dst)] => match rex.digit {
-                Some(digit) => {
-                    fmtln!(f, "let digit = 0x{digit:x};");
-                    fmtln!(f, "let dst = self.{dst}.enc();");
-                    fmtln!(f, "let rex = RexPrefix::two_op(digit, dst, {bits});");
-                }
-                None => {
-                    assert!(rex.opcode_mod.is_some());
-                    fmtln!(f, "let dst = self.{dst}.enc();");
-                    fmtln!(f, "let rex = RexPrefix::one_op(dst, {bits});");
-                }
-            },
+            [Reg(dst)] => {
+                assert_eq!(rex.digit, None);
+                assert!(rex.opcode_mod.is_some());
+                fmtln!(f, "let dst = self.{dst}.enc();");
+                fmtln!(f, "let rex = RexPrefix::one_op(dst, {bits});");
+            }
+            [Reg(dst), Imm(_)] => {
+                let digit = rex.digit.unwrap();
+                fmtln!(f, "let digit = 0x{digit:x};");
+                fmtln!(f, "let dst = self.{dst}.enc();");
+                fmtln!(f, "let rex = RexPrefix::two_op(digit, dst, {bits});");
+            }
             [FixedReg(_), RegMem(mem)]
             | [FixedReg(_), FixedReg(_), RegMem(mem)]
             | [RegMem(mem), FixedReg(_)] => {

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -140,12 +140,18 @@ impl dsl::Format {
                 fmtln!(f, "let dst = self.{dst}.enc();");
                 fmtln!(f, "let rex = RexPrefix::with_digit(digit, dst, {bits});");
             }
-            [Reg(dst), Imm(_)] => {
-                let digit = rex.digit.unwrap();
-                fmtln!(f, "let digit = 0x{digit:x};");
-                fmtln!(f, "let dst = self.{dst}.enc();");
-                fmtln!(f, "let rex = RexPrefix::two_op(digit, dst, {bits});");
-            }
+            [Reg(dst), Imm(_)] | [Reg(dst)] => match rex.digit {
+                Some(digit) => {
+                    fmtln!(f, "let digit = 0x{digit:x};");
+                    fmtln!(f, "let dst = self.{dst}.enc();");
+                    fmtln!(f, "let rex = RexPrefix::two_op(digit, dst, {bits});");
+                }
+                None => {
+                    assert!(rex.opcode_mod.is_some());
+                    fmtln!(f, "let dst = self.{dst}.enc();");
+                    fmtln!(f, "let rex = RexPrefix::one_op(dst, {bits});");
+                }
+            },
             [FixedReg(_), RegMem(mem)]
             | [FixedReg(_), FixedReg(_), RegMem(mem)]
             | [RegMem(mem), FixedReg(_)] => {

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -39,5 +39,8 @@ pub fn list() -> Vec<Inst> {
         inst("cwtd", fmt("ZO", [w(implicit(dx)), r(implicit(ax))]), rex([0x66, 0x99]), _64b | compat),
         inst("cltd", fmt("ZO", [w(implicit(edx)), r(implicit(eax))]), rex([0x99]), _64b | compat),
         inst("cqto", fmt("ZO", [w(implicit(rdx)), r(implicit(rax))]), rex([0x99]).w(), _64b),
+
+        inst("bswapl", fmt("O", [rw(r32)]), rex([0x0F, 0xC8]).rd(), _64b | compat),
+        inst("bswapq", fmt("O", [rw(r64)]), rex([0x0F, 0xC8]).w().ro(), _64b),
     ]
 }

--- a/cranelift/assembler-x64/src/rex.rs
+++ b/cranelift/assembler-x64/src/rex.rs
@@ -49,7 +49,7 @@ impl RexPrefix {
     ///   bit of the opcode digit.
     #[inline]
     #[must_use]
-    pub const fn one_op(self, enc: u8, w_bit: bool, uses_8bit: bool) -> Self {
+    pub const fn one_op(enc: u8, w_bit: bool, uses_8bit: bool) -> Self {
         let must_emit = uses_8bit && is_special(enc);
         let w = if w_bit { 1 } else { 0 };
         let r = 0;

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -135,11 +135,6 @@
        (Setcc (cc CC)
               (dst WritableGpr))
 
-       ;; Swaps byte order in register
-       (Bswap (size OperandSize) ;; 4 or 8
-              (src Gpr)
-              (dst WritableGpr))
-
        ;; =========================================
        ;; Conditional moves.
 
@@ -3012,11 +3007,8 @@
 ;; In x64, 32- and 64-bit registers use BSWAP instruction, and
 ;; for 16-bit registers one must instead use xchg or rol/ror
 (decl x64_bswap (Type Gpr) Gpr)
-(rule (x64_bswap ty src)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (_ Unit (emit (MInst.Bswap size src dst))))
-        dst))
+(rule (x64_bswap $I32 src) (x64_bswapl_o src))
+(rule (x64_bswap $I64 src) (x64_bswapq_o src))
 
 ;; Helper for creating `MInst.CmpRmiR` instructions.
 (decl cmp_rmi_r (OperandSize CmpOpcode Gpr GprMemImm) ProducesFlags)

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -844,21 +844,6 @@ pub(crate) fn emit(
             );
         }
 
-        Inst::Bswap { size, src, dst } => {
-            let src = src.to_reg();
-            let dst = dst.to_reg().to_reg();
-            debug_assert_eq!(src, dst);
-            let enc_reg = int_reg_enc(dst);
-
-            // BSWAP reg32 is (REX.W==0) 0F C8
-            // BSWAP reg64 is (REX.W==1) 0F C8
-            let rex_flags = RexFlags::from(*size);
-            rex_flags.emit_one_op(sink, enc_reg);
-
-            sink.put1(0x0F);
-            sink.put1(0xC8 | (enc_reg & 7));
-        }
-
         Inst::Cmove {
             size,
             cc,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -92,13 +92,6 @@ impl Inst {
         Inst::Setcc { cc, dst }
     }
 
-    fn bswap(size: OperandSize, dst: Writable<Reg>) -> Inst {
-        debug_assert!(dst.to_reg().class() == RegClass::Int);
-        let src = Gpr::unwrap_new(dst.to_reg());
-        let dst = WritableGpr::from_writable_reg(dst).unwrap();
-        Inst::Bswap { size, src, dst }
-    }
-
     fn xmm_rm_r_imm(
         op: SseOpcode,
         src: RegMem,
@@ -2356,54 +2349,6 @@ fn test_x64_emit() {
     insns.push((Inst::setcc(CC::LE, w_r14), "410F9EC6", "setle   %r14b"));
     insns.push((Inst::setcc(CC::P, w_r9), "410F9AC1", "setp    %r9b"));
     insns.push((Inst::setcc(CC::NP, w_r8), "410F9BC0", "setnp   %r8b"));
-
-    // ========================================================
-    // Bswap
-    insns.push((
-        Inst::bswap(OperandSize::Size64, w_rax),
-        "480FC8",
-        "bswapq  %rax, %rax",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size64, w_r8),
-        "490FC8",
-        "bswapq  %r8, %r8",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size32, w_rax),
-        "0FC8",
-        "bswapl  %eax, %eax",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size64, w_rcx),
-        "480FC9",
-        "bswapq  %rcx, %rcx",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size32, w_rcx),
-        "0FC9",
-        "bswapl  %ecx, %ecx",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size64, w_r11),
-        "490FCB",
-        "bswapq  %r11, %r11",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size32, w_r11),
-        "410FCB",
-        "bswapl  %r11d, %r11d",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size64, w_r14),
-        "490FCE",
-        "bswapq  %r14, %r14",
-    ));
-    insns.push((
-        Inst::bswap(OperandSize::Size32, w_r14),
-        "410FCE",
-        "bswapl  %r14d, %r14d",
-    ));
 
     // ========================================================
     // Cmove

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -77,7 +77,6 @@ impl Inst {
             // These instructions are part of SSE2, which is a basic requirement in Cranelift, and
             // don't have to be checked.
             Inst::AtomicRmwSeq { .. }
-            | Inst::Bswap { .. }
             | Inst::CallKnown { .. }
             | Inst::CallUnknown { .. }
             | Inst::ReturnCallKnown { .. }
@@ -1196,13 +1195,6 @@ impl PrettyPrint for Inst {
                 format!("{op} {dst}")
             }
 
-            Inst::Bswap { size, src, dst } => {
-                let src = pretty_print_reg(src.to_reg(), size.to_bytes());
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
-                let op = ljustify2("bswap".to_string(), suffix_bwlq(*size));
-                format!("{op} {src}, {dst}")
-            }
-
             Inst::Cmove {
                 size,
                 cc,
@@ -1931,10 +1923,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         }
         Inst::Setcc { dst, .. } => {
             collector.reg_def(dst);
-        }
-        Inst::Bswap { src, dst, .. } => {
-            collector.reg_use(src);
-            collector.reg_reuse_def(dst, 0);
         }
         Inst::Cmove {
             consequent,

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -250,8 +250,6 @@ pub(crate) fn check(
 
         Inst::Setcc { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
 
-        Inst::Bswap { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
-
         Inst::Cmove {
             size,
             dst,

--- a/cranelift/filetests/filetests/isa/x64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/x64/bswap.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   bswapq  %rax, %rax
+;   bswapq %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -39,7 +39,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   bswapl  %eax, %eax
+;   bswapl %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
This instruction is encoded a bit differently than other instructions already supported where the main opcode byte additionally carries bits corresponding to the register being swapped.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
