### PR TITLE
winch: Fix order of fcmp comparison on AArch64

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -435,7 +435,6 @@ impl WastTest {
                     "misc_testsuite/component-model/strings.wast",
                     "misc_testsuite/winch/select.wast",
                     "misc_testsuite/sink-float-but-dont-trap.wast",
-                    "misc_testsuite/issue4840.wast",
                     "misc_testsuite/winch/use-innermost-frame.wast",
                 ];
 

--- a/tests/disas/winch/aarch64/f32_eq/const.wat
+++ b/tests/disas/winch/aarch64/f32_eq/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f32_eq/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_eq/params.wat
+++ b/tests/disas/winch/aarch64/f32_eq/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ge/const.wat
+++ b/tests/disas/winch/aarch64/f32_ge/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0xbf800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ge/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ge/params.wat
+++ b/tests/disas/winch/aarch64/f32_ge/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_gt/const.wat
+++ b/tests/disas/winch/aarch64/f32_gt/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0xbf800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_gt/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_gt/params.wat
+++ b/tests/disas/winch/aarch64/f32_gt/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_le/const.wat
+++ b/tests/disas/winch/aarch64/f32_le/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0xbf800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_le/locals.wat
+++ b/tests/disas/winch/aarch64/f32_le/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_le/params.wat
+++ b/tests/disas/winch/aarch64/f32_le/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_lt/const.wat
+++ b/tests/disas/winch/aarch64/f32_lt/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0xbf800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f32_lt/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_lt/params.wat
+++ b/tests/disas/winch/aarch64/f32_lt/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ne/const.wat
+++ b/tests/disas/winch/aarch64/f32_ne/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    s0, w16
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s1, w16
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f32_ne/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    s0, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f32_ne/params.wat
+++ b/tests/disas/winch/aarch64/f32_ne/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    s1, [x28]
 ;;       ldur    s0, [x28]
 ;;       ldur    s1, [x28, #4]
-;;       fcmp    s0, s1
+;;       fcmp    s1, s0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_eq/const.wat
+++ b/tests/disas/winch/aarch64/f64_eq/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_eq/locals.wat
+++ b/tests/disas/winch/aarch64/f64_eq/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_eq/params.wat
+++ b/tests/disas/winch/aarch64/f64_eq/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, eq
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ge/const.wat
+++ b/tests/disas/winch/aarch64/f64_ge/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #-0x4010000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ge/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ge/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ge/params.wat
+++ b/tests/disas/winch/aarch64/f64_ge/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ge
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_gt/const.wat
+++ b/tests/disas/winch/aarch64/f64_gt/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #-0x4010000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_gt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_gt/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_gt/params.wat
+++ b/tests/disas/winch/aarch64/f64_gt/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, gt
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_le/const.wat
+++ b/tests/disas/winch/aarch64/f64_le/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #-0x4010000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_le/locals.wat
+++ b/tests/disas/winch/aarch64/f64_le/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_le/params.wat
+++ b/tests/disas/winch/aarch64/f64_le/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ls
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_lt/const.wat
+++ b/tests/disas/winch/aarch64/f64_lt/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #-0x4010000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_lt/locals.wat
+++ b/tests/disas/winch/aarch64/f64_lt/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_lt/params.wat
+++ b/tests/disas/winch/aarch64/f64_lt/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, mi
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ne/const.wat
+++ b/tests/disas/winch/aarch64/f64_ne/const.wat
@@ -30,7 +30,7 @@
 ;;       fmov    d0, x16
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d1, x16
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ne/locals.wat
+++ b/tests/disas/winch/aarch64/f64_ne/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/f64_ne/params.wat
+++ b/tests/disas/winch/aarch64/f64_ne/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    d1, [x28]
 ;;       ldur    d0, [x28]
 ;;       ldur    d1, [x28, #8]
-;;       fcmp    d0, d1
+;;       fcmp    d1, d0
 ;;       cset    x0, ne
 ;;       add     x28, x28, #0x20
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
@@ -33,11 +33,11 @@
 ;;       b.vs    #0x94
 ;;   54: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x98
 ;;   64: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x9c
 ;;   74: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #0xcf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/const.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x8c
 ;;   50: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/locals.wat
@@ -32,11 +32,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x90
 ;;   54: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_u/params.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x8c
 ;;   50: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x4f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  w0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/const.wat
@@ -31,11 +31,11 @@
 ;;   50: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x98
 ;;   64: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x9c
 ;;   74: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/locals.wat
@@ -34,11 +34,11 @@
 ;;   54: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x9c
 ;;   68: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0xa0
 ;;   78: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_s/params.wat
@@ -31,11 +31,11 @@
 ;;   50: mov     x16, #0x200000
 ;;       movk    x16, #0xc1e0, lsl #48
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x98
 ;;   64: mov     x16, #0x41e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x9c
 ;;   74: fcvtzs  w0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/const.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x8c
 ;;   50: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/locals.wat
@@ -32,11 +32,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x90
 ;;   54: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x98
 ;;   70: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f64_u/params.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x8c
 ;;   50: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x41f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  w0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
@@ -33,11 +33,11 @@
 ;;       b.vs    #0x94
 ;;   54: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x98
 ;;   64: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x9c
 ;;   74: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #0xdf000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/const.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x8c
 ;;   50: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/locals.wat
@@ -32,11 +32,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x90
 ;;   54: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x98
 ;;   70: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_u/params.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    s0, s0
 ;;       b.vs    #0x8c
 ;;   50: fmov    s31, #-1.00000000
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x5f800000
 ;;       fmov    s31, w16
-;;       fcmp    s31, s0
+;;       fcmp    s0, s31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  x0, s0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
@@ -33,11 +33,11 @@
 ;;       b.vs    #0x94
 ;;   54: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x98
 ;;   64: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x9c
 ;;   74: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
@@ -30,11 +30,11 @@
 ;;       b.vs    #0x90
 ;;   50: mov     x16, #-0x3c20000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x98
 ;;   70: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/const.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x8c
 ;;   50: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/locals.wat
@@ -32,11 +32,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x90
 ;;   54: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x94
 ;;   60: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x98
 ;;   70: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_u/params.wat
@@ -29,11 +29,11 @@
 ;;       fcmp    d0, d0
 ;;       b.vs    #0x8c
 ;;   50: fmov    d31, #-1.00000000
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.le    #0x90
 ;;   5c: mov     x16, #0x43f0000000000000
 ;;       fmov    d31, x16
-;;       fcmp    d31, d0
+;;       fcmp    d0, d31
 ;;       b.ge    #0x94
 ;;   6c: fcvtzu  x0, d0
 ;;       add     x28, x28, #0x18

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -730,7 +730,7 @@ impl Assembler {
     }
 
     /// Float compare.
-    pub fn fcmp(&mut self, rm: Reg, rn: Reg, size: OperandSize) {
+    pub fn fcmp(&mut self, rn: Reg, rm: Reg, size: OperandSize) {
         self.emit(Inst::FpuCmp {
             size: size.into(),
             rn: rn.into(),


### PR DESCRIPTION
Fixes a typo to ensure that float-to-int conversions work correctly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
