### PR TITLE
Store an `InstanceId` in `vm::Instance`

### DIFF
--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -10,10 +10,12 @@ use core::ops::{Index, IndexMut};
 // it only as `pub(crate)`. This avoids a ton of
 // crate-private-type-in-public-interface errors that aren't really too
 // interesting to deal with.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct InstanceId(pub(super) usize);
 
 impl InstanceId {
+    pub const INVALID: InstanceId = InstanceId(usize::MAX);
+
     pub fn from_index(idx: usize) -> InstanceId {
         InstanceId(idx)
     }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -17,6 +17,7 @@ impl InstanceId {
     pub const INVALID: InstanceId = InstanceId(usize::MAX);
 
     pub fn from_index(idx: usize) -> InstanceId {
+        debug_assert!(idx != Self::INVALID.0);
         InstanceId(idx)
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -13,10 +13,9 @@ use self::memory::create_memory;
 use self::table::create_table;
 use crate::prelude::*;
 use crate::runtime::vm::{
-    Imports, InstanceAllocationRequest, InstanceAllocator, ModuleRuntimeInfo,
-    OnDemandInstanceAllocator, SharedMemory, StorePtr, VMFunctionImport,
+    Imports, ModuleRuntimeInfo, OnDemandInstanceAllocator, SharedMemory, VMFunctionImport,
 };
-use crate::store::{InstanceId, StoreOpaque};
+use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque};
 use crate::{MemoryType, TableType};
 use alloc::sync::Arc;
 use core::any::Any;
@@ -33,24 +32,17 @@ fn create_handle(
     imports.functions = func_imports;
 
     unsafe {
-        let config = store.engine().config();
-        // Use the on-demand allocator when creating handles associated with host objects
-        // The configured instance allocator should only be used when creating module instances
-        // as we don't want host objects to count towards instance limits.
+        let allocator =
+            OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
         let module = Arc::new(module);
-        let runtime_info = &ModuleRuntimeInfo::bare_maybe_imported_func(module, one_signature);
-        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0, false);
-        let handle = allocator.allocate_module(InstanceAllocationRequest {
+        store.allocate_instance(
+            AllocateInstanceKind::Dummy {
+                allocator: &allocator,
+            },
+            &ModuleRuntimeInfo::bare_maybe_imported_func(module, one_signature),
             imports,
             host_state,
-            store: StorePtr::new(store.traitobj()),
-            runtime_info,
-            wmemcheck: false,
-            pkey: None,
-            tunables: store.engine().tunables(),
-        })?;
-
-        Ok(store.add_dummy_instance(handle))
+        )
     }
 }
 

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -3,11 +3,11 @@ use crate::memory::{LinearMemory, MemoryCreator};
 use crate::prelude::*;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::{
-    CompiledModuleId, Imports, InstanceAllocationRequest, InstanceAllocator, InstanceAllocatorImpl,
-    Memory, MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo, OnDemandInstanceAllocator,
-    RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, StorePtr, Table, TableAllocationIndex,
+    CompiledModuleId, InstanceAllocationRequest, InstanceAllocatorImpl, Memory,
+    MemoryAllocationIndex, MemoryBase, ModuleRuntimeInfo, OnDemandInstanceAllocator,
+    RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory, Table, TableAllocationIndex,
 };
-use crate::store::{InstanceId, StoreOpaque};
+use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque};
 use alloc::sync::Arc;
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, EntityIndex, HostPtr, Module, Tunables, VMOffsets,
@@ -47,27 +47,19 @@ pub fn create_memory(
     // associated with external objects. The configured instance allocator
     // should only be used when creating module instances as we don't want host
     // objects to count towards instance limits.
-    let runtime_info = &ModuleRuntimeInfo::bare_maybe_imported_func(Arc::new(module), None);
-    let host_state = Box::new(());
-    let imports = Imports::default();
-    let request = InstanceAllocationRequest {
-        imports,
-        host_state,
-        store: StorePtr::new(store.traitobj()),
-        runtime_info,
-        wmemcheck: false,
-        pkey: None,
-        tunables: store.engine().tunables(),
+    let allocator = SingleMemoryInstance {
+        preallocation,
+        ondemand: OnDemandInstanceAllocator::default(),
     };
-
     unsafe {
-        let handle = SingleMemoryInstance {
-            preallocation,
-            ondemand: OnDemandInstanceAllocator::default(),
-        }
-        .allocate_module(request)?;
-        let instance_id = store.add_dummy_instance(handle.clone());
-        Ok(instance_id)
+        store.allocate_instance(
+            AllocateInstanceKind::Dummy {
+                allocator: &allocator,
+            },
+            &ModuleRuntimeInfo::bare_maybe_imported_func(Arc::new(module), None),
+            Default::default(),
+            Box::new(()),
+        )
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -16,7 +16,7 @@ use crate::runtime::vm::{
     ModuleRuntimeInfo, SendSyncPtr, VMFunctionBody, VMGcRef, VMStore, VMStoreRawPtr, VmPtr, VmSafe,
     WasmFault,
 };
-use crate::store::{StoreInner, StoreOpaque};
+use crate::store::{InstanceId, StoreInner, StoreOpaque};
 use crate::{StoreContextMut, prelude::*};
 use alloc::sync::Arc;
 use core::alloc::Layout;
@@ -184,6 +184,9 @@ impl InstanceAndStore {
 /// values, whether or not they were created on the host or through a module.
 #[repr(C)] // ensure that the vmctx field is last.
 pub struct Instance {
+    /// The index, within a `Store` that this instance lives at
+    id: InstanceId,
+
     /// The runtime info (corresponding to the "compiled module"
     /// abstraction in higher layers) that is retained and needed for
     /// lazy initialization. This provides access to the underlying
@@ -317,6 +320,7 @@ impl Instance {
         ptr::write(
             ptr,
             Instance {
+                id: req.id,
                 runtime_info: req.runtime_info.clone(),
                 memories,
                 tables,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -6,7 +6,7 @@ use crate::runtime::vm::memory::Memory;
 use crate::runtime::vm::mpk::ProtectionKey;
 use crate::runtime::vm::table::Table;
 use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, VMFuncRef, VMGcRef, VMStore};
-use crate::store::{AutoAssertNoGc, StoreOpaque};
+use crate::store::{AutoAssertNoGc, InstanceId, StoreOpaque};
 use crate::vm::VMGlobalDefinition;
 use core::ptr::NonNull;
 use core::{any::Any, mem, ptr};
@@ -38,6 +38,10 @@ pub use self::pooling::{
 
 /// Represents a request for a new runtime instance.
 pub struct InstanceAllocationRequest<'a> {
+    /// The instance id that this will be assigned within the store once the
+    /// allocation has finished.
+    pub id: InstanceId,
+
     /// The info related to the compiled version of this module,
     /// needed for instantiation: function metadata, JIT code
     /// addresses, precomputed images for lazy memory and table


### PR DESCRIPTION
This commit is the beginning of an effort to clean up `unsafe`-related code about how we manage instances in the guts of Wasmtime. This doesn't have any affect on the public API but it's will result eventually in changes to the internals of types in the public API. This change is also done in preparation for simplifying `Stored<T>` and how it works in Wasmtime to avoid requiring allocations (aka pushing onto a `StoreData` vector) when converting from Wasmtime's internal representation to the external representation of tables, globals, memories, etc.

For now all this commit does is add `id: InstanceId` to the `vm::Instance` structure. This led to some refactorings to ensure that it's correctly listed by centralizing various methods to allocate an instance into one helper method which manages this configuration.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
