### PR TITLE
x64: Update codegen of `XmmCmove` pseudo-inst

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -891,20 +891,7 @@ pub(crate) fn emit(
 
             // Jump if cc is *not* set.
             one_way_jmp(sink, cc.invert(), next);
-
-            let op = match *ty {
-                types::F64 => SseOpcode::Movsd,
-                types::F32 => SseOpcode::Movsd,
-                types::F16 => SseOpcode::Movsd,
-                types::F32X4 => SseOpcode::Movaps,
-                types::F64X2 => SseOpcode::Movapd,
-                ty => {
-                    debug_assert!((ty.is_float() || ty.is_vector()) && ty.bytes() <= 16);
-                    SseOpcode::Movdqa
-                }
-            };
-            let inst = Inst::xmm_unary_rm_r(op, consequent.into(), dst);
-            inst.emit(sink, info, state);
+            Inst::gen_move(dst, consequent, *ty).emit(sink, info, state);
 
             sink.bind_label(next, state.ctrl_plane_mut());
         }

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -81,10 +81,10 @@ block0(v0: f64, v1: i64):
 ;   movzbq %dil, %rax
 ;   ucomisd %xmm1, %xmm0
 ;   movdqa %xmm0, %xmm2
-;   jnp 0x2c
-;   movsd %xmm2, %xmm0
-;   je 0x36
-;   movsd %xmm2, %xmm0
+;   jnp 0x2b
+;   movaps %xmm2, %xmm0
+;   je 0x34
+;   movaps %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -91,8 +91,8 @@ block0(v0: i8, v1: f16, v2: f16):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x19
-;   movsd %xmm6, %xmm0
+;   je 0x18
+;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -123,8 +123,8 @@ block0(v0: i8, v1: f32, v2: f32):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x19
-;   movsd %xmm6, %xmm0
+;   je 0x18
+;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -155,8 +155,8 @@ block0(v0: i8, v1: f64, v2: f64):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x19
-;   movsd %xmm6, %xmm0
+;   je 0x18
+;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
+++ b/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
@@ -26,8 +26,8 @@ block0(v0: i32, v1: f64, v2: i64):
 ; block1: ; offset 0x4
 ;   movsd (%rsi), %xmm5 ; trap: heap_oob
 ;   testl %edi, %edi
-;   je 0x14
-;   movsd %xmm5, %xmm0
+;   je 0x13
+;   movaps %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/tests/disas/winch/x64/select/f32.wat
+++ b/tests/disas/winch/x64/select/f32.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x66
+;;       ja      0x65
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,9 +26,9 @@
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       cmpl    $0, %eax
-;;       je      0x5d
-;;   59: movsd   %xmm1, %xmm0
+;;       je      0x5c
+;;   59: movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   65: ud2

--- a/tests/disas/winch/x64/select/f64.wat
+++ b/tests/disas/winch/x64/select/f64.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x66
+;;       ja      0x65
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -26,9 +26,9 @@
 ;;       movsd   0x10(%rsp), %xmm0
 ;;       movsd   0x18(%rsp), %xmm1
 ;;       cmpl    $0, %eax
-;;       je      0x5d
-;;   59: movsd   %xmm1, %xmm0
+;;       je      0x5c
+;;   59: movaps  %xmm1, %xmm0
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   66: ud2
+;;   65: ud2


### PR DESCRIPTION
In #4317 this instruction was updated to handle 128-bit vectors in addition to the previous handling of 32/64-bit floats. Originally the pseudo-instruction used `movs{s,d}` to achieve its task and when adding 128-bit support I mistakenly switched both f32/f64 paths to using `movsd` instead of conditionally using `movss` for `f32`. In retrospect though it's probably best to use a full register move here instead of just a singular mov because `movss` and `movsd` preserve the upper bits of the register, needlessly creating a data dependency with the previous value in the register.

This commit updates this helper to using `Inst::gen_move` which already internally does this optimization of using `movaps`, a documented zero-latency instruction, for all xmm-style register movements.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
