### PR TITLE
ci: Use Clang on Windows

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -64,6 +64,7 @@ else
 fi
 
 if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then
+  # Avoid emitting `/DEFAULTLIB:MSVCRT` into the static library by using clang.
   export CC=clang
   export CXX=clang++
 fi

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -63,6 +63,11 @@ else
   bin_flags="--features all-arch,component-model"
 fi
 
+if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then
+  export CC=clang
+  export CXX=clang++
+fi
+
 cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --features run
 
 mkdir -p target/c-api-build


### PR DESCRIPTION
I was running into linker warnings on Windows when linking a prebuilt `wasmtime.lib` against a debug version of my application:
```
LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library
```

But this didn't appear when using self-built `wasmtime.lib`, for either debug or release version of my app.

It turns out my build was built using Clang, while the prebuilt was using GCC.

Linker directives when built with GCC:
```
   Linker Directives
   -----------------
   /DEFAULTLIB:uuid.lib
   /DEFAULTLIB:uuid.lib
   /DEFAULTLIB:MSVCRT
   /DEFAULTLIB:OLDNAMES
```

Linker directives when built with Clang:
```
   Linker Directives
   -----------------
   /DEFAULTLIB:uuid.lib
   /DEFAULTLIB:uuid.lib
```

Please note that I'm not a Windows expert, I don't know if `/DEFAULTLIB:MSVCRT` is the correct option, but it _seems_ fine without it.

Feel free to let me know if this is not desired! (it might break something)

edit:
It seems to work the same in CI, now with Clang it only contains `/DEFAULTLIB:uuid.lib`.
Clang would need to be installed for the other targets in the case that this is something you want to go forward with.