### PR TITLE
x64: Convert `compare` instructions to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl.rs
+++ b/cranelift/assembler-x64/meta/src/dsl.rs
@@ -13,7 +13,9 @@ pub use encoding::{
     VexLength, VexMMMMM, VexPP, rex, vex,
 };
 pub use features::{ALL_FEATURES, Feature, Features};
-pub use format::{Extension, Format, Location, Mutability, Operand, OperandKind, RegClass};
+pub use format::{
+    EflagsMutability, Extension, Format, Location, Mutability, Operand, OperandKind, RegClass,
+};
 pub use format::{align, fmt, implicit, r, rw, sxl, sxq, sxw, w};
 
 /// Abbreviated constructor for an x64 instruction.

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -15,7 +15,6 @@
 //!
 //! [link]: https://software.intel.com/content/www/us/en/develop/articles/intel-sdm.html
 
-
 use super::{Operand, OperandKind};
 use core::fmt;
 

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -15,7 +15,6 @@
 //!
 //! [link]: https://software.intel.com/content/www/us/en/develop/articles/intel-sdm.html
 
-use crate::dsl::RegClass;
 
 use super::{Operand, OperandKind};
 use core::fmt;

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -15,6 +15,8 @@
 //!
 //! [link]: https://software.intel.com/content/www/us/en/develop/articles/intel-sdm.html
 
+use crate::dsl::RegClass;
+
 use super::{Operand, OperandKind};
 use core::fmt;
 

--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -24,6 +24,7 @@ pub fn fmt(
     Format {
         name: name.into(),
         operands: operands.into_iter().map(Into::into).collect(),
+        eflags: EflagsMutability::default(),
     }
 }
 
