### PR TITLE
Add a new `ComponentInstanceId` type

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -555,6 +555,7 @@ impl<'a> Instantiator<'a> {
                 instances: PrimaryMap::with_capacity(env_component.num_runtime_instances as usize),
                 component: component.clone(),
                 state: OwnedComponentInstance::new(
+                    store.store_data().components.next_component_instance_id(),
                     component.runtime_info(),
                     Arc::new(imported_resources),
                     store.traitobj(),
@@ -932,7 +933,7 @@ impl<T: 'static> InstancePre<T> {
             e
         })?;
         let data = Box::new(instantiator.data);
-        let instance = Instance(store.0.store_data_mut().insert(Some(data)));
+        let instance = Instance(store.0.store_data_mut().push_component_instance(data));
         store.0.push_component_instance(instance);
         Ok(instance)
     }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -131,6 +131,7 @@ pub use self::types::{ResourceType, Type};
 pub use self::values::Val;
 
 pub(crate) use self::resources::HostResourceData;
+pub(crate) use self::store::ComponentInstanceId;
 
 // Re-export wasm_wave crate so the compatible version of this dep doesn't have to be
 // tracked separately from wasmtime.

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -1,5 +1,7 @@
+use crate::component::instance::InstanceData;
 use crate::prelude::*;
-use crate::store::{StoreData, StoredData};
+use crate::runtime::vm::component::ComponentInstance;
+use crate::store::{StoreData, StoreOpaque, Stored, StoredData};
 
 macro_rules! component_store_data {
     ($($field:ident => $t:ty,)*) => (
@@ -25,5 +27,43 @@ macro_rules! component_store_data {
 
 component_store_data! {
     funcs => crate::component::func::FuncData,
-    instances => Option<Box<crate::component::instance::InstanceData>>,
+    instances => Option<Box<InstanceData>>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ComponentInstanceId(usize);
+
+impl ComponentInstanceId {
+    pub fn from_index(idx: usize) -> ComponentInstanceId {
+        ComponentInstanceId(idx)
+    }
+}
+
+impl ComponentStoreData {
+    pub fn next_component_instance_id(&self) -> ComponentInstanceId {
+        ComponentInstanceId(self.instances.len())
+    }
+}
+
+impl StoreData {
+    pub(crate) fn push_component_instance(
+        &mut self,
+        data: Box<InstanceData>,
+    ) -> Stored<Option<Box<InstanceData>>> {
+        assert_eq!(
+            data.instance().id(),
+            self.components.next_component_instance_id()
+        );
+        self.insert(Some(data))
+    }
+}
+
+impl StoreOpaque {
+    #[expect(dead_code, reason = "to be used soon")]
+    pub(crate) fn component_instance(&self, id: ComponentInstanceId) -> &ComponentInstance {
+        self.store_data().components.instances[id.0]
+            .as_ref()
+            .unwrap()
+            .instance()
+    }
 }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -307,7 +307,7 @@ impl<T> Stored<T> {
         self.store_id.assert_belongs_to(store)
     }
 
-    fn index(&self) -> usize {
+    pub(crate) fn index(&self) -> usize {
         self.index
     }
 }


### PR DESCRIPTION
This is intended to be similar to `InstanceId`, but used for components.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
