### PR TITLE
winch: Move the `AtomicWaitKind` definition to the MacroAssembler

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -3,8 +3,9 @@ use crate::{
     codegen::BlockSig,
     isa::reg::{Reg, writable},
     masm::{
-        Extend, Imm, IntCmpKind, LaneSelector, LoadKind, MacroAssembler, OperandSize, RegImm,
-        RmwOp, SPOffset, ShiftKind, StoreKind, TrapCode, UNTRUSTED_FLAGS, Zero,
+        AtomicWaitKind, Extend, Imm, IntCmpKind, LaneSelector, LoadKind, MacroAssembler,
+        OperandSize, RegImm, RmwOp, SPOffset, ShiftKind, StoreKind, TrapCode, UNTRUSTED_FLAGS,
+        Zero,
     },
     stack::TypedReg,
 };
@@ -81,13 +82,6 @@ pub(crate) struct SourceLocation {
     /// The current relative source code location along with its associated
     /// machine code offset.
     pub current: (CodeOffset, RelSourceLoc),
-}
-
-/// Represents the `memory.atomic.wait*` kind.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum AtomicWaitKind {
-    Wait32,
-    Wait64,
 }
 
 /// The code generation abstraction.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -23,6 +23,13 @@ pub(crate) enum DivKind {
     Unsigned,
 }
 
+/// Represents the `memory.atomic.wait*` kind.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AtomicWaitKind {
+    Wait32,
+    Wait64,
+}
+
 /// Remainder kind.
 #[derive(Copy, Clone)]
 pub(crate) enum RemKind {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -6,16 +6,16 @@
 
 use crate::abi::RetArea;
 use crate::codegen::{
-    AtomicWaitKind, Callee, CodeGen, CodeGenError, ConditionalBranch, ControlStackFrame, Emission,
-    FnCall, UnconditionalBranch, control_index,
+    Callee, CodeGen, CodeGenError, ConditionalBranch, ControlStackFrame, Emission, FnCall,
+    UnconditionalBranch, control_index,
 };
 use crate::masm::{
-    DivKind, Extend, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind, MacroAssembler,
-    MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp, RoundingMode, SPOffset,
-    ShiftKind, Signed, SplatKind, SplatLoadKind, StoreKind, TruncKind, V128AbsKind, V128AddKind,
-    V128ConvertKind, V128ExtAddKind, V128ExtMulKind, V128ExtendKind, V128LoadExtendKind,
-    V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind, V128SubKind, V128TruncKind,
-    VectorCompareKind, VectorEqualityKind, Zero,
+    AtomicWaitKind, DivKind, Extend, ExtractLaneKind, FloatCmpKind, IntCmpKind, LoadKind,
+    MacroAssembler, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp,
+    RoundingMode, SPOffset, ShiftKind, Signed, SplatKind, SplatLoadKind, StoreKind, TruncKind,
+    V128AbsKind, V128AddKind, V128ConvertKind, V128ExtAddKind, V128ExtMulKind, V128ExtendKind,
+    V128LoadExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind,
+    V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero,
 };
 
 use crate::reg::{Reg, writable};


### PR DESCRIPTION
This commit is a small refactoring which moves the definition of the `AtomicWaitKind` enum to the `MacroAssembler`, to ensure consistency with the other operation kind definitions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
