### PR TITLE
Add a `DefinedTableIndex` to table imports/exports

### DIFF
--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -148,7 +148,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             size(trampoline_func_refs) = cmul(ret.num_trampolines, ret.ptr.size_of_vm_func_ref()),
             size(lowerings) = cmul(ret.num_lowerings, ret.ptr.size() * 2),
             size(memories) = cmul(ret.num_runtime_memories, ret.ptr.size()),
-            size(tables) = cmul(ret.num_runtime_tables, ret.size_of_vmtable()),
+            size(tables) = cmul(ret.num_runtime_tables, ret.size_of_vmtable_import()),
             size(reallocs) = cmul(ret.num_runtime_reallocs, ret.ptr.size()),
             size(callbacks) = cmul(ret.num_runtime_callbacks, ret.ptr.size()),
             size(post_returns) = cmul(ret.num_runtime_post_returns, ret.ptr.size()),
@@ -276,14 +276,14 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     #[inline]
     pub fn runtime_table(&self, index: RuntimeTableIndex) -> u32 {
         assert!(index.as_u32() < self.num_runtime_tables);
-        self.runtime_tables() + index.as_u32() * u32::from(self.size_of_vmtable())
+        self.runtime_tables() + index.as_u32() * u32::from(self.size_of_vmtable_import())
     }
 
-    /// Return the size of `VMTable`, used here to hold the pointers to
+    /// Return the size of `VMTableImport`, used here to hold the pointers to
     /// the `VMTableDefinition` and `VMContext`.
     #[inline]
-    pub fn size_of_vmtable(&self) -> u8 {
-        2 * self.pointer_size()
+    pub fn size_of_vmtable_import(&self) -> u8 {
+        3 * self.pointer_size()
     }
 
     /// The offset of the base of the `runtime_reallocs` field

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -25,7 +25,7 @@
 //      memories: [*mut VMMemoryDefinition; module.num_defined_memories],
 //      owned_memories: [VMMemoryDefinition; module.num_owned_memories],
 //      imported_functions: [VMFunctionImport; module.num_imported_functions],
-//      imported_tables: [VMTable; module.num_imported_tables],
+//      imported_tables: [VMTableImport; module.num_imported_tables],
 //      imported_globals: [VMGlobalImport; module.num_imported_globals],
 //      imported_tags: [VMTagImport; module.num_imported_tags],
 //      tables: [VMTableDefinition; module.num_defined_tables],
@@ -526,7 +526,7 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
             size(imported_functions)
                 = cmul(ret.num_imported_functions, ret.size_of_vmfunction_import()),
             size(imported_tables)
-                = cmul(ret.num_imported_tables, ret.size_of_vmtable()),
+                = cmul(ret.num_imported_tables, ret.size_of_vmtable_import()),
             size(imported_globals)
                 = cmul(ret.num_imported_globals, ret.size_of_vmglobal_import()),
             size(imported_tags)
@@ -584,24 +584,24 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 }
 
-/// Offsets for `VMTable`.
+/// Offsets for `VMTableImport`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `from` field.
     #[inline]
-    pub fn vmtable_from(&self) -> u8 {
+    pub fn vmtable_import_from(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
     #[inline]
-    pub fn vmtable_vmctx(&self) -> u8 {
+    pub fn vmtable_import_vmctx(&self) -> u8 {
         1 * self.pointer_size()
     }
 
-    /// Return the size of `VMTable`.
+    /// Return the size of `VMTableImport`.
     #[inline]
-    pub fn size_of_vmtable(&self) -> u8 {
-        2 * self.pointer_size()
+    pub fn size_of_vmtable_import(&self) -> u8 {
+        3 * self.pointer_size()
     }
 }
 
@@ -777,7 +777,8 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_tables);
-        self.vmctx_imported_tables_begin() + index.as_u32() * u32::from(self.size_of_vmtable())
+        self.vmctx_imported_tables_begin()
+            + index.as_u32() * u32::from(self.size_of_vmtable_import())
     }
 
     /// Return the offset to `VMMemoryImport` index `index`.
@@ -872,7 +873,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// `index`.
     #[inline]
     pub fn vmctx_vmtable_from(&self, index: TableIndex) -> u32 {
-        self.vmctx_vmtable_import(index) + u32::from(self.vmtable_from())
+        self.vmctx_vmtable_import(index) + u32::from(self.vmtable_import_from())
     }
 
     /// Return the offset to the `base` field in `VMTableDefinition` index `index`.

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -738,9 +738,12 @@ impl<'a> Instantiator<'a> {
             crate::runtime::vm::Export::Table(t) => t,
             _ => unreachable!(),
         };
-        self.data
-            .state
-            .set_runtime_table(table.index, export.definition, export.vmctx);
+        self.data.state.set_runtime_table(
+            table.index,
+            export.definition,
+            export.vmctx,
+            export.index,
+        );
     }
 
     fn build_imports<'b>(

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -410,11 +410,12 @@ impl Table {
         &data[self.0].table
     }
 
