### PR TITLE
Enable the `from_over_into` Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,7 @@ unnecessary_mut_passed = 'warn'
 unnecessary_fallible_conversions = 'warn'
 unnecessary_cast = 'warn'
 allow_attributes_without_reason = 'warn'
+from_over_into = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }

--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -779,9 +779,9 @@ impl From<u8> for Register {
         Self(reg)
     }
 }
-impl Into<u8> for Register {
-    fn into(self) -> u8 {
-        self.0
+impl From<Register> for u8 {
+    fn from(reg: Register) -> u8 {
+        reg.0
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -25,9 +25,9 @@ use std::sync::OnceLock;
 /// Support for the AArch64 ABI from the callee side (within a function body).
 pub(crate) type AArch64Callee = Callee<AArch64MachineDeps>;
 
-impl Into<AMode> for StackAMode {
-    fn into(self) -> AMode {
-        match self {
+impl From<StackAMode> for AMode {
+    fn from(stack: StackAMode) -> AMode {
+        match stack {
             StackAMode::IncomingArg(off, stack_args_size) => AMode::IncomingArg {
                 off: i64::from(stack_args_size) - off,
             },

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -198,9 +198,9 @@ impl Display for AMode {
     }
 }
 
-impl Into<AMode> for StackAMode {
-    fn into(self) -> AMode {
-        match self {
+impl From<StackAMode> for AMode {
+    fn from(stack: StackAMode) -> AMode {
+        match stack {
             StackAMode::IncomingArg(offset, stack_args_size) => {
                 AMode::IncomingArg(i64::from(stack_args_size) - offset)
             }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -49,9 +49,9 @@ impl Imm12 {
     }
 }
 
-impl Into<i64> for Imm12 {
-    fn into(self) -> i64 {
-        self.as_i16().into()
+impl From<Imm12> for i64 {
+    fn from(imm12: Imm12) -> i64 {
+        imm12.as_i16().into()
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -253,9 +253,9 @@ fn get_vecreg_for_ret(idx: usize) -> Option<Reg> {
 /// The size of the register save area
 pub static REG_SAVE_AREA_SIZE: u32 = 160;
 
-impl Into<MemArg> for StackAMode {
-    fn into(self) -> MemArg {
-        match self {
+impl From<StackAMode> for MemArg {
+    fn from(stack: StackAMode) -> MemArg {
+        match stack {
             StackAMode::IncomingArg(off, stack_args_size) => MemArg::IncomingArgOffset {
                 off: off - stack_args_size as i64,
             },

--- a/cranelift/codegen/src/isa/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/unwind/systemv.rs
@@ -93,26 +93,25 @@ impl From<gimli::write::CallFrameInstruction> for CallFrameInstruction {
     }
 }
 
-impl Into<gimli::write::CallFrameInstruction> for CallFrameInstruction {
-    fn into(self) -> gimli::write::CallFrameInstruction {
-        use gimli::{Register, write::CallFrameInstruction, write::Expression};
+impl From<CallFrameInstruction> for gimli::write::CallFrameInstruction {
+    fn from(cfi: CallFrameInstruction) -> gimli::write::CallFrameInstruction {
+        use CallFrameInstruction as ClifCfi;
+        use gimli::{Register, write::CallFrameInstruction as GimliCfi, write::Expression};
 
-        match self {
-            Self::Cfa(reg, offset) => CallFrameInstruction::Cfa(Register(reg), offset),
-            Self::CfaRegister(reg) => CallFrameInstruction::CfaRegister(Register(reg)),
-            Self::CfaOffset(offset) => CallFrameInstruction::CfaOffset(offset),
-            Self::Restore(reg) => CallFrameInstruction::Restore(Register(reg)),
-            Self::Undefined(reg) => CallFrameInstruction::Undefined(Register(reg)),
-            Self::SameValue(reg) => CallFrameInstruction::SameValue(Register(reg)),
-            Self::Offset(reg, offset) => CallFrameInstruction::Offset(Register(reg), offset),
-            Self::ValOffset(reg, offset) => CallFrameInstruction::ValOffset(Register(reg), offset),
-            Self::Register(reg1, reg2) => {
-                CallFrameInstruction::Register(Register(reg1), Register(reg2))
-            }
-            Self::RememberState => CallFrameInstruction::RememberState,
-            Self::RestoreState => CallFrameInstruction::RestoreState,
-            Self::ArgsSize(size) => CallFrameInstruction::ArgsSize(size),
-            Self::Aarch64SetPointerAuth { return_addresses } => {
+        match cfi {
+            ClifCfi::Cfa(reg, offset) => GimliCfi::Cfa(Register(reg), offset),
+            ClifCfi::CfaRegister(reg) => GimliCfi::CfaRegister(Register(reg)),
+            ClifCfi::CfaOffset(offset) => GimliCfi::CfaOffset(offset),
+            ClifCfi::Restore(reg) => GimliCfi::Restore(Register(reg)),
+            ClifCfi::Undefined(reg) => GimliCfi::Undefined(Register(reg)),
+            ClifCfi::SameValue(reg) => GimliCfi::SameValue(Register(reg)),
+            ClifCfi::Offset(reg, offset) => GimliCfi::Offset(Register(reg), offset),
+            ClifCfi::ValOffset(reg, offset) => GimliCfi::ValOffset(Register(reg), offset),
+            ClifCfi::Register(reg1, reg2) => GimliCfi::Register(Register(reg1), Register(reg2)),
+            ClifCfi::RememberState => GimliCfi::RememberState,
+            ClifCfi::RestoreState => GimliCfi::RestoreState,
+            ClifCfi::ArgsSize(size) => GimliCfi::ArgsSize(size),
+            ClifCfi::Aarch64SetPointerAuth { return_addresses } => {
                 // To enable pointer authentication for return addresses in dwarf directives, we
                 // use a small dwarf expression that sets the value of the pseudo-register
                 // RA_SIGN_STATE (RA stands for return address) to 0 or 1. This behavior is
@@ -125,7 +124,7 @@ impl Into<gimli::write::CallFrameInstruction> for CallFrameInstruction {
                     gimli::DW_OP_lit0
                 });
                 const RA_SIGN_STATE: Register = Register(34);
-                CallFrameInstruction::ValExpression(RA_SIGN_STATE, expr)
+                GimliCfi::ValExpression(RA_SIGN_STATE, expr)
             }
         }
     }

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -315,9 +315,9 @@ impl From<u8> for Register {
         Self(reg)
     }
 }
-impl Into<u8> for Register {
-    fn into(self) -> u8 {
-        self.0
+impl From<Register> for u8 {
+    fn from(reg: Register) -> u8 {
+        reg.0
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -556,15 +556,15 @@ impl SyntheticAmode {
     }
 }
 
-impl Into<SyntheticAmode> for Amode {
-    fn into(self) -> SyntheticAmode {
-        SyntheticAmode::Real(self)
+impl From<Amode> for SyntheticAmode {
+    fn from(amode: Amode) -> SyntheticAmode {
+        SyntheticAmode::Real(amode)
     }
 }
 
-impl Into<SyntheticAmode> for VCodeConstant {
-    fn into(self) -> SyntheticAmode {
-        SyntheticAmode::ConstantOffset(self)
+impl From<VCodeConstant> for SyntheticAmode {
+    fn from(c: VCodeConstant) -> SyntheticAmode {
+        SyntheticAmode::ConstantOffset(c)
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -331,9 +331,9 @@ fn fixed_reg(enc: u8, class: RegClass) -> Reg {
     Reg::from_real_reg(preg)
 }
 
-impl Into<asm::Amode<Gpr>> for SyntheticAmode {
-    fn into(self) -> asm::Amode<Gpr> {
-        match self {
+impl From<SyntheticAmode> for asm::Amode<Gpr> {
+    fn from(amode: SyntheticAmode) -> asm::Amode<Gpr> {
+        match amode {
             SyntheticAmode::Real(amode) => amode.into(),
             SyntheticAmode::IncomingArg { offset } => asm::Amode::ImmReg {
                 base: Gpr::unwrap_new(regs::rbp()),
@@ -358,9 +358,9 @@ impl Into<asm::Amode<Gpr>> for SyntheticAmode {
     }
 }
 
-impl Into<asm::Amode<Gpr>> for Amode {
-    fn into(self) -> asm::Amode<Gpr> {
-        match self {
+impl From<Amode> for asm::Amode<Gpr> {
+    fn from(amode: Amode) -> asm::Amode<Gpr> {
+        match amode {
             Amode::ImmReg {
                 simm32,
                 base,

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -229,15 +229,19 @@ impl From<Vec<VerifierError>> for VerifierErrors {
     }
 }
 
-impl Into<Vec<VerifierError>> for VerifierErrors {
-    fn into(self) -> Vec<VerifierError> {
-        self.0
+impl From<VerifierErrors> for Vec<VerifierError> {
+    fn from(errors: VerifierErrors) -> Vec<VerifierError> {
+        errors.0
     }
 }
 
-impl Into<VerifierResult<()>> for VerifierErrors {
-    fn into(self) -> VerifierResult<()> {
-        if self.is_empty() { Ok(()) } else { Err(self) }
+impl From<VerifierErrors> for VerifierResult<()> {
+    fn from(errors: VerifierErrors) -> VerifierResult<()> {
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 

--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -100,9 +100,9 @@ impl<T: ReservedValue> From<Option<T>> for PackedOption<T> {
     }
 }
 
-impl<T: ReservedValue> Into<Option<T>> for PackedOption<T> {
-    fn into(self) -> Option<T> {
-        self.expand()
+impl<T: ReservedValue> From<PackedOption<T>> for Option<T> {
+    fn from(packed: PackedOption<T>) -> Option<T> {
+        packed.expand()
     }
 }
 

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -14,9 +14,9 @@ impl From<Error> for wasmtime_error_t {
     }
 }
 
-impl Into<Error> for wasmtime_error_t {
-    fn into(self) -> Error {
-        self.error
+impl From<wasmtime_error_t> for Error {
+    fn from(cerr: wasmtime_error_t) -> Error {
+        cerr.error
     }
 }
 

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -110,9 +110,9 @@ impl From<&DiffValue> for SpecValue {
     }
 }
 
-impl Into<DiffValue> for SpecValue {
-    fn into(self) -> DiffValue {
-        match self {
+impl From<SpecValue> for DiffValue {
+    fn from(spec: SpecValue) -> DiffValue {
+        match spec {
             SpecValue::I32(n) => DiffValue::I32(n),
             SpecValue::I64(n) => DiffValue::I64(n),
             SpecValue::F32(n) => DiffValue::F32(n as u32),

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -227,9 +227,9 @@ impl From<&DiffValue> for Val {
     }
 }
 
-impl Into<DiffValue> for Val {
-    fn into(self) -> DiffValue {
-        match self {
+impl From<Val> for DiffValue {
+    fn from(val: Val) -> DiffValue {
+        match val {
             Val::I32(n) => DiffValue::I32(n),
             Val::I64(n) => DiffValue::I64(n),
             Val::F32(n) => DiffValue::F32(n),

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -35,9 +35,9 @@ where
     }
 }
 
-impl Into<Vec<MemArea>> for MemAreas {
-    fn into(self) -> Vec<MemArea> {
-        self.0.clone()
+impl From<MemAreas> for Vec<MemArea> {
+    fn from(areas: MemAreas) -> Vec<MemArea> {
+        areas.0.clone()
     }
 }
 

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -259,9 +259,9 @@ impl<R: Reg> From<ScalarBitSet<u16>> for UpperRegSet<R> {
     }
 }
 
-impl<R: Reg> Into<ScalarBitSet<u16>> for UpperRegSet<R> {
-    fn into(self) -> ScalarBitSet<u16> {
-        self.bitset
+impl<R: Reg> From<UpperRegSet<R>> for ScalarBitSet<u16> {
+    fn from(upper: UpperRegSet<R>) -> ScalarBitSet<u16> {
+        upper.bitset
     }
 }
 

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -71,9 +71,9 @@ impl From<FloatCmpKind> for Cond {
     }
 }
 
-impl Into<ScalarSize> for OperandSize {
-    fn into(self) -> ScalarSize {
-        match self {
+impl From<OperandSize> for ScalarSize {
+    fn from(size: OperandSize) -> ScalarSize {
+        match size {
             OperandSize::S8 => ScalarSize::Size8,
             OperandSize::S16 => ScalarSize::Size16,
             OperandSize::S32 => ScalarSize::Size32,


### PR DESCRIPTION
This requires implementing `From<T> for U` instead of `Into<U> for T`. While both trait impls are valid the `From`  one is more useful because it implies `Into` and additionally gives you `From`. This additionally then migrates the existing codebase to using the new style of impls.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
