### PR TITLE
Cranelift: properly reject unimplemented big-endian loads/stores.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1258,7 +1258,7 @@
 ;; Atomic loads will also automatically zero their upper bits so the `uextend`
 ;; instruction can effectively get skipped here.
 (rule 1 (lower (has_type (fits_in_64 out)
-                       (uextend x @ (and (value_type in) (atomic_load flags _)))))
+                       (uextend x @ (and (value_type in) (atomic_load (little_or_native_endian flags) _)))))
       (if-let mem_op (is_sinkable_inst x))
       (load_acquire in flags (sink_atomic_load mem_op)))
 
@@ -1275,7 +1275,7 @@
       (value_regs (mov_from_vec (put_in_reg vec) lane (lane_size in)) (imm $I64 (ImmExtend.Zero) 0)))
 
 ;; Zero extensions from a load can be encoded in the load itself
-(rule (lower (has_type (fits_in_64 _) (uextend x @ (has_type in_ty (load flags address offset)))))
+(rule (lower (has_type (fits_in_64 _) (uextend x @ (has_type in_ty (load (little_or_native_endian flags) address offset)))))
       (if-let inst (is_sinkable_inst x))
       (let ((_ Unit (sink_inst inst)))
             (aarch64_uload in_ty (amode in_ty address offset) flags)))
@@ -1334,7 +1334,7 @@
         (value_regs lo hi)))
 
 ;; Signed extensions from a load can be encoded in the load itself
-(rule (lower (has_type (fits_in_64 _) (sextend x @ (has_type in_ty (load flags address offset)))))
+(rule (lower (has_type (fits_in_64 _) (sextend x @ (has_type in_ty (load (little_or_native_endian flags) address offset)))))
       (if-let inst (is_sinkable_inst x))
       (let ((_ Unit (sink_inst inst)))
             (aarch64_sload in_ty (amode in_ty address offset) flags)))
@@ -2298,12 +2298,12 @@
             (ld1r addr (vector_size ty) flags)))
 
 ;;;; Rules for `AtomicLoad` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (has_type (valid_atomic_transaction ty) (atomic_load flags addr)))
