### PR TITLE
winch: Fix rotate-left on aarch64

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -532,7 +532,6 @@ impl WastTest {
                     "spec_testsuite/f32_cmp.wast",
                     "spec_testsuite/f64_cmp.wast",
                     "spec_testsuite/func_ptrs.wast",
-                    "spec_testsuite/i64.wast",
                     "spec_testsuite/if.wast",
                     "spec_testsuite/imports.wast",
                     "spec_testsuite/local_set.wast",

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -27,7 +27,7 @@
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
-;;       sub     w0, w0, wzr
+;;       neg     w0, w0
 ;;       mov     x16, #0x200
 ;;       ror     w0, w0, w16
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i32_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/8_const.wat
@@ -27,7 +27,7 @@
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     w0, w16
-;;       sub     w0, w0, wzr
+;;       neg     w0, w0
 ;;       ror     w0, w0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/i32_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/locals.wat
@@ -44,7 +44,7 @@
 ;;       stur    w0, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       sub     w0, w0, wzr
+;;       neg     w0, w0
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i32_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    w3, [x28]
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
-;;       sub     w0, w0, wzr
+;;       neg     w0, w0
 ;;       ror     w1, w1, w0
 ;;       mov     w0, w1
 ;;       add     x28, x28, #0x18

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -27,7 +27,7 @@
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
-;;       sub     x0, x0, xzr
+;;       neg     x0, x0
 ;;       mov     x16, #0x200
 ;;       ror     x0, x0, x16
 ;;       add     x28, x28, #0x10

--- a/tests/disas/winch/aarch64/i64_rotl/8_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/8_const.wat
@@ -27,7 +27,7 @@
 ;;       stur    x1, [x28]
 ;;       mov     x16, #1
 ;;       mov     x0, x16
-;;       sub     x0, x0, xzr
+;;       neg     x0, x0
 ;;       ror     x0, x0, #2
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/i64_rotl/locals.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/locals.wat
@@ -45,7 +45,7 @@
 ;;       stur    x0, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       sub     x0, x0, xzr
+;;       neg     x0, x0
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20

--- a/tests/disas/winch/aarch64/i64_rotl/params.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/params.wat
@@ -29,7 +29,7 @@
 ;;       stur    x3, [x28]
 ;;       ldur    x0, [x28]
 ;;       ldur    x1, [x28, #8]
-;;       sub     x0, x0, xzr
+;;       neg     x0, x0
 ;;       ror     x1, x1, x0
 ;;       mov     x0, x1
 ;;       add     x28, x28, #0x20

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -1066,7 +1066,7 @@ impl Assembler {
             ShiftKind::Rotr => ALUOp::Extr,
             ShiftKind::Rotl => {
                 // neg(r) is sub(zero, r).
-                self.alu_rrr(ALUOp::Sub, regs::zero(), r, writable!(r), size);
+                self.alu_rrr(ALUOp::Sub, r, regs::zero(), writable!(r), size);
                 ALUOp::Extr
             }
         }


### PR DESCRIPTION
Swap the order of two operands to ensure that the correct calculation is done of negating a value in a register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
