### PR TITLE
Merge wasip3-prototyping bindgen changes to main 

### DIFF
--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::chars::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::chars::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::chars::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_chars(&self) -> &exports::foo::foo::chars::Guest {
@@ -180,14 +180,24 @@ pub mod foo {
                 /// A function that returns a character
                 async fn return_char(&mut self) -> char;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                /// A function that accepts a character
+                async fn take_char(&mut self, x: char) -> () {
+                    Host::take_char(*self, x).await
+                }
+                /// A function that returns a character
+                async fn return_char(&mut self) -> char {
+                    Host::return_char(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap_async(
@@ -243,16 +253,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                /// A function that accepts a character
-                async fn take_char(&mut self, x: char) -> () {
-                    Host::take_char(*self, x).await
-                }
-                /// A function that returns a character
-                async fn return_char(&mut self) -> char {
-                    Host::return_char(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::conventions::Host,
             T: 'static,
         {
-            foo::foo::conventions::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::conventions::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
@@ -220,6 +220,50 @@ pub mod foo {
                 fn explicit_kebab(&mut self) -> ();
                 /// Identifiers with the same name as keywords are quoted.
                 fn bool(&mut self) -> ();
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn kebab_case(&mut self) -> () {
+                    Host::kebab_case(*self)
+                }
+                fn foo(&mut self, x: LudicrousSpeed) -> () {
+                    Host::foo(*self, x)
+                }
+                fn function_with_dashes(&mut self) -> () {
+                    Host::function_with_dashes(*self)
+                }
+                fn function_with_no_weird_characters(&mut self) -> () {
+                    Host::function_with_no_weird_characters(*self)
+                }
+                fn apple(&mut self) -> () {
+                    Host::apple(*self)
+                }
+                fn apple_pear(&mut self) -> () {
+                    Host::apple_pear(*self)
+                }
+                fn apple_pear_grape(&mut self) -> () {
+                    Host::apple_pear_grape(*self)
+                }
+                fn a0(&mut self) -> () {
+                    Host::a0(*self)
+                }
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                ///  https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                fn is_xml(&mut self) -> () {
+                    Host::is_xml(*self)
+                }
+                fn explicit(&mut self) -> () {
+                    Host::explicit(*self)
+                }
+                fn explicit_kebab(&mut self) -> () {
+                    Host::explicit_kebab(*self)
+                }
+                /// Identifiers with the same name as keywords are quoted.
+                fn bool(&mut self) -> () {
+                    Host::bool(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -331,50 +375,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn kebab_case(&mut self) -> () {
-                    Host::kebab_case(*self)
-                }
-                fn foo(&mut self, x: LudicrousSpeed) -> () {
-                    Host::foo(*self, x)
-                }
-                fn function_with_dashes(&mut self) -> () {
-                    Host::function_with_dashes(*self)
-                }
-                fn function_with_no_weird_characters(&mut self) -> () {
-                    Host::function_with_no_weird_characters(*self)
-                }
-                fn apple(&mut self) -> () {
-                    Host::apple(*self)
-                }
-                fn apple_pear(&mut self) -> () {
-                    Host::apple_pear(*self)
-                }
-                fn apple_pear_grape(&mut self) -> () {
-                    Host::apple_pear_grape(*self)
-                }
-                fn a0(&mut self) -> () {
-                    Host::a0(*self)
-                }
-                /// Comment out identifiers that collide when mapped to snake_case, for now; see
-                ///  https://github.com/WebAssembly/component-model/issues/118
-                /// APPLE: func()
-                /// APPLE-pear-GRAPE: func()
-                /// apple-PEAR-grape: func()
-                fn is_xml(&mut self) -> () {
-                    Host::is_xml(*self)
-                }
-                fn explicit(&mut self) -> () {
-                    Host::explicit(*self)
-                }
-                fn explicit_kebab(&mut self) -> () {
-                    Host::explicit_kebab(*self)
-                }
-                /// Identifiers with the same name as keywords are quoted.
-                fn bool(&mut self) -> () {
-                    Host::bool(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::conventions::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::conventions::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::conventions::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
@@ -228,14 +228,58 @@ pub mod foo {
                 /// Identifiers with the same name as keywords are quoted.
                 async fn bool(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn kebab_case(&mut self) -> () {
+                    Host::kebab_case(*self).await
+                }
+                async fn foo(&mut self, x: LudicrousSpeed) -> () {
+                    Host::foo(*self, x).await
+                }
+                async fn function_with_dashes(&mut self) -> () {
+                    Host::function_with_dashes(*self).await
+                }
+                async fn function_with_no_weird_characters(&mut self) -> () {
+                    Host::function_with_no_weird_characters(*self).await
+                }
+                async fn apple(&mut self) -> () {
+                    Host::apple(*self).await
+                }
+                async fn apple_pear(&mut self) -> () {
+                    Host::apple_pear(*self).await
+                }
+                async fn apple_pear_grape(&mut self) -> () {
+                    Host::apple_pear_grape(*self).await
+                }
+                async fn a0(&mut self) -> () {
+                    Host::a0(*self).await
+                }
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                ///  https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                async fn is_xml(&mut self) -> () {
+                    Host::is_xml(*self).await
+                }
+                async fn explicit(&mut self) -> () {
+                    Host::explicit(*self).await
+                }
+                async fn explicit_kebab(&mut self) -> () {
+                    Host::explicit_kebab(*self).await
+                }
+                /// Identifiers with the same name as keywords are quoted.
+                async fn bool(&mut self) -> () {
+                    Host::bool(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_async(
@@ -362,50 +406,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn kebab_case(&mut self) -> () {
-                    Host::kebab_case(*self).await
-                }
-                async fn foo(&mut self, x: LudicrousSpeed) -> () {
-                    Host::foo(*self, x).await
-                }
-                async fn function_with_dashes(&mut self) -> () {
-                    Host::function_with_dashes(*self).await
-                }
-                async fn function_with_no_weird_characters(&mut self) -> () {
-                    Host::function_with_no_weird_characters(*self).await
-                }
-                async fn apple(&mut self) -> () {
-                    Host::apple(*self).await
-                }
-                async fn apple_pear(&mut self) -> () {
-                    Host::apple_pear(*self).await
-                }
-                async fn apple_pear_grape(&mut self) -> () {
-                    Host::apple_pear_grape(*self).await
-                }
-                async fn a0(&mut self) -> () {
-                    Host::a0(*self).await
-                }
-                /// Comment out identifiers that collide when mapped to snake_case, for now; see
-                ///  https://github.com/WebAssembly/component-model/issues/118
-                /// APPLE: func()
-                /// APPLE-pear-GRAPE: func()
-                /// apple-PEAR-grape: func()
-                async fn is_xml(&mut self) -> () {
-                    Host::is_xml(*self).await
-                }
-                async fn explicit(&mut self) -> () {
-                    Host::explicit(*self).await
-                }
-                async fn explicit_kebab(&mut self) -> () {
-                    Host::explicit_kebab(*self).await
-                }
-                /// Identifiers with the same name as keywords are quoted.
-                async fn bool(&mut self) -> () {
-                    Host::bool(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::conventions::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::conventions::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::conventions::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_conventions(&self) -> &exports::foo::foo::conventions::Guest {
@@ -228,14 +228,58 @@ pub mod foo {
                 /// Identifiers with the same name as keywords are quoted.
                 async fn bool(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn kebab_case(&mut self) -> () {
+                    Host::kebab_case(*self).await
+                }
+                async fn foo(&mut self, x: LudicrousSpeed) -> () {
+                    Host::foo(*self, x).await
+                }
+                async fn function_with_dashes(&mut self) -> () {
+                    Host::function_with_dashes(*self).await
+                }
+                async fn function_with_no_weird_characters(&mut self) -> () {
+                    Host::function_with_no_weird_characters(*self).await
+                }
+                async fn apple(&mut self) -> () {
+                    Host::apple(*self).await
+                }
+                async fn apple_pear(&mut self) -> () {
+                    Host::apple_pear(*self).await
+                }
+                async fn apple_pear_grape(&mut self) -> () {
+                    Host::apple_pear_grape(*self).await
+                }
+                async fn a0(&mut self) -> () {
+                    Host::a0(*self).await
+                }
+                /// Comment out identifiers that collide when mapped to snake_case, for now; see
+                ///  https://github.com/WebAssembly/component-model/issues/118
+                /// APPLE: func()
+                /// APPLE-pear-GRAPE: func()
+                /// apple-PEAR-grape: func()
+                async fn is_xml(&mut self) -> () {
+                    Host::is_xml(*self).await
+                }
+                async fn explicit(&mut self) -> () {
+                    Host::explicit(*self).await
+                }
+                async fn explicit_kebab(&mut self) -> () {
+                    Host::explicit_kebab(*self).await
+                }
+                /// Identifiers with the same name as keywords are quoted.
+                async fn bool(&mut self) -> () {
+                    Host::bool(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_async(
@@ -522,50 +566,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn kebab_case(&mut self) -> () {
-                    Host::kebab_case(*self).await
-                }
-                async fn foo(&mut self, x: LudicrousSpeed) -> () {
-                    Host::foo(*self, x).await
-                }
-                async fn function_with_dashes(&mut self) -> () {
-                    Host::function_with_dashes(*self).await
-                }
-                async fn function_with_no_weird_characters(&mut self) -> () {
-                    Host::function_with_no_weird_characters(*self).await
-                }
-                async fn apple(&mut self) -> () {
-                    Host::apple(*self).await
-                }
-                async fn apple_pear(&mut self) -> () {
-                    Host::apple_pear(*self).await
-                }
-                async fn apple_pear_grape(&mut self) -> () {
-                    Host::apple_pear_grape(*self).await
-                }
-                async fn a0(&mut self) -> () {
-                    Host::a0(*self).await
-                }
-                /// Comment out identifiers that collide when mapped to snake_case, for now; see
-                ///  https://github.com/WebAssembly/component-model/issues/118
-                /// APPLE: func()
-                /// APPLE-pear-GRAPE: func()
-                /// apple-PEAR-grape: func()
-                async fn is_xml(&mut self) -> () {
-                    Host::is_xml(*self).await
-                }
-                async fn explicit(&mut self) -> () {
-                    Host::explicit(*self).await
-                }
-                async fn explicit_kebab(&mut self) -> () {
-                    Host::explicit_kebab(*self).await
-                }
-                /// Identifiers with the same name as keywords are quoted.
-                async fn bool(&mut self) -> () {
-                    Host::bool(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -146,7 +146,7 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
@@ -154,10 +154,10 @@ const _: () = {
                 'a,
             >: a::b::interface_with_live_type::Host
                 + a::b::interface_with_dead_type::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            a::b::interface_with_live_type::add_to_linker::<T, D>(linker, get)?;
-            a::b::interface_with_dead_type::add_to_linker::<T, D>(linker, get)?;
+            a::b::interface_with_live_type::add_to_linker::<T, D>(linker, host_getter)?;
+            a::b::interface_with_dead_type::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -192,14 +192,19 @@ pub mod a {
             pub trait Host: Send {
                 async fn f(&mut self) -> LiveType;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn f(&mut self) -> LiveType {
+                    Host::f(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap_async(
@@ -213,11 +218,6 @@ pub mod a {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn f(&mut self) -> LiveType {
-                    Host::f(*self).await
-                }
             }
         }
         #[allow(clippy::all)]
@@ -276,19 +276,19 @@ pub mod a {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/direct-import.rs
+++ b/crates/component-macro/tests/expanded/direct-import.rs
@@ -169,14 +169,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: FooImports,
             T: 'static,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/direct-import_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_async.rs
@@ -160,7 +160,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: FooImports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             linker
@@ -178,14 +178,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: FooImports + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/direct-import_tracing_async.rs
@@ -160,7 +160,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: FooImports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             linker
@@ -191,14 +191,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: FooImports + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::flegs::Host,
             T: 'static,
         {
-            foo::foo::flegs::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::flegs::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
@@ -290,6 +290,29 @@ pub mod foo {
                 fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32;
                 fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
+                    Host::roundtrip_flag1(*self, x)
+                }
+                fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
+                    Host::roundtrip_flag2(*self, x)
+                }
+                fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
+                    Host::roundtrip_flag4(*self, x)
+                }
+                fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
+                    Host::roundtrip_flag8(*self, x)
+                }
+                fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
+                    Host::roundtrip_flag16(*self, x)
+                }
+                fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
+                    Host::roundtrip_flag32(*self, x)
+                }
+                fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
+                    Host::roundtrip_flag64(*self, x)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -378,29 +401,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
-                    Host::roundtrip_flag1(*self, x)
-                }
-                fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
-                    Host::roundtrip_flag2(*self, x)
-                }
-                fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
-                    Host::roundtrip_flag4(*self, x)
-                }
-                fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
-                    Host::roundtrip_flag8(*self, x)
-                }
-                fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
-                    Host::roundtrip_flag16(*self, x)
-                }
-                fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
-                    Host::roundtrip_flag32(*self, x)
-                }
-                fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
-                    Host::roundtrip_flag64(*self, x)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::flegs::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::flegs::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
@@ -297,14 +297,37 @@ pub mod foo {
                 async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32;
                 async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
+                    Host::roundtrip_flag1(*self, x).await
+                }
+                async fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
+                    Host::roundtrip_flag2(*self, x).await
+                }
+                async fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
+                    Host::roundtrip_flag4(*self, x).await
+                }
+                async fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
+                    Host::roundtrip_flag8(*self, x).await
+                }
+                async fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
+                    Host::roundtrip_flag16(*self, x).await
+                }
+                async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
+                    Host::roundtrip_flag32(*self, x).await
+                }
+                async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
+                    Host::roundtrip_flag64(*self, x).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_async(
@@ -399,29 +422,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
-                    Host::roundtrip_flag1(*self, x).await
-                }
-                async fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
-                    Host::roundtrip_flag2(*self, x).await
-                }
-                async fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
-                    Host::roundtrip_flag4(*self, x).await
-                }
-                async fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
-                    Host::roundtrip_flag8(*self, x).await
-                }
-                async fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
-                    Host::roundtrip_flag16(*self, x).await
-                }
-                async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
-                    Host::roundtrip_flag32(*self, x).await
-                }
-                async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
-                    Host::roundtrip_flag64(*self, x).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::flegs::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::flegs::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
@@ -297,14 +297,37 @@ pub mod foo {
                 async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32;
                 async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
+                    Host::roundtrip_flag1(*self, x).await
+                }
+                async fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
+                    Host::roundtrip_flag2(*self, x).await
+                }
+                async fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
+                    Host::roundtrip_flag4(*self, x).await
+                }
+                async fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
+                    Host::roundtrip_flag8(*self, x).await
+                }
+                async fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
+                    Host::roundtrip_flag16(*self, x).await
+                }
+                async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
+                    Host::roundtrip_flag32(*self, x).await
+                }
+                async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
+                    Host::roundtrip_flag64(*self, x).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_async(
@@ -511,29 +534,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn roundtrip_flag1(&mut self, x: Flag1) -> Flag1 {
-                    Host::roundtrip_flag1(*self, x).await
-                }
-                async fn roundtrip_flag2(&mut self, x: Flag2) -> Flag2 {
-                    Host::roundtrip_flag2(*self, x).await
-                }
-                async fn roundtrip_flag4(&mut self, x: Flag4) -> Flag4 {
-                    Host::roundtrip_flag4(*self, x).await
-                }
-                async fn roundtrip_flag8(&mut self, x: Flag8) -> Flag8 {
-                    Host::roundtrip_flag8(*self, x).await
-                }
-                async fn roundtrip_flag16(&mut self, x: Flag16) -> Flag16 {
-                    Host::roundtrip_flag16(*self, x).await
-                }
-                async fn roundtrip_flag32(&mut self, x: Flag32) -> Flag32 {
-                    Host::roundtrip_flag32(*self, x).await
-                }
-                async fn roundtrip_flag64(&mut self, x: Flag64) -> Flag64 {
-                    Host::roundtrip_flag64(*self, x).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::floats::Host,
             T: 'static,
         {
-            foo::foo::floats::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::floats::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
@@ -174,6 +174,20 @@ pub mod foo {
                 fn f64_param(&mut self, x: f64) -> ();
                 fn f32_result(&mut self) -> f32;
                 fn f64_result(&mut self) -> f64;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn f32_param(&mut self, x: f32) -> () {
+                    Host::f32_param(*self, x)
+                }
+                fn f64_param(&mut self, x: f64) -> () {
+                    Host::f64_param(*self, x)
+                }
+                fn f32_result(&mut self) -> f32 {
+                    Host::f32_result(*self)
+                }
+                fn f64_result(&mut self) -> f64 {
+                    Host::f64_result(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -218,20 +232,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn f32_param(&mut self, x: f32) -> () {
-                    Host::f32_param(*self, x)
-                }
-                fn f64_param(&mut self, x: f64) -> () {
-                    Host::f64_param(*self, x)
-                }
-                fn f32_result(&mut self) -> f32 {
-                    Host::f32_result(*self)
-                }
-                fn f64_result(&mut self) -> f64 {
-                    Host::f64_result(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::floats::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::floats::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::floats::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
@@ -182,14 +182,28 @@ pub mod foo {
                 async fn f32_result(&mut self) -> f32;
                 async fn f64_result(&mut self) -> f64;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn f32_param(&mut self, x: f32) -> () {
+                    Host::f32_param(*self, x).await
+                }
+                async fn f64_param(&mut self, x: f64) -> () {
+                    Host::f64_param(*self, x).await
+                }
+                async fn f32_result(&mut self) -> f32 {
+                    Host::f32_result(*self).await
+                }
+                async fn f64_result(&mut self) -> f64 {
+                    Host::f64_result(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_async(
@@ -291,20 +305,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn f32_param(&mut self, x: f32) -> () {
-                    Host::f32_param(*self, x).await
-                }
-                async fn f64_param(&mut self, x: f64) -> () {
-                    Host::f64_param(*self, x).await
-                }
-                async fn f32_result(&mut self) -> f32 {
-                    Host::f32_result(*self).await
-                }
-                async fn f64_result(&mut self) -> f64 {
-                    Host::f64_result(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/host-world.rs
+++ b/crates/component-macro/tests/expanded/host-world.rs
@@ -169,14 +169,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: Host_Imports,
             T: 'static,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/host-world_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_async.rs
@@ -160,7 +160,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: Host_Imports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             linker
@@ -178,14 +178,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: Host_Imports + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/host-world_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/host-world_tracing_async.rs
@@ -160,7 +160,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: Host_Imports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             linker
@@ -191,14 +191,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: Host_Imports + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::integers::Host,
             T: 'static,
         {
-            foo::foo::integers::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::integers::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
@@ -198,6 +198,72 @@ pub mod foo {
                 fn r7(&mut self) -> u64;
                 fn r8(&mut self) -> i64;
                 fn pair_ret(&mut self) -> (i64, u8);
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn a1(&mut self, x: u8) -> () {
+                    Host::a1(*self, x)
+                }
+                fn a2(&mut self, x: i8) -> () {
+                    Host::a2(*self, x)
+                }
+                fn a3(&mut self, x: u16) -> () {
+                    Host::a3(*self, x)
+                }
+                fn a4(&mut self, x: i16) -> () {
+                    Host::a4(*self, x)
+                }
+                fn a5(&mut self, x: u32) -> () {
+                    Host::a5(*self, x)
+                }
+                fn a6(&mut self, x: i32) -> () {
+                    Host::a6(*self, x)
+                }
+                fn a7(&mut self, x: u64) -> () {
+                    Host::a7(*self, x)
+                }
+                fn a8(&mut self, x: i64) -> () {
+                    Host::a8(*self, x)
+                }
+                fn a9(
+                    &mut self,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> () {
+                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8)
+                }
+                fn r1(&mut self) -> u8 {
+                    Host::r1(*self)
+                }
+                fn r2(&mut self) -> i8 {
+                    Host::r2(*self)
+                }
+                fn r3(&mut self) -> u16 {
+                    Host::r3(*self)
+                }
+                fn r4(&mut self) -> i16 {
+                    Host::r4(*self)
+                }
+                fn r5(&mut self) -> u32 {
+                    Host::r5(*self)
+                }
+                fn r6(&mut self) -> i32 {
+                    Host::r6(*self)
+                }
+                fn r7(&mut self) -> u64 {
+                    Host::r7(*self)
+                }
+                fn r8(&mut self) -> i64 {
+                    Host::r8(*self)
+                }
+                fn pair_ret(&mut self) -> (i64, u8) {
+                    Host::pair_ret(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -376,72 +442,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn a1(&mut self, x: u8) -> () {
-                    Host::a1(*self, x)
-                }
-                fn a2(&mut self, x: i8) -> () {
-                    Host::a2(*self, x)
-                }
-                fn a3(&mut self, x: u16) -> () {
-                    Host::a3(*self, x)
-                }
-                fn a4(&mut self, x: i16) -> () {
-                    Host::a4(*self, x)
-                }
-                fn a5(&mut self, x: u32) -> () {
-                    Host::a5(*self, x)
-                }
-                fn a6(&mut self, x: i32) -> () {
-                    Host::a6(*self, x)
-                }
-                fn a7(&mut self, x: u64) -> () {
-                    Host::a7(*self, x)
-                }
-                fn a8(&mut self, x: i64) -> () {
-                    Host::a8(*self, x)
-                }
-                fn a9(
-                    &mut self,
-                    p1: u8,
-                    p2: i8,
-                    p3: u16,
-                    p4: i16,
-                    p5: u32,
-                    p6: i32,
-                    p7: u64,
-                    p8: i64,
-                ) -> () {
-                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8)
-                }
-                fn r1(&mut self) -> u8 {
-                    Host::r1(*self)
-                }
-                fn r2(&mut self) -> i8 {
-                    Host::r2(*self)
-                }
-                fn r3(&mut self) -> u16 {
-                    Host::r3(*self)
-                }
-                fn r4(&mut self) -> i16 {
-                    Host::r4(*self)
-                }
-                fn r5(&mut self) -> u32 {
-                    Host::r5(*self)
-                }
-                fn r6(&mut self) -> i32 {
-                    Host::r6(*self)
-                }
-                fn r7(&mut self) -> u64 {
-                    Host::r7(*self)
-                }
-                fn r8(&mut self) -> i64 {
-                    Host::r8(*self)
-                }
-                fn pair_ret(&mut self) -> (i64, u8) {
-                    Host::pair_ret(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::integers::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::integers::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
@@ -206,14 +206,80 @@ pub mod foo {
                 async fn r8(&mut self) -> i64;
                 async fn pair_ret(&mut self) -> (i64, u8);
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a1(&mut self, x: u8) -> () {
+                    Host::a1(*self, x).await
+                }
+                async fn a2(&mut self, x: i8) -> () {
+                    Host::a2(*self, x).await
+                }
+                async fn a3(&mut self, x: u16) -> () {
+                    Host::a3(*self, x).await
+                }
+                async fn a4(&mut self, x: i16) -> () {
+                    Host::a4(*self, x).await
+                }
+                async fn a5(&mut self, x: u32) -> () {
+                    Host::a5(*self, x).await
+                }
+                async fn a6(&mut self, x: i32) -> () {
+                    Host::a6(*self, x).await
+                }
+                async fn a7(&mut self, x: u64) -> () {
+                    Host::a7(*self, x).await
+                }
+                async fn a8(&mut self, x: i64) -> () {
+                    Host::a8(*self, x).await
+                }
+                async fn a9(
+                    &mut self,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> () {
+                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8).await
+                }
+                async fn r1(&mut self) -> u8 {
+                    Host::r1(*self).await
+                }
+                async fn r2(&mut self) -> i8 {
+                    Host::r2(*self).await
+                }
+                async fn r3(&mut self) -> u16 {
+                    Host::r3(*self).await
+                }
+                async fn r4(&mut self) -> i16 {
+                    Host::r4(*self).await
+                }
+                async fn r5(&mut self) -> u32 {
+                    Host::r5(*self).await
+                }
+                async fn r6(&mut self) -> i32 {
+                    Host::r6(*self).await
+                }
+                async fn r7(&mut self) -> u64 {
+                    Host::r7(*self).await
+                }
+                async fn r8(&mut self) -> i64 {
+                    Host::r8(*self).await
+                }
+                async fn pair_ret(&mut self) -> (i64, u8) {
+                    Host::pair_ret(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_async(
@@ -420,72 +486,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a1(&mut self, x: u8) -> () {
-                    Host::a1(*self, x).await
-                }
-                async fn a2(&mut self, x: i8) -> () {
-                    Host::a2(*self, x).await
-                }
-                async fn a3(&mut self, x: u16) -> () {
-                    Host::a3(*self, x).await
-                }
-                async fn a4(&mut self, x: i16) -> () {
-                    Host::a4(*self, x).await
-                }
-                async fn a5(&mut self, x: u32) -> () {
-                    Host::a5(*self, x).await
-                }
-                async fn a6(&mut self, x: i32) -> () {
-                    Host::a6(*self, x).await
-                }
-                async fn a7(&mut self, x: u64) -> () {
-                    Host::a7(*self, x).await
-                }
-                async fn a8(&mut self, x: i64) -> () {
-                    Host::a8(*self, x).await
-                }
-                async fn a9(
-                    &mut self,
-                    p1: u8,
-                    p2: i8,
-                    p3: u16,
-                    p4: i16,
-                    p5: u32,
-                    p6: i32,
-                    p7: u64,
-                    p8: i64,
-                ) -> () {
-                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8).await
-                }
-                async fn r1(&mut self) -> u8 {
-                    Host::r1(*self).await
-                }
-                async fn r2(&mut self) -> i8 {
-                    Host::r2(*self).await
-                }
-                async fn r3(&mut self) -> u16 {
-                    Host::r3(*self).await
-                }
-                async fn r4(&mut self) -> i16 {
-                    Host::r4(*self).await
-                }
-                async fn r5(&mut self) -> u32 {
-                    Host::r5(*self).await
-                }
-                async fn r6(&mut self) -> i32 {
-                    Host::r6(*self).await
-                }
-                async fn r7(&mut self) -> u64 {
-                    Host::r7(*self).await
-                }
-                async fn r8(&mut self) -> i64 {
-                    Host::r8(*self).await
-                }
-                async fn pair_ret(&mut self) -> (i64, u8) {
-                    Host::pair_ret(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::integers::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::integers::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
@@ -206,14 +206,80 @@ pub mod foo {
                 async fn r8(&mut self) -> i64;
                 async fn pair_ret(&mut self) -> (i64, u8);
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a1(&mut self, x: u8) -> () {
+                    Host::a1(*self, x).await
+                }
+                async fn a2(&mut self, x: i8) -> () {
+                    Host::a2(*self, x).await
+                }
+                async fn a3(&mut self, x: u16) -> () {
+                    Host::a3(*self, x).await
+                }
+                async fn a4(&mut self, x: i16) -> () {
+                    Host::a4(*self, x).await
+                }
+                async fn a5(&mut self, x: u32) -> () {
+                    Host::a5(*self, x).await
+                }
+                async fn a6(&mut self, x: i32) -> () {
+                    Host::a6(*self, x).await
+                }
+                async fn a7(&mut self, x: u64) -> () {
+                    Host::a7(*self, x).await
+                }
+                async fn a8(&mut self, x: i64) -> () {
+                    Host::a8(*self, x).await
+                }
+                async fn a9(
+                    &mut self,
+                    p1: u8,
+                    p2: i8,
+                    p3: u16,
+                    p4: i16,
+                    p5: u32,
+                    p6: i32,
+                    p7: u64,
+                    p8: i64,
+                ) -> () {
+                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8).await
+                }
+                async fn r1(&mut self) -> u8 {
+                    Host::r1(*self).await
+                }
+                async fn r2(&mut self) -> i8 {
+                    Host::r2(*self).await
+                }
+                async fn r3(&mut self) -> u16 {
+                    Host::r3(*self).await
+                }
+                async fn r4(&mut self) -> i16 {
+                    Host::r4(*self).await
+                }
+                async fn r5(&mut self) -> u32 {
+                    Host::r5(*self).await
+                }
+                async fn r6(&mut self) -> i32 {
+                    Host::r6(*self).await
+                }
+                async fn r7(&mut self) -> u64 {
+                    Host::r7(*self).await
+                }
+                async fn r8(&mut self) -> i64 {
+                    Host::r8(*self).await
+                }
+                async fn pair_ret(&mut self) -> (i64, u8) {
+                    Host::pair_ret(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_async(
@@ -685,72 +751,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a1(&mut self, x: u8) -> () {
-                    Host::a1(*self, x).await
-                }
-                async fn a2(&mut self, x: i8) -> () {
-                    Host::a2(*self, x).await
-                }
-                async fn a3(&mut self, x: u16) -> () {
-                    Host::a3(*self, x).await
-                }
-                async fn a4(&mut self, x: i16) -> () {
-                    Host::a4(*self, x).await
-                }
-                async fn a5(&mut self, x: u32) -> () {
-                    Host::a5(*self, x).await
-                }
-                async fn a6(&mut self, x: i32) -> () {
-                    Host::a6(*self, x).await
-                }
-                async fn a7(&mut self, x: u64) -> () {
-                    Host::a7(*self, x).await
-                }
-                async fn a8(&mut self, x: i64) -> () {
-                    Host::a8(*self, x).await
-                }
-                async fn a9(
-                    &mut self,
-                    p1: u8,
-                    p2: i8,
-                    p3: u16,
-                    p4: i16,
-                    p5: u32,
-                    p6: i32,
-                    p7: u64,
-                    p8: i64,
-                ) -> () {
-                    Host::a9(*self, p1, p2, p3, p4, p5, p6, p7, p8).await
-                }
-                async fn r1(&mut self) -> u8 {
-                    Host::r1(*self).await
-                }
-                async fn r2(&mut self) -> i8 {
-                    Host::r2(*self).await
-                }
-                async fn r3(&mut self) -> u16 {
-                    Host::r3(*self).await
-                }
-                async fn r4(&mut self) -> i16 {
-                    Host::r4(*self).await
-                }
-                async fn r5(&mut self) -> u32 {
-                    Host::r5(*self).await
-                }
-                async fn r6(&mut self) -> i32 {
-                    Host::r6(*self).await
-                }
-                async fn r7(&mut self) -> u64 {
-                    Host::r7(*self).await
-                }
-                async fn r8(&mut self) -> i64 {
-                    Host::r8(*self).await
-                }
-                async fn pair_ret(&mut self) -> (i64, u8) {
-                    Host::pair_ret(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::lists::Host,
             T: 'static,
         {
-            foo::foo::lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
@@ -445,6 +445,163 @@ pub mod foo {
                     &mut self,
                     a: LoadStoreAllSizes,
                 ) -> LoadStoreAllSizes;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn list_u8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> () {
+                    Host::list_u8_param(*self, x)
+                }
+                fn list_u16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> () {
+                    Host::list_u16_param(*self, x)
+                }
+                fn list_u32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::list_u32_param(*self, x)
+                }
+                fn list_u64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> () {
+                    Host::list_u64_param(*self, x)
+                }
+                fn list_s8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> () {
+                    Host::list_s8_param(*self, x)
+                }
+                fn list_s16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> () {
+                    Host::list_s16_param(*self, x)
+                }
+                fn list_s32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> () {
+                    Host::list_s32_param(*self, x)
+                }
+                fn list_s64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> () {
+                    Host::list_s64_param(*self, x)
+                }
+                fn list_f32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> () {
+                    Host::list_f32_param(*self, x)
+                }
+                fn list_f64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> () {
+                    Host::list_f64_param(*self, x)
+                }
+                fn list_u8_ret(&mut self) -> wasmtime::component::__internal::Vec<u8> {
+                    Host::list_u8_ret(*self)
+                }
+                fn list_u16_ret(&mut self) -> wasmtime::component::__internal::Vec<u16> {
+                    Host::list_u16_ret(*self)
+                }
+                fn list_u32_ret(&mut self) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::list_u32_ret(*self)
+                }
+                fn list_u64_ret(&mut self) -> wasmtime::component::__internal::Vec<u64> {
+                    Host::list_u64_ret(*self)
+                }
+                fn list_s8_ret(&mut self) -> wasmtime::component::__internal::Vec<i8> {
+                    Host::list_s8_ret(*self)
+                }
+                fn list_s16_ret(&mut self) -> wasmtime::component::__internal::Vec<i16> {
+                    Host::list_s16_ret(*self)
+                }
+                fn list_s32_ret(&mut self) -> wasmtime::component::__internal::Vec<i32> {
+                    Host::list_s32_ret(*self)
+                }
+                fn list_s64_ret(&mut self) -> wasmtime::component::__internal::Vec<i64> {
+                    Host::list_s64_ret(*self)
+                }
+                fn list_f32_ret(&mut self) -> wasmtime::component::__internal::Vec<f32> {
+                    Host::list_f32_ret(*self)
+                }
+                fn list_f64_ret(&mut self) -> wasmtime::component::__internal::Vec<f64> {
+                    Host::list_f64_ret(*self)
+                }
+                fn tuple_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
+                    Host::tuple_list(*self, x)
+                }
+                fn string_list_arg(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> () {
+                    Host::string_list_arg(*self, a)
+                }
+                fn string_list_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list_ret(*self)
+                }
+                fn tuple_string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    (wasmtime::component::__internal::String, u8),
+                > {
+                    Host::tuple_string_list(*self, x)
+                }
+                fn string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list(*self, x)
+                }
+                fn record_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
+                    Host::record_list(*self, x)
+                }
+                fn record_list_reverse(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
+                    Host::record_list_reverse(*self, x)
+                }
+                fn variant_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
+                    Host::variant_list(*self, x)
+                }
+                fn load_store_everything(
+                    &mut self,
+                    a: LoadStoreAllSizes,
+                ) -> LoadStoreAllSizes {
+                    Host::load_store_everything(*self, a)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -761,163 +918,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn list_u8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u8>,
-                ) -> () {
-                    Host::list_u8_param(*self, x)
-                }
-                fn list_u16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u16>,
-                ) -> () {
-                    Host::list_u16_param(*self, x)
-                }
-                fn list_u32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::list_u32_param(*self, x)
-                }
-                fn list_u64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u64>,
-                ) -> () {
-                    Host::list_u64_param(*self, x)
-                }
-                fn list_s8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i8>,
-                ) -> () {
-                    Host::list_s8_param(*self, x)
-                }
-                fn list_s16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i16>,
-                ) -> () {
-                    Host::list_s16_param(*self, x)
-                }
-                fn list_s32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i32>,
-                ) -> () {
-                    Host::list_s32_param(*self, x)
-                }
-                fn list_s64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i64>,
-                ) -> () {
-                    Host::list_s64_param(*self, x)
-                }
-                fn list_f32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f32>,
-                ) -> () {
-                    Host::list_f32_param(*self, x)
-                }
-                fn list_f64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f64>,
-                ) -> () {
-                    Host::list_f64_param(*self, x)
-                }
-                fn list_u8_ret(&mut self) -> wasmtime::component::__internal::Vec<u8> {
-                    Host::list_u8_ret(*self)
-                }
-                fn list_u16_ret(&mut self) -> wasmtime::component::__internal::Vec<u16> {
-                    Host::list_u16_ret(*self)
-                }
-                fn list_u32_ret(&mut self) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::list_u32_ret(*self)
-                }
-                fn list_u64_ret(&mut self) -> wasmtime::component::__internal::Vec<u64> {
-                    Host::list_u64_ret(*self)
-                }
-                fn list_s8_ret(&mut self) -> wasmtime::component::__internal::Vec<i8> {
-                    Host::list_s8_ret(*self)
-                }
-                fn list_s16_ret(&mut self) -> wasmtime::component::__internal::Vec<i16> {
-                    Host::list_s16_ret(*self)
-                }
-                fn list_s32_ret(&mut self) -> wasmtime::component::__internal::Vec<i32> {
-                    Host::list_s32_ret(*self)
-                }
-                fn list_s64_ret(&mut self) -> wasmtime::component::__internal::Vec<i64> {
-                    Host::list_s64_ret(*self)
-                }
-                fn list_f32_ret(&mut self) -> wasmtime::component::__internal::Vec<f32> {
-                    Host::list_f32_ret(*self)
-                }
-                fn list_f64_ret(&mut self) -> wasmtime::component::__internal::Vec<f64> {
-                    Host::list_f64_ret(*self)
-                }
-                fn tuple_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
-                    Host::tuple_list(*self, x)
-                }
-                fn string_list_arg(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> () {
-                    Host::string_list_arg(*self, a)
-                }
-                fn string_list_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list_ret(*self)
-                }
-                fn tuple_string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        (u8, wasmtime::component::__internal::String),
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    (wasmtime::component::__internal::String, u8),
-                > {
-                    Host::tuple_string_list(*self, x)
-                }
-                fn string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list(*self, x)
-                }
-                fn record_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
-                    Host::record_list(*self, x)
-                }
-                fn record_list_reverse(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
-                    Host::record_list_reverse(*self, x)
-                }
-                fn variant_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
-                    Host::variant_list(*self, x)
-                }
-                fn load_store_everything(
-                    &mut self,
-                    a: LoadStoreAllSizes,
-                ) -> LoadStoreAllSizes {
-                    Host::load_store_everything(*self, a)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
@@ -473,14 +473,191 @@ pub mod foo {
                     a: LoadStoreAllSizes,
                 ) -> LoadStoreAllSizes;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn list_u8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> () {
+                    Host::list_u8_param(*self, x).await
+                }
+                async fn list_u16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> () {
+                    Host::list_u16_param(*self, x).await
+                }
+                async fn list_u32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::list_u32_param(*self, x).await
+                }
+                async fn list_u64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> () {
+                    Host::list_u64_param(*self, x).await
+                }
+                async fn list_s8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> () {
+                    Host::list_s8_param(*self, x).await
+                }
+                async fn list_s16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> () {
+                    Host::list_s16_param(*self, x).await
+                }
+                async fn list_s32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> () {
+                    Host::list_s32_param(*self, x).await
+                }
+                async fn list_s64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> () {
+                    Host::list_s64_param(*self, x).await
+                }
+                async fn list_f32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> () {
+                    Host::list_f32_param(*self, x).await
+                }
+                async fn list_f64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> () {
+                    Host::list_f64_param(*self, x).await
+                }
+                async fn list_u8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u8> {
+                    Host::list_u8_ret(*self).await
+                }
+                async fn list_u16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u16> {
+                    Host::list_u16_ret(*self).await
+                }
+                async fn list_u32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::list_u32_ret(*self).await
+                }
+                async fn list_u64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u64> {
+                    Host::list_u64_ret(*self).await
+                }
+                async fn list_s8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i8> {
+                    Host::list_s8_ret(*self).await
+                }
+                async fn list_s16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i16> {
+                    Host::list_s16_ret(*self).await
+                }
+                async fn list_s32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i32> {
+                    Host::list_s32_ret(*self).await
+                }
+                async fn list_s64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i64> {
+                    Host::list_s64_ret(*self).await
+                }
+                async fn list_f32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f32> {
+                    Host::list_f32_ret(*self).await
+                }
+                async fn list_f64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f64> {
+                    Host::list_f64_ret(*self).await
+                }
+                async fn tuple_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
+                    Host::tuple_list(*self, x).await
+                }
+                async fn string_list_arg(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> () {
+                    Host::string_list_arg(*self, a).await
+                }
+                async fn string_list_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list_ret(*self).await
+                }
+                async fn tuple_string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    (wasmtime::component::__internal::String, u8),
+                > {
+                    Host::tuple_string_list(*self, x).await
+                }
+                async fn string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list(*self, x).await
+                }
+                async fn record_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
+                    Host::record_list(*self, x).await
+                }
+                async fn record_list_reverse(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
+                    Host::record_list_reverse(*self, x).await
+                }
+                async fn variant_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
+                    Host::variant_list(*self, x).await
+                }
+                async fn load_store_everything(
+                    &mut self,
+                    a: LoadStoreAllSizes,
+                ) -> LoadStoreAllSizes {
+                    Host::load_store_everything(*self, a).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_async(
@@ -846,183 +1023,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn list_u8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u8>,
-                ) -> () {
-                    Host::list_u8_param(*self, x).await
-                }
-                async fn list_u16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u16>,
-                ) -> () {
-                    Host::list_u16_param(*self, x).await
-                }
-                async fn list_u32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::list_u32_param(*self, x).await
-                }
-                async fn list_u64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u64>,
-                ) -> () {
-                    Host::list_u64_param(*self, x).await
-                }
-                async fn list_s8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i8>,
-                ) -> () {
-                    Host::list_s8_param(*self, x).await
-                }
-                async fn list_s16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i16>,
-                ) -> () {
-                    Host::list_s16_param(*self, x).await
-                }
-                async fn list_s32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i32>,
-                ) -> () {
-                    Host::list_s32_param(*self, x).await
-                }
-                async fn list_s64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i64>,
-                ) -> () {
-                    Host::list_s64_param(*self, x).await
-                }
-                async fn list_f32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f32>,
-                ) -> () {
-                    Host::list_f32_param(*self, x).await
-                }
-                async fn list_f64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f64>,
-                ) -> () {
-                    Host::list_f64_param(*self, x).await
-                }
-                async fn list_u8_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u8> {
-                    Host::list_u8_ret(*self).await
-                }
-                async fn list_u16_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u16> {
-                    Host::list_u16_ret(*self).await
-                }
-                async fn list_u32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::list_u32_ret(*self).await
-                }
-                async fn list_u64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u64> {
-                    Host::list_u64_ret(*self).await
-                }
-                async fn list_s8_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i8> {
-                    Host::list_s8_ret(*self).await
-                }
-                async fn list_s16_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i16> {
-                    Host::list_s16_ret(*self).await
-                }
-                async fn list_s32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i32> {
-                    Host::list_s32_ret(*self).await
-                }
-                async fn list_s64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i64> {
-                    Host::list_s64_ret(*self).await
-                }
-                async fn list_f32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<f32> {
-                    Host::list_f32_ret(*self).await
-                }
-                async fn list_f64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<f64> {
-                    Host::list_f64_ret(*self).await
-                }
-                async fn tuple_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
-                    Host::tuple_list(*self, x).await
-                }
-                async fn string_list_arg(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> () {
-                    Host::string_list_arg(*self, a).await
-                }
-                async fn string_list_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list_ret(*self).await
-                }
-                async fn tuple_string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        (u8, wasmtime::component::__internal::String),
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    (wasmtime::component::__internal::String, u8),
-                > {
-                    Host::tuple_string_list(*self, x).await
-                }
-                async fn string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list(*self, x).await
-                }
-                async fn record_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
-                    Host::record_list(*self, x).await
-                }
-                async fn record_list_reverse(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
-                    Host::record_list_reverse(*self, x).await
-                }
-                async fn variant_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
-                    Host::variant_list(*self, x).await
-                }
-                async fn load_store_everything(
-                    &mut self,
-                    a: LoadStoreAllSizes,
-                ) -> LoadStoreAllSizes {
-                    Host::load_store_everything(*self, a).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
@@ -473,14 +473,191 @@ pub mod foo {
                     a: LoadStoreAllSizes,
                 ) -> LoadStoreAllSizes;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn list_u8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u8>,
+                ) -> () {
+                    Host::list_u8_param(*self, x).await
+                }
+                async fn list_u16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u16>,
+                ) -> () {
+                    Host::list_u16_param(*self, x).await
+                }
+                async fn list_u32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::list_u32_param(*self, x).await
+                }
+                async fn list_u64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<u64>,
+                ) -> () {
+                    Host::list_u64_param(*self, x).await
+                }
+                async fn list_s8_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i8>,
+                ) -> () {
+                    Host::list_s8_param(*self, x).await
+                }
+                async fn list_s16_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i16>,
+                ) -> () {
+                    Host::list_s16_param(*self, x).await
+                }
+                async fn list_s32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i32>,
+                ) -> () {
+                    Host::list_s32_param(*self, x).await
+                }
+                async fn list_s64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<i64>,
+                ) -> () {
+                    Host::list_s64_param(*self, x).await
+                }
+                async fn list_f32_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f32>,
+                ) -> () {
+                    Host::list_f32_param(*self, x).await
+                }
+                async fn list_f64_param(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<f64>,
+                ) -> () {
+                    Host::list_f64_param(*self, x).await
+                }
+                async fn list_u8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u8> {
+                    Host::list_u8_ret(*self).await
+                }
+                async fn list_u16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u16> {
+                    Host::list_u16_ret(*self).await
+                }
+                async fn list_u32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::list_u32_ret(*self).await
+                }
+                async fn list_u64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u64> {
+                    Host::list_u64_ret(*self).await
+                }
+                async fn list_s8_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i8> {
+                    Host::list_s8_ret(*self).await
+                }
+                async fn list_s16_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i16> {
+                    Host::list_s16_ret(*self).await
+                }
+                async fn list_s32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i32> {
+                    Host::list_s32_ret(*self).await
+                }
+                async fn list_s64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<i64> {
+                    Host::list_s64_ret(*self).await
+                }
+                async fn list_f32_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f32> {
+                    Host::list_f32_ret(*self).await
+                }
+                async fn list_f64_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<f64> {
+                    Host::list_f64_ret(*self).await
+                }
+                async fn tuple_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
+                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
+                    Host::tuple_list(*self, x).await
+                }
+                async fn string_list_arg(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> () {
+                    Host::string_list_arg(*self, a).await
+                }
+                async fn string_list_ret(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list_ret(*self).await
+                }
+                async fn tuple_string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        (u8, wasmtime::component::__internal::String),
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    (wasmtime::component::__internal::String, u8),
+                > {
+                    Host::tuple_string_list(*self, x).await
+                }
+                async fn string_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::String,
+                > {
+                    Host::string_list(*self, x).await
+                }
+                async fn record_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeRecord>,
+                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
+                    Host::record_list(*self, x).await
+                }
+                async fn record_list_reverse(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<OtherRecord>,
+                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
+                    Host::record_list_reverse(*self, x).await
+                }
+                async fn variant_list(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<SomeVariant>,
+                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
+                    Host::variant_list(*self, x).await
+                }
+                async fn load_store_everything(
+                    &mut self,
+                    a: LoadStoreAllSizes,
+                ) -> LoadStoreAllSizes {
+                    Host::load_store_everything(*self, a).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_async(
@@ -1277,183 +1454,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn list_u8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u8>,
-                ) -> () {
-                    Host::list_u8_param(*self, x).await
-                }
-                async fn list_u16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u16>,
-                ) -> () {
-                    Host::list_u16_param(*self, x).await
-                }
-                async fn list_u32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::list_u32_param(*self, x).await
-                }
-                async fn list_u64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<u64>,
-                ) -> () {
-                    Host::list_u64_param(*self, x).await
-                }
-                async fn list_s8_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i8>,
-                ) -> () {
-                    Host::list_s8_param(*self, x).await
-                }
-                async fn list_s16_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i16>,
-                ) -> () {
-                    Host::list_s16_param(*self, x).await
-                }
-                async fn list_s32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i32>,
-                ) -> () {
-                    Host::list_s32_param(*self, x).await
-                }
-                async fn list_s64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<i64>,
-                ) -> () {
-                    Host::list_s64_param(*self, x).await
-                }
-                async fn list_f32_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f32>,
-                ) -> () {
-                    Host::list_f32_param(*self, x).await
-                }
-                async fn list_f64_param(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<f64>,
-                ) -> () {
-                    Host::list_f64_param(*self, x).await
-                }
-                async fn list_u8_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u8> {
-                    Host::list_u8_ret(*self).await
-                }
-                async fn list_u16_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u16> {
-                    Host::list_u16_ret(*self).await
-                }
-                async fn list_u32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::list_u32_ret(*self).await
-                }
-                async fn list_u64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u64> {
-                    Host::list_u64_ret(*self).await
-                }
-                async fn list_s8_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i8> {
-                    Host::list_s8_ret(*self).await
-                }
-                async fn list_s16_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i16> {
-                    Host::list_s16_ret(*self).await
-                }
-                async fn list_s32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i32> {
-                    Host::list_s32_ret(*self).await
-                }
-                async fn list_s64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<i64> {
-                    Host::list_s64_ret(*self).await
-                }
-                async fn list_f32_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<f32> {
-                    Host::list_f32_ret(*self).await
-                }
-                async fn list_f64_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<f64> {
-                    Host::list_f64_ret(*self).await
-                }
-                async fn tuple_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> wasmtime::component::__internal::Vec<(i64, u32)> {
-                    Host::tuple_list(*self, x).await
-                }
-                async fn string_list_arg(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> () {
-                    Host::string_list_arg(*self, a).await
-                }
-                async fn string_list_ret(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list_ret(*self).await
-                }
-                async fn tuple_string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        (u8, wasmtime::component::__internal::String),
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    (wasmtime::component::__internal::String, u8),
-                > {
-                    Host::tuple_string_list(*self, x).await
-                }
-                async fn string_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::String,
-                > {
-                    Host::string_list(*self, x).await
-                }
-                async fn record_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> wasmtime::component::__internal::Vec<OtherRecord> {
-                    Host::record_list(*self, x).await
-                }
-                async fn record_list_reverse(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> wasmtime::component::__internal::Vec<SomeRecord> {
-                    Host::record_list_reverse(*self, x).await
-                }
-                async fn variant_list(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> wasmtime::component::__internal::Vec<OtherVariant> {
-                    Host::variant_list(*self, x).await
-                }
-                async fn load_store_everything(
-                    &mut self,
-                    a: LoadStoreAllSizes,
-                ) -> LoadStoreAllSizes {
-                    Host::load_store_everything(*self, a).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host,
             T: 'static,
         {
-            foo::foo::manyarg::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::manyarg::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
@@ -272,6 +272,50 @@ pub mod foo {
                 ) -> ();
                 fn big_argument(&mut self, x: BigStruct) -> ();
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn many_args(
+                    &mut self,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> () {
+                    Host::many_args(
+                        *self,
+                        a1,
+                        a2,
+                        a3,
+                        a4,
+                        a5,
+                        a6,
+                        a7,
+                        a8,
+                        a9,
+                        a10,
+                        a11,
+                        a12,
+                        a13,
+                        a14,
+                        a15,
+                        a16,
+                    )
+                }
+                fn big_argument(&mut self, x: BigStruct) -> () {
+                    Host::big_argument(*self, x)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -357,50 +401,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn many_args(
-                    &mut self,
-                    a1: u64,
-                    a2: u64,
-                    a3: u64,
-                    a4: u64,
-                    a5: u64,
-                    a6: u64,
-                    a7: u64,
-                    a8: u64,
-                    a9: u64,
-                    a10: u64,
-                    a11: u64,
-                    a12: u64,
-                    a13: u64,
-                    a14: u64,
-                    a15: u64,
-                    a16: u64,
-                ) -> () {
-                    Host::many_args(
-                        *self,
-                        a1,
-                        a2,
-                        a3,
-                        a4,
-                        a5,
-                        a6,
-                        a7,
-                        a8,
-                        a9,
-                        a10,
-                        a11,
-                        a12,
-                        a13,
-                        a14,
-                        a15,
-                        a16,
-                    )
-                }
-                fn big_argument(&mut self, x: BigStruct) -> () {
-                    Host::big_argument(*self, x)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::manyarg::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::manyarg::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
@@ -279,14 +279,59 @@ pub mod foo {
                 ) -> ();
                 async fn big_argument(&mut self, x: BigStruct) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn many_args(
+                    &mut self,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> () {
+                    Host::many_args(
+                            *self,
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            a10,
+                            a11,
+                            a12,
+                            a13,
+                            a14,
+                            a15,
+                            a16,
+                        )
+                        .await
+                }
+                async fn big_argument(&mut self, x: BigStruct) -> () {
+                    Host::big_argument(*self, x).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap_async(
@@ -369,51 +414,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn many_args(
-                    &mut self,
-                    a1: u64,
-                    a2: u64,
-                    a3: u64,
-                    a4: u64,
-                    a5: u64,
-                    a6: u64,
-                    a7: u64,
-                    a8: u64,
-                    a9: u64,
-                    a10: u64,
-                    a11: u64,
-                    a12: u64,
-                    a13: u64,
-                    a14: u64,
-                    a15: u64,
-                    a16: u64,
-                ) -> () {
-                    Host::many_args(
-                            *self,
-                            a1,
-                            a2,
-                            a3,
-                            a4,
-                            a5,
-                            a6,
-                            a7,
-                            a8,
-                            a9,
-                            a10,
-                            a11,
-                            a12,
-                            a13,
-                            a14,
-                            a15,
-                            a16,
-                        )
-                        .await
-                }
-                async fn big_argument(&mut self, x: BigStruct) -> () {
-                    Host::big_argument(*self, x).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::manyarg::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::manyarg::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::manyarg::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_manyarg(&self) -> &exports::foo::foo::manyarg::Guest {
@@ -279,14 +279,59 @@ pub mod foo {
                 ) -> ();
                 async fn big_argument(&mut self, x: BigStruct) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn many_args(
+                    &mut self,
+                    a1: u64,
+                    a2: u64,
+                    a3: u64,
+                    a4: u64,
+                    a5: u64,
+                    a6: u64,
+                    a7: u64,
+                    a8: u64,
+                    a9: u64,
+                    a10: u64,
+                    a11: u64,
+                    a12: u64,
+                    a13: u64,
+                    a14: u64,
+                    a15: u64,
+                    a16: u64,
+                ) -> () {
+                    Host::many_args(
+                            *self,
+                            a1,
+                            a2,
+                            a3,
+                            a4,
+                            a5,
+                            a6,
+                            a7,
+                            a8,
+                            a9,
+                            a10,
+                            a11,
+                            a12,
+                            a13,
+                            a14,
+                            a15,
+                            a16,
+                        )
+                        .await
+                }
+                async fn big_argument(&mut self, x: BigStruct) -> () {
+                    Host::big_argument(*self, x).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap_async(
@@ -412,51 +457,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn many_args(
-                    &mut self,
-                    a1: u64,
-                    a2: u64,
-                    a3: u64,
-                    a4: u64,
-                    a5: u64,
-                    a6: u64,
-                    a7: u64,
-                    a8: u64,
-                    a9: u64,
-                    a10: u64,
-                    a11: u64,
-                    a12: u64,
-                    a13: u64,
-                    a14: u64,
-                    a15: u64,
-                    a16: u64,
-                ) -> () {
-                    Host::many_args(
-                            *self,
-                            a1,
-                            a2,
-                            a3,
-                            a4,
-                            a5,
-                            a6,
-                            a7,
-                            a8,
-                            a9,
-                            a10,
-                            a11,
-                            a12,
-                            a13,
-                            a14,
-                            a15,
-                            a16,
-                        )
-                        .await
-                }
-                async fn big_argument(&mut self, x: BigStruct) -> () {
-                    Host::big_argument(*self, x).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -153,15 +153,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host,
             T: 'static,
         {
-            my::dep0_1_0::a::add_to_linker::<T, D>(linker, get)?;
-            my::dep0_2_0::a::add_to_linker::<T, D>(linker, get)?;
+            my::dep0_1_0::a::add_to_linker::<T, D>(linker, host_getter)?;
+            my::dep0_2_0::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
@@ -180,6 +180,11 @@ pub mod my {
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait Host {
                 fn x(&mut self) -> ();
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn x(&mut self) -> () {
+                    Host::x(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -201,11 +206,6 @@ pub mod my {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn x(&mut self) -> () {
-                    Host::x(*self)
-                }
-            }
         }
     }
     pub mod dep0_2_0 {
@@ -215,6 +215,11 @@ pub mod my {
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait Host {
                 fn x(&mut self) -> ();
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn x(&mut self) -> () {
+                    Host::x(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -235,11 +240,6 @@ pub mod my {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn x(&mut self) -> () {
-                    Host::x(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -159,15 +159,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            my::dep0_1_0::a::add_to_linker::<T, D>(linker, get)?;
-            my::dep0_2_0::a::add_to_linker::<T, D>(linker, get)?;
+            my::dep0_1_0::a::add_to_linker::<T, D>(linker, host_getter)?;
+            my::dep0_2_0::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
@@ -188,14 +188,19 @@ pub mod my {
             pub trait Host: Send {
                 async fn x(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn x(&mut self) -> () {
+                    Host::x(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_async(
@@ -210,11 +215,6 @@ pub mod my {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn x(&mut self) -> () {
-                    Host::x(*self).await
-                }
-            }
         }
     }
     pub mod dep0_2_0 {
@@ -226,14 +226,19 @@ pub mod my {
             pub trait Host: Send {
                 async fn x(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn x(&mut self) -> () {
+                    Host::x(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_async(
@@ -247,11 +252,6 @@ pub mod my {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn x(&mut self) -> () {
-                    Host::x(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -159,15 +159,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            my::dep0_1_0::a::add_to_linker::<T, D>(linker, get)?;
-            my::dep0_2_0::a::add_to_linker::<T, D>(linker, get)?;
+            my::dep0_1_0::a::add_to_linker::<T, D>(linker, host_getter)?;
+            my::dep0_2_0::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
@@ -188,14 +188,19 @@ pub mod my {
             pub trait Host: Send {
                 async fn x(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn x(&mut self) -> () {
+                    Host::x(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_async(
@@ -223,11 +228,6 @@ pub mod my {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn x(&mut self) -> () {
-                    Host::x(*self).await
-                }
-            }
         }
     }
     pub mod dep0_2_0 {
@@ -239,14 +239,19 @@ pub mod my {
             pub trait Host: Send {
                 async fn x(&mut self) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn x(&mut self) -> () {
+                    Host::x(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_async(
@@ -273,11 +278,6 @@ pub mod my {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn x(&mut self) -> () {
-                    Host::x(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -140,14 +140,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path1::test::Host,
             T: 'static,
         {
-            paths::path1::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path1::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -159,6 +159,7 @@ pub mod paths {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait Host {}
+            impl<_T: Host + ?Sized> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -171,7 +172,6 @@ pub mod paths {
                 let mut inst = linker.instance("paths:path1/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path1::test::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            paths::path1::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path1::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -166,19 +166,19 @@ pub mod paths {
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path1::test::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            paths::path1::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path1::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -166,19 +166,19 @@ pub mod paths {
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -140,14 +140,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path2::test::Host,
             T: 'static,
         {
-            paths::path2::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path2::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -159,6 +159,7 @@ pub mod paths {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait Host {}
+            impl<_T: Host + ?Sized> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -171,7 +172,6 @@ pub mod paths {
                 let mut inst = linker.instance("paths:path2/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path2::test::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            paths::path2::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path2::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -166,19 +166,19 @@ pub mod paths {
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: paths::path2::test::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            paths::path2::test::add_to_linker::<T, D>(linker, get)?;
+            paths::path2::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -166,19 +166,19 @@ pub mod paths {
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::records::Host,
             T: 'static,
         {
-            foo::foo::records::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::records::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
@@ -337,6 +337,41 @@ pub mod foo {
                 fn aggregate_result(&mut self) -> Aggregates;
                 fn typedef_inout(&mut self, e: TupleTypedef2) -> i32;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn tuple_arg(&mut self, x: (char, u32)) -> () {
+                    Host::tuple_arg(*self, x)
+                }
+                fn tuple_result(&mut self) -> (char, u32) {
+                    Host::tuple_result(*self)
+                }
+                fn empty_arg(&mut self, x: Empty) -> () {
+                    Host::empty_arg(*self, x)
+                }
+                fn empty_result(&mut self) -> Empty {
+                    Host::empty_result(*self)
+                }
+                fn scalar_arg(&mut self, x: Scalars) -> () {
+                    Host::scalar_arg(*self, x)
+                }
+                fn scalar_result(&mut self) -> Scalars {
+                    Host::scalar_result(*self)
+                }
+                fn flags_arg(&mut self, x: ReallyFlags) -> () {
+                    Host::flags_arg(*self, x)
+                }
+                fn flags_result(&mut self) -> ReallyFlags {
+                    Host::flags_result(*self)
+                }
+                fn aggregate_arg(&mut self, x: Aggregates) -> () {
+                    Host::aggregate_arg(*self, x)
+                }
+                fn aggregate_result(&mut self) -> Aggregates {
+                    Host::aggregate_result(*self)
+                }
+                fn typedef_inout(&mut self, e: TupleTypedef2) -> i32 {
+                    Host::typedef_inout(*self, e)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -454,41 +489,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn tuple_arg(&mut self, x: (char, u32)) -> () {
-                    Host::tuple_arg(*self, x)
-                }
-                fn tuple_result(&mut self) -> (char, u32) {
-                    Host::tuple_result(*self)
-                }
-                fn empty_arg(&mut self, x: Empty) -> () {
-                    Host::empty_arg(*self, x)
-                }
-                fn empty_result(&mut self) -> Empty {
-                    Host::empty_result(*self)
-                }
-                fn scalar_arg(&mut self, x: Scalars) -> () {
-                    Host::scalar_arg(*self, x)
-                }
-                fn scalar_result(&mut self) -> Scalars {
-                    Host::scalar_result(*self)
-                }
-                fn flags_arg(&mut self, x: ReallyFlags) -> () {
-                    Host::flags_arg(*self, x)
-                }
-                fn flags_result(&mut self) -> ReallyFlags {
-                    Host::flags_result(*self)
-                }
-                fn aggregate_arg(&mut self, x: Aggregates) -> () {
-                    Host::aggregate_arg(*self, x)
-                }
-                fn aggregate_result(&mut self) -> Aggregates {
-                    Host::aggregate_result(*self)
-                }
-                fn typedef_inout(&mut self, e: TupleTypedef2) -> i32 {
-                    Host::typedef_inout(*self, e)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::records::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::records::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::records::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
@@ -344,14 +344,49 @@ pub mod foo {
                 async fn aggregate_result(&mut self) -> Aggregates;
                 async fn typedef_inout(&mut self, e: TupleTypedef2) -> i32;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn tuple_arg(&mut self, x: (char, u32)) -> () {
+                    Host::tuple_arg(*self, x).await
+                }
+                async fn tuple_result(&mut self) -> (char, u32) {
+                    Host::tuple_result(*self).await
+                }
+                async fn empty_arg(&mut self, x: Empty) -> () {
+                    Host::empty_arg(*self, x).await
+                }
+                async fn empty_result(&mut self) -> Empty {
+                    Host::empty_result(*self).await
+                }
+                async fn scalar_arg(&mut self, x: Scalars) -> () {
+                    Host::scalar_arg(*self, x).await
+                }
+                async fn scalar_result(&mut self) -> Scalars {
+                    Host::scalar_result(*self).await
+                }
+                async fn flags_arg(&mut self, x: ReallyFlags) -> () {
+                    Host::flags_arg(*self, x).await
+                }
+                async fn flags_result(&mut self) -> ReallyFlags {
+                    Host::flags_result(*self).await
+                }
+                async fn aggregate_arg(&mut self, x: Aggregates) -> () {
+                    Host::aggregate_arg(*self, x).await
+                }
+                async fn aggregate_result(&mut self) -> Aggregates {
+                    Host::aggregate_result(*self).await
+                }
+                async fn typedef_inout(&mut self, e: TupleTypedef2) -> i32 {
+                    Host::typedef_inout(*self, e).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap_async(
@@ -644,41 +679,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn tuple_arg(&mut self, x: (char, u32)) -> () {
-                    Host::tuple_arg(*self, x).await
-                }
-                async fn tuple_result(&mut self) -> (char, u32) {
-                    Host::tuple_result(*self).await
-                }
-                async fn empty_arg(&mut self, x: Empty) -> () {
-                    Host::empty_arg(*self, x).await
-                }
-                async fn empty_result(&mut self) -> Empty {
-                    Host::empty_result(*self).await
-                }
-                async fn scalar_arg(&mut self, x: Scalars) -> () {
-                    Host::scalar_arg(*self, x).await
-                }
-                async fn scalar_result(&mut self) -> Scalars {
-                    Host::scalar_result(*self).await
-                }
-                async fn flags_arg(&mut self, x: ReallyFlags) -> () {
-                    Host::flags_arg(*self, x).await
-                }
-                async fn flags_result(&mut self) -> ReallyFlags {
-                    Host::flags_result(*self).await
-                }
-                async fn aggregate_arg(&mut self, x: Aggregates) -> () {
-                    Host::aggregate_arg(*self, x).await
-                }
-                async fn aggregate_result(&mut self) -> Aggregates {
-                    Host::aggregate_result(*self).await
-                }
-                async fn typedef_inout(&mut self, e: TupleTypedef2) -> i32 {
-                    Host::typedef_inout(*self, e).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -146,15 +146,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::green::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::red::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::green::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::red::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -172,19 +172,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
         #[allow(clippy::all)]
         pub mod red {
@@ -199,14 +199,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn foo(&mut self) -> Thing;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn foo(&mut self) -> Thing {
+                    Host::foo(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_async(
@@ -220,11 +225,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn foo(&mut self) -> Thing {
-                    Host::foo(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/rename_tracing_async.rs
@@ -146,15 +146,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::green::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::red::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::green::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::red::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -172,19 +172,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
         #[allow(clippy::all)]
         pub mod red {
@@ -199,14 +199,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn foo(&mut self) -> Thing;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn foo(&mut self) -> Thing {
+                    Host::foo(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_async(
@@ -233,11 +238,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn foo(&mut self) -> Thing {
-                    Host::foo(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -176,14 +176,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::transitive_import::Host,
             T: 'static,
         {
-            foo::foo::transitive_import::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::transitive_import::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple_export(&self) -> &exports::foo::foo::simple_export::Guest {
@@ -213,7 +213,7 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Y {}
-            pub trait HostY: Sized {
+            pub trait HostY {
                 fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<Y>,
@@ -227,7 +227,8 @@ pub mod foo {
                     HostY::drop(*self, rep)
                 }
             }
-            pub trait Host: HostY + Sized {}
+            pub trait Host: HostY {}
+            impl<_T: Host + ?Sized> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -250,7 +251,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -1,6 +1,6 @@
 pub enum WorldResource {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-pub trait HostWorldResource: Sized {
+pub trait HostWorldResource: Send {
     async fn new(&mut self) -> wasmtime::component::Resource<WorldResource>;
     async fn foo(&mut self, self_: wasmtime::component::Resource<WorldResource>) -> ();
     async fn static_foo(&mut self) -> ();
@@ -237,7 +237,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: TheWorldImports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             linker
@@ -360,7 +360,7 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
@@ -371,18 +371,18 @@ const _: () = {
                 + foo::foo::long_use_chain4::Host
                 + foo::foo::transitive_interface_with_resource::Host + TheWorldImports
                 + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            Self::add_to_linker_imports::<T, D>(linker, get)?;
-            foo::foo::resources::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::long_use_chain1::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::long_use_chain2::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::long_use_chain3::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::long_use_chain4::add_to_linker::<T, D>(linker, get)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
+            foo::foo::resources::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain1::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain2::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain3::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain4::add_to_linker::<T, D>(linker, host_getter)?;
             foo::foo::transitive_interface_with_resource::add_to_linker::<
                 T,
                 D,
-            >(linker, get)?;
+            >(linker, host_getter)?;
             Ok(())
         }
         pub async fn call_some_world_func2<S: wasmtime::AsContextMut>(
@@ -425,7 +425,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Bar {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostBar: Sized {
+            pub trait HostBar: Send {
                 async fn new(&mut self) -> wasmtime::component::Resource<Bar>;
                 async fn static_a(&mut self) -> u32;
                 async fn method_a(
@@ -513,7 +513,7 @@ pub mod foo {
                 );
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostBar + Sized {
+            pub trait Host: Send + HostBar {
                 async fn bar_own_arg(
                     &mut self,
                     x: wasmtime::component::Resource<Bar>,
@@ -578,14 +578,117 @@ pub mod foo {
                 async fn record_result(&mut self) -> NestedOwn;
                 async fn func_with_handle_typedef(&mut self, x: SomeHandle) -> ();
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn bar_own_arg(
+                    &mut self,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> () {
+                    Host::bar_own_arg(*self, x).await
+                }
+                async fn bar_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> () {
+                    Host::bar_borrow_arg(*self, x).await
+                }
+                async fn bar_result(&mut self) -> wasmtime::component::Resource<Bar> {
+                    Host::bar_result(*self).await
+                }
+                async fn tuple_own_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> () {
+                    Host::tuple_own_arg(*self, x).await
+                }
+                async fn tuple_borrow_arg(
+                    &mut self,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> () {
+                    Host::tuple_borrow_arg(*self, x).await
+                }
+                async fn tuple_result(
+                    &mut self,
+                ) -> (wasmtime::component::Resource<Bar>, u32) {
+                    Host::tuple_result(*self).await
+                }
+                async fn option_own_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> () {
+                    Host::option_own_arg(*self, x).await
+                }
+                async fn option_borrow_arg(
+                    &mut self,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> () {
+                    Host::option_borrow_arg(*self, x).await
+                }
+                async fn option_result(
+                    &mut self,
+                ) -> Option<wasmtime::component::Resource<Bar>> {
+                    Host::option_result(*self).await
+                }
+                async fn result_own_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> () {
+                    Host::result_own_arg(*self, x).await
+                }
+                async fn result_borrow_arg(
+                    &mut self,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> () {
+                    Host::result_borrow_arg(*self, x).await
+                }
+                async fn result_result(
+                    &mut self,
+                ) -> Result<wasmtime::component::Resource<Bar>, ()> {
+                    Host::result_result(*self).await
+                }
+                async fn list_own_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> () {
+                    Host::list_own_arg(*self, x).await
+                }
+                async fn list_borrow_arg(
+                    &mut self,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> () {
+                    Host::list_borrow_arg(*self, x).await
+                }
+                async fn list_result(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::Resource<Bar>,
+                > {
+                    Host::list_result(*self).await
+                }
+                async fn record_own_arg(&mut self, x: NestedOwn) -> () {
+                    Host::record_own_arg(*self, x).await
+                }
+                async fn record_borrow_arg(&mut self, x: NestedBorrow) -> () {
+                    Host::record_borrow_arg(*self, x).await
+                }
+                async fn record_result(&mut self) -> NestedOwn {
+                    Host::record_result(*self).await
+                }
+                async fn func_with_handle_typedef(&mut self, x: SomeHandle) -> () {
+                    Host::func_with_handle_typedef(*self, x).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/resources")?;
                 inst.resource_async(
@@ -1205,109 +1308,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn bar_own_arg(
-                    &mut self,
-                    x: wasmtime::component::Resource<Bar>,
-                ) -> () {
-                    Host::bar_own_arg(*self, x).await
-                }
-                async fn bar_borrow_arg(
-                    &mut self,
-                    x: wasmtime::component::Resource<Bar>,
-                ) -> () {
-                    Host::bar_borrow_arg(*self, x).await
-                }
-                async fn bar_result(&mut self) -> wasmtime::component::Resource<Bar> {
-                    Host::bar_result(*self).await
-                }
-                async fn tuple_own_arg(
-                    &mut self,
-                    x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> () {
-                    Host::tuple_own_arg(*self, x).await
-                }
-                async fn tuple_borrow_arg(
-                    &mut self,
-                    x: (wasmtime::component::Resource<Bar>, u32),
-                ) -> () {
-                    Host::tuple_borrow_arg(*self, x).await
-                }
-                async fn tuple_result(
-                    &mut self,
-                ) -> (wasmtime::component::Resource<Bar>, u32) {
-                    Host::tuple_result(*self).await
-                }
-                async fn option_own_arg(
-                    &mut self,
-                    x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> () {
-                    Host::option_own_arg(*self, x).await
-                }
-                async fn option_borrow_arg(
-                    &mut self,
-                    x: Option<wasmtime::component::Resource<Bar>>,
-                ) -> () {
-                    Host::option_borrow_arg(*self, x).await
-                }
-                async fn option_result(
-                    &mut self,
-                ) -> Option<wasmtime::component::Resource<Bar>> {
-                    Host::option_result(*self).await
-                }
-                async fn result_own_arg(
-                    &mut self,
-                    x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> () {
-                    Host::result_own_arg(*self, x).await
-                }
-                async fn result_borrow_arg(
-                    &mut self,
-                    x: Result<wasmtime::component::Resource<Bar>, ()>,
-                ) -> () {
-                    Host::result_borrow_arg(*self, x).await
-                }
-                async fn result_result(
-                    &mut self,
-                ) -> Result<wasmtime::component::Resource<Bar>, ()> {
-                    Host::result_result(*self).await
-                }
-                async fn list_own_arg(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::Resource<Bar>,
-                    >,
-                ) -> () {
-                    Host::list_own_arg(*self, x).await
-                }
-                async fn list_borrow_arg(
-                    &mut self,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::Resource<Bar>,
-                    >,
-                ) -> () {
-                    Host::list_borrow_arg(*self, x).await
-                }
-                async fn list_result(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::Resource<Bar>,
-                > {
-                    Host::list_result(*self).await
-                }
-                async fn record_own_arg(&mut self, x: NestedOwn) -> () {
-                    Host::record_own_arg(*self, x).await
-                }
-                async fn record_borrow_arg(&mut self, x: NestedBorrow) -> () {
-                    Host::record_borrow_arg(*self, x).await
-                }
-                async fn record_result(&mut self) -> NestedOwn {
-                    Host::record_result(*self).await
-                }
-                async fn func_with_handle_typedef(&mut self, x: SomeHandle) -> () {
-                    Host::func_with_handle_typedef(*self, x).await
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain1 {
@@ -1315,7 +1315,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum A {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostA: Sized {
+            pub trait HostA: Send {
                 async fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<A>,
@@ -1330,15 +1330,16 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostA + Sized {}
+            pub trait Host: Send + HostA {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain1")?;
                 inst.resource_async(
@@ -1356,7 +1357,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
         #[allow(clippy::all)]
         pub mod long_use_chain2 {
@@ -1365,19 +1365,19 @@ pub mod foo {
             pub type A = super::super::super::foo::foo::long_use_chain1::A;
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain2")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
         #[allow(clippy::all)]
         pub mod long_use_chain3 {
@@ -1386,19 +1386,19 @@ pub mod foo {
             pub type A = super::super::super::foo::foo::long_use_chain2::A;
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain3")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
         #[allow(clippy::all)]
         pub mod long_use_chain4 {
@@ -1409,14 +1409,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn foo(&mut self) -> wasmtime::component::Resource<A>;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn foo(&mut self) -> wasmtime::component::Resource<A> {
+                    Host::foo(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain4")?;
                 inst.func_wrap_async(
@@ -1444,11 +1449,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn foo(&mut self) -> wasmtime::component::Resource<A> {
-                    Host::foo(*self).await
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod transitive_interface_with_resource {
@@ -1456,7 +1456,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Foo {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostFoo: Sized {
+            pub trait HostFoo: Send {
                 async fn drop(
                     &mut self,
                     rep: wasmtime::component::Resource<Foo>,
@@ -1471,15 +1471,16 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostFoo + Sized {}
+            pub trait Host: Send + HostFoo {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker
                     .instance("foo:foo/transitive-interface-with-resource")?;
@@ -1498,7 +1499,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -152,15 +152,15 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::http_types::add_to_linker::<T, D>(linker, get)?;
-            http_fetch::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::http_types::add_to_linker::<T, D>(linker, host_getter)?;
+            http_fetch::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn http_handler(&self) -> &exports::http_handler::Guest {
@@ -214,19 +214,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/http-types")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }
@@ -248,14 +248,19 @@ pub mod http_fetch {
     pub trait Host: Send {
         async fn fetch_request(&mut self, request: Request) -> Response;
     }
+    impl<_T: Host + ?Sized + Send> Host for &mut _T {
+        async fn fetch_request(&mut self, request: Request) -> Response {
+            Host::fetch_request(*self, request).await
+        }
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
         D: wasmtime::component::HasData,
-        for<'a> D::Data<'a>: Host + Send,
-        T: Send + 'static,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
     {
         let mut inst = linker.instance("http-fetch")?;
         inst.func_wrap_async(
@@ -269,11 +274,6 @@ pub mod http_fetch {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {
-        async fn fetch_request(&mut self, request: Request) -> Response {
-            Host::fetch_request(*self, request).await
-        }
     }
 }
 pub mod exports {

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::simple::Host,
             T: 'static,
         {
-            foo::foo::simple::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::simple::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple(&self) -> &exports::foo::foo::simple::Guest {
@@ -176,6 +176,26 @@ pub mod foo {
                 fn f4(&mut self) -> u32;
                 fn f5(&mut self) -> (u32, u32);
                 fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32);
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn f1(&mut self) -> () {
+                    Host::f1(*self)
+                }
+                fn f2(&mut self, a: u32) -> () {
+                    Host::f2(*self, a)
+                }
+                fn f3(&mut self, a: u32, b: u32) -> () {
+                    Host::f3(*self, a, b)
+                }
+                fn f4(&mut self) -> u32 {
+                    Host::f4(*self)
+                }
+                fn f5(&mut self) -> (u32, u32) {
+                    Host::f5(*self)
+                }
+                fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32) {
+                    Host::f6(*self, a, b, c)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -242,26 +262,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn f1(&mut self) -> () {
-                    Host::f1(*self)
-                }
-                fn f2(&mut self, a: u32) -> () {
-                    Host::f2(*self, a)
-                }
-                fn f3(&mut self, a: u32, b: u32) -> () {
-                    Host::f3(*self, a, b)
-                }
-                fn f4(&mut self) -> u32 {
-                    Host::f4(*self)
-                }
-                fn f5(&mut self) -> (u32, u32) {
-                    Host::f5(*self)
-                }
-                fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32) {
-                    Host::f6(*self, a, b, c)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::simple::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::simple::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::simple::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple(&self) -> &exports::foo::foo::simple::Guest {
@@ -184,14 +184,34 @@ pub mod foo {
                 async fn f5(&mut self) -> (u32, u32);
                 async fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32);
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn f1(&mut self) -> () {
+                    Host::f1(*self).await
+                }
+                async fn f2(&mut self, a: u32) -> () {
+                    Host::f2(*self, a).await
+                }
+                async fn f3(&mut self, a: u32, b: u32) -> () {
+                    Host::f3(*self, a, b).await
+                }
+                async fn f4(&mut self) -> u32 {
+                    Host::f4(*self).await
+                }
+                async fn f5(&mut self) -> (u32, u32) {
+                    Host::f5(*self).await
+                }
+                async fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32) {
+                    Host::f6(*self, a, b, c).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap_async(
@@ -261,26 +281,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn f1(&mut self) -> () {
-                    Host::f1(*self).await
-                }
-                async fn f2(&mut self, a: u32) -> () {
-                    Host::f2(*self, a).await
-                }
-                async fn f3(&mut self, a: u32, b: u32) -> () {
-                    Host::f3(*self, a, b).await
-                }
-                async fn f4(&mut self) -> u32 {
-                    Host::f4(*self).await
-                }
-                async fn f5(&mut self) -> (u32, u32) {
-                    Host::f5(*self).await
-                }
-                async fn f6(&mut self, a: u32, b: u32, c: u32) -> (u32, u32, u32) {
-                    Host::f6(*self, a, b, c).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host,
             T: 'static,
         {
-            foo::foo::simple_lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::simple_lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
@@ -191,6 +191,37 @@ pub mod foo {
                 ) -> wasmtime::component::__internal::Vec<
                     wasmtime::component::__internal::Vec<u32>,
                 >;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn simple_list1(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::simple_list1(*self, l)
+                }
+                fn simple_list2(&mut self) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::simple_list2(*self)
+                }
+                fn simple_list3(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> (
+                    wasmtime::component::__internal::Vec<u32>,
+                    wasmtime::component::__internal::Vec<u32>,
+                ) {
+                    Host::simple_list3(*self, a, b)
+                }
+                fn simple_list4(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::Vec<u32>,
+                > {
+                    Host::simple_list4(*self, l)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -256,37 +287,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn simple_list1(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::simple_list1(*self, l)
-                }
-                fn simple_list2(&mut self) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::simple_list2(*self)
-                }
-                fn simple_list3(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<u32>,
-                    b: wasmtime::component::__internal::Vec<u32>,
-                ) -> (
-                    wasmtime::component::__internal::Vec<u32>,
-                    wasmtime::component::__internal::Vec<u32>,
-                ) {
-                    Host::simple_list3(*self, a, b)
-                }
-                fn simple_list4(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::Vec<u32>,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::Vec<u32>,
-                > {
-                    Host::simple_list4(*self, l)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::simple_lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::simple_lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
@@ -201,14 +201,47 @@ pub mod foo {
                     wasmtime::component::__internal::Vec<u32>,
                 >;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn simple_list1(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::simple_list1(*self, l).await
+                }
+                async fn simple_list2(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::simple_list2(*self).await
+                }
+                async fn simple_list3(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> (
+                    wasmtime::component::__internal::Vec<u32>,
+                    wasmtime::component::__internal::Vec<u32>,
+                ) {
+                    Host::simple_list3(*self, a, b).await
+                }
+                async fn simple_list4(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::Vec<u32>,
+                > {
+                    Host::simple_list4(*self, l).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_async(
@@ -273,39 +306,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn simple_list1(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::simple_list1(*self, l).await
-                }
-                async fn simple_list2(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::simple_list2(*self).await
-                }
-                async fn simple_list3(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<u32>,
-                    b: wasmtime::component::__internal::Vec<u32>,
-                ) -> (
-                    wasmtime::component::__internal::Vec<u32>,
-                    wasmtime::component::__internal::Vec<u32>,
-                ) {
-                    Host::simple_list3(*self, a, b).await
-                }
-                async fn simple_list4(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::Vec<u32>,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::Vec<u32>,
-                > {
-                    Host::simple_list4(*self, l).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::simple_lists::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::simple_lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
@@ -201,14 +201,47 @@ pub mod foo {
                     wasmtime::component::__internal::Vec<u32>,
                 >;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn simple_list1(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<u32>,
+                ) -> () {
+                    Host::simple_list1(*self, l).await
+                }
+                async fn simple_list2(
+                    &mut self,
+                ) -> wasmtime::component::__internal::Vec<u32> {
+                    Host::simple_list2(*self).await
+                }
+                async fn simple_list3(
+                    &mut self,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
+                ) -> (
+                    wasmtime::component::__internal::Vec<u32>,
+                    wasmtime::component::__internal::Vec<u32>,
+                ) {
+                    Host::simple_list3(*self, a, b).await
+                }
+                async fn simple_list4(
+                    &mut self,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> wasmtime::component::__internal::Vec<
+                    wasmtime::component::__internal::Vec<u32>,
+                > {
+                    Host::simple_list4(*self, l).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_async(
@@ -334,39 +367,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn simple_list1(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<u32>,
-                ) -> () {
-                    Host::simple_list1(*self, l).await
-                }
-                async fn simple_list2(
-                    &mut self,
-                ) -> wasmtime::component::__internal::Vec<u32> {
-                    Host::simple_list2(*self).await
-                }
-                async fn simple_list3(
-                    &mut self,
-                    a: wasmtime::component::__internal::Vec<u32>,
-                    b: wasmtime::component::__internal::Vec<u32>,
-                ) -> (
-                    wasmtime::component::__internal::Vec<u32>,
-                    wasmtime::component::__internal::Vec<u32>,
-                ) {
-                    Host::simple_list3(*self, a, b).await
-                }
-                async fn simple_list4(
-                    &mut self,
-                    l: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::Vec<u32>,
-                    >,
-                ) -> wasmtime::component::__internal::Vec<
-                    wasmtime::component::__internal::Vec<u32>,
-                > {
-                    Host::simple_list4(*self, l).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -146,17 +146,17 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::wasi_filesystem::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::wall_clock::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::wasi_filesystem::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::wall_clock::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -233,14 +233,22 @@ pub mod foo {
                 async fn create_directory_at(&mut self) -> Result<(), Errno>;
                 async fn stat(&mut self) -> Result<DescriptorStat, Errno>;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn create_directory_at(&mut self) -> Result<(), Errno> {
+                    Host::create_directory_at(*self).await
+                }
+                async fn stat(&mut self) -> Result<DescriptorStat, Errno> {
+                    Host::stat(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_async(
@@ -264,14 +272,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn create_directory_at(&mut self) -> Result<(), Errno> {
-                    Host::create_directory_at(*self).await
-                }
-                async fn stat(&mut self) -> Result<DescriptorStat, Errno> {
-                    Host::stat(*self).await
-                }
             }
         }
         #[allow(clippy::all)]
@@ -299,19 +299,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -146,17 +146,17 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<
                 'a,
             >: foo::foo::wasi_filesystem::Host + foo::foo::wall_clock::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::wasi_filesystem::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::wall_clock::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::wasi_filesystem::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::wall_clock::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -233,14 +233,22 @@ pub mod foo {
                 async fn create_directory_at(&mut self) -> Result<(), Errno>;
                 async fn stat(&mut self) -> Result<DescriptorStat, Errno>;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn create_directory_at(&mut self) -> Result<(), Errno> {
+                    Host::create_directory_at(*self).await
+                }
+                async fn stat(&mut self) -> Result<DescriptorStat, Errno> {
+                    Host::stat(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_async(
@@ -291,14 +299,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn create_directory_at(&mut self) -> Result<(), Errno> {
-                    Host::create_directory_at(*self).await
-                }
-                async fn stat(&mut self) -> Result<DescriptorStat, Errno> {
-                    Host::stat(*self).await
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod wall_clock {
@@ -325,19 +325,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::anon::Host,
             T: 'static,
         {
-            foo::foo::anon::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::anon::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_anon(&self) -> &exports::foo::foo::anon::Guest {
@@ -217,6 +217,13 @@ pub mod foo {
                     &mut self,
                 ) -> Result<Option<wasmtime::component::__internal::String>, Error>;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn option_test(
+                    &mut self,
+                ) -> Result<Option<wasmtime::component::__internal::String>, Error> {
+                    Host::option_test(*self)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -236,13 +243,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn option_test(
-                    &mut self,
-                ) -> Result<Option<wasmtime::component::__internal::String>, Error> {
-                    Host::option_test(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -152,14 +152,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::anon::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::anon::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::anon::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_anon(&self) -> &exports::foo::foo::anon::Guest {
@@ -224,14 +224,21 @@ pub mod foo {
                     &mut self,
                 ) -> Result<Option<wasmtime::component::__internal::String>, Error>;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn option_test(
+                    &mut self,
+                ) -> Result<Option<wasmtime::component::__internal::String>, Error> {
+                    Host::option_test(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/anon")?;
                 inst.func_wrap_async(
@@ -258,13 +265,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn option_test(
-                    &mut self,
-                ) -> Result<Option<wasmtime::component::__internal::String>, Error> {
-                    Host::option_test(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -140,14 +140,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: imports::Host,
             T: 'static,
         {
-            imports::add_to_linker::<T, D>(linker, get)?;
+            imports::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -158,6 +158,11 @@ pub mod imports {
     use wasmtime::component::__internal::{anyhow, Box};
     pub trait Host {
         fn y(&mut self) -> ();
+    }
+    impl<_T: Host + ?Sized> Host for &mut _T {
+        fn y(&mut self) -> () {
+            Host::y(*self)
+        }
     }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
@@ -178,10 +183,5 @@ pub mod imports {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized> Host for &mut _T {
-        fn y(&mut self) -> () {
-            Host::y(*self)
-        }
     }
 }

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: imports::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            imports::add_to_linker::<T, D>(linker, get)?;
+            imports::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -166,14 +166,19 @@ pub mod imports {
     pub trait Host: Send {
         async fn y(&mut self) -> ();
     }
+    impl<_T: Host + ?Sized + Send> Host for &mut _T {
+        async fn y(&mut self) -> () {
+            Host::y(*self).await
+        }
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
         D: wasmtime::component::HasData,
-        for<'a> D::Data<'a>: Host + Send,
-        T: Send + 'static,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
     {
         let mut inst = linker.instance("imports")?;
         inst.func_wrap_async(
@@ -187,10 +192,5 @@ pub mod imports {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {
-        async fn y(&mut self) -> () {
-            Host::y(*self).await
-        }
     }
 }

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::strings::Host,
             T: 'static,
         {
-            foo::foo::strings::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::strings::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
@@ -177,6 +177,21 @@ pub mod foo {
                     a: wasmtime::component::__internal::String,
                     b: wasmtime::component::__internal::String,
                 ) -> wasmtime::component::__internal::String;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn a(&mut self, x: wasmtime::component::__internal::String) -> () {
+                    Host::a(*self, x)
+                }
+                fn b(&mut self) -> wasmtime::component::__internal::String {
+                    Host::b(*self)
+                }
+                fn c(
+                    &mut self,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> wasmtime::component::__internal::String {
+                    Host::c(*self, a, b)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -225,21 +240,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn a(&mut self, x: wasmtime::component::__internal::String) -> () {
-                    Host::a(*self, x)
-                }
-                fn b(&mut self) -> wasmtime::component::__internal::String {
-                    Host::b(*self)
-                }
-                fn c(
-                    &mut self,
-                    a: wasmtime::component::__internal::String,
-                    b: wasmtime::component::__internal::String,
-                ) -> wasmtime::component::__internal::String {
-                    Host::c(*self, a, b)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::strings::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::strings::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
@@ -185,14 +185,29 @@ pub mod foo {
                     b: wasmtime::component::__internal::String,
                 ) -> wasmtime::component::__internal::String;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self, x: wasmtime::component::__internal::String) -> () {
+                    Host::a(*self, x).await
+                }
+                async fn b(&mut self) -> wasmtime::component::__internal::String {
+                    Host::b(*self).await
+                }
+                async fn c(
+                    &mut self,
+                    a: wasmtime::component::__internal::String,
+                    b: wasmtime::component::__internal::String,
+                ) -> wasmtime::component::__internal::String {
+                    Host::c(*self, a, b).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/strings")?;
                 inst.func_wrap_async(
@@ -238,21 +253,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self, x: wasmtime::component::__internal::String) -> () {
-                    Host::a(*self, x).await
-                }
-                async fn b(&mut self) -> wasmtime::component::__internal::String {
-                    Host::b(*self).await
-                }
-                async fn c(
-                    &mut self,
-                    a: wasmtime::component::__internal::String,
-                    b: wasmtime::component::__internal::String,
-                ) -> wasmtime::component::__internal::String {
-                    Host::c(*self, a, b).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -80,7 +80,7 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
 }
 pub enum Baz {}
 #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-pub trait HostBaz: Sized {
+pub trait HostBaz: Send {
     async fn foo(&mut self, self_: wasmtime::component::Resource<Baz>) -> ();
     async fn drop(
         &mut self,
@@ -261,7 +261,7 @@ const _: () = {
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: TheWorldImports,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             let mut linker = linker.root();
             if options.experimental_world {
@@ -316,20 +316,20 @@ const _: () = {
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             options: &LinkOptions,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
             if options.experimental_world {
-                Self::add_to_linker_imports::<T, D>(linker, options, get)?;
+                Self::add_to_linker_imports::<T, D>(linker, options, host_getter)?;
                 if options.experimental_world_interface_import {
                     foo::foo::the_interface::add_to_linker::<
                         T,
                         D,
-                    >(linker, &options.into(), get)?;
+                    >(linker, &options.into(), host_getter)?;
                 }
             }
             Ok(())
@@ -383,7 +383,7 @@ pub mod foo {
             }
             pub enum Bar {}
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait HostBar: Sized {
+            pub trait HostBar: Send {
                 async fn foo(&mut self, self_: wasmtime::component::Resource<Bar>) -> ();
                 async fn drop(
                     &mut self,
@@ -405,8 +405,13 @@ pub mod foo {
                 }
             }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-            pub trait Host: Send + HostBar + Sized {
+            pub trait Host: Send + HostBar {
                 async fn foo(&mut self) -> ();
+            }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn foo(&mut self) -> () {
+                    Host::foo(*self).await
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -415,8 +420,8 @@ pub mod foo {
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 if options.experimental_interface {
                     let mut inst = linker.instance("foo:foo/the-interface")?;
@@ -464,11 +469,6 @@ pub mod foo {
                     }
                 }
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn foo(&mut self) -> () {
-                    Host::foo(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -140,14 +140,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::a::Host,
             T: 'static,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -189,6 +189,11 @@ pub mod foo {
             pub trait Host {
                 fn g(&mut self) -> Result<(), Error>;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn g(&mut self) -> Result<(), Error> {
+                    Host::g(*self)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -208,11 +213,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn g(&mut self) -> Result<(), Error> {
-                    Host::g(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -146,14 +146,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::a::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -196,14 +196,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn g(&mut self) -> Result<(), Error>;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn g(&mut self) -> Result<(), Error> {
+                    Host::g(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
@@ -217,11 +222,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn g(&mut self) -> Result<(), Error> {
-                    Host::g(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -140,7 +140,7 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
@@ -149,10 +149,10 @@ const _: () = {
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host,
             T: 'static,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::b::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::c::add_to_linker::<T, D>(linker, get)?;
-            d::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::b::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::c::add_to_linker::<T, D>(linker, host_getter)?;
+            d::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -181,6 +181,11 @@ pub mod foo {
             pub trait Host {
                 fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn a(&mut self) -> Foo {
+                    Host::a(*self)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -201,11 +206,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn a(&mut self) -> Foo {
-                    Host::a(*self)
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod b {
@@ -218,6 +218,11 @@ pub mod foo {
             };
             pub trait Host {
                 fn a(&mut self) -> Foo;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn a(&mut self) -> Foo {
+                    Host::a(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -239,11 +244,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn a(&mut self) -> Foo {
-                    Host::a(*self)
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod c {
@@ -256,6 +256,11 @@ pub mod foo {
             };
             pub trait Host {
                 fn a(&mut self) -> Foo;
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn a(&mut self) -> Foo {
+                    Host::a(*self)
+                }
             }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
@@ -277,11 +282,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn a(&mut self) -> Foo {
-                    Host::a(*self)
-                }
-            }
         }
     }
 }
@@ -296,6 +296,11 @@ pub mod d {
     };
     pub trait Host {
         fn b(&mut self) -> Foo;
+    }
+    impl<_T: Host + ?Sized> Host for &mut _T {
+        fn b(&mut self) -> Foo {
+            Host::b(*self)
+        }
     }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
@@ -316,10 +321,5 @@ pub mod d {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized> Host for &mut _T {
-        fn b(&mut self) -> Foo {
-            Host::b(*self)
-        }
     }
 }

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -146,7 +146,7 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
@@ -154,12 +154,12 @@ const _: () = {
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
                 + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::b::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::c::add_to_linker::<T, D>(linker, get)?;
-            d::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::b::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::c::add_to_linker::<T, D>(linker, host_getter)?;
+            d::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -189,14 +189,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
@@ -210,11 +215,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
             }
         }
         #[allow(clippy::all)]
@@ -230,14 +230,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_async(
@@ -251,11 +256,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
             }
         }
         #[allow(clippy::all)]
@@ -271,14 +271,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_async(
@@ -292,11 +297,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
             }
         }
     }
@@ -314,14 +314,19 @@ pub mod d {
     pub trait Host: Send {
         async fn b(&mut self) -> Foo;
     }
+    impl<_T: Host + ?Sized + Send> Host for &mut _T {
+        async fn b(&mut self) -> Foo {
+            Host::b(*self).await
+        }
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
         D: wasmtime::component::HasData,
-        for<'a> D::Data<'a>: Host + Send,
-        T: Send + 'static,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
     {
         let mut inst = linker.instance("d")?;
         inst.func_wrap_async(
@@ -335,10 +340,5 @@ pub mod d {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {
-        async fn b(&mut self) -> Foo {
-            Host::b(*self).await
-        }
     }
 }

--- a/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
@@ -146,7 +146,7 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
@@ -154,12 +154,12 @@ const _: () = {
                 'a,
             >: foo::foo::a::Host + foo::foo::b::Host + foo::foo::c::Host + d::Host
                 + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::b::add_to_linker::<T, D>(linker, get)?;
-            foo::foo::c::add_to_linker::<T, D>(linker, get)?;
-            d::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::b::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::c::add_to_linker::<T, D>(linker, host_getter)?;
+            d::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
@@ -189,14 +189,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
@@ -224,11 +229,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod b {
@@ -243,14 +243,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_async(
@@ -278,11 +283,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
-            }
         }
         #[allow(clippy::all)]
         pub mod c {
@@ -297,14 +297,19 @@ pub mod foo {
             pub trait Host: Send {
                 async fn a(&mut self) -> Foo;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn a(&mut self) -> Foo {
+                    Host::a(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_async(
@@ -332,11 +337,6 @@ pub mod foo {
                 )?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn a(&mut self) -> Foo {
-                    Host::a(*self).await
-                }
-            }
         }
     }
 }
@@ -353,14 +353,19 @@ pub mod d {
     pub trait Host: Send {
         async fn b(&mut self) -> Foo;
     }
+    impl<_T: Host + ?Sized + Send> Host for &mut _T {
+        async fn b(&mut self) -> Foo {
+            Host::b(*self).await
+        }
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
         D: wasmtime::component::HasData,
-        for<'a> D::Data<'a>: Host + Send,
-        T: Send + 'static,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
     {
         let mut inst = linker.instance("d")?;
         inst.func_wrap_async(
@@ -387,10 +392,5 @@ pub mod d {
             },
         )?;
         Ok(())
-    }
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {
-        async fn b(&mut self) -> Foo {
-            Host::b(*self).await
-        }
     }
 }

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -148,14 +148,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::variants::Host,
             T: 'static,
         {
-            foo::foo::variants::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::variants::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_variants(&self) -> &exports::foo::foo::variants::Guest {
@@ -511,6 +511,116 @@ pub mod foo {
                 fn is_clone_arg(&mut self, a: IsClone) -> ();
                 fn is_clone_return(&mut self) -> IsClone;
             }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn e1_arg(&mut self, x: E1) -> () {
+                    Host::e1_arg(*self, x)
+                }
+                fn e1_result(&mut self) -> E1 {
+                    Host::e1_result(*self)
+                }
+                fn v1_arg(&mut self, x: V1) -> () {
+                    Host::v1_arg(*self, x)
+                }
+                fn v1_result(&mut self) -> V1 {
+                    Host::v1_result(*self)
+                }
+                fn bool_arg(&mut self, x: bool) -> () {
+                    Host::bool_arg(*self, x)
+                }
+                fn bool_result(&mut self) -> bool {
+                    Host::bool_result(*self)
+                }
+                fn option_arg(
+                    &mut self,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> () {
+                    Host::option_arg(*self, a, b, c, d, e, g)
+                }
+                fn option_result(
+                    &mut self,
+                ) -> (
+                    Option<bool>,
+                    Option<()>,
+                    Option<u32>,
+                    Option<E1>,
+                    Option<f32>,
+                    Option<Option<bool>>,
+                ) {
+                    Host::option_result(*self)
+                }
+                fn casts(
+                    &mut self,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6) {
+                    Host::casts(*self, a, b, c, d, e, f)
+                }
+                fn result_arg(
+                    &mut self,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> () {
+                    Host::result_arg(*self, a, b, c, d, e, f)
+                }
+                fn result_result(
+                    &mut self,
+                ) -> (
+                    Result<(), ()>,
+                    Result<(), E1>,
+                    Result<E1, ()>,
+                    Result<(), ()>,
+                    Result<u32, V1>,
+                    Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) {
+                    Host::result_result(*self)
+                }
+                fn return_result_sugar(&mut self) -> Result<i32, MyErrno> {
+                    Host::return_result_sugar(*self)
+                }
+                fn return_result_sugar2(&mut self) -> Result<(), MyErrno> {
+                    Host::return_result_sugar2(*self)
+                }
+                fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno> {
+                    Host::return_result_sugar3(*self)
+                }
+                fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno> {
+                    Host::return_result_sugar4(*self)
+                }
+                fn return_option_sugar(&mut self) -> Option<i32> {
+                    Host::return_option_sugar(*self)
+                }
+                fn return_option_sugar2(&mut self) -> Option<MyErrno> {
+                    Host::return_option_sugar2(*self)
+                }
+                fn result_simple(&mut self) -> Result<u32, i32> {
+                    Host::result_simple(*self)
+                }
+                fn is_clone_arg(&mut self, a: IsClone) -> () {
+                    Host::is_clone_arg(*self, a)
+                }
+                fn is_clone_return(&mut self) -> IsClone {
+                    Host::is_clone_return(*self)
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -751,116 +861,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized> Host for &mut _T {
-                fn e1_arg(&mut self, x: E1) -> () {
-                    Host::e1_arg(*self, x)
-                }
-                fn e1_result(&mut self) -> E1 {
-                    Host::e1_result(*self)
-                }
-                fn v1_arg(&mut self, x: V1) -> () {
-                    Host::v1_arg(*self, x)
-                }
-                fn v1_result(&mut self) -> V1 {
-                    Host::v1_result(*self)
-                }
-                fn bool_arg(&mut self, x: bool) -> () {
-                    Host::bool_arg(*self, x)
-                }
-                fn bool_result(&mut self) -> bool {
-                    Host::bool_result(*self)
-                }
-                fn option_arg(
-                    &mut self,
-                    a: Option<bool>,
-                    b: Option<()>,
-                    c: Option<u32>,
-                    d: Option<E1>,
-                    e: Option<f32>,
-                    g: Option<Option<bool>>,
-                ) -> () {
-                    Host::option_arg(*self, a, b, c, d, e, g)
-                }
-                fn option_result(
-                    &mut self,
-                ) -> (
-                    Option<bool>,
-                    Option<()>,
-                    Option<u32>,
-                    Option<E1>,
-                    Option<f32>,
-                    Option<Option<bool>>,
-                ) {
-                    Host::option_result(*self)
-                }
-                fn casts(
-                    &mut self,
-                    a: Casts1,
-                    b: Casts2,
-                    c: Casts3,
-                    d: Casts4,
-                    e: Casts5,
-                    f: Casts6,
-                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6) {
-                    Host::casts(*self, a, b, c, d, e, f)
-                }
-                fn result_arg(
-                    &mut self,
-                    a: Result<(), ()>,
-                    b: Result<(), E1>,
-                    c: Result<E1, ()>,
-                    d: Result<(), ()>,
-                    e: Result<u32, V1>,
-                    f: Result<
-                        wasmtime::component::__internal::String,
-                        wasmtime::component::__internal::Vec<u8>,
-                    >,
-                ) -> () {
-                    Host::result_arg(*self, a, b, c, d, e, f)
-                }
-                fn result_result(
-                    &mut self,
-                ) -> (
-                    Result<(), ()>,
-                    Result<(), E1>,
-                    Result<E1, ()>,
-                    Result<(), ()>,
-                    Result<u32, V1>,
-                    Result<
-                        wasmtime::component::__internal::String,
-                        wasmtime::component::__internal::Vec<u8>,
-                    >,
-                ) {
-                    Host::result_result(*self)
-                }
-                fn return_result_sugar(&mut self) -> Result<i32, MyErrno> {
-                    Host::return_result_sugar(*self)
-                }
-                fn return_result_sugar2(&mut self) -> Result<(), MyErrno> {
-                    Host::return_result_sugar2(*self)
-                }
-                fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno> {
-                    Host::return_result_sugar3(*self)
-                }
-                fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno> {
-                    Host::return_result_sugar4(*self)
-                }
-                fn return_option_sugar(&mut self) -> Option<i32> {
-                    Host::return_option_sugar(*self)
-                }
-                fn return_option_sugar2(&mut self) -> Option<MyErrno> {
-                    Host::return_option_sugar2(*self)
-                }
-                fn result_simple(&mut self) -> Result<u32, i32> {
-                    Host::result_simple(*self)
-                }
-                fn is_clone_arg(&mut self, a: IsClone) -> () {
-                    Host::is_clone_arg(*self, a)
-                }
-                fn is_clone_return(&mut self) -> IsClone {
-                    Host::is_clone_return(*self)
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -154,14 +154,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::variants::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::variants::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::variants::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_variants(&self) -> &exports::foo::foo::variants::Guest {
@@ -518,14 +518,124 @@ pub mod foo {
                 async fn is_clone_arg(&mut self, a: IsClone) -> ();
                 async fn is_clone_return(&mut self) -> IsClone;
             }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                async fn e1_arg(&mut self, x: E1) -> () {
+                    Host::e1_arg(*self, x).await
+                }
+                async fn e1_result(&mut self) -> E1 {
+                    Host::e1_result(*self).await
+                }
+                async fn v1_arg(&mut self, x: V1) -> () {
+                    Host::v1_arg(*self, x).await
+                }
+                async fn v1_result(&mut self) -> V1 {
+                    Host::v1_result(*self).await
+                }
+                async fn bool_arg(&mut self, x: bool) -> () {
+                    Host::bool_arg(*self, x).await
+                }
+                async fn bool_result(&mut self) -> bool {
+                    Host::bool_result(*self).await
+                }
+                async fn option_arg(
+                    &mut self,
+                    a: Option<bool>,
+                    b: Option<()>,
+                    c: Option<u32>,
+                    d: Option<E1>,
+                    e: Option<f32>,
+                    g: Option<Option<bool>>,
+                ) -> () {
+                    Host::option_arg(*self, a, b, c, d, e, g).await
+                }
+                async fn option_result(
+                    &mut self,
+                ) -> (
+                    Option<bool>,
+                    Option<()>,
+                    Option<u32>,
+                    Option<E1>,
+                    Option<f32>,
+                    Option<Option<bool>>,
+                ) {
+                    Host::option_result(*self).await
+                }
+                async fn casts(
+                    &mut self,
+                    a: Casts1,
+                    b: Casts2,
+                    c: Casts3,
+                    d: Casts4,
+                    e: Casts5,
+                    f: Casts6,
+                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6) {
+                    Host::casts(*self, a, b, c, d, e, f).await
+                }
+                async fn result_arg(
+                    &mut self,
+                    a: Result<(), ()>,
+                    b: Result<(), E1>,
+                    c: Result<E1, ()>,
+                    d: Result<(), ()>,
+                    e: Result<u32, V1>,
+                    f: Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) -> () {
+                    Host::result_arg(*self, a, b, c, d, e, f).await
+                }
+                async fn result_result(
+                    &mut self,
+                ) -> (
+                    Result<(), ()>,
+                    Result<(), E1>,
+                    Result<E1, ()>,
+                    Result<(), ()>,
+                    Result<u32, V1>,
+                    Result<
+                        wasmtime::component::__internal::String,
+                        wasmtime::component::__internal::Vec<u8>,
+                    >,
+                ) {
+                    Host::result_result(*self).await
+                }
+                async fn return_result_sugar(&mut self) -> Result<i32, MyErrno> {
+                    Host::return_result_sugar(*self).await
+                }
+                async fn return_result_sugar2(&mut self) -> Result<(), MyErrno> {
+                    Host::return_result_sugar2(*self).await
+                }
+                async fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno> {
+                    Host::return_result_sugar3(*self).await
+                }
+                async fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno> {
+                    Host::return_result_sugar4(*self).await
+                }
+                async fn return_option_sugar(&mut self) -> Option<i32> {
+                    Host::return_option_sugar(*self).await
+                }
+                async fn return_option_sugar2(&mut self) -> Option<MyErrno> {
+                    Host::return_option_sugar2(*self).await
+                }
+                async fn result_simple(&mut self) -> Result<u32, i32> {
+                    Host::result_simple(*self).await
+                }
+                async fn is_clone_arg(&mut self, a: IsClone) -> () {
+                    Host::is_clone_arg(*self, a).await
+                }
+                async fn is_clone_return(&mut self) -> IsClone {
+                    Host::is_clone_return(*self).await
+                }
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap_async(
@@ -1099,116 +1209,6 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
-            }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                async fn e1_arg(&mut self, x: E1) -> () {
-                    Host::e1_arg(*self, x).await
-                }
-                async fn e1_result(&mut self) -> E1 {
-                    Host::e1_result(*self).await
-                }
-                async fn v1_arg(&mut self, x: V1) -> () {
-                    Host::v1_arg(*self, x).await
-                }
-                async fn v1_result(&mut self) -> V1 {
-                    Host::v1_result(*self).await
-                }
-                async fn bool_arg(&mut self, x: bool) -> () {
-                    Host::bool_arg(*self, x).await
-                }
-                async fn bool_result(&mut self) -> bool {
-                    Host::bool_result(*self).await
-                }
-                async fn option_arg(
-                    &mut self,
-                    a: Option<bool>,
-                    b: Option<()>,
-                    c: Option<u32>,
-                    d: Option<E1>,
-                    e: Option<f32>,
-                    g: Option<Option<bool>>,
-                ) -> () {
-                    Host::option_arg(*self, a, b, c, d, e, g).await
-                }
-                async fn option_result(
-                    &mut self,
-                ) -> (
-                    Option<bool>,
-                    Option<()>,
-                    Option<u32>,
-                    Option<E1>,
-                    Option<f32>,
-                    Option<Option<bool>>,
-                ) {
-                    Host::option_result(*self).await
-                }
-                async fn casts(
-                    &mut self,
-                    a: Casts1,
-                    b: Casts2,
-                    c: Casts3,
-                    d: Casts4,
-                    e: Casts5,
-                    f: Casts6,
-                ) -> (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6) {
-                    Host::casts(*self, a, b, c, d, e, f).await
-                }
-                async fn result_arg(
-                    &mut self,
-                    a: Result<(), ()>,
-                    b: Result<(), E1>,
-                    c: Result<E1, ()>,
-                    d: Result<(), ()>,
-                    e: Result<u32, V1>,
-                    f: Result<
-                        wasmtime::component::__internal::String,
-                        wasmtime::component::__internal::Vec<u8>,
-                    >,
-                ) -> () {
-                    Host::result_arg(*self, a, b, c, d, e, f).await
-                }
-                async fn result_result(
-                    &mut self,
-                ) -> (
-                    Result<(), ()>,
-                    Result<(), E1>,
-                    Result<E1, ()>,
-                    Result<(), ()>,
-                    Result<u32, V1>,
-                    Result<
-                        wasmtime::component::__internal::String,
-                        wasmtime::component::__internal::Vec<u8>,
-                    >,
-                ) {
-                    Host::result_result(*self).await
-                }
-                async fn return_result_sugar(&mut self) -> Result<i32, MyErrno> {
-                    Host::return_result_sugar(*self).await
-                }
-                async fn return_result_sugar2(&mut self) -> Result<(), MyErrno> {
-                    Host::return_result_sugar2(*self).await
-                }
-                async fn return_result_sugar3(&mut self) -> Result<MyErrno, MyErrno> {
-                    Host::return_result_sugar3(*self).await
-                }
-                async fn return_result_sugar4(&mut self) -> Result<(i32, u32), MyErrno> {
-                    Host::return_result_sugar4(*self).await
-                }
-                async fn return_option_sugar(&mut self) -> Option<i32> {
-                    Host::return_option_sugar(*self).await
-                }
-                async fn return_option_sugar2(&mut self) -> Option<MyErrno> {
-                    Host::return_option_sugar2(*self).await
-                }
-                async fn result_simple(&mut self) -> Result<u32, i32> {
-                    Host::result_simple(*self).await
-                }
-                async fn is_clone_arg(&mut self, a: IsClone) -> () {
-                    Host::is_clone_arg(*self, a).await
-                }
-                async fn is_clone_return(&mut self) -> IsClone {
-                    Host::is_clone_return(*self).await
-                }
             }
         }
     }

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -187,14 +187,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::i::Host,
             T: 'static,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn call_f<S: wasmtime::AsContextMut>(
@@ -222,6 +222,7 @@ pub mod foo {
                 assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait Host {}
+            impl<_T: Host + ?Sized> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -234,7 +235,6 @@ pub mod foo {
                 let mut inst = linker.instance("foo:foo/i")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -193,14 +193,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::i::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub async fn call_f<S: wasmtime::AsContextMut>(
@@ -232,19 +232,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/i")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -193,14 +193,14 @@ const _: () = {
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: fn(&mut T) -> D::Data<'_>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
             D: wasmtime::component::HasData,
             for<'a> D::Data<'a>: foo::foo::i::Host + Send,
-            T: Send + 'static,
+            T: 'static + Send,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, get)?;
+            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub async fn call_f<S: wasmtime::AsContextMut>(
@@ -240,19 +240,19 @@ pub mod foo {
             };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
                 D: wasmtime::component::HasData,
-                for<'a> D::Data<'a>: Host + Send,
-                T: Send + 'static,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/i")?;
                 Ok(())
             }
-            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
         }
     }
 }


### PR DESCRIPTION
This commit wholesale copies the `wasmtime-wit-bindgen` changes from the
wasip3-prototyping repository to the Wasmtime repository here. This is
done to make the future merge with `wasip3-prototyping` smaller
complexity-wise.

This is intended to be a no-functional-change for non-"concurrent"
imports, or those for component model async. That means that it's
intended that no current embedding is affected by these changes.
Internally though there has been restructuring.

Namely internally the generation of an interface trait, a resource
trait, and a world trait are all unified in a single method now. In the
future with component model async these traits are being split into
async/sync versions and so it was much nicer to do this in one location
rather than across three different locations.

This required some minor renamings in the generated code and moving
around some impls, but otherwise the generated code should mostly be the
same as before (see golden output diff in the subsequent commit of this
PR)