### PR TITLE
Update cache configuration documentation and references

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -195,8 +195,7 @@
 //!
 //! * `cache` - Enabled by default, this feature adds support for wasmtime to
 //!   perform internal caching of modules in a global location. This must still
-//!   be enabled explicitly through [`Config::cache_config_load`] or
-//!   [`Config::cache_config_load_default`].
+//!   be enabled explicitly through [`Config::cache`].
 //!
 //! * `wat` - Enabled by default, this feature adds support for accepting the
 //!   text format of WebAssembly in [`Module::new`] and

--- a/docs/cli-cache.md
+++ b/docs/cli-cache.md
@@ -8,7 +8,7 @@ wasmtime config new
 It will print the location regardless of the success.
 Please refer to the  `--help` message for using a custom location.
 
-All settings, except `enabled`, are **optional**.
+All settings are **optional**.
 If the setting is not specified, the **default** value is used.
 ***Thus, if you don't know what values to use, don't specify them.***
 The default values might be tuned in the future.
@@ -30,20 +30,6 @@ should be introduced or some behavior should be changed, you are
 welcome to discuss it and contribute to [the Wasmtime repository].
 
 [the Wasmtime repository]: https://github.com/bytecodealliance/wasmtime
-
-Setting `enabled`
------------------
-- **type**: boolean
-- **format**: `true | false`
-- **default**: `true`
-
-Specifies whether the cache system is used or not.
-
-This field is *mandatory*.
-The default value is used when configuration file is not specified
-and none exists at the default location.
-
-[`enabled`]: #setting-enabled
 
 Setting `directory`
 -----------------

--- a/docs/examples-fast-compilation.md
+++ b/docs/examples-fast-compilation.md
@@ -15,9 +15,7 @@ result rather than performing compilation all over again.
 
 See these API docs for more details:
 
-* [`wasmtime::Config::cache_config_load`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.cache_config_load)
-* [`wasmtime::Config::cache_config_load_default`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.cache_config_load_default)
-* [`wasmtime::Config::disable_cache`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.disable_cache)
+* [`wasmtime::Config::cache`](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.cache)
 * [`wasmtime::CacheStore`](https://docs.rs/wasmtime/latest/wasmtime/trait.CacheStore.html)
 
 ## Enable Winch


### PR DESCRIPTION
Remove references to deprecated cache config methods and update to use the new simplified `Config::cache` API. Also remove the mandatory `enabled` field from cache configuration documentation since all cache settings are now optional.

Follow-up to https://github.com/bytecodealliance/wasmtime/pull/10665
