### PR TITLE
Update release builds from Ubuntu 16.04 to 18.04

### DIFF
--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates curl make git ninja-build
 RUN git config --global --add safe.directory '*'

--- a/ci/docker/armv7-linux/Dockerfile
+++ b/ci/docker/armv7-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-arm-linux-gnueabihf ca-certificates curl make git ninja-build
 RUN git config --global --add safe.directory '*'

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates curl make git ninja-build
 RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
We're getting quite a lot of spurious failures on CI due to a failure to install packages in Ubuntu 16.04 images. According to https://ubuntu.com/about/release-cycle Ubuntu 16.04 ended standard support 2 years ago and is nearing the end of "Pro Support". Overall it seems clear that this version is on the way out and mirrors are getting flakier, so this commit updates the images to 18.04 in an attempt to make CI more reliable under the assumption that mirrors for more recent versions of the distribution are more reliable.

This has the consequence though that release binaries are going to have a higher glibc requirement. That means if anyone is Downloading Wasmtime onto these older systems and running it then our precompiled binaries will no longer work.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
