### PR TITLE
Remove use of `sptr` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,12 +3169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4154,7 +4148,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
- "sptr",
  "target-lexicon",
  "tempfile",
  "trait-variant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,6 @@ memfd = "0.6.2"
 psm = "0.1.11"
 proptest = "1.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
-sptr = "0.3.2"
 # serde and serde_derive must have the same version
 serde = { version = "1.0.215", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.188"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -44,7 +44,6 @@ wat = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true, optional = true }
-sptr = { workspace = true }
 postcard = { workspace = true }
 indexmap = { workspace = true }
 once_cell = { version = "1.12.0", optional = true }

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -21,7 +21,6 @@ use core::mem;
 use core::mem::offset_of;
 use core::ops::Deref;
 use core::ptr::{self, NonNull};
-use sptr::Strict;
 use wasmtime_environ::component::*;
 use wasmtime_environ::{HostPtr, PrimaryMap, VMSharedTypeIndex};
 
@@ -241,7 +240,7 @@ impl ComponentInstance {
 
     fn vmctx(&self) -> NonNull<VMComponentContext> {
         let addr = &raw const self.vmctx;
-        let ret = Strict::with_addr(self.vmctx_self_reference.as_ptr(), Strict::addr(addr));
+        let ret = self.vmctx_self_reference.as_ptr().with_addr(addr.addr());
         NonNull::new(ret).unwrap()
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -26,7 +26,6 @@ use core::ptr::NonNull;
 #[cfg(target_has_atomic = "64")]
 use core::sync::atomic::AtomicU64;
 use core::{mem, ptr};
-use sptr::Strict;
 #[cfg(feature = "gc")]
 use wasmtime_environ::ModuleInternedTypeIndex;
 use wasmtime_environ::{
@@ -656,13 +655,8 @@ impl Instance {
         // (there's an actual load of the field) it does look like that by the
         // time the backend runs. (that's magic to me, the backend removing
         // loads...)
-        //
-        // As a final minor note, strict provenance APIs are not stable on Rust
-        // today so the `sptr` crate is used. This crate provides the extension
-        // trait `Strict` but the method names conflict with the nightly methods
-        // so a different syntax is used to invoke methods here.
         let addr = &raw const self.vmctx;
-        let ret = Strict::with_addr(self.vmctx_self_reference.as_ptr(), Strict::addr(addr));
+        let ret = self.vmctx_self_reference.as_ptr().with_addr(addr.addr());
         NonNull::new(ret).unwrap()
     }
 

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -13,7 +13,6 @@ use core::ops::Range;
 use core::ptr::{self, NonNull};
 use core::slice;
 use core::{cmp, usize};
-use sptr::Strict;
 use wasmtime_environ::{
     FUNCREF_INIT_BIT, FUNCREF_MASK, IndexType, Trap, Tunables, WasmHeapTopType, WasmRefType,
 };
@@ -117,7 +116,7 @@ impl TaggedFuncRef {
     fn from(ptr: Option<NonNull<VMFuncRef>>, lazy_init: bool) -> Self {
         let ptr = ptr.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut());
         if lazy_init {
-            let masked = Strict::map_addr(ptr, |a| a | FUNCREF_INIT_BIT);
+            let masked = ptr.map_addr(|a| a | FUNCREF_INIT_BIT);
             TaggedFuncRef(masked)
         } else {
             TaggedFuncRef(ptr)
@@ -133,7 +132,7 @@ impl TaggedFuncRef {
         } else {
             // Masking off the tag bit is harmless whether the table uses lazy
             // init or not.
-            let unmasked = Strict::map_addr(ptr, |a| a & FUNCREF_MASK);
+            let unmasked = ptr.map_addr(|a| a & FUNCREF_MASK);
             TableElement::FuncRef(NonNull::new(unmasked))
         }
     }

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -867,7 +867,6 @@ pub(crate) mod tls {
     // these functions are free to be inlined.
     pub(super) mod raw {
         use super::CallThreadState;
-        use sptr::Strict;
 
         pub type Ptr = *const CallThreadState;
 
@@ -877,7 +876,7 @@ pub(crate) mod tls {
 
         fn tls_get() -> (Ptr, bool) {
             let mut initialized = false;
-            let p = Strict::map_addr(crate::runtime::vm::sys::tls_get(), |a| {
+            let p = crate::runtime::vm::sys::tls_get().map_addr(|a| {
                 initialized = (a & 1) != 0;
                 a & !1
             });
@@ -885,7 +884,7 @@ pub(crate) mod tls {
         }
 
         fn tls_set(ptr: Ptr, initialized: bool) {
-            let encoded = Strict::map_addr(ptr, |a| a | usize::from(initialized));
+            let encoded = ptr.map_addr(|a| a | usize::from(initialized));
             crate::runtime::vm::sys::tls_set(encoded.cast_mut().cast::<u8>());
         }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -14,7 +14,6 @@ use core::marker;
 use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicUsize, Ordering};
-use sptr::Strict;
 use wasmtime_environ::{
     BuiltinFunctionIndex, DefinedMemoryIndex, Unsigned, VMCONTEXT_MAGIC, VMSharedTypeIndex,
     WasmHeapTopType, WasmValType,
@@ -1409,7 +1408,7 @@ impl ValRaw {
     #[inline]
     pub fn funcref(i: *mut c_void) -> ValRaw {
         ValRaw {
-            funcref: Strict::map_addr(i, |i| i.to_le()),
+            funcref: i.map_addr(|i| i.to_le()),
         }
     }
 
@@ -1474,7 +1473,7 @@ impl ValRaw {
     /// Gets the WebAssembly `funcref` value
     #[inline]
     pub fn get_funcref(&self) -> *mut c_void {
-        unsafe { Strict::map_addr(self.funcref, |i| usize::from_le(i)) }
+        unsafe { self.funcref.map_addr(|i| usize::from_le(i)) }
     }
 
     /// Gets the WebAssembly `externref` value


### PR DESCRIPTION
This was a polyfill before strict provenance APIs were on stable Rust, but they're now stable so use the native methods in `std::ptr` instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
