### PR TITLE
x64: Flag unpack instructions as requiring aligned loads

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/unpack.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/unpack.rs
@@ -1,20 +1,20 @@
 use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex, rw};
+use crate::dsl::{align, fmt, inst, r, rex, rw};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
     vec![
         // Vector instructions.
-        inst("unpcklps", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0xF, 0x14]).r(), _64b | compat | sse),
-        inst("unpcklpd", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x14]).r(), _64b | compat | sse2),
-        inst("unpckhps", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0xF, 0x15]).r(), _64b | compat | sse),
-        inst("punpckhbw", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x68]).r(), _64b | compat | sse2),
-        inst("punpckhwd", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x69]).r(), _64b | compat | sse2),
-        inst("punpckhdq", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x6A]).r(), _64b | compat | sse2),
-        inst("punpcklwd", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x61]).r(), _64b | compat | sse2),
-        inst("punpcklqdq", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x6C]).r(), _64b | compat | sse2),
-        inst("punpcklbw", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x60]).r(), _64b | compat | sse2),
-        inst("punpckldq", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x62]).r(), _64b | compat | sse2),
-        inst("punpckhqdq", fmt("A", [rw(xmm1), r(xmm_m128)]), rex([0x66, 0x0F, 0x6D]).r(), _64b | compat | sse2),
+        inst("unpcklps", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0xF, 0x14]).r(), _64b | compat | sse),
+        inst("unpcklpd", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x14]).r(), _64b | compat | sse2),
+        inst("unpckhps", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0xF, 0x15]).r(), _64b | compat | sse),
+        inst("punpckhbw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x68]).r(), _64b | compat | sse2),
+        inst("punpckhwd", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x69]).r(), _64b | compat | sse2),
+        inst("punpckhdq", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x6A]).r(), _64b | compat | sse2),
+        inst("punpcklwd", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x61]).r(), _64b | compat | sse2),
+        inst("punpcklqdq", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x6C]).r(), _64b | compat | sse2),
+        inst("punpcklbw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x60]).r(), _64b | compat | sse2),
+        inst("punpckldq", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x62]).r(), _64b | compat | sse2),
+        inst("punpckhqdq", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x6D]).r(), _64b | compat | sse2),
     ]
 }

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -576,6 +576,7 @@ impl WastTest {
                         "misc_testsuite/simd/issue6725-no-egraph-panic.wast",
                         "misc_testsuite/simd/replace-lane-preserve.wast",
                         "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
+                        "misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast",
                         "misc_testsuite/winch/issue-10331.wast",
                         "misc_testsuite/winch/replace_lane.wast",
                         "spec_testsuite/simd_align.wast",

--- a/tests/disas/x64-sse-no-fold-unaligned-load.wat
+++ b/tests/disas/x64-sse-no-fold-unaligned-load.wat
@@ -1,0 +1,28 @@
+;;! target = 'x86_64'
+;;! test = 'compile'
+;;! flags = '-Ccranelift-has-ssse3'
+
+(module
+  (memory 1)
+  (func $punpckhbw (param v128 i32) (result v128)
+    local.get 0
+    (v128.load offset=1 (local.get 1))
+    i8x16.shuffle
+      0x08 0x18 0x09 0x19
+      0x0a 0x1a 0x0b 0x1b
+      0x0c 0x1c 0x0d 0x1d
+      0x0e 0x1e 0x0f 0x1f
+    return
+  )
+)
+
+;; wasm[0]::function[0]::punpckhbw:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movl    %edx, %r9d
+;;       addq    0x40(%rdi), %r9
+;;       movdqu  1(%r9), %xmm6
+;;       punpckhbw %xmm6, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq

--- a/tests/misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast
+++ b/tests/misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast
@@ -1,0 +1,16 @@
+(module
+  (memory 1)
+  (func (export "punpckhbw") (param v128 i32) (result v128)
+    local.get 0
+    (v128.load offset=1 (local.get 1))
+    i8x16.shuffle
+      0x08 0x18 0x09 0x19
+      0x0a 0x1a 0x0b 0x1b
+      0x0c 0x1c 0x0d 0x1d
+      0x0e 0x1e 0x0f 0x1f
+    return
+  )
+)
+
+(assert_return (invoke "punpckhbw" (v128.const i64x2 0 0) (i32.const 0))
+  (v128.const i64x2 0 0))

--- a/tests/misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast
+++ b/tests/misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast
@@ -1,3 +1,5 @@
+;;! simd = true
+
 (module
   (memory 1)
   (func (export "punpckhbw") (param v128 i32) (result v128)


### PR DESCRIPTION
This commit fixes a minor mistake from #10842 where the instructions weren't tagged as requiring aligned loads meaning that wasm loads could get folded into the instruction, producing unexpected alignment faults.

A test is added here which would trigger this a bit more quickly during fuzzing as fuzzing runs `*.wast` tests with a variety of codegen parameters, and would in theory eventually run this without AVX.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