+(rule (lower (has_type (valid_atomic_transaction ty) (atomic_load (little_or_native_endian flags) addr)))
       (load_acquire ty flags addr))
 
 
 ;;;; Rules for `AtomicStore` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (atomic_store flags
+(rule (lower (atomic_store (little_or_native_endian flags)
                 src @ (value_type (valid_atomic_transaction ty))
                 addr))
       (side_effect (store_release ty flags src addr)))
@@ -2312,84 +2312,84 @@
 
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Add) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Add) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Add) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Xor) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xor) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Eor) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Or) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Or) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Set) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Smax) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Smax) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Smax) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Smin) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Smin) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Smin) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Umax) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Umax) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Umax) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Umin) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Umin) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Umin) addr src ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.Sub) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Add) addr (sub ty (zero_reg) src) ty flags))
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                      (atomic_rmw flags (AtomicRmwOp.And) addr src))))
+                      (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.And) addr src))))
       (lse_atomic_rmw (AtomicRMWOp.Clr) addr (eon ty src (zero_reg)) ty flags))
 
 
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Add) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Add) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Add) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Sub) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Sub) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.And) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.And) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.And) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Nand) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Nand) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Nand) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Or) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Or) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Orr) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Xor) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xor) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Eor) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Smin) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Smin) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Smin) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Smax) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Smax) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Smax) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Umin) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Umin) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Umin) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Umax) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Umax) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Umax) addr src ty flags))
 (rule (lower (has_type (valid_atomic_transaction ty)
-             (atomic_rmw flags (AtomicRmwOp.Xchg) addr src)))
+             (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xchg) addr src)))
       (atomic_rmw_loop (AtomicRMWLoopOp.Xchg) addr src ty flags))
 
 ;;;; Rules for `AtomicCAS` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (and (use_lse)
                   (has_type (valid_atomic_transaction ty)
-                  (atomic_cas flags addr src1 src2))))
+                  (atomic_cas (little_or_native_endian flags) addr src1 src2))))
       (lse_atomic_cas addr src1 src2 ty flags))
 
 (rule (lower (and (has_type (valid_atomic_transaction ty)
-                  (atomic_cas flags addr src1 src2))))
+                  (atomic_cas (little_or_native_endian flags) addr src1 src2))))
       (atomic_cas_loop addr src1 src2 ty flags))
 
 ;;;; Rules for 'fvdemote' ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2603,92 +2603,92 @@
 ;;;; Rules for loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule load_i8_aarch64_uload8 (lower
-       (has_type $I8 (load flags address offset)))
+       (has_type $I8 (load (little_or_native_endian flags) address offset)))
       (aarch64_uload8 (amode $I8 address offset) flags))
 (rule load_i16_aarch64_uload16 (lower
-       (has_type $I16 (load flags address offset)))
+       (has_type $I16 (load (little_or_native_endian flags) address offset)))
       (aarch64_uload16 (amode $I16 address offset) flags))
 (rule load_i32_aarch64_uload32 (lower
-       (has_type $I32 (load flags address offset)))
+       (has_type $I32 (load (little_or_native_endian flags) address offset)))
       (aarch64_uload32 (amode $I32 address offset) flags))
 (rule load_i64_aarch64_uload64 (lower
-       (has_type $I64 (load flags address offset)))
+       (has_type $I64 (load (little_or_native_endian flags) address offset)))
       (aarch64_uload64 (amode $I64 address offset) flags))
 (rule (lower
-       (has_type $I128 (load flags address offset)))
+       (has_type $I128 (load (little_or_native_endian flags) address offset)))
       (aarch64_loadp64 (pair_amode address offset) flags))
 (rule -1 (lower
-       (has_type (ty_float_or_vec (ty_16 _)) (load flags address offset)))
+       (has_type (ty_float_or_vec (ty_16 _)) (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload16 (amode $F16 address offset) flags))
 (rule -2 (lower
-       (has_type (ty_float_or_vec (ty_32 _)) (load flags address offset)))
+       (has_type (ty_float_or_vec (ty_32 _)) (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload32 (amode $F32 address offset) flags))
 (rule -3 (lower
-       (has_type (ty_float_or_vec (ty_64 _)) (load flags address offset)))
+       (has_type (ty_float_or_vec (ty_64 _)) (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload64 (amode $F64 address offset) flags))
 (rule -4 (lower
-       (has_type (ty_float_or_vec (ty_128 _)) (load flags address offset)))
+       (has_type (ty_float_or_vec (ty_128 _)) (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload128 (amode $F128 address offset) flags))
 (rule -5 (lower
        (has_type (ty_dyn_vec64 _)
-                        (load flags address offset)))
+                        (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload64 (amode $F64 address offset) flags))
 (rule -6 (lower
        (has_type (ty_dyn_vec128 _)
-                        (load flags address offset)))
+                        (load (little_or_native_endian flags) address offset)))
       (aarch64_fpuload128 (amode $I8X16 address offset) flags))
 
 (rule (lower
-       (uload8 flags address offset))
+       (uload8 (little_or_native_endian flags) address offset))
       (aarch64_uload8 (amode $I8 address offset) flags))
 (rule (lower
-       (sload8 flags address offset))
+       (sload8 (little_or_native_endian flags) address offset))
       (aarch64_sload8 (amode $I8 address offset) flags))
 (rule (lower
-       (uload16 flags address offset))
+       (uload16 (little_or_native_endian flags) address offset))
       (aarch64_uload16 (amode $I16 address offset) flags))
 (rule (lower
-       (sload16 flags address offset))
+       (sload16 (little_or_native_endian flags) address offset))
       (aarch64_sload16 (amode $I16 address offset) flags))
 (rule (lower
-       (uload32 flags address offset))
+       (uload32 (little_or_native_endian flags) address offset))
       (aarch64_uload32 (amode $I32 address offset) flags))
 (rule (lower
-       (sload32 flags address offset))
+       (sload32 (little_or_native_endian flags) address offset))
       (aarch64_sload32 (amode $I32 address offset) flags))
 
 (rule (lower
-       (sload8x8 flags address offset))
+       (sload8x8 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Sxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
                   (ScalarSize.Size16)))
 (rule (lower
-       (uload8x8 flags address offset))
+       (uload8x8 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Uxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
                   (ScalarSize.Size16)))
 (rule (lower
-       (sload16x4 flags address offset))
+       (sload16x4 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Sxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
                   (ScalarSize.Size32)))
 (rule (lower
-       (uload16x4 flags address offset))
+       (uload16x4 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Uxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
                   (ScalarSize.Size32)))
 (rule (lower
-       (sload32x2 flags address offset))
+       (sload32x2 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Sxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
                   (ScalarSize.Size64)))
 (rule (lower
-       (uload32x2 flags address offset))
+       (uload32x2 (little_or_native_endian flags) address offset))
       (vec_extend (VecExtendOp.Uxtl)
                   (aarch64_fpuload64 (amode $F64 address offset) flags)
                   false
@@ -2697,65 +2697,65 @@
 ;;;; Rules for stores ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule store_i8_aarch64_store8 (lower
-       (store flags value @ (value_type $I8) address offset))
+       (store (little_or_native_endian flags) value @ (value_type $I8) address offset))
       (side_effect
        (aarch64_store8 (amode $I8 address offset) flags value)))
 (rule store_i16_aarch64_store16 (lower
-       (store flags value @ (value_type $I16) address offset))
+       (store (little_or_native_endian flags) value @ (value_type $I16) address offset))
       (side_effect
        (aarch64_store16 (amode $I16 address offset) flags value)))
 (rule store_i32_aarch64_store32 (lower
-       (store flags value @ (value_type $I32) address offset))
+       (store (little_or_native_endian flags) value @ (value_type $I32) address offset))
       (side_effect
        (aarch64_store32 (amode $I32 address offset) flags value)))
 (rule store_i64_aarch64_store64 (lower
-       (store flags value @ (value_type $I64) address offset))
+       (store (little_or_native_endian flags) value @ (value_type $I64) address offset))
       (side_effect
        (aarch64_store64 (amode $I64 address offset) flags value)))
 
 (rule (lower
-       (istore8 flags value address offset))
+       (istore8 (little_or_native_endian flags) value address offset))
       (side_effect
        (aarch64_store8 (amode $I8 address offset) flags value)))
 (rule (lower
-       (istore16 flags value address offset))
+       (istore16 (little_or_native_endian flags) value address offset))
       (side_effect
        (aarch64_store16 (amode $I16 address offset) flags value)))
 (rule (lower
-       (istore32 flags value address offset))
+       (istore32 (little_or_native_endian flags) value address offset))
       (side_effect
        (aarch64_store32 (amode $I32 address offset) flags value)))
 
 (rule (lower
-       (store flags value @ (value_type $I128) address offset))
+       (store (little_or_native_endian flags) value @ (value_type $I128) address offset))
       (side_effect
        (aarch64_storep64 (pair_amode address offset) flags
                          (value_regs_get value 0)
                          (value_regs_get value 1))))
 
 (rule -1 (lower
-       (store flags value @ (value_type (ty_float_or_vec (ty_16 _))) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_float_or_vec (ty_16 _))) address offset))
       (side_effect
        (aarch64_fpustore16 (amode $F16 address offset) flags value)))
 (rule -2 (lower
-       (store flags value @ (value_type (ty_float_or_vec (ty_32 _))) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_float_or_vec (ty_32 _))) address offset))
       (side_effect
        (aarch64_fpustore32 (amode $F32 address offset) flags value)))
 (rule -3 (lower
-       (store flags value @ (value_type (ty_float_or_vec (ty_64 _))) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_float_or_vec (ty_64 _))) address offset))
       (side_effect
        (aarch64_fpustore64 (amode $F64 address offset) flags value)))
 (rule -4 (lower
-       (store flags value @ (value_type (ty_float_or_vec (ty_128 _))) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_float_or_vec (ty_128 _))) address offset))
       (side_effect
        (aarch64_fpustore128 (amode $F128 address offset) flags value)))
 
 (rule -5 (lower
-       (store flags value @ (value_type (ty_dyn_vec64 _)) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_dyn_vec64 _)) address offset))
       (side_effect
        (aarch64_fpustore64 (amode $F64 address offset) flags value)))
 (rule -6 (lower
-       (store flags value @ (value_type (ty_dyn_vec128 _)) address offset))
+       (store (little_or_native_endian flags) value @ (value_type (ty_dyn_vec128 _)) address offset))
       (side_effect
        (aarch64_fpustore128 (amode $I8X16 address offset) flags value)))
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2450,7 +2450,7 @@
 (decl sinkable_load (Inst Type MemFlags Value Offset32) Value)
 (extractor (sinkable_load inst ty flags addr offset)
            (and
-              (load flags addr offset)
+              (load (little_or_native_endian flags) addr offset)
               (sinkable_inst (has_type ty inst))))
 
 ;; Returns a canonical type for a LoadOP. We only return I64 or F64.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1639,34 +1639,34 @@
 (rule -1
   ;;
   (lower
-    (has_type (valid_atomic_transaction ty) (atomic_rmw flags op addr x)))
+    (has_type (valid_atomic_transaction ty) (atomic_rmw (little_or_native_endian flags) op addr x)))
   (gen_atomic (get_atomic_rmw_op ty op) addr x (atomic_amo)))
 
 ;;; for I8 and I16
 (rule 1
   (lower
-    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw flags op addr x)))
+    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw (little_or_native_endian flags) op addr x)))
   (gen_atomic_rmw_loop op ty addr x))
 
 ;;;special for I8 and I16 max min etc.
 ;;;because I need uextend or sextend the value.
 (rule 2
   (lower
-    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw flags (is_atomic_rmw_max_etc op true) addr x)))
+    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw (little_or_native_endian flags) (is_atomic_rmw_max_etc op true) addr x)))
   (gen_atomic_rmw_loop op ty addr (sext x)))
 
 
 (rule 2
   ;;
   (lower
-    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw flags (is_atomic_rmw_max_etc op false) addr x)))
+    (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw (little_or_native_endian flags) (is_atomic_rmw_max_etc op false) addr x)))
   ;;
   (gen_atomic_rmw_loop op ty addr (zext x)))
 
 ;;;;;  Rules for `AtomicRmwOp.Sub`
 (rule
   (lower
-    (has_type (valid_atomic_transaction ty) (atomic_rmw flags (AtomicRmwOp.Sub) addr x)))
+    (has_type (valid_atomic_transaction ty) (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) addr x)))
   (let
     ((tmp WritableReg (temp_writable_reg ty))
      (x2 Reg (rv_neg x)))
@@ -1684,7 +1684,7 @@
 ;;;;;  Rules for `AtomicRmwOp.Nand`
 (rule
   (lower
-    (has_type (valid_atomic_transaction ty) (atomic_rmw flags (AtomicRmwOp.Nand) addr x)))
+    (has_type (valid_atomic_transaction ty) (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Nand) addr x)))
     (gen_atomic_rmw_loop (AtomicRmwOp.Nand) ty addr x))
 
 (decl is_atomic_rmw_max_etc (AtomicRmwOp bool) AtomicRmwOp)