-    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTable {
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTableImport {
         let export = &store[self.0];
-        crate::runtime::vm::VMTable {
+        crate::runtime::vm::VMTableImport {
             from: export.definition.into(),
             vmctx: export.vmctx.into(),
+            index: export.index,
         }
     }
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -2,7 +2,7 @@ use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     Imports, ModuleRuntimeInfo, VMFuncRef, VMFunctionImport, VMGlobalImport, VMMemoryImport,
-    VMOpaqueContext, VMTable, VMTagImport,
+    VMOpaqueContext, VMTableImport, VMTagImport,
 };
 use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque, Stored};
 use crate::types::matching;
@@ -635,7 +635,7 @@ impl Instance {
 
 pub(crate) struct OwnedImports {
     functions: PrimaryMap<FuncIndex, VMFunctionImport>,
-    tables: PrimaryMap<TableIndex, VMTable>,
+    tables: PrimaryMap<TableIndex, VMTableImport>,
     memories: PrimaryMap<MemoryIndex, VMMemoryImport>,
     globals: PrimaryMap<GlobalIndex, VMGlobalImport>,
     tags: PrimaryMap<TagIndex, VMTagImport>,
@@ -718,9 +718,10 @@ impl OwnedImports {
                 });
             }
             crate::runtime::vm::Export::Table(t) => {
-                self.tables.push(VMTable {
+                self.tables.push(VMTableImport {
                     from: t.definition.into(),
                     vmctx: t.vmctx.into(),
+                    index: t.index,
                 });
             }
             crate::runtime::vm::Export::Memory(m) => {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -123,7 +123,7 @@ pub use crate::runtime::vm::vmcontext::VMTableDefinition;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMStoreContext, VMTable, VMTagImport, VMWasmCallFunction, ValRaw,
+    VMOpaqueContext, VMStoreContext, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -3,7 +3,9 @@ use crate::runtime::vm::vmcontext::{
     VMTagDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, DefinedTagIndex, Global, Memory, Table, Tag};
+use wasmtime_environ::{
+    DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, Global, Memory, Table, Tag,
+};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -54,6 +56,8 @@ pub struct ExportTable {
     pub vmctx: NonNull<VMContext>,
     /// The table declaration, used for compatibility checking.
     pub table: Table,
+    /// The index at which the table is defined within the `vmctx`.
+    pub index: DefinedTableIndex,
 }
 
 // See docs on send/sync for `ExportFunction` above.

--- a/crates/wasmtime/src/runtime/vm/imports.rs
+++ b/crates/wasmtime/src/runtime/vm/imports.rs
@@ -1,5 +1,5 @@
 use crate::runtime::vm::vmcontext::{
-    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTable, VMTagImport,
+    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport, VMTagImport,
 };
 
 /// Resolved import pointers.
@@ -19,7 +19,7 @@ pub struct Imports<'a> {
     pub functions: &'a [VMFunctionImport],
 
     /// Resolved addresses for imported tables.
-    pub tables: &'a [VMTable],
+    pub tables: &'a [VMTableImport],
 
     /// Resolved addresses for imported memories.
     pub memories: &'a [VMMemoryImport],


### PR DESCRIPTION
This commit extends `ExportTable` and `VMTableImport` (renamed from `VMTable`) to include a `DefinedTableIndex` in the same manner that memories carry their index they're defined at as well. The main goal of this change is to power the next change which will update how tables are stored in a store.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