@@ -134,6 +135,8 @@ pub struct Format {
     /// These operands should match the "Instruction" column in the reference
     /// manual.
     pub operands: Vec<Operand>,
+    /// This should match eflags description of an instruction.
+    pub eflags: EflagsMutability,
 }
 
 impl Format {
@@ -166,17 +169,38 @@ impl Format {
     pub fn operands_by_kind(&self) -> Vec<OperandKind> {
         self.locations().map(Location::kind).collect()
     }
+
+    /// Set the EFLAGS mutability for this instruction.
+    pub fn flags(mut self, eflags: EflagsMutability) -> Self {
+        self.eflags = eflags;
+        self
+    }
+
+    /// Return true if an instruction uses EFLAGS.
+    pub fn uses_eflags(&self) -> bool {
+        self.eflags != EflagsMutability::None
+    }
 }
 
 impl core::fmt::Display for Format {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        let Format { name, operands } = self;
+        let Format {
+            name,
+            operands,
+            eflags,
+        } = self;
         let operands = operands
             .iter()
             .map(|operand| format!("{operand}"))
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "{name}({operands})")
+        write!(f, "{name}({operands})")?;
+
+        if *eflags != EflagsMutability::None {
+            write!(f, "[flags:{eflags}]")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -256,6 +280,7 @@ impl From<Location> for Operand {
 }
 
 /// The kind of register used in a [`Location`].
+#[derive(PartialEq)]
 pub enum RegClass {
     Gpr,
     Xmm,
@@ -534,6 +559,31 @@ impl core::fmt::Display for Extension {
             Extension::SignExtendQuad => write!(f, "sxq"),
             Extension::SignExtendLong => write!(f, "sxl"),
             Extension::SignExtendWord => write!(f, "sxw"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EflagsMutability {
+    None,
+    R,
+    W,
+    RW,
+}
+
+impl Default for EflagsMutability {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl core::fmt::Display for EflagsMutability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, ""),
+            Self::R => write!(f, "r"),
+            Self::W => write!(f, "w"),
+            Self::RW => write!(f, "rw"),
         }
     }
 }

--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -217,6 +217,54 @@ impl dsl::Inst {
                             let to_string = location.generate_to_string(op.extension);
                             fmtln!(f, "let {location} = {to_string};");
                         }
+                        // Fix the mnemonic for comparison instructions: we want to print pseudo-ops without
+                        // the immediate operand.
+                        if self.mnemonic.starts_with("cmp")
+                            && ["cmppd", "cmpps", "cmpsd", "cmpss"]
+                                .contains(&self.mnemonic.as_str())
+                            && self.format.operands.len() == 3
+                            && matches!(
+                                self.format.operands[2].location.kind(),
+                                dsl::OperandKind::Imm(_)
+                            )
+                        {
+                            let imm_operand = self.format.operands[2].location;
+                            f.add_block(
+                                &format!("let mnemonic = match self.{}.value()", imm_operand),
+                                |f| {
+                                    let suffix = &self.mnemonic[3..];
+                                    fmtln!(f, "0 => \"cmpeq{suffix}\",");
+                                    fmtln!(f, "1 => \"cmplt{suffix}\",");
+                                    fmtln!(f, "2 => \"cmple{suffix}\",");
+                                    fmtln!(f, "3 => \"cmpunord{suffix}\",");
+                                    fmtln!(f, "4 => \"cmpneq{suffix}\",");
+                                    fmtln!(f, "5 => \"cmpnlt{suffix}\",");
+                                    fmtln!(f, "6 => \"cmpnle{suffix}\",");
+                                    fmtln!(f, "7 => \"cmpord{suffix}\",");
+                                    fmtln!(f, "_ => \"{}\",", self.mnemonic);
+                                },
+                            );
+                            fmtln!(f, ";");
+                            fmtln!(f, "let operands = if mnemonic != \"{}\" {{", self.mnemonic);
+                            fmtln!(
+                                f,
+                                "  format!(\"{{}}, {{}}\", {}, {})",
+                                self.format.operands[1].location,
+                                self.format.operands[0].location
+                            );
+                            fmtln!(f, "}} else {{");
+                            fmtln!(
+                                f,
+                                "  format!(\"{{}}, {{}}, {{}}\", {}, {}, {})",
+                                imm_operand,
+                                self.format.operands[1].location,
+                                self.format.operands[0].location
+                            );
+                            fmtln!(f, "}};");
+
+                            fmtln!(f, "write!(f, \"{} {{}}\", operands)", "{mnemonic}");
+                            return;
+                        }
                         // Fix up the mnemonic for locked instructions: we want to print
                         // "lock <inst>", not "lock_<inst>".
                         let inst_name = if self.mnemonic.starts_with("lock_") {

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -3,6 +3,7 @@
 mod add;
 mod and;
 mod bitmanip;
+mod cmp;
 mod cvt;
 mod div;
 mod lanes;
@@ -24,6 +25,7 @@ pub fn list() -> Vec<Inst> {
     all.extend(add::list());
     all.extend(and::list());
     all.extend(bitmanip::list());
+    all.extend(cmp::list());
     all.extend(cvt::list());
     all.extend(div::list());
     all.extend(lanes::list());

--- a/cranelift/assembler-x64/meta/src/instructions/cmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cmp.rs
@@ -1,5 +1,5 @@
 use crate::dsl::{EflagsMutability::*, Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq, sxw, w};
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq, sxw};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -24,11 +24,11 @@ pub fn list() -> Vec<Inst> {
         inst("cmpl", fmt("RM", [r(r32), r(rm32)]), rex(0x3B).r(), _64b | compat),
         inst("cmpq", fmt("RM", [r(r64), r(rm64)]), rex(0x3B).w().r(), _64b),
         // Vector instructions
-        inst("cmppd", fmt("A", [rw(xmm), r(xmm_m128), r(imm8)]), rex([0x66, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
-        inst("cmpps", fmt("A", [rw(xmm), r(xmm_m128), r(imm8)]), rex([0x0F, 0xC2]).r().ib(), _64b | compat | sse),
-        inst("cmpsd", fmt("A", [rw(xmm), r(xmm_m64), r(imm8)]), rex([0x66, 0xF2, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
-        inst("cmpss", fmt("A", [rw(xmm), r(xmm_m32), r(imm8)]), rex([0xF3, 0x0F, 0xC2]).r().ib(), _64b | compat | sse),
-        inst("ucomisd", fmt("A", [r(xmm), r(xmm_m64)]).flags(W), rex([0x66, 0x0F, 0x2E]).r(), _64b | compat | sse2),
-        inst("ucomiss", fmt("A", [r(xmm), r(xmm_m32)]).flags(W), rex([0x0F, 0x2E]).r(), _64b | compat | sse),
+        inst("cmppd", fmt("A", [rw(xmm1), r(xmm_m128), r(imm8)]), rex([0x66, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
+        inst("cmpps", fmt("A", [rw(xmm1), r(xmm_m128), r(imm8)]), rex([0x0F, 0xC2]).r().ib(), _64b | compat | sse),
+        inst("cmpsd", fmt("A", [rw(xmm1), r(xmm_m64), r(imm8)]), rex([0x66, 0xF2, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
+        inst("cmpss", fmt("A", [rw(xmm1), r(xmm_m32), r(imm8)]), rex([0xF3, 0x0F, 0xC2]).r().ib(), _64b | compat | sse),
+        inst("ucomisd", fmt("A", [r(xmm1), r(xmm_m64)]).flags(W), rex([0x66, 0x0F, 0x2E]).r(), _64b | compat | sse2),
+        inst("ucomiss", fmt("A", [r(xmm1), r(xmm_m32)]).flags(W), rex([0x0F, 0x2E]).r(), _64b | compat | sse),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/cmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cmp.rs
@@ -1,0 +1,34 @@
+use crate::dsl::{EflagsMutability::*, Feature::*, Inst, Location::*};
+use crate::dsl::{fmt, inst, r, rex, rw, sxl, sxq, sxw, w};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("cmpb", fmt("I", [r(al), r(imm8)]), rex(0x3C).ib(), _64b | compat),
+        inst("cmpw", fmt("I", [r(ax), r(imm16)]), rex([0x66, 0x3D]).iw(), _64b | compat),
+        inst("cmpl", fmt("I", [r(eax), r(imm32)]), rex(0x3D).id(), _64b | compat),
+        inst("cmpq", fmt("I_SXL", [r(rax), sxq(imm32)]), rex(0x3D).w().id(), _64b),
+        inst("cmpb", fmt("MI", [r(rm8), r(imm8)]), rex(0x80).digit(7).ib(), _64b | compat),
+        inst("cmpw", fmt("MI", [r(rm16), r(imm16)]), rex([0x66, 0x81]).digit(7).iw(), _64b | compat),
+        inst("cmpl", fmt("MI", [r(rm32), r(imm32)]), rex(0x81).digit(7).id(), _64b | compat),
+        inst("cmpq", fmt("MI_SXL", [r(rm64), sxq(imm32)]), rex(0x81).w().digit(7).id(), _64b),
+        inst("cmpw", fmt("MI_SXW", [r(rm16), sxw(imm8)]), rex([0x66, 0x83]).digit(7).ib(), _64b | compat),
+        inst("cmpl", fmt("MI_SXB", [r(rm32), sxl(imm8)]), rex(0x83).digit(7).ib(), _64b | compat),
+        inst("cmpq", fmt("MI_SXB", [r(rm64), sxq(imm8)]), rex(0x83).w().digit(7).ib(), _64b),
+        inst("cmpb", fmt("MR", [r(rm8), r(r8)]), rex(0x38).r(), _64b | compat),
+        inst("cmpw", fmt("MR", [r(rm16), r(r16)]), rex([0x66, 0x39]).r(), _64b | compat),
+        inst("cmpl", fmt("MR", [r(rm32), r(r32)]), rex(0x39).r(), _64b | compat),
+        inst("cmpq", fmt("MR", [r(rm64), r(r64)]), rex(0x39).w().r(), _64b),
+        inst("cmpb", fmt("RM", [r(r8), r(rm8)]), rex(0x3A).r(), _64b | compat),
+        inst("cmpw", fmt("RM", [r(r16), r(rm16)]), rex([0x66, 0x3B]).r(), _64b | compat),
+        inst("cmpl", fmt("RM", [r(r32), r(rm32)]), rex(0x3B).r(), _64b | compat),
+        inst("cmpq", fmt("RM", [r(r64), r(rm64)]), rex(0x3B).w().r(), _64b),
+        // Vector instructions
+        inst("cmppd", fmt("A", [rw(xmm), r(xmm_m128), r(imm8)]), rex([0x66, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
+        inst("cmpps", fmt("A", [rw(xmm), r(xmm_m128), r(imm8)]), rex([0x0F, 0xC2]).r().ib(), _64b | compat | sse),
+        inst("cmpsd", fmt("A", [rw(xmm), r(xmm_m64), r(imm8)]), rex([0x66, 0xF2, 0x0F, 0xC2]).r().ib(), _64b | compat | sse2),
+        inst("cmpss", fmt("A", [rw(xmm), r(xmm_m32), r(imm8)]), rex([0xF3, 0x0F, 0xC2]).r().ib(), _64b | compat | sse),
+        inst("ucomisd", fmt("A", [r(xmm), r(xmm_m64)]).flags(W), rex([0x66, 0x0F, 0x2E]).r(), _64b | compat | sse2),
+        inst("ucomiss", fmt("A", [r(xmm), r(xmm_m32)]).flags(W), rex([0x0F, 0x2E]).r(), _64b | compat | sse),
+    ]
+}

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -310,7 +310,7 @@ impl IsleConstructor {
     pub fn includes_write_only_reg_mem(&self) -> bool {
         match self {
             IsleConstructor::RetMemorySideEffect => true,
-            IsleConstructor::RetGpr | IsleConstructor::RetXmm | IsleConstructor::RetValueRegs => {
+            IsleConstructor::RetGpr | IsleConstructor::RetXmm | IsleConstructor::RetValueRegs | IsleConstructor::NoReturnSideEffect => {
                 false
             }
         }
@@ -497,7 +497,7 @@ pub fn generate_isle_inst_decls(f: &mut Formatter, inst: &Inst) {
             .map(|o| {
                 assert!(matches!(o.location.kind(), OperandKind::RegMem(_)));
                 match ctor {
-                    IsleConstructor::RetMemorySideEffect => unreachable!(),
+                    IsleConstructor::RetMemorySideEffect | IsleConstructor::NoReturnSideEffect => unreachable!(),
                     IsleConstructor::RetGpr => "(temp_writable_gpr)",
                     IsleConstructor::RetXmm => "(temp_writable_xmm)",
                     IsleConstructor::RetValueRegs => todo!(),

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -310,9 +310,10 @@ impl IsleConstructor {
     pub fn includes_write_only_reg_mem(&self) -> bool {
         match self {
             IsleConstructor::RetMemorySideEffect => true,
-            IsleConstructor::RetGpr | IsleConstructor::RetXmm | IsleConstructor::RetValueRegs | IsleConstructor::NoReturnSideEffect => {
-                false
-            }
+            IsleConstructor::RetGpr
+            | IsleConstructor::RetXmm
+            | IsleConstructor::RetValueRegs
+            | IsleConstructor::NoReturnSideEffect => false,
         }
     }
 }
@@ -497,7 +498,9 @@ pub fn generate_isle_inst_decls(f: &mut Formatter, inst: &Inst) {
             .map(|o| {
                 assert!(matches!(o.location.kind(), OperandKind::RegMem(_)));
                 match ctor {
-                    IsleConstructor::RetMemorySideEffect | IsleConstructor::NoReturnSideEffect => unreachable!(),
+                    IsleConstructor::RetMemorySideEffect | IsleConstructor::NoReturnSideEffect => {
+                        unreachable!()
+                    }
                     IsleConstructor::RetGpr => "(temp_writable_gpr)",
                     IsleConstructor::RetXmm => "(temp_writable_xmm)",
                     IsleConstructor::RetValueRegs => todo!(),

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -150,7 +150,7 @@ pub fn generate_macro_inst_fn(f: &mut Formatter, inst: &Inst) {
                 (ty, var)
             };
             match results.as_slice() {
-                [] => fmtln!(f, "SideEffectNoResult::Inst(inst)"),
+                [] => fmtln!(f, "AssemblerOutputs::SideEffect {{ inst }}"),
                 [op] => match op.location.kind() {
                     OperandKind::Imm(_) => unreachable!(),
                     OperandKind::Reg(r) | OperandKind::FixedReg(r) => {
@@ -260,16 +260,21 @@ pub enum IsleConstructor {
     /// This "special" constructor captures multiple written-to registers (e.g.
     /// `mul`).
     RetValueRegs,
+
+    /// This constructor does not return any results, but produces a side effect affecting EFLAGs.
+    NoReturnSideEffect,
 }
 
 impl IsleConstructor {
     /// Returns the result type, in ISLE, that this constructor generates.
     pub fn result_ty(&self) -> &'static str {
         match self {
-            IsleConstructor::RetMemorySideEffect => "SideEffectNoResult",
             IsleConstructor::RetGpr => "Gpr",
             IsleConstructor::RetXmm => "Xmm",
             IsleConstructor::RetValueRegs => "ValueRegs",
+            IsleConstructor::NoReturnSideEffect | IsleConstructor::RetMemorySideEffect => {
+                "SideEffectNoResult"
+            }
         }
     }
 
@@ -277,7 +282,9 @@ impl IsleConstructor {
     /// type returned by [`Self::result_ty`].
     pub fn conversion_constructor(&self) -> &'static str {
         match self {
-            IsleConstructor::RetMemorySideEffect => "defer_side_effect",
+            IsleConstructor::NoReturnSideEffect | IsleConstructor::RetMemorySideEffect => {
+                "defer_side_effect"
+            }
             IsleConstructor::RetGpr => "emit_ret_gpr",
             IsleConstructor::RetXmm => "emit_ret_xmm",
             IsleConstructor::RetValueRegs => "emit_ret_value_regs",
@@ -288,7 +295,10 @@ impl IsleConstructor {
     pub fn suffix(&self) -> &'static str {
         match self {
             IsleConstructor::RetMemorySideEffect => "_mem",
-            IsleConstructor::RetGpr | IsleConstructor::RetXmm | IsleConstructor::RetValueRegs => "",
+            IsleConstructor::RetGpr
+            | IsleConstructor::RetXmm
+            | IsleConstructor::RetValueRegs
+            | IsleConstructor::NoReturnSideEffect => "",
         }
     }
 
@@ -316,6 +326,7 @@ pub fn isle_param_for_ctor(op: &Operand, ctor: IsleConstructor) -> String {
         // other constructor it's operating on registers so the argument is
         // a `Gpr`.
         OperandKind::RegMem(_) if op.mutability.is_write() => match ctor {
+            IsleConstructor::NoReturnSideEffect => "".to_string(),
             IsleConstructor::RetMemorySideEffect => "Amode".to_string(),
             IsleConstructor::RetGpr => "Gpr".to_string(),
             IsleConstructor::RetXmm => "Xmm".to_string(),
@@ -342,9 +353,7 @@ pub fn isle_constructors(format: &Format) -> Vec<IsleConstructor> {
         .filter(|o| o.mutability.is_write())
         .collect::<Vec<_>>();
     match &write_operands[..] {
-        [] => unimplemented!(
-            "if you truly need this (and not a `SideEffect*`), add a `NoReturn` variant to `AssemblerOutputs`"
-        ),
+        [] => vec![IsleConstructor::NoReturnSideEffect],
         [one] => match one.mutability {
             Read => unreachable!(),
             ReadWrite | Write => match one.location.kind() {

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -753,11 +753,6 @@
 (type SseOpcode extern
       (enum Blendvpd
             Blendvps
-            Comiss
-            Comisd
-            Cmpps
-            Cmppd
-            Cmpss
             Cmpsd
             Divps
             Divpd
@@ -827,8 +822,6 @@
             Roundsd
             Rsqrtss
             Shufps
-            Ucomiss
-            Ucomisd
             Unpcklps
             Unpcklpd
             Unpckhps
@@ -2514,6 +2507,8 @@
 (decl asm_produce_flags_side_effect (AssemblerOutputs) ProducesFlags)
 (rule (asm_produce_flags_side_effect (AssemblerOutputs.RetGpr inst gpr))
       (ProducesFlags.ProducesFlagsSideEffect inst))
+(rule (asm_produce_flags_side_effect (AssemblerOutputs.SideEffect inst))
+      (ProducesFlags.ProducesFlagsSideEffect inst))
 
 ;; Other helpers for instruction emission.
 
@@ -3044,9 +3039,9 @@
 ;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
 (decl x64_ucomis (Type Xmm XmmMem) ProducesFlags)
 (rule (x64_ucomis $F32 src1 src2)
-      (xmm_cmp_rm_r (SseOpcode.Ucomiss) src1 src2))
+      (asm_produce_flags_side_effect (x64_ucomiss_a_raw src1 src2)))
 (rule (x64_ucomis $F64 src1 src2)
-      (xmm_cmp_rm_r (SseOpcode.Ucomisd) src1 src2))
+      (asm_produce_flags_side_effect (x64_ucomisd_a_raw src1 src2)))
 (rule 1 (x64_ucomis $F32 src1 src2)
         (if-let true (use_avx))
         (xmm_cmp_rm_r_vex (AvxOpcode.Vucomiss) src1 src2))
@@ -3867,12 +3862,7 @@
 (rule (x64_cmpp $F64X2 x y imm) (x64_cmppd x y imm))
 
 (decl x64_cmpps (Xmm XmmMem FcmpImm) Xmm)
-(rule 0 (x64_cmpps src1 src2 imm)
-      (xmm_rm_r_imm (SseOpcode.Cmpps)
-                    src1
-                    src2
-                    (encode_fcmp_imm imm)
-                    (OperandSize.Size32)))
+(rule 0 (x64_cmpps src1 src2 imm) (x64_cmpps_a src1 src2 (encode_fcmp_imm imm)))
 (rule 1 (x64_cmpps src1 src2 imm)
       (if-let true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vcmpps)
@@ -3884,12 +3874,7 @@
 ;; operations, since this presumably induces the correct encoding of the
 ;; instruction.
 (decl x64_cmppd (Xmm XmmMem FcmpImm) Xmm)
-(rule 0 (x64_cmppd src1 src2 imm)
-      (xmm_rm_r_imm (SseOpcode.Cmppd)
-                    src1
-                    src2
-                    (encode_fcmp_imm imm)
-                    (OperandSize.Size32)))
+(rule 0 (x64_cmppd src1 src2 imm) (x64_cmppd_a src1 src2 (encode_fcmp_imm imm)))
 (rule 1 (x64_cmppd src1 src2 imm)
       (if-let true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vcmppd)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -823,12 +823,6 @@ pub(crate) enum InstructionSet {
 pub enum SseOpcode {
     Blendvpd,
     Blendvps,
-    Comiss,
-    Comisd,
-    Cmpps,
-    Cmppd,
-    Cmpss,
-    Cmpsd,
     Divps,
     Divpd,
     Divss,
@@ -897,8 +891,6 @@ pub enum SseOpcode {
     Roundsd,
     Rsqrtss,
     Shufps,
-    Ucomiss,
-    Ucomisd,
     Unpcklps,
     Unpcklpd,
     Unpckhps,
@@ -917,10 +909,7 @@ impl SseOpcode {
     pub(crate) fn available_from(&self) -> InstructionSet {
         use InstructionSet::*;
         match self {
-            SseOpcode::Comiss
-            | SseOpcode::Cmpps
-            | SseOpcode::Cmpss
-            | SseOpcode::Divps
+            SseOpcode::Divps
             | SseOpcode::Divss
             | SseOpcode::Movaps
             | SseOpcode::Movlhps
@@ -929,14 +918,10 @@ impl SseOpcode {
             | SseOpcode::Rcpss
             | SseOpcode::Rsqrtss
             | SseOpcode::Shufps
-            | SseOpcode::Ucomiss
             | SseOpcode::Unpcklps
             | SseOpcode::Unpckhps => SSE,
 
-            SseOpcode::Cmppd
-            | SseOpcode::Cmpsd
-            | SseOpcode::Comisd
-            | SseOpcode::Divpd
+            SseOpcode::Divpd
             | SseOpcode::Divsd
             | SseOpcode::Movapd
             | SseOpcode::Movsd
@@ -964,7 +949,6 @@ impl SseOpcode {
             | SseOpcode::Punpckhwd
             | SseOpcode::Punpcklbw
             | SseOpcode::Punpcklwd
-            | SseOpcode::Ucomisd
             | SseOpcode::Punpckldq
             | SseOpcode::Punpckhdq
             | SseOpcode::Punpcklqdq
@@ -1045,12 +1029,6 @@ impl fmt::Debug for SseOpcode {
         let name = match self {
             SseOpcode::Blendvpd => "blendvpd",
             SseOpcode::Blendvps => "blendvps",
-            SseOpcode::Cmpps => "cmpps",
-            SseOpcode::Cmppd => "cmppd",
-            SseOpcode::Cmpss => "cmpss",
-            SseOpcode::Cmpsd => "cmpsd",
-            SseOpcode::Comiss => "comiss",
-            SseOpcode::Comisd => "comisd",
             SseOpcode::Divps => "divps",
             SseOpcode::Divpd => "divpd",
             SseOpcode::Divss => "divss",
@@ -1120,8 +1098,6 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Roundsd => "roundsd",
             SseOpcode::Rsqrtss => "rsqrtss",
             SseOpcode::Shufps => "shufps",
-            SseOpcode::Ucomiss => "ucomiss",
-            SseOpcode::Ucomisd => "ucomisd",
             SseOpcode::Unpcklps => "unpcklps",
             SseOpcode::Unpckhps => "unpckhps",
             SseOpcode::Punpckldq => "punpckldq",

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -7,7 +7,7 @@ use crate::isa::x64::encoding::rex::{
     low8_will_sign_extend_to_64, reg_enc,
 };
 use crate::isa::x64::encoding::vex::{VexInstruction, VexVectorLength};
-use crate::isa::x64::external::{PairedGpr, CraneliftRegisters};
+use crate::isa::x64::external::{CraneliftRegisters, PairedGpr};
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::x64::lower::isle::generated_code::{Atomic128RmwSeqOp, AtomicRmwSeqOp};

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -7,7 +7,7 @@ use crate::isa::x64::encoding::rex::{
     low8_will_sign_extend_to_64, reg_enc,
 };
 use crate::isa::x64::encoding::vex::{VexInstruction, VexVectorLength};
-use crate::isa::x64::external::{CraneliftRegisters, PairedGpr};
+use crate::isa::x64::external::PairedGpr;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::x64::lower::isle::generated_code::{Atomic128RmwSeqOp, AtomicRmwSeqOp};

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -7,7 +7,7 @@ use crate::isa::x64::encoding::rex::{
     low8_will_sign_extend_to_64, reg_enc,
 };
 use crate::isa::x64::encoding::vex::{VexInstruction, VexVectorLength};
-use crate::isa::x64::external::PairedGpr;
+use crate::isa::x64::external::{PairedGpr, CraneliftRegisters};
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::x64::lower::isle::generated_code::{Atomic128RmwSeqOp, AtomicRmwSeqOp};
@@ -2599,10 +2599,9 @@ pub(crate) fn emit(
             let propagate_nan = sink.get_label();
             let do_min_max = sink.get_label();
 
-            let (add_op, cmp_op, and_op, or_op, min_max_op) = match size {
+            let (add_op, and_op, or_op, min_max_op) = match size {
                 OperandSize::Size32 => (
                     asm::inst::addss_a::new(dst, lhs).into(),
-                    SseOpcode::Ucomiss,
                     asm::inst::andps_a::new(dst, lhs).into(),
                     asm::inst::orps_a::new(dst, lhs).into(),
                     if *is_min {
@@ -2613,7 +2612,6 @@ pub(crate) fn emit(
                 ),
                 OperandSize::Size64 => (
                     asm::inst::addsd_a::new(dst, lhs).into(),
-                    SseOpcode::Ucomisd,
                     asm::inst::andpd_a::new(dst, lhs).into(),
                     asm::inst::orpd_a::new(dst, lhs).into(),
                     if *is_min {
@@ -2625,8 +2623,7 @@ pub(crate) fn emit(
                 _ => unreachable!(),
             };
 
-            let inst = Inst::xmm_cmp_rm_r(cmp_op, dst.to_reg(), RegMem::reg(lhs));
-            inst.emit(sink, info, state);
+            Inst::x64_ucomis(*size, dst.to_reg(), RegMem::reg(lhs)).emit(sink, info, state);
 
             one_way_jmp(sink, CC::NZ, do_min_max);
             one_way_jmp(sink, CC::P, propagate_nan);
@@ -2668,10 +2665,6 @@ pub(crate) fn emit(
             debug_assert_eq!(src1, dst);
 
             let (prefix, opcode, len) = match op {
-                SseOpcode::Cmpps => (LegacyPrefixes::None, 0x0FC2, 2),
-                SseOpcode::Cmppd => (LegacyPrefixes::_66, 0x0FC2, 2),
-                SseOpcode::Cmpss => (LegacyPrefixes::_F3, 0x0FC2, 2),
-                SseOpcode::Cmpsd => (LegacyPrefixes::_F2, 0x0FC2, 2),
                 SseOpcode::Insertps => (LegacyPrefixes::_66, 0x0F3A21, 3),
                 SseOpcode::Palignr => (LegacyPrefixes::_66, 0x0F3A0F, 3),
                 SseOpcode::Shufps => (LegacyPrefixes::None, 0x0FC6, 2),
@@ -2725,8 +2718,6 @@ pub(crate) fn emit(
             let rex = RexFlags::clear_w();
             let (prefix, opcode, len) = match op {
                 SseOpcode::Ptest => (LegacyPrefixes::_66, 0x0F3817, 3),
-                SseOpcode::Ucomisd => (LegacyPrefixes::_66, 0x0F2E, 2),
-                SseOpcode::Ucomiss => (LegacyPrefixes::None, 0x0F2E, 2),
                 _ => unimplemented!("Emit xmm cmp rm r"),
             };
 
@@ -2951,12 +2942,6 @@ pub(crate) fn emit(
             //
             // done:
 
-            let cmp_op = match src_size {
-                Size64 => SseOpcode::Ucomisd,
-                Size32 => SseOpcode::Ucomiss,
-                _ => unreachable!(),
-            };
-
             let cvtt_op = |dst, src| Inst::External {
                 inst: match (*src_size, *dst_size) {
                     (Size32, Size32) => asm::inst::cvttss2si_a::new(dst, src).into(),
@@ -2980,7 +2965,7 @@ pub(crate) fn emit(
 
             // Check for NaN.
 
-            let inst = Inst::xmm_cmp_rm_r(cmp_op, src, RegMem::reg(src));
+            let inst = Inst::x64_ucomis(*src_size, src, RegMem::reg(src));
             inst.emit(sink, info, state);
 
             if *is_saturating {
@@ -3006,7 +2991,7 @@ pub(crate) fn emit(
                 let inst = asm::inst::xorpd_a::new(tmp_xmm, tmp_xmm.to_reg()).into();
                 Inst::External { inst }.emit(sink, info, state);
 
-                let inst = Inst::xmm_cmp_rm_r(cmp_op, tmp_xmm.to_reg(), RegMem::reg(src));
+                let inst = Inst::x64_ucomis(*src_size, tmp_xmm.to_reg(), RegMem::reg(src));
                 inst.emit(sink, info, state);
 
                 // Jump if >= to done.
@@ -3063,7 +3048,7 @@ pub(crate) fn emit(
                 };
                 Inst::External { inst }.emit(sink, info, state);
 
-                let inst = Inst::xmm_cmp_rm_r(cmp_op, src, RegMem::reg(tmp_xmm.to_reg()));
+                let inst = Inst::x64_ucomis(*src_size, src, RegMem::reg(tmp_xmm.to_reg()));
                 inst.emit(sink, info, state);
 
                 // no trap if src >= or > threshold
@@ -3076,7 +3061,7 @@ pub(crate) fn emit(
                 let inst = asm::inst::xorpd_a::new(tmp_xmm, tmp_xmm.to_reg()).into();
                 Inst::External { inst }.emit(sink, info, state);
 
-                let inst = Inst::xmm_cmp_rm_r(cmp_op, tmp_xmm.to_reg(), RegMem::reg(src));
+                let inst = Inst::x64_ucomis(*src_size, tmp_xmm.to_reg(), RegMem::reg(src));
                 inst.emit(sink, info, state);
 
                 // no trap if 0 >= src
@@ -3141,12 +3126,6 @@ pub(crate) fn emit(
 
             assert_ne!(tmp_xmm.to_reg(), src, "tmp_xmm clobbers src!");
 
-            let cmp_op = match src_size {
-                Size32 => SseOpcode::Ucomiss,
-                Size64 => SseOpcode::Ucomisd,
-                _ => unreachable!(),
-            };
-
             let xor_op = |dst, src| Inst::External {
                 inst: match *dst_size {
                     Size32 => asm::inst::xorl_rm::new(dst, src).into(),
@@ -3194,7 +3173,7 @@ pub(crate) fn emit(
             };
             Inst::External { inst }.emit(sink, info, state);
 
-            let inst = Inst::xmm_cmp_rm_r(cmp_op, src, RegMem::reg(tmp_xmm.to_reg()));
+            let inst = Inst::x64_ucomis(*src_size, src, RegMem::reg(tmp_xmm.to_reg()));
             inst.emit(sink, info, state);
 
             let handle_large = sink.get_label();

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -2610,33 +2610,6 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
-    // XMM_CMP_RM_R
-
-    insns.push((
-        Inst::xmm_cmp_rm_r(SseOpcode::Ucomiss, xmm2, RegMem::reg(xmm1)),
-        "0F2ED1",
-        "ucomiss %xmm1, %xmm2",
-    ));
-
-    insns.push((
-        Inst::xmm_cmp_rm_r(SseOpcode::Ucomiss, xmm9, RegMem::reg(xmm0)),
-        "440F2EC8",
-        "ucomiss %xmm0, %xmm9",
-    ));
-
-    insns.push((
-        Inst::xmm_cmp_rm_r(SseOpcode::Ucomisd, xmm4, RegMem::reg(xmm13)),
-        "66410F2EE5",
-        "ucomisd %xmm13, %xmm4",
-    ));
-
-    insns.push((
-        Inst::xmm_cmp_rm_r(SseOpcode::Ucomisd, xmm12, RegMem::reg(xmm11)),
-        "66450F2EE3",
-        "ucomisd %xmm11, %xmm12",
-    ));
-
-    // ========================================================
     // XMM_RM_R: float binary ops
 
     insns.push((
@@ -2980,28 +2953,6 @@ fn test_x64_emit() {
 
     // ========================================================
     // XmmRmRImm
-    insns.push((
-        Inst::xmm_rm_r_imm(
-            SseOpcode::Cmppd,
-            RegMem::reg(xmm5),
-            w_xmm1,
-            2,
-            OperandSize::Size32,
-        ),
-        "660FC2CD02",
-        "cmppd   $2, %xmm1, %xmm5, %xmm1",
-    ));
-    insns.push((
-        Inst::xmm_rm_r_imm(
-            SseOpcode::Cmpps,
-            RegMem::reg(xmm15),
-            w_xmm7,
-            0,
-            OperandSize::Size32,
-        ),
-        "410FC2FF00",
-        "cmpps   $0, %xmm7, %xmm15, %xmm7",
-    ));
     insns.push((
         Inst::xmm_rm_r_imm(
             SseOpcode::Palignr,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -292,14 +292,6 @@ impl Inst {
         }
     }
 
-    pub(crate) fn xmm_cmp_rm_r(op: SseOpcode, src1: Reg, src2: RegMem) -> Inst {
-        src2.assert_regclass_is(RegClass::Float);
-        debug_assert!(src1.class() == RegClass::Float);
-        let src2 = XmmMemAligned::unwrap_new(src2);
-        let src1 = Xmm::unwrap_new(src1);
-        Inst::XmmCmpRmR { op, src1, src2 }
-    }
-
     /// Compare two floating-point registers, returning the result in the flags.
     pub fn x64_ucomis(size: OperandSize, src1: Reg, src2: RegMem) -> Self {
         debug_assert!(src1.class() == RegClass::Float);

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -300,6 +300,37 @@ impl Inst {
         Inst::XmmCmpRmR { op, src1, src2 }
     }
 
+    /// Compare two floating-point registers, returning the result in the flags.
+    pub fn x64_ucomis(size: OperandSize, src1: Reg, src2: RegMem) -> Self {
+        debug_assert!(src1.class() == RegClass::Float);
+        let inst = match size {
+            OperandSize::Size32 => match src2 {
+                RegMem::Reg { reg } => {
+                    debug_assert!(reg.class() == RegClass::Float);
+                    asm::inst::ucomiss_a::new(src1, reg).into()
+                }
+                RegMem::Mem { addr } => {
+                    let xmm = Xmm::unwrap_new(src1);
+                    let xmm_mem = asm::XmmMem::Mem(addr.into());
+                    asm::inst::ucomiss_a::new(xmm, xmm_mem).into()
+                }
+            },
+            OperandSize::Size64 => match src2 {
+                RegMem::Reg { reg } => {
+                    debug_assert!(reg.class() == RegClass::Float);
+                    asm::inst::ucomisd_a::new(src1, reg).into()
+                }
+                RegMem::Mem { addr } => {
+                    let xmm = Xmm::unwrap_new(src1);
+                    let xmm_mem = asm::XmmMem::Mem(addr.into());
+                    asm::inst::ucomisd_a::new(xmm, xmm_mem).into()
+                }
+            },
+            _ => unreachable!("ucomis only supports 32 and 64 bit operands"),
+        };
+        Inst::External { inst }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn xmm_min_max_seq(
         size: OperandSize,

--- a/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
@@ -17,7 +17,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movd %r10d, %xmm7
 ;   shufps  $0, %xmm7, const(0), %xmm7
 ;   movdqa  %xmm0, %xmm1
-;   cmpps   $3, %xmm1, %xmm0, %xmm1
+;   cmpunordps %xmm0, %xmm1
 ;   movdqa  %xmm0, %xmm2
 ;   movdqa  %xmm1, %xmm0
 ;   movdqa  %xmm2, %xmm1
@@ -70,7 +70,7 @@ block0(v0: f64, v1: f64):
 ;   movabsq $9221120237041090560, %r9
 ;   movq %r9, %xmm1
 ;   movdqa  %xmm0, %xmm7
-;   cmppd   $3, %xmm7, %xmm0, %xmm7
+;   cmpunordpd %xmm0, %xmm7
 ;   movdqa  %xmm0, %xmm5
 ;   movdqa  %xmm7, %xmm0
 ;   pblendvb %xmm5, %xmm1, %xmm5
@@ -111,7 +111,7 @@ block0(v0: f32, v1: f32):
 ;   movl    $2143289344, %r9d
 ;   movd %r9d, %xmm1
 ;   movdqa  %xmm0, %xmm7
-;   cmpps   $3, %xmm7, %xmm0, %xmm7
+;   cmpunordps %xmm0, %xmm7
 ;   movdqa  %xmm0, %xmm5
 ;   movdqa  %xmm7, %xmm0
 ;   pblendvb %xmm5, %xmm1, %xmm5

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -635,12 +635,12 @@ block202:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   ucomiss const(1), %xmm0
+;   ucomiss (%rip), %xmm0
 ;   jp,nz   label2; j label1
 ; block1:
 ;   jmp     label5
 ; block2:
-;   ucomiss const(0), %xmm0
+;   ucomiss (%rip), %xmm0
 ;   jnp     label4; j label3
 ; block3:
 ;   jmp     label5

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -1072,7 +1072,7 @@ block0(v0: f32x4):
 ;   cvtdq2ps %xmm6, %xmm7
 ;   cvttps2dq %xmm0, %xmm6
 ;   subps %xmm7, %xmm0
-;   cmpps   $2, %xmm7, %xmm0, %xmm7
+;   cmpleps %xmm0, %xmm7
 ;   cvttps2dq %xmm0, %xmm0
 ;   pxor %xmm7, %xmm0
 ;   uninit  %xmm1
@@ -1116,7 +1116,7 @@ block0(v0: f32x4):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
-;   cmpps   $0, %xmm4, %xmm0, %xmm4
+;   cmpeqps %xmm0, %xmm4
 ;   andps %xmm4, %xmm0
 ;   pxor %xmm0, %xmm4
 ;   cvttps2dq %xmm0, %xmm1

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
@@ -17,7 +17,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movd %r10d, %xmm7
 ;   shufps  $0, %xmm7, const(0), %xmm7
 ;   movdqa  %xmm0, %xmm1
-;   cmpps   $3, %xmm1, %xmm0, %xmm1
+;   cmpunordps %xmm0, %xmm1
 ;   movdqa  %xmm0, %xmm2
 ;   movdqa  %xmm1, %xmm0
 ;   movdqa  %xmm2, %xmm1
@@ -70,7 +70,7 @@ block0(v0: f64, v1: f64):
 ;   movabsq $9221120237041090560, %r9
 ;   movq %r9, %xmm1
 ;   movdqa  %xmm0, %xmm7
-;   cmppd   $3, %xmm7, %xmm0, %xmm7
+;   cmpunordpd %xmm0, %xmm7
 ;   movdqa  %xmm0, %xmm5
 ;   movdqa  %xmm7, %xmm0
 ;   pblendvb %xmm5, %xmm1, %xmm5
@@ -111,7 +111,7 @@ block0(v0: f32, v1: f32):
 ;   movl    $2143289344, %r9d
 ;   movd %r9d, %xmm1
 ;   movdqa  %xmm0, %xmm7
-;   cmpps   $3, %xmm7, %xmm0, %xmm7
+;   cmpunordps %xmm0, %xmm7
 ;   movdqa  %xmm0, %xmm5
 ;   movdqa  %xmm7, %xmm0
 ;   pblendvb %xmm5, %xmm1, %xmm5

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
@@ -64,7 +64,7 @@ block0(v0: f64, v1: f64):
 ;   addsd %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm7
 ;   movabsq $9221120237041090560, %r11
-;   movq    %r11, %xmm5
+;   movq %r11, %xmm5
 ;   cmpunordpd %xmm7, %xmm0
 ;   andpd %xmm0, %xmm5
 ;   andnpd %xmm7, %xmm0
@@ -103,7 +103,7 @@ block0(v0: f32, v1: f32):
 ;   addss %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm7
 ;   movl    $2143289344, %r11d
-;   movd    %r11d, %xmm5
+;   movd %r11d, %xmm5
 ;   cmpunordps %xmm7, %xmm0
 ;   andps %xmm0, %xmm5
 ;   andnps %xmm7, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
@@ -17,7 +17,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movl    $2143289344, %esi
 ;   movd %esi, %xmm5
 ;   shufps  $0, %xmm5, const(0), %xmm5
-;   cmpps   $3, %xmm0, %xmm1, %xmm0
+;   cmpunordps %xmm1, %xmm0
 ;   andps %xmm0, %xmm5
 ;   andnps %xmm1, %xmm0
 ;   orps %xmm5, %xmm0
@@ -64,8 +64,8 @@ block0(v0: f64, v1: f64):
 ;   addsd %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm7
 ;   movabsq $9221120237041090560, %r11
-;   movq %r11, %xmm5
-;   cmppd   $3, %xmm0, %xmm7, %xmm0
+;   movq    %r11, %xmm5
+;   cmpunordpd %xmm7, %xmm0
 ;   andpd %xmm0, %xmm5
 ;   andnpd %xmm7, %xmm0
 ;   orpd %xmm5, %xmm0
@@ -103,8 +103,8 @@ block0(v0: f32, v1: f32):
 ;   addss %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm7
 ;   movl    $2143289344, %r11d
-;   movd %r11d, %xmm5
-;   cmpps   $3, %xmm0, %xmm7, %xmm0
+;   movd    %r11d, %xmm5
+;   cmpunordps %xmm7, %xmm0
 ;   andps %xmm0, %xmm5
 ;   andnps %xmm7, %xmm0
 ;   orps %xmm5, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -64,7 +64,7 @@ block0(v0: f64x2):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
-;   cmppd   $0, %xmm3, %xmm0, %xmm3
+;   cmpeqpd %xmm0, %xmm3
 ;   andps (%rip), %xmm3
 ;   minpd %xmm3, %xmm0
 ;   cvttpd2dq %xmm0, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -50,7 +50,7 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   cmpps   $0, %xmm0, %xmm1, %xmm0
+;   cmpeqps %xmm1, %xmm0
 ;   movdqa  %xmm3, %xmm6
 ;   pblendvb %xmm6, %xmm2, %xmm6
 ;   movdqa  %xmm6, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/simd-float-min-max.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-float-min-max.clif
@@ -21,7 +21,7 @@ block0(v0: i64, v1: f32x4):
 ;   orps %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm4
 ;   subps %xmm1, %xmm4
-;   cmpps   $3, %xmm0, %xmm0, %xmm0
+;   cmpunordps %xmm0, %xmm0
 ;   psrld $0xa, %xmm0
 ;   andnps %xmm4, %xmm0
 ;   movq    %rbp, %rsp
@@ -66,7 +66,7 @@ block0(v0: i64, v1: f32x4):
 ;   minps %xmm0, %xmm4
 ;   orps %xmm4, %xmm1
 ;   movdqa  %xmm1, %xmm0
-;   cmpps   $3, %xmm0, %xmm4, %xmm0
+;   cmpunordps %xmm4, %xmm0
 ;   orps %xmm0, %xmm1
 ;   psrld $0xa, %xmm0
 ;   andnps %xmm1, %xmm0
@@ -113,7 +113,7 @@ block0(v0: i64, v1: f64x2):
 ;   orpd %xmm1, %xmm0
 ;   movdqa  %xmm0, %xmm4
 ;   subpd %xmm1, %xmm4
-;   cmppd   $3, %xmm0, %xmm0, %xmm0
+;   cmpunordpd %xmm0, %xmm0
 ;   psrlq $0xd, %xmm0
 ;   andnpd %xmm4, %xmm0
 ;   movq    %rbp, %rsp
@@ -158,7 +158,7 @@ block0(v0: i64, v1: f64x2):
 ;   minpd %xmm5, %xmm4
 ;   movdqa  %xmm0, %xmm2
 ;   orpd %xmm4, %xmm2
-;   cmppd   $3, %xmm0, %xmm4, %xmm0
+;   cmpunordpd %xmm4, %xmm0
 ;   orpd %xmm0, %xmm2
 ;   psrlq $0xd, %xmm0
 ;   andnpd %xmm2, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
+++ b/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
@@ -27,7 +27,7 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   ucomiss 0(%rdi), %xmm0
+;   ucomiss (%rdi), %xmm0
 ;   cmovpl  %edx, %esi, %esi
 ;   movq    %rsi, %rax
 ;   cmovnzl %edx, %eax, %eax
@@ -47,7 +47,6 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-
 
 function %select_cond_lhs(f32, i64, i32, i32) -> i32 {
 block0(v0: f32, v1: i64, v2: i32, v3: i32):

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1388,16 +1388,15 @@ impl Assembler {
     /// register.
     pub fn ucomis(&mut self, src1: Reg, src2: Reg, size: OperandSize) {
         let op = match size {
-            OperandSize::S32 => SseOpcode::Ucomiss,
-            OperandSize::S64 => SseOpcode::Ucomisd,
+            OperandSize::S32 => {
+                Inst::x64_ucomis(size.into(), src1.into(), RegMem::reg(src2.into()))
+            }
+            OperandSize::S64 => {
+                Inst::x64_ucomis(size.into(), src1.into(), RegMem::reg(src2.into()))
+            }
             OperandSize::S8 | OperandSize::S16 | OperandSize::S128 => unreachable!(),
         };
-
-        self.emit(Inst::XmmCmpRmR {
-            op,
-            src1: src1.into(),
-            src2: Xmm::from(src2).into(),
-        });
+        self.emit(op);
     }
 
     pub fn popcnt(&mut self, src: Reg, dst: WritableReg, size: OperandSize) {


### PR DESCRIPTION
Implement `compare` instructions.
Implement `Eflags` logic for DSL and wire up isle rules to set flags when appropriate.
