### PR TITLE
Add `VMContext` and `DefinedTagIndex` fields to tag-related imports/exports

### DIFF
--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -44,6 +44,8 @@ impl Tag {
         let export = &store[self.0];
         crate::runtime::vm::VMTagImport {
             from: export.definition.into(),
+            vmctx: export.vmctx.into(),
+            index: export.index,
         }
     }
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -733,6 +733,8 @@ impl OwnedImports {
             crate::runtime::vm::Export::Tag(t) => {
                 self.tags.push(VMTagImport {
                     from: t.definition.into(),
+                    vmctx: t.vmctx.into(),
+                    index: t.index,
                 });
             }
         }

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -3,7 +3,7 @@ use crate::runtime::vm::vmcontext::{
     VMTagDefinition,
 };
 use core::ptr::NonNull;
-use wasmtime_environ::{DefinedMemoryIndex, Global, Memory, Table, Tag};
+use wasmtime_environ::{DefinedMemoryIndex, DefinedTagIndex, Global, Memory, Table, Tag};
 
 /// The value of an export passed from one instance to another.
 pub enum Export {
@@ -116,8 +116,12 @@ impl From<ExportGlobal> for Export {
 pub struct ExportTag {
     /// The address of the global storage.
     pub definition: NonNull<VMTagDefinition>,
+    /// The instance that owns this tag.
+    pub vmctx: NonNull<VMContext>,
     /// The global declaration, used for compatibility checking.
     pub tag: Tag,
+    /// The index at which the tag is defined within the `vmctx`.
+    pub index: DefinedTagIndex,
 }
 
 // See docs on send/sync for `ExportFunction` above.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -721,13 +721,23 @@ impl Instance {
     }
 
     fn get_exported_tag(&mut self, index: TagIndex) -> ExportTag {
-        ExportTag {
-            definition: if let Some(def_index) = self.env_module().defined_tag_index(index) {
-                self.tag_ptr(def_index)
+        let tag = self.env_module().tags[index];
+        let (vmctx, definition, index) =
+            if let Some(def_index) = self.env_module().defined_tag_index(index) {
+                (self.vmctx(), self.tag_ptr(def_index), def_index)
             } else {
-                self.imported_tag(index).from.as_non_null()
-            },
-            tag: self.env_module().tags[index],
+                let import = self.imported_tag(index);
+                (
+                    import.vmctx.as_non_null(),
+                    import.from.as_non_null(),
+                    import.index,
+                )
+            };
+        ExportTag {
+            definition,
+            vmctx,
+            index,
+            tag,
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -15,8 +15,8 @@ use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use wasmtime_environ::{
-    BuiltinFunctionIndex, DefinedMemoryIndex, Unsigned, VMCONTEXT_MAGIC, VMSharedTypeIndex,
-    WasmHeapTopType, WasmValType,
+    BuiltinFunctionIndex, DefinedMemoryIndex, DefinedTagIndex, Unsigned, VMCONTEXT_MAGIC,
+    VMSharedTypeIndex, WasmHeapTopType, WasmValType,
 };
 
 /// A function pointer that exposes the array calling convention.
@@ -282,6 +282,12 @@ mod test_vmglobal_import {
 pub struct VMTagImport {
     /// A pointer to the imported tag description.
     pub from: VmPtr<VMTagDefinition>,
+
+    /// The instance that owns this tag.
+    pub vmctx: VmPtr<VMContext>,
+
+    /// The index of the tag in the containing `vmctx`.
+    pub index: DefinedTagIndex,
 }
 
 // SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.


### PR DESCRIPTION

Similar to memories/tables, will be used in subsequent commits.

Split out of https://github.com/bytecodealliance/wasmtime/pull/10870