### PR TITLE
x64: Use manual-defined names for ModR/M byte

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -10,27 +10,22 @@ enum ModRmStyle {
     /// This instruction does not use a ModR/M byte.
     None,
 
-    /// The R/M bits are encoded with `reg`, and the Reg/Opcode bits are encoded
-    /// with `digit`.
-    RegWithDigit { reg: dsl::Location, digit: u8 },
-
-    /// The R/M bits are encoded with `mem`, and the Reg/Opcode bits are encoded
-    /// with `digit`.
-    RegMemWithDigit { mem: dsl::Location, digit: u8 },
-
-    /// The R/M bits are encoded with `mem`, and the Reg/Opcode bits are encoded
+    /// The R/M bits are encoded with `rm` which is a `Gpr` or `Xmm` (it does
+    /// not have a "mem" possibility), and the Reg/Opcode bits are encoded
     /// with `reg`.
-    RegMem {
-        reg: dsl::Location,
-        mem: dsl::Location,
-    },
+    Reg { reg: ModRmReg, rm: dsl::Location },
 
-    /// The R/M bits are encoded with `reg`, and the Reg/Opcode bits are encoded
-    /// with `dst`.
-    RegReg {
-        reg: dsl::Location,
-        dst: dsl::Location,
-    },
+    /// The R/M bits are encoded with `rm` which is a `GprMem` or `XmmMem`, and
+    /// the Reg/Opcode bits are encoded with `reg`.
+    RegMem { reg: ModRmReg, rm: dsl::Location },
+}
+
+/// Different methods of encoding the Reg/Opcode bits in a ModR/M byte.
+enum ModRmReg {
+    /// A static set of bits is used.
+    Digit(u8),
+    /// A runtime-defined register is used with this field name.
+    Reg(dsl::Location),
 }
 
 impl dsl::Format {
@@ -137,7 +132,10 @@ impl dsl::Format {
                     fmtln!(f, "let digit = 0x{digit:x};");
                     fmtln!(f, "let dst = self.{dst}.enc();");
                     fmtln!(f, "let rex = RexPrefix::two_op(digit, dst, {bits});");
-                    ModRmStyle::RegWithDigit { reg: *dst, digit }
+                    ModRmStyle::Reg {
+                        reg: ModRmReg::Digit(digit),
+                        rm: *dst,
+                    }
                 }
                 None => {
                     assert!(rex.opcode_mod.is_some());
@@ -155,7 +153,10 @@ impl dsl::Format {
                 let digit = rex.unwrap_digit().unwrap();
                 fmtln!(f, "let digit = 0x{digit:x};");
                 fmtln!(f, "let rex = self.{mem}.as_rex_prefix(digit, {bits});");
-                ModRmStyle::RegMemWithDigit { mem: *mem, digit }
+                ModRmStyle::RegMem {
+                    reg: ModRmReg::Digit(digit),
+                    rm: *mem,
+                }
             }
             [Reg(reg), RegMem(mem) | Mem(mem)]
             | [Reg(reg), RegMem(mem), Imm(_)]
@@ -164,17 +165,17 @@ impl dsl::Format {
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let rex = self.{mem}.as_rex_prefix(reg, {bits});");
                 ModRmStyle::RegMem {
-                    reg: *reg,
-                    mem: *mem,
+                    reg: ModRmReg::Reg(*reg),
+                    rm: *mem,
                 }
             }
             [Reg(dst), Reg(src), Imm(_)] | [Reg(dst), Reg(src)] => {
                 fmtln!(f, "let reg = self.{dst}.enc();");
                 fmtln!(f, "let rm = self.{src}.enc();");
                 fmtln!(f, "let rex = RexPrefix::two_op(reg, rm, {bits});");
-                ModRmStyle::RegReg {
-                    reg: *src,
-                    dst: *dst,
+                ModRmStyle::Reg {
+                    reg: ModRmReg::Reg(*dst),
+                    rm: *src,
                 }
             }
             unknown => unimplemented!("unknown pattern: {unknown:?}"),
@@ -201,8 +202,8 @@ impl dsl::Format {
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
                 fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
                 ModRmStyle::RegMem {
-                    reg: *reg,
-                    mem: *rm,
+                    reg: ModRmReg::Reg(*reg),
+                    rm: *rm,
                 }
             }
             [Reg(reg), RegMem(rm), Imm(_)] => {
@@ -211,8 +212,8 @@ impl dsl::Format {
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
                 fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
                 ModRmStyle::RegMem {
-                    reg: *reg,
-                    mem: *rm,
+                    reg: ModRmReg::Reg(*reg),
+                    rm: *rm,
                 }
             }
             unknown => unimplemented!("unknown pattern: {unknown:?}"),
@@ -238,26 +239,22 @@ impl dsl::Format {
 
         match modrm_style {
             ModRmStyle::None => {}
-            ModRmStyle::RegWithDigit { reg, digit } => {
-                fmtln!(f, "let digit = 0x{digit:x};");
-                fmtln!(f, "self.{reg}.encode_modrm(buf, digit);");
-            }
-            ModRmStyle::RegMemWithDigit { mem, digit } => {
-                fmtln!(f, "let digit = 0x{digit:x};");
+            ModRmStyle::RegMem { reg, rm } => {
+                match reg {
+                    ModRmReg::Reg(reg) => fmtln!(f, "let reg = self.{reg}.enc();"),
+                    ModRmReg::Digit(digit) => fmtln!(f, "let reg = {digit:#x};"),
+                }
                 fmtln!(
                     f,
-                    "self.{mem}.encode_rex_suffixes(buf, off, digit, {bytes_at_end});"
+                    "self.{rm}.encode_rex_suffixes(buf, off, reg, {bytes_at_end});"
                 );
             }
-            ModRmStyle::RegMem { reg, mem } => {
-                fmtln!(f, "let reg = self.{reg}.enc();");
-                fmtln!(
-                    f,
-                    "self.{mem}.encode_rex_suffixes(buf, off, reg, {bytes_at_end});"
-                );
-            }
-            ModRmStyle::RegReg { reg, dst } => {
-                fmtln!(f, "self.{reg}.encode_modrm(buf, self.{dst}.enc());");
+            ModRmStyle::Reg { reg, rm } => {
+                match reg {
+                    ModRmReg::Reg(reg) => fmtln!(f, "let reg = self.{reg}.enc();"),
+                    ModRmReg::Digit(digit) => fmtln!(f, "let reg = {digit:#x};"),
+                }
+                fmtln!(f, "self.{rm}.encode_modrm(buf, reg);");
             }
         }
     }


### PR DESCRIPTION
Follow-up to #10889 with some comments from that PR

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