@@ -1692,13 +1692,13 @@
 
 ;;;;;  Rules for `atomic load`;;;;;;;;;;;;;;;;;
 (rule
-  (lower (has_type (valid_atomic_transaction ty) (atomic_load flags p)))
+  (lower (has_type (valid_atomic_transaction ty) (atomic_load (little_or_native_endian flags) p)))
   (gen_atomic_load p ty))
 
 
 ;;;;;  Rules for `atomic store`;;;;;;;;;;;;;;;;;
 (rule
-  (lower (atomic_store flags src @ (value_type (valid_atomic_transaction ty)) p))
+  (lower (atomic_store (little_or_native_endian flags) src @ (value_type (valid_atomic_transaction ty)) p))
   (gen_atomic_store p ty src))
 
 (decl gen_atomic_offset (XReg Type) XReg)
@@ -1718,7 +1718,7 @@
 
 ;;;;;  Rules for `atomic cas`;;;;;;;;;;;;;;;;;
 (rule
-  (lower (has_type (valid_atomic_transaction ty) (atomic_cas flags p e x)))
+  (lower (has_type (valid_atomic_transaction ty) (atomic_cas (little_or_native_endian flags) p e x)))
   (let
     ((t0 WritableReg (temp_writable_reg ty))
       (dst WritableReg (temp_writable_reg ty))
@@ -2105,40 +2105,40 @@
   (gen_trapif cc x y code))
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
-(rule (lower (uload8 flags addr offset))
+(rule (lower (uload8 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lbu) flags))
 
 ;;;;;  Rules for `sload8`;;;;;;;;;
-(rule (lower (sload8 flags addr offset))
+(rule (lower (sload8 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lb) flags))
 
 ;;;;;  Rules for `uload16`;;;;;;;;;
-(rule (lower (uload16 flags addr offset))
+(rule (lower (uload16 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lhu) flags))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
-(rule (lower (sload16 flags addr offset))
+(rule (lower (sload16 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lh) flags))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
-(rule (lower (uload32 flags addr offset))
+(rule (lower (uload32 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lwu) flags))
 
 ;;;;;  Rules for `sload32`;;;;;;;;;
-(rule (lower (sload32 flags addr offset))
+(rule (lower (sload32 (little_or_native_endian flags) addr offset))
   (gen_load (amode addr offset) (LoadOP.Lw) flags))
 
 ;;;;;  Rules for `load`;;;;;;;;;
-(rule (lower (has_type ty (load flags addr offset)))
+(rule (lower (has_type ty (load (little_or_native_endian flags) addr offset)))
   (gen_load (amode addr offset) (load_op ty) flags))
 
-(rule 1 (lower (has_type (ty_reg_pair _) (load flags addr offset)))
+(rule 1 (lower (has_type (ty_reg_pair _) (load (little_or_native_endian flags) addr offset)))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
   (let ((lo XReg (gen_load (amode addr offset) (LoadOP.Ld) flags))
         (hi XReg (gen_load (amode addr offset_plus_8) (LoadOP.Ld) flags)))
     (value_regs lo hi)))
 
-(rule 2 (lower (has_type (ty_supported_vec ty) (load flags addr offset)))
+(rule 2 (lower (has_type (ty_supported_vec ty) (load (little_or_native_endian flags) addr offset)))
   (let ((eew VecElementWidth (element_width_from_type ty))
         (amode AMode (amode addr offset)))
     (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) ty)))
@@ -2165,58 +2165,59 @@
     (rv_vzext_vf2 loaded (unmasked) ty)))
 
 ;;;;;  Rules for `uload8x8`;;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I16X8) (uload8x8 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I16X8) (uload8x8 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `uload16x4`;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I32X4) (uload16x4 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I32X4) (uload16x4 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `uload32x2`;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I64X2) (uload32x2 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I64X2) (uload32x2 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload8x8`;;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I16X8) (sload8x8 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I16X8) (sload8x8 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload16x4`;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I32X4) (sload16x4 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I32X4) (sload16x4 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload32x2`;;;;;;;;;
-(rule (lower (has_type (ty_supported_vec ty @ $I64X2) (sload32x2 flags addr offset)))
+(rule (lower (has_type (ty_supported_vec ty @ $I64X2) (sload32x2 (little_or_native_endian flags) addr offset)))
   (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `istore8`;;;;;;;;;
-(rule (lower (istore8 flags src addr offset))
+(rule (lower (istore8 (little_or_native_endian flags) src addr offset))
   (rv_store (amode addr offset) (StoreOP.Sb) flags src))
 
 ;;;;;  Rules for `istore16`;;;;;;;;;
-(rule (lower (istore16 flags src addr offset))
+(rule (lower (istore16 (little_or_native_endian flags) src addr offset))
   (rv_store (amode addr offset) (StoreOP.Sh) flags src))
 
 ;;;;;  Rules for `istore32`;;;;;;;;;
-(rule (lower (istore32 flags src addr offset))
+(rule (lower (istore32 (little_or_native_endian flags) src addr offset))
   (rv_store (amode addr offset) (StoreOP.Sw) flags src))
 
 ;;;;;  Rules for `store`;;;;;;;;;
-(rule (lower (store flags src @ (value_type ty) addr offset))
+(rule (lower (store (little_or_native_endian flags) src @ (value_type ty) addr offset))
   (gen_store (amode addr offset) flags src))
 
-(rule 1 (lower (store flags src @ (value_type (ty_reg_pair _)) addr offset))
+(rule 1 (lower (store (little_or_native_endian flags) src @ (value_type (ty_reg_pair _)) addr offset))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
   (let ((_ InstOutput (rv_store (amode addr offset) (StoreOP.Sd) flags (value_regs_get src 0))))
     (rv_store (amode addr offset_plus_8) (StoreOP.Sd) flags (value_regs_get src 1))))
 
-(rule 2 (lower (store flags src @ (value_type (ty_supported_vec ty)) addr offset))
+(rule 2 (lower (store (little_or_native_endian flags) src @ (value_type (ty_supported_vec ty)) addr offset))
   (let ((eew VecElementWidth (element_width_from_type ty))
         (amode AMode (amode addr offset)))
     (vec_store eew (VecAMode.UnitStride amode) src flags (unmasked) ty)))
 
 ;; Avoid unnecessary moves to floating point registers for `F16` memory to memory copies when
 ;; `Zfhmin` is unavailable.
-(rule 3 (lower (store store_flags (sinkable_load inst $F16 load_flags load_addr load_offset) store_addr store_offset))
+(rule 3 (lower (store (little_or_native_endian store_flags)
+                      (sinkable_load inst $F16 (little_or_native_endian load_flags) load_addr load_offset) store_addr store_offset))
   (if-let false (has_zfhmin))
   (rv_store (amode store_addr store_offset) (StoreOP.Sh) store_flags (gen_sunk_load inst (amode load_addr load_offset) (LoadOP.Lh) load_flags)))
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2996,48 +2996,49 @@
 ;; 8-bit loads.
 ;;
 ;; By default, we zero-extend all sub-64-bit loads to a GPR.
-(rule load_sub64_x64_movzx -4 (lower (has_type (and (fits_in_32 ty) (is_gpr_type _)) (load flags address offset)))
+(rule load_sub64_x64_movzx -4 (lower (has_type (and (fits_in_32 ty) (is_gpr_type _))
+                                               (load (little_or_native_endian flags) address offset)))
       (x64_movzx (ext_mode (ty_bits_u16 ty) 64) (to_amode flags address offset)))
 ;; But if we know that both the `from` and `to` are 64 bits, we simply load with
 ;; no extension.
-(rule load_64_x64_movzx -1 (lower (has_type (ty_int_ref_64 ty) (load flags address offset)))
+(rule load_64_x64_movzx -1 (lower (has_type (ty_int_ref_64 ty) (load (little_or_native_endian flags) address offset)))
       (x64_mov (to_amode flags address offset)))
 ;; Also, certain scalar loads have a specific `from` width and extension kind
 ;; (signed -> `sx`, zeroed -> `zx`). We overwrite the high bits of the 64-bit
 ;; GPR even if the `to` type is smaller (e.g., 16-bits).
-(rule (lower (has_type (is_gpr_type ty) (uload8 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (uload8 (little_or_native_endian flags) address offset)))
       (x64_movzx (ExtMode.BQ) (to_amode flags address offset)))
-(rule (lower (has_type (is_gpr_type ty) (sload8 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (sload8 (little_or_native_endian flags) address offset)))
       (x64_movsx (ExtMode.BQ) (to_amode flags address offset)))
-(rule (lower (has_type (is_gpr_type ty) (uload16 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (uload16 (little_or_native_endian flags) address offset)))
       (x64_movzx (ExtMode.WQ) (to_amode flags address offset)))
-(rule (lower (has_type (is_gpr_type ty) (sload16 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (sload16 (little_or_native_endian flags) address offset)))
       (x64_movsx (ExtMode.WQ) (to_amode flags address offset)))
-(rule (lower (has_type (is_gpr_type ty) (uload32 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (uload32 (little_or_native_endian flags) address offset)))
       (x64_movzx (ExtMode.LQ) (to_amode flags address offset)))
-(rule (lower (has_type (is_gpr_type ty) (sload32 flags address offset)))
+(rule (lower (has_type (is_gpr_type ty) (sload32 (little_or_native_endian flags) address offset)))
       (x64_movsx (ExtMode.LQ) (to_amode flags address offset)))
 
 ;; To load to XMM registers, we use the x64-specific instructions for each type.
 ;; For `$F32` and `$F64` this is important--we only want to load 32 or 64 bits.
 ;; But for the 128-bit types, this is not strictly necessary for performance but
 ;; might help with clarity during disassembly.
-(rule 4 (lower (has_type (is_xmm_type (ty_16 _)) (load flags address offset)))
+(rule 4 (lower (has_type (is_xmm_type (ty_16 _)) (load (little_or_native_endian flags) address offset)))
       (x64_pinsrw (xmm_uninit_value) (to_amode flags address offset) 0))
-(rule 3 (lower (has_type (is_xmm_type (ty_32 _)) (load flags address offset)))
+(rule 3 (lower (has_type (is_xmm_type (ty_32 _)) (load (little_or_native_endian flags) address offset)))
       (x64_movss_load (to_amode flags address offset)))
-(rule 2 (lower (has_type (is_xmm_type (ty_64 _)) (load flags address offset)))
+(rule 2 (lower (has_type (is_xmm_type (ty_64 _)) (load (little_or_native_endian flags) address offset)))
       (x64_movsd_load (to_amode flags address offset)))
-(rule 1 (lower (has_type $F32X4 (load flags address offset)))
+(rule 1 (lower (has_type $F32X4 (load (little_or_native_endian flags) address offset)))
       (x64_movups_load (to_amode flags address offset)))
-(rule 1 (lower (has_type $F64X2 (load flags address offset)))
+(rule 1 (lower (has_type $F64X2 (load (little_or_native_endian flags) address offset)))
       (x64_movupd_load (to_amode flags address offset)))
-(rule 0 (lower (has_type (is_xmm_type (ty_128 _)) (load flags address offset)))
+(rule 0 (lower (has_type (is_xmm_type (ty_128 _)) (load (little_or_native_endian flags) address offset)))
       (x64_movdqu_load (to_amode flags address offset)))
 
 ;; We can load an I128 by doing two 64-bit loads.
 (rule -3 (lower (has_type $I128
-                       (load flags address offset)))
+                       (load (little_or_native_endian flags) address offset)))
       (let ((addr_lo Amode (to_amode flags address offset))
             (addr_hi Amode (amode_offset addr_lo 8))
             (value_lo Reg (x64_mov addr_lo))
@@ -3046,42 +3047,42 @@
 
 ;; We also include widening vector loads; these sign- or zero-extend each lane
 ;; to the next wider width (e.g., 16x4 -> 32x4).
-(rule 1 (lower (has_type $I16X8 (sload8x8 flags address offset)))
+(rule 1 (lower (has_type $I16X8 (sload8x8 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovsxbw (to_amode flags address offset)))
-(rule 1 (lower (has_type $I16X8 (uload8x8 flags address offset)))
+(rule 1 (lower (has_type $I16X8 (uload8x8 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovzxbw (to_amode flags address offset)))
-(rule 1 (lower (has_type $I32X4 (sload16x4 flags address offset)))
+(rule 1 (lower (has_type $I32X4 (sload16x4 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovsxwd (to_amode flags address offset)))
-(rule 1 (lower (has_type $I32X4 (uload16x4 flags address offset)))
+(rule 1 (lower (has_type $I32X4 (uload16x4 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovzxwd (to_amode flags address offset)))
-(rule 1 (lower (has_type $I64X2 (sload32x2 flags address offset)))
+(rule 1 (lower (has_type $I64X2 (sload32x2 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovsxdq (to_amode flags address offset)))
-(rule 1 (lower (has_type $I64X2 (uload32x2 flags address offset)))
+(rule 1 (lower (has_type $I64X2 (uload32x2 (little_or_native_endian flags) address offset)))
         (if-let true (use_sse41))
         (x64_pmovzxdq (to_amode flags address offset)))
 
-(rule (lower (has_type $I16X8 (sload8x8 flags address offset)))
+(rule (lower (has_type $I16X8 (sload8x8 (little_or_native_endian flags) address offset)))
       (lower_swiden_low $I16X8 (x64_movq_to_xmm (to_amode flags address offset))))
-(rule (lower (has_type $I16X8 (uload8x8 flags address offset)))
+(rule (lower (has_type $I16X8 (uload8x8 (little_or_native_endian flags) address offset)))
       (lower_uwiden_low $I16X8 (x64_movq_to_xmm (to_amode flags address offset))))
-(rule (lower (has_type $I32X4 (sload16x4 flags address offset)))
+(rule (lower (has_type $I32X4 (sload16x4 (little_or_native_endian flags) address offset)))
       (lower_swiden_low $I32X4 (x64_movq_to_xmm (to_amode flags address offset))))
-(rule (lower (has_type $I32X4 (uload16x4 flags address offset)))
+(rule (lower (has_type $I32X4 (uload16x4 (little_or_native_endian flags) address offset)))
       (lower_uwiden_low $I32X4 (x64_movq_to_xmm (to_amode flags address offset))))
-(rule (lower (has_type $I64X2 (sload32x2 flags address offset)))
+(rule (lower (has_type $I64X2 (sload32x2 (little_or_native_endian flags) address offset)))
       (lower_swiden_low $I64X2 (x64_movq_to_xmm (to_amode flags address offset))))
-(rule (lower (has_type $I64X2 (uload32x2 flags address offset)))
+(rule (lower (has_type $I64X2 (uload32x2 (little_or_native_endian flags) address offset)))
       (lower_uwiden_low $I64X2 (x64_movq_to_xmm (to_amode flags address offset))))
 
 ;; Rules for `store*` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 8-, 16-, 32- and 64-bit GPR stores.
-(rule store_x64_movrm -2 (lower (store flags
+(rule store_x64_movrm -2 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_gpr_type ty))
                     address
                     offset))
@@ -3089,31 +3090,31 @@
        (x64_movrm ty (to_amode flags address offset) value)))
 
 ;; Explicit 8/16/32-bit opcodes.
-(rule (lower (istore8 flags value address offset))
+(rule (lower (istore8 (little_or_native_endian flags) value address offset))
       (side_effect
        (x64_movrm $I8 (to_amode flags address offset) value)))
-(rule (lower (istore16 flags value address offset))
+(rule (lower (istore16 (little_or_native_endian flags) value address offset))
       (side_effect
        (x64_movrm $I16 (to_amode flags address offset) value)))
-(rule (lower (istore32 flags value address offset))
+(rule (lower (istore32 (little_or_native_endian flags) value address offset))
       (side_effect
        (x64_movrm $I32 (to_amode flags address offset) value)))
 
 ;; IMM stores
-(rule 4 (lower (store flags value @ (value_type (fits_in_64 ty)) address offset))
+(rule 4 (lower (store (little_or_native_endian flags) value @ (value_type (fits_in_64 ty)) address offset))
       (if-let (i32_from_iconst imm) value)
       (side_effect
        (x64_movimm_m ty (to_amode flags address offset) imm)))
 
 ;; F16 stores of values in XMM registers.
-(rule -2 (lower (store flags
+(rule -2 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_xmm_type (ty_16 _)))
                     address
                     offset))
       (side_effect
        (x64_movrm $I16 (to_amode flags address offset) (bitcast_xmm_to_gpr 16 value))))
 
-(rule -1 (lower (store flags
+(rule -1 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_xmm_type (ty_16 _)))
                     address
                     offset))
@@ -3122,7 +3123,7 @@
        (x64_pextrw_store (to_amode flags address offset) value 0)))
 
 ;; F32 stores of values in XMM registers.
-(rule -3 (lower (store flags
+(rule -3 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_xmm_type (ty_32 _)))
                     address
                     offset))
@@ -3130,7 +3131,7 @@
        (x64_movss_store (to_amode flags address offset) value)))
 
 ;; F64 stores of values in XMM registers.
-(rule -4 (lower (store flags
+(rule -4 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_xmm_type (ty_64 _)))
                     address
                     offset))
@@ -3138,7 +3139,7 @@
        (x64_movsd_store (to_amode flags address offset) value)))
 
 ;; Stores of F32X4 vectors.
-(rule 1 (lower (store flags
+(rule 1 (lower (store (little_or_native_endian flags)
                     value @ (value_type $F32X4)
                     address
                     offset))
@@ -3146,7 +3147,7 @@
        (x64_movups_store (to_amode flags address offset) value)))
 
 ;; Stores of F64X2 vectors.
-(rule 1 (lower (store flags
+(rule 1 (lower (store (little_or_native_endian flags)
                     value @ (value_type $F64X2)
                     address
                     offset))
@@ -3154,7 +3155,7 @@
        (x64_movupd_store (to_amode flags address offset) value)))
 
 ;; Stores of all other 128-bit vector types with integer lanes.
-(rule -5 (lower (store flags
+(rule -5 (lower (store (little_or_native_endian flags)
                     value @ (value_type (is_xmm_type (ty_128 _)))
                     address
                     offset))
@@ -3162,7 +3163,7 @@
        (x64_movdqu_store (to_amode flags address offset) value)))
 
 ;; Stores of I128 values: store the two 64-bit halves separately.
-(rule 0 (lower (store flags
+(rule 0 (lower (store (little_or_native_endian flags)
                     value @ (value_type $I128)
                     address
                     offset))
@@ -3181,40 +3182,40 @@
 ;; standard `movss` and `movsd` instructions can be used as-if we're storing a
 ;; f32 or f64 despite the source perhaps being an integer vector since the
 ;; result of the instruction is the same.
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $F32 (extractlane value (u8_from_uimm8 0)))
                     address
                     offset))
       (side_effect
        (x64_movss_store (to_amode flags address offset) value)))
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $F64 (extractlane value (u8_from_uimm8 0)))
                     address
                     offset))
       (side_effect
        (x64_movsd_store (to_amode flags address offset) value)))
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $I8 (extractlane value (u8_from_uimm8 n)))
                     address
                     offset))
       (if-let true (use_sse41))
       (side_effect
        (x64_pextrb_store (to_amode flags address offset) value n)))
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $I16 (extractlane value (u8_from_uimm8 n)))
                     address
                     offset))
       (if-let true (use_sse41))
       (side_effect
        (x64_pextrw_store (to_amode flags address offset) value n)))
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $I32 (extractlane value (u8_from_uimm8 n)))
                     address
                     offset))
       (if-let true (use_sse41))
       (side_effect
        (x64_pextrd_store (to_amode flags address offset) value n)))
-(rule 2 (lower (store flags
+(rule 2 (lower (store (little_or_native_endian flags)
                     (has_type $I64 (extractlane value (u8_from_uimm8 n)))
                     address
                     offset))
@@ -3226,7 +3227,7 @@
 
 ;; Add mem, reg
 (rule store_x64_add_mem 3 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (iadd (and
                                (sinkable_load sink)
@@ -3240,7 +3241,7 @@
 
 ;; Add mem, reg with args swapped
 (rule 2 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (iadd src2
                               (and
@@ -3254,7 +3255,7 @@
 
 ;; Sub mem, reg
 (rule 2 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (isub (and
                                (sinkable_load sink)
@@ -3268,7 +3269,7 @@
 
 ;; And mem, reg
 (rule 3 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (band (and
                                (sinkable_load sink)
@@ -3282,7 +3283,7 @@
 
 ;; And mem, reg with args swapped
 (rule 2 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (band src2
                               (and
@@ -3296,7 +3297,7 @@
 
 ;; Or mem, reg
 (rule 3 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (bor (and
                                (sinkable_load sink)
@@ -3310,7 +3311,7 @@
 
 ;; Or mem, reg with args swapped
 (rule 2 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (bor src2
                               (and
@@ -3324,7 +3325,7 @@
 
 ;; Xor mem, reg
 (rule 3 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (bxor (and
                                (sinkable_load sink)
@@ -3338,7 +3339,7 @@
 
 ;; Xor mem, reg with args swapped
 (rule 2 (lower
-       (store flags
+       (store (little_or_native_endian flags)
               (has_type (ty_32_or_64 ty)
                         (bxor src2
                               (and
@@ -3373,12 +3374,12 @@
 ;;
 ;; This lowering is only valid for I8, I16, I32, and I64. The sub-64-bit types
 ;; are zero extended, as with a normal load.
-(rule 1 (lower (has_type $I64 (atomic_load flags address)))
+(rule 1 (lower (has_type $I64 (atomic_load (little_or_native_endian flags) address)))
       (x64_mov (to_amode flags address (zero_offset))))
-(rule (lower (has_type (and (fits_in_32 ty) (ty_int _)) (atomic_load flags address)))
+(rule (lower (has_type (and (fits_in_32 ty) (ty_int _)) (atomic_load (little_or_native_endian flags) address)))
       (x64_movzx (ext_mode (ty_bits_u16 ty) 64) (to_amode flags address (zero_offset))))
 ;; Lower 128-bit `atomic_load` using `cmpxchg16b`.
-(rule 1 (lower (has_type $I128 (atomic_load flags address)))
+(rule 1 (lower (has_type $I128 (atomic_load (little_or_native_endian flags) address)))
       (if-let true (use_cmpxchg16b))
       (x64_cmpxchg16b (value_regs (imm $I64 0) (imm $I64 0)) (value_regs (imm $I64 0) (imm $I64 0)) (to_amode flags address (zero_offset))))
 
@@ -3386,21 +3387,21 @@
 
 ;; This is a normal store followed by an `mfence` instruction. This lowering is
 ;; only valid for I8, I16, I32, and I64.
-(rule (lower (atomic_store flags
+(rule (lower (atomic_store (little_or_native_endian flags)
                            value @ (value_type (and (fits_in_64 ty) (ty_int _)))
                            address))
       (side_effect (side_effect_concat
        (x64_movrm ty (to_amode flags address (zero_offset)) value)
        (x64_mfence))))
 ;; Lower 128-bit `atomic_store` using `cmpxchg16b`.
-(rule 1 (lower (atomic_store flags value @ (value_type $I128) address))
+(rule 1 (lower (atomic_store (little_or_native_endian flags) value @ (value_type $I128) address))
       (if-let true (use_cmpxchg16b))
       (side_effect (x64_atomic_128_store_seq (to_amode flags address (zero_offset)) value)))
 
 ;; Rules for `atomic_cas` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
-                  (atomic_cas flags address expected replacement)))
+                  (atomic_cas (little_or_native_endian flags) address expected replacement)))
       (x64_cmpxchg ty expected replacement (to_amode flags address (zero_offset))))
 (rule 1 (lower (has_type $I128 (atomic_cas flags address expected replacement)))
         (if-let true (use_cmpxchg16b))
@@ -3411,51 +3412,51 @@
 ;; This is a simple, general-case atomic update, based on a loop involving
 ;; `cmpxchg`.
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
-                  (atomic_rmw flags op address input)))
+                  (atomic_rmw (little_or_native_endian flags) op address input)))
       (x64_atomic_rmw_seq ty (atomic_rmw_seq_op op) (to_amode flags address (zero_offset)) input))
 
 ;; `Add` and `Sub` can use `lock xadd`
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
-                  (atomic_rmw flags (AtomicRmwOp.Add) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Add) address input)))
       (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
-                  (atomic_rmw flags (AtomicRmwOp.Sub) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) address input)))
       (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) (x64_neg ty input)))
 ;; `Xchg` can use `xchg`
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
-                  (atomic_rmw flags (AtomicRmwOp.Xchg) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xchg) address input)))
       (x64_xchg (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
 
 ;; `Add`, `Sub`, `And`, `Or` and `Xor` can use `lock`-prefixed instructions if
 ;; the old value is not required.
 (rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
-                  (atomic_rmw flags (AtomicRmwOp.Add) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Add) address input)))
       (if-let (first_result res) i)
       (if-let true (value_is_unused res))
       (side_effect_as_invalid (x64_lock_add (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input)))
 (rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
-                  (atomic_rmw flags (AtomicRmwOp.Sub) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) address input)))
       (if-let (first_result res) i)
       (if-let true (value_is_unused res))
       (side_effect_as_invalid (x64_lock_sub (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input)))
 (rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
-                  (atomic_rmw flags (AtomicRmwOp.And) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.And) address input)))
       (if-let (first_result res) i)
       (if-let true (value_is_unused res))
       (side_effect_as_invalid (x64_lock_and (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input)))
 (rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
-                  (atomic_rmw flags (AtomicRmwOp.Or) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Or) address input)))
       (if-let (first_result res) i)
       (if-let true (value_is_unused res))
       (side_effect_as_invalid (x64_lock_or (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input)))
 (rule 2 (lower i @ (has_type (fits_in_64 (ty_int ty))
-                  (atomic_rmw flags (AtomicRmwOp.Xor) address input)))
+                  (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xor) address input)))
       (if-let (first_result res) i)
       (if-let true (value_is_unused res))
       (side_effect_as_invalid (x64_lock_xor (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input)))
 
 ;; 128-bit integers always use a `lock cmpxchg16b` loop.
-(rule 3 (lower (has_type $I128 (atomic_rmw flags op address input)))
+(rule 3 (lower (has_type $I128 (atomic_rmw (little_or_native_endian flags) op address input)))
         (if-let true (use_cmpxchg16b))
         (x64_atomic_128_rmw_seq op (to_amode flags address (zero_offset)) input))
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -4,7 +4,9 @@
 pub(super) mod isle;
 
 use crate::ir::pcc::{FactContext, PccResult};
-use crate::ir::{ExternalName, Inst as IRInst, InstructionData, LibCall, Opcode, Type, types};
+use crate::ir::{
+    Endianness, ExternalName, Inst as IRInst, InstructionData, LibCall, Opcode, Type, types,
+};
 use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
@@ -116,6 +118,13 @@ fn is_mergeable_load(
         match size {
             MergeableLoadSize::Exact => {}
             MergeableLoadSize::Min32 => return None,
+        }
+    }
+
+    // If the load's flags specify big-endian, we can't merge.
+    if let Some(flags) = ctx.memflags(src_insn) {
+        if flags.explicit_endianness() == Some(Endianness::Big) {
+            return None;
         }
     }
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -804,6 +804,14 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn little_or_native_endian(&mut self, flags: MemFlags) -> Option<MemFlags> {
+            match flags.explicit_endianness() {
+                Some(crate::ir::Endianness::Little) | None => Some(flags),
+                Some(crate::ir::Endianness::Big) => None,
+            }
+        }
+
+        #[inline]
         fn intcc_unsigned(&mut self, x: &IntCC) -> IntCC {
             x.unsigned()
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -525,6 +525,10 @@
 (decl pure mem_flags_trusted () MemFlags)
 (extern constructor mem_flags_trusted mem_flags_trusted)
 
+;; Determine if flags specify little- or native-endian.
+(decl little_or_native_endian (MemFlags) MemFlags)
+(extern extractor little_or_native_endian little_or_native_endian)
+
 ;;;; Helpers for Working with Flags ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Swap args of an IntCC flag.

--- a/cranelift/filetests/filetests/isa/aarch64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/big-endian.clif
@@ -1,0 +1,286 @@
+test compile expect-fail
+set enable_llvm_abi_extensions=true
+target aarch64
+
+;; Technically this could succeed (little- and big-endian treatment of
+;; a single byte is the same) but we have a blanket exclusion on all
+;; big-endian loads/stores for now.
+function %f(i64) -> i8 {
+    block0(v0: i64):
+        v1 = load.i8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16 {
+    block0(v0: i64):
+        v1 = load.i16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i128 {
+    block0(v0: i64):
+        v1 = load.i128 big v0+8
+        return v1
+}
+
+function %f(i64) -> i8x16 {
+    block0(v0: i64):
+        v1 = load.i8x16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16x8 {
+    block0(v0: i64):
+        v1 = load.i16x8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32x4 {
+    block0(v0: i64):
+        v1 = load.i32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64x2 {
+    block0(v0: i64):
+        v1 = load.i64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> f32x4 {
+    block0(v0: i64):
+        v1 = load.f32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> f64x2 {
+    block0(v0: i64):
+        v1 = load.f64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = uload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = sload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64, i8) {
+    block0(v0: i64, v1: i8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16) {
+    block0(v0: i64, v1: i16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32) {
+    block0(v0: i64, v1: i32):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i128) {
+    block0(v0: i64, v1: i128):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore8.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore16.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore32.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i8x16) {
+    block0(v0: i64, v1: i8x16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16x8) {
+    block0(v0: i64, v1: i16x8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32x4) {
+    block0(v0: i64, v1: i32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64x2) {
+    block0(v0: i64, v1: i64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f32x4) {
+    block0(v0: i64, v1: f32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f64x2) {
+    block0(v0: i64, v1: f64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        v2 = iadd v0, v1
+        return v2
+}
+
+function %f(i64) {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        v2 = iadd_imm v0, 1
+        store v2, v0
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = atomic_load.i64 big v0
+        return v1
+}
+
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        atomic_store.i64 big v1, v0
+        return
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big add v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big sub v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big and v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big nand v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big or v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xor v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xchg v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smax v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umax v1, v0
+        return v2
+}

--- a/cranelift/filetests/filetests/isa/riscv64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/big-endian.clif
@@ -1,0 +1,286 @@
+test compile expect-fail
+set enable_llvm_abi_extensions=true
+target riscv64
+
+;; Technically this could succeed (little- and big-endian treatment of
+;; a single byte is the same) but we have a blanket exclusion on all
+;; big-endian loads/stores for now.
+function %f(i64) -> i8 {
+    block0(v0: i64):
+        v1 = load.i8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16 {
+    block0(v0: i64):
+        v1 = load.i16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i128 {
+    block0(v0: i64):
+        v1 = load.i128 big v0+8
+        return v1
+}
+
+function %f(i64) -> i8x16 {
+    block0(v0: i64):
+        v1 = load.i8x16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16x8 {
+    block0(v0: i64):
+        v1 = load.i16x8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32x4 {
+    block0(v0: i64):
+        v1 = load.i32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64x2 {
+    block0(v0: i64):
+        v1 = load.i64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> f32x4 {
+    block0(v0: i64):
+        v1 = load.f32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> f64x2 {
+    block0(v0: i64):
+        v1 = load.f64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = uload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = sload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64, i8) {
+    block0(v0: i64, v1: i8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16) {
+    block0(v0: i64, v1: i16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32) {
+    block0(v0: i64, v1: i32):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i128) {
+    block0(v0: i64, v1: i128):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore8.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore16.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore32.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i8x16) {
+    block0(v0: i64, v1: i8x16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16x8) {
+    block0(v0: i64, v1: i16x8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32x4) {
+    block0(v0: i64, v1: i32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64x2) {
+    block0(v0: i64, v1: i64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f32x4) {
+    block0(v0: i64, v1: f32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f64x2) {
+    block0(v0: i64, v1: f64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        v2 = iadd v0, v1
+        return v2
+}
+
+function %f(i64) {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        v2 = iadd_imm v0, 1
+        store v2, v0
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = atomic_load.i64 big v0
+        return v1
+}
+
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        atomic_store.i64 big v1, v0
+        return
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big add v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big sub v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big and v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big nand v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big or v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xor v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xchg v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smax v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umax v1, v0
+        return v2
+}

--- a/cranelift/filetests/filetests/isa/x64/big-endian.clif
+++ b/cranelift/filetests/filetests/isa/x64/big-endian.clif
@@ -1,0 +1,286 @@
+test compile expect-fail
+set enable_llvm_abi_extensions=true
+target x86_64
+
+;; Technically this could succeed (little- and big-endian treatment of
+;; a single byte is the same) but we have a blanket exclusion on all
+;; big-endian loads/stores for now.
+function %f(i64) -> i8 {
+    block0(v0: i64):
+        v1 = load.i8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16 {
+    block0(v0: i64):
+        v1 = load.i16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i128 {
+    block0(v0: i64):
+        v1 = load.i128 big v0+8
+        return v1
+}
+
+function %f(i64) -> i8x16 {
+    block0(v0: i64):
+        v1 = load.i8x16 big v0+8
+        return v1
+}
+
+function %f(i64) -> i16x8 {
+    block0(v0: i64):
+        v1 = load.i16x8 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32x4 {
+    block0(v0: i64):
+        v1 = load.i32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64x2 {
+    block0(v0: i64):
+        v1 = load.i64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> f32x4 {
+    block0(v0: i64):
+        v1 = load.f32x4 big v0+8
+        return v1
+}
+
+function %f(i64) -> f64x2 {
+    block0(v0: i64):
+        v1 = load.f64x2 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload8.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = uload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i32 {
+    block0(v0: i64):
+        v1 = sload16.i32 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = uload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = sload32.i64 big v0+8
+        return v1
+}
+
+function %f(i64, i8) {
+    block0(v0: i64, v1: i8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16) {
+    block0(v0: i64, v1: i16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32) {
+    block0(v0: i64, v1: i32):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i128) {
+    block0(v0: i64, v1: i128):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore8.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore16.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        istore32.i64 big v1, v0+8
+        return
+}
+
+function %f(i64, i8x16) {
+    block0(v0: i64, v1: i8x16):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i16x8) {
+    block0(v0: i64, v1: i16x8):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i32x4) {
+    block0(v0: i64, v1: i32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, i64x2) {
+    block0(v0: i64, v1: i64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f32x4) {
+    block0(v0: i64, v1: f32x4):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64, f64x2) {
+    block0(v0: i64, v1: f64x2):
+        store big v1, v0+8
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = load.i64 big v0+8
+        v2 = iadd v0, v1
+        return v2
+}
+
+function %f(i64) {
+    block0(v0: i64):
+        v1 = load.i32 big v0+8
+        v2 = iadd_imm v0, 1
+        store v2, v0
+        return
+}
+
+function %f(i64) -> i64 {
+    block0(v0: i64):
+        v1 = atomic_load.i64 big v0
+        return v1
+}
+
+
+function %f(i64, i64) {
+    block0(v0: i64, v1: i64):
+        atomic_store.i64 big v1, v0
+        return
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big add v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big sub v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big and v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big nand v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big or v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xor v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big xchg v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umin v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big smax v1, v0
+        return v2
+}
+
+function %f(i64, i64) -> i64 {
+    block0(v0: i64, v1: i64):
+        v2 = atomic_rmw.i64 big umax v1, v0
+        return v2
+}


### PR DESCRIPTION
At some point during the development of the Cranelift backend infrastructure, to properly support big-endian architectures such as s390x, we added explicit endianness flags to `MemFlags`, which are given to all memory operations (e.g., loads, stores, and atomic ops). In s390x in particular, the backend carefully observes these flags, because a prominent use of Cranelift (as a Wasm backend) requires explicit little-endian behavior and the system is big-endian. However, all of our other supported ISAs are little-endian and so we did not implement explicit checks at the time, instead accepting all loads and stores as an artifact of our little-endian-only origins.

This PR adds explicit conditions to all ISLE rules that lower loads, stores, and atomic ops on x86-64, aarch64, and riscv64 to accept little or "native" (also little) endian operations only. Compilation of a big-endian operation will now result in a compilation error because no ISLE rule will match (no lowering exists). At some later point we could add these lowerings, but for now we at least do not miscompile.

Fixes #10861.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
