### PR TITLE
Refactor float-to-int conversion bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "smallvec",
  "souper-ir",
  "target-lexicon",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -4383,6 +4384,7 @@ dependencies = [
  "thiserror 2.0.12",
  "wasmparser 0.230.0",
  "wasmtime-environ",
+ "wasmtime-math",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -4930,6 +4932,7 @@ dependencies = [
  "wasmparser 0.230.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
+ "wasmtime-math",
 ]
 
 [[package]]

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -43,6 +43,7 @@ regalloc2 = { workspace = true, features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 rustc-hash = { workspace = true }
+wasmtime-math = { workspace = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1605,34 +1605,6 @@ impl Inst {
     }
 }
 
-pub(crate) fn f32_cvt_to_int_bounds(signed: bool, out_bits: u32) -> (f32, f32) {
-    match (signed, out_bits) {
-        (true, 8) => (i8::min_value() as f32 - 1., i8::max_value() as f32 + 1.),
-        (true, 16) => (i16::min_value() as f32 - 1., i16::max_value() as f32 + 1.),
-        (true, 32) => (-2147483904.0, 2147483648.0),
-        (true, 64) => (-9223373136366403584.0, 9223372036854775808.0),
-        (false, 8) => (-1., u8::max_value() as f32 + 1.),
-        (false, 16) => (-1., u16::max_value() as f32 + 1.),
-        (false, 32) => (-1., 4294967296.0),
-        (false, 64) => (-1., 18446744073709551616.0),
-        _ => unreachable!(),
-    }
-}
-
-pub(crate) fn f64_cvt_to_int_bounds(signed: bool, out_bits: u32) -> (f64, f64) {
-    match (signed, out_bits) {
-        (true, 8) => (i8::min_value() as f64 - 1., i8::max_value() as f64 + 1.),
-        (true, 16) => (i16::min_value() as f64 - 1., i16::max_value() as f64 + 1.),
-        (true, 32) => (-2147483649.0, 2147483648.0),
-        (true, 64) => (-9223372036854777856.0, 9223372036854775808.0),
-        (false, 8) => (-1., u8::max_value() as f64 + 1.),
-        (false, 16) => (-1., u16::max_value() as f64 + 1.),
-        (false, 32) => (-1., 4294967296.0),
-        (false, 64) => (-1., 18446744073709551616.0),
-        _ => unreachable!(),
-    }
-}
-
 impl CsrRegOP {
     pub(crate) fn funct3(self) -> u32 {
         match self {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -25,6 +25,7 @@ use crate::{
 use regalloc2::PReg;
 use std::boxed::Box;
 use std::vec::Vec;
+use wasmtime_math::{f32_cvt_to_int_bounds, f64_cvt_to_int_bounds};
 
 type BoxCallInfo = Box<CallInfo<ExternalName>>;
 type BoxCallIndInfo = Box<CallInfo<Reg>>;

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -33,6 +33,7 @@ cfg-if = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }
 itertools = { workspace = true }
 pulley-interpreter = { workspace = true, optional = true }
+wasmtime-math = { workspace = true }
 
 [features]
 all-arch = ["cranelift-codegen/all-arch"]

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/const.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x10
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x10
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x90
-;;   50: mov     x16, #0xcf000000
+;;       b.vs    #0x94
+;;   50: mov     w16, #1
+;;       movk    w16, #0xcf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x4f000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x98
-;;   70: fcvtzs  w0, s0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/locals.wat
@@ -20,7 +20,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x90
+;;       b.lo    #0x94
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -30,23 +30,24 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x94
-;;   54: mov     x16, #0xcf000000
+;;       b.vs    #0x98
+;;   54: mov     w16, #1
+;;       movk    w16, #0xcf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x98
-;;   64: mov     x16, #0x4f000000
+;;       b.le    #0x9c
+;;   68: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x9c
-;;   74: fcvtzs  w0, s0
+;;       b.ge    #0xa0
+;;   78: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i32_trunc_f32_s/params.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x90
-;;   50: mov     x16, #0xcf000000
+;;       b.vs    #0x94
+;;   50: mov     w16, #1
+;;       movk    w16, #0xcf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x4f000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x4f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x98
-;;   70: fcvtzs  w0, s0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  w0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/const.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x10
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x10
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       mov     x16, #0x3f800000
 ;;       fmov    s0, w16
 ;;       fcmp    s0, s0
-;;       b.vs    #0x90
-;;   50: mov     x16, #0xdf000000
+;;       b.vs    #0x94
+;;   50: mov     w16, #1
+;;       movk    w16, #0xdf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x5f000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x98
-;;   70: fcvtzs  x0, s0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/locals.wat
@@ -20,7 +20,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x90
+;;       b.lo    #0x94
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -30,23 +30,24 @@
 ;;       stur    x16, [x28]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x94
-;;   54: mov     x16, #0xdf000000
+;;       b.vs    #0x98
+;;   54: mov     w16, #1
+;;       movk    w16, #0xdf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x98
-;;   64: mov     x16, #0x5f000000
+;;       b.le    #0x9c
+;;   68: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x9c
-;;   74: fcvtzs  x0, s0
+;;       b.ge    #0xa0
+;;   78: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f32_s/params.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       stur    s0, [x28, #4]
 ;;       ldur    s0, [x28, #4]
 ;;       fcmp    s0, s0
-;;       b.vs    #0x90
-;;   50: mov     x16, #0xdf000000
+;;       b.vs    #0x94
+;;   50: mov     w16, #1
+;;       movk    w16, #0xdf00, lsl #16
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x5f000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x5f000000
 ;;       fmov    s31, w16
 ;;       fcmp    s0, s31
-;;       b.ge    #0x98
-;;   70: fcvtzs  x0, s0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  x0, s0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/const.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x10
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x10
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       mov     x16, #0x3ff0000000000000
 ;;       fmov    d0, x16
 ;;       fcmp    d0, d0
-;;       b.vs    #0x90
-;;   50: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x94
+;;   50: mov     x16, #1
+;;       movk    x16, #0xc3e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x43e0000000000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.ge    #0x98
-;;   70: fcvtzs  x0, d0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/locals.wat
@@ -20,7 +20,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x90
+;;       b.lo    #0x94
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -30,23 +30,24 @@
 ;;       stur    x16, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x94
-;;   54: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x98
+;;   54: mov     x16, #1
+;;       movk    x16, #0xc3e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.le    #0x98
-;;   64: mov     x16, #0x43e0000000000000
+;;       b.le    #0x9c
+;;   68: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.ge    #0x9c
-;;   74: fcvtzs  x0, d0
+;;       b.ge    #0xa0
+;;   78: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/aarch64/i64_trunc_f64_s/params.wat
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x8c
+;;       b.lo    #0x90
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -27,23 +27,24 @@
 ;;       stur    d0, [x28]
 ;;       ldur    d0, [x28]
 ;;       fcmp    d0, d0
-;;       b.vs    #0x90
-;;   50: mov     x16, #-0x3c20000000000000
+;;       b.vs    #0x94
+;;   50: mov     x16, #1
+;;       movk    x16, #0xc3e0, lsl #48
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.le    #0x94
-;;   60: mov     x16, #0x43e0000000000000
+;;       b.le    #0x98
+;;   64: mov     x16, #0x43e0000000000000
 ;;       fmov    d31, x16
 ;;       fcmp    d0, d31
-;;       b.ge    #0x98
-;;   70: fcvtzs  x0, d0
+;;       b.ge    #0x9c
+;;   74: fcvtzs  x0, d0
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   8c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   90: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   94: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;   98: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -27,6 +27,7 @@ gimli = { workspace = true }
 wasmtime-environ = { workspace = true }
 wasmtime-cranelift = { workspace = true }
 thiserror = { workspace = true }
+wasmtime-math = { workspace = true }
 
 [features]
 x64 = ["cranelift-codegen/x86"]


### PR DESCRIPTION
This commit deduplicates a number of locations throughout the codebase that contain the bounds for float-to-int conversions. These bounds are relatively subtle and not easy to get right so it's probably best to keep them all centralized in one location.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
