### PR TITLE
Refactor the representation of `Func`

### DIFF
--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -30,7 +30,7 @@ typedef struct wasmtime_func {
   /// this field is otherwise never zero.
   uint64_t store_id;
   /// Private field for Wasmtime, undefined if `store_id` is zero.
-  size_t __private;
+  void *__private;
 } wasmtime_func_t;
 
 /// \brief Representation of a table in Wasmtime.

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -182,9 +182,8 @@ impl Global {
                 Val::F64(f) => *definition.as_u64_mut() = f,
                 Val::V128(i) => definition.set_u128(i.into()),
                 Val::FuncRef(f) => {
-                    *definition.as_func_ref_mut() = f.map_or(ptr::null_mut(), |f| {
-                        f.vm_func_ref(&mut store).as_ptr().cast()
-                    });
+                    *definition.as_func_ref_mut() =
+                        f.map_or(ptr::null_mut(), |f| f.vm_func_ref(&store).as_ptr().cast());
                 }
                 Val::ExternRef(e) => {
                     let new = match e {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1227,7 +1227,7 @@ impl Func {
         unsafe {
             let f = self.vm_func_ref(store);
             VMFunctionImport {
-                // Note that this is a load-bearing assertion here, but is
+                // Note that this is a load-bearing `unwrap` here, but is
                 // never expected to trip at runtime. The general problem is
                 // that host functions do not have a `wasm_call` function so
                 // the `VMFuncRef` type has an optional pointer there. This is

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -4,11 +4,11 @@ use crate::runtime::vm::{
     ExportFunction, InterpreterRef, SendSyncPtr, StoreBox, VMArrayCallHostFuncContext, VMContext,
     VMFuncRef, VMFunctionImport, VMOpaqueContext, VMStoreContext,
 };
-use crate::store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored};
+use crate::store::{AutoAssertNoGc, StoreId, StoreOpaque};
 use crate::type_registry::RegisteredType;
 use crate::{
-    AsContext, AsContextMut, CallHook, Engine, Extern, FuncType, Instance, Module, ModuleExport,
-    Ref, StoreContext, StoreContextMut, Val, ValRaw, ValType,
+    AsContext, AsContextMut, CallHook, Engine, Extern, FuncType, Instance, ModuleExport, Ref,
+    StoreContext, StoreContextMut, Val, ValRaw, ValType,
 };
 use alloc::sync::Arc;
 use core::ffi::c_void;
@@ -261,77 +261,33 @@ impl NoFunc {
 /// # }
 /// ```
 #[derive(Copy, Clone, Debug)]
-#[repr(transparent)] // here for the C API
-pub struct Func(Stored<FuncData>);
+#[repr(C)] // here for the C API
+pub struct Func {
+    /// The store that the below pointer belongs to.
+    ///
+    /// It's only safe to look at the contents of the pointer below when the
+    /// `StoreOpaque` matching this id is in-scope.
+    store: StoreId,
 
-pub(crate) struct FuncData {
-    kind: FuncKind,
-
-    // A pointer to the in-store `VMFuncRef` for this function, if
-    // any.
-    //
-    // When a function is passed to Wasm but doesn't have a Wasm-to-native
-    // trampoline, we have to patch it in. But that requires mutating the
-    // `VMFuncRef`, and this function could be shared across
-    // threads. So we instead copy and pin the `VMFuncRef` into
-    // `StoreOpaque::func_refs`, where we can safely patch the field without
-    // worrying about synchronization and we hold a pointer to it here so we can
-    // reuse it rather than re-copy if it is passed to Wasm again.
-    in_store_func_ref: Option<SendSyncPtr<VMFuncRef>>,
-
-    // This is somewhat expensive to load from the `Engine` and in most
-    // optimized use cases (e.g. `TypedFunc`) it's not actually needed or it's
-    // only needed rarely. To handle that this is an optionally-contained field
-    // which is lazily loaded into as part of `Func::call`.
-    //
-    // Also note that this is intentionally placed behind a pointer to keep it
-    // small as `FuncData` instances are often inserted into a `Store`.
-    ty: Option<Box<FuncType>>,
+    /// The raw `VMFuncRef`, whose lifetime is bound to the store this func
+    /// belongs to.
+    ///
+    /// Note that this field has an `unsafe_*` prefix to discourage use of it.
+    /// This is only safe to read/use if `self.store` is validated to belong to
+    /// an ambiently provided `StoreOpaque` or similar. Use the
+    /// `self.func_ref()` method instead of this field to perform this check.
+    unsafe_func_ref: SendSyncPtr<VMFuncRef>,
 }
 
-/// The ways that a function can be created and referenced from within a store.
-enum FuncKind {
-    /// A function already owned by the store via some other means. This is
-    /// used, for example, when creating a `Func` from an instance's exported
-    /// function. The instance's `InstanceHandle` is already owned by the store
-    /// and we just have some pointers into that which represent how to call the
-    /// function.
-    StoreOwned { export: ExportFunction },
-
-    /// A function is shared across possibly other stores, hence the `Arc`. This
-    /// variant happens when a `Linker`-defined function is instantiated within
-    /// a `Store` (e.g. via `Linker::get` or similar APIs). The `Arc` here
-    /// indicates that there's some number of other stores holding this function
-    /// too, so dropping this may not deallocate the underlying
-    /// `InstanceHandle`.
-    SharedHost(Arc<HostFunc>),
-
-    /// A uniquely-owned host function within a `Store`. This comes about with
-    /// `Func::new` or similar APIs. The `HostFunc` internally owns the
-    /// `InstanceHandle` and that will get dropped when this `HostFunc` itself
-    /// is dropped.
-    ///
-    /// Note that this is intentionally placed behind a `Box` to minimize the
-    /// size of this enum since the most common variant for high-performance
-    /// situations is `SharedHost` and `StoreOwned`, so this ideally isn't
-    /// larger than those two.
-    Host(Box<HostFunc>),
-
-    /// A reference to a `HostFunc`, but one that's "rooted" in the `Store`
-    /// itself.
-    ///
-    /// This variant is created when an `InstancePre<T>` is instantiated in to a
-    /// `Store<T>`. In that situation the `InstancePre<T>` already has a list of
-    /// host functions that are packaged up in an `Arc`, so the `Arc<[T]>` is
-    /// cloned once into the `Store` to avoid each individual function requiring
-    /// an `Arc::clone`.
-    ///
-    /// The lifetime management of this type is `unsafe` because
-    /// `RootedHostFunc` is a small wrapper around `NonNull<HostFunc>`. To be
-    /// safe this is required that the memory of the host function is pinned
-    /// elsewhere (e.g. the `Arc` in the `Store`).
-    RootedHost(RootedHostFunc),
-}
+// Double-check that the C representation in `extern.h` matches our in-Rust
+// representation here in terms of size/alignment/etc.
+const _: () = {
+    #[repr(C)]
+    struct C(u64, *mut u8);
+    assert!(core::mem::size_of::<C>() == core::mem::size_of::<Func>());
+    assert!(core::mem::align_of::<C>() == core::mem::align_of::<Func>());
+    assert!(core::mem::offset_of!(Func, store) == 0);
+};
 
 macro_rules! for_each_function_signature {
     ($mac:ident) => {
@@ -575,8 +531,10 @@ impl Func {
         func_ref: NonNull<VMFuncRef>,
     ) -> Func {
         debug_assert!(func_ref.as_ref().type_index != VMSharedTypeIndex::default());
-        let export = ExportFunction { func_ref };
-        Func::from_wasmtime_function(export, store)
+        Func {
+            store: store.id(),
+            unsafe_func_ref: func_ref.into(),
+        }
     }
 
     /// Creates a new `Func` from the given Rust closure.
@@ -909,8 +867,7 @@ impl Func {
     /// Note that this is a somewhat expensive method since it requires taking a
     /// lock as well as cloning a type.
     pub(crate) fn load_ty(&self, store: &StoreOpaque) -> FuncType {
-        assert!(self.comes_from_same_store(store));
-        FuncType::from_shared_type_index(store.engine(), self.type_index(store.store_data()))
+        FuncType::from_shared_type_index(store.engine(), self.type_index(store))
     }
 
     /// Does this function match the given type?
@@ -942,27 +899,8 @@ impl Func {
         }
     }
 
-    /// Gets a reference to the `FuncType` for this function.
-    ///
-    /// Note that this returns both a reference to the type of this function as
-    /// well as a reference back to the store itself. This enables using the
-    /// `StoreOpaque` while the `FuncType` is also being used (from the
-    /// perspective of the borrow-checker) because otherwise the signature would
-    /// consider `StoreOpaque` borrowed mutable while `FuncType` is in use.
-    #[inline]
-    fn ty_ref<'a>(&self, store: &'a mut StoreOpaque) -> (&'a FuncType, &'a StoreOpaque) {
-        // If we haven't loaded our type into the store yet then do so lazily at
-        // this time.
-        if store.store_data()[self.0].ty.is_none() {
-            let ty = self.load_ty(store);
-            store.store_data_mut()[self.0].ty = Some(Box::new(ty));
-        }
-
-        (store.store_data()[self.0].ty.as_ref().unwrap(), store)
-    }
-
-    pub(crate) fn type_index(&self, data: &StoreData) -> VMSharedTypeIndex {
-        data[self.0].sig_index()
+    pub(crate) fn type_index(&self, data: &StoreOpaque) -> VMSharedTypeIndex {
+        unsafe { self.vm_func_ref(data).as_ref().type_index }
     }
 
     /// Invokes this function with the `params` given and writes returned values
@@ -1068,8 +1006,7 @@ impl Func {
         params_and_returns: *mut [ValRaw],
     ) -> Result<()> {
         let mut store = store.as_context_mut();
-        let data = &store.0.store_data()[self.0];
-        let func_ref = data.export().func_ref;
+        let func_ref = self.vm_func_ref(store.0);
         let params_and_returns = NonNull::new(params_and_returns).unwrap_or(NonNull::from(&mut []));
         Self::call_unchecked_raw(&mut store, func_ref, params_and_returns)
     }
@@ -1188,7 +1125,7 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> Result<bool> {
-        let (ty, opaque) = self.ty_ref(store.0);
+        let ty = self.load_ty(store.0);
         if ty.params().len() != params.len() {
             bail!(
                 "expected {} arguments, got {}",
@@ -1204,9 +1141,9 @@ impl Func {
             );
         }
         for (ty, arg) in ty.params().zip(params) {
-            arg.ensure_matches_ty(opaque, &ty)
+            arg.ensure_matches_ty(store.0, &ty)
                 .context("argument type mismatch")?;
-            if !arg.comes_from_same_store(opaque) {
+            if !arg.comes_from_same_store(store.0) {
                 bail!("cross-`Store` values are not currently supported");
             }
         }
@@ -1222,7 +1159,8 @@ impl Func {
             // to free up space.
             let num_gc_refs = ty.as_wasm_func_type().non_i31_gc_ref_params_count();
             if let Some(num_gc_refs) = core::num::NonZeroUsize::new(num_gc_refs) {
-                return Ok(opaque
+                return Ok(store
+                    .0
                     .optional_gc_store()
                     .is_some_and(|s| s.gc_heap.need_gc_before_entering_wasm(num_gc_refs)));
             }
@@ -1245,7 +1183,7 @@ impl Func {
         results: &mut [Val],
     ) -> Result<()> {
         // Store the argument values into `values_vec`.
-        let (ty, _) = self.ty_ref(store.0);
+        let ty = self.load_ty(store.0);
         let values_vec_size = params.len().max(ty.results().len());
         let mut values_vec = store.0.take_wasm_val_raw_storage();
         debug_assert!(values_vec.is_empty());
@@ -1264,7 +1202,7 @@ impl Func {
         }
 
         for ((i, slot), val) in results.iter_mut().enumerate().zip(&values_vec) {
-            let ty = self.ty_ref(store.0).0.results().nth(i).unwrap();
+            let ty = ty.results().nth(i).unwrap();
             *slot = unsafe { Val::from_raw(&mut *store, *val, ty) };
         }
         values_vec.truncate(0);
@@ -1273,80 +1211,47 @@ impl Func {
     }
 
     #[inline]
-    pub(crate) fn vm_func_ref(&self, store: &mut StoreOpaque) -> NonNull<VMFuncRef> {
-        let func_data = &mut store.store_data_mut()[self.0];
-        let func_ref = func_data.export().func_ref;
-        if unsafe { func_ref.as_ref().wasm_call.is_some() } {
-            return func_ref;
-        }
-
-        if let Some(in_store) = func_data.in_store_func_ref {
-            in_store.as_non_null()
-        } else {
-            unsafe {
-                // Move this uncommon/slow path out of line.
-                self.copy_func_ref_into_store_and_fill(store, func_ref)
-            }
-        }
-    }
-
-    unsafe fn copy_func_ref_into_store_and_fill(
-        &self,
-        store: &mut StoreOpaque,
-        func_ref: NonNull<VMFuncRef>,
-    ) -> NonNull<VMFuncRef> {
-        let func_ref = store.func_refs().push(func_ref.as_ref().clone());
-        store.store_data_mut()[self.0].in_store_func_ref = Some(SendSyncPtr::new(func_ref));
-        store.fill_func_refs();
-        func_ref
+    pub(crate) fn vm_func_ref(&self, store: &StoreOpaque) -> NonNull<VMFuncRef> {
+        self.store.assert_belongs_to(store.id());
+        self.unsafe_func_ref.as_non_null()
     }
 
     pub(crate) unsafe fn from_wasmtime_function(
         export: ExportFunction,
         store: &mut StoreOpaque,
     ) -> Self {
-        Func::from_func_kind(FuncKind::StoreOwned { export }, store)
+        Self::from_vm_func_ref(store, export.func_ref)
     }
 
-    fn from_func_kind(kind: FuncKind, store: &mut StoreOpaque) -> Self {
-        Func(store.store_data_mut().insert(FuncData {
-            kind,
-            in_store_func_ref: None,
-            ty: None,
-        }))
-    }
-
-    pub(crate) fn vmimport(&self, store: &mut StoreOpaque, module: &Module) -> VMFunctionImport {
+    pub(crate) fn vmimport(&self, store: &mut StoreOpaque) -> VMFunctionImport {
         unsafe {
-            let f = {
-                let func_data = &mut store.store_data_mut()[self.0];
-                // If we already patched this `funcref.wasm_call` and saved a
-                // copy in the store, use the patched version. Otherwise, use
-                // the potentially un-patched version.
-                if let Some(func_ref) = func_data.in_store_func_ref {
-                    func_ref.as_non_null()
-                } else {
-                    func_data.export().func_ref
-                }
-            };
+            let f = self.vm_func_ref(store);
             VMFunctionImport {
-                wasm_call: if let Some(wasm_call) = f.as_ref().wasm_call {
-                    wasm_call
-                } else {
-                    // Assert that this is a array-call function, since those
-                    // are the only ones that could be missing a `wasm_call`
-                    // trampoline.
-                    let _ = VMArrayCallHostFuncContext::from_opaque(f.as_ref().vmctx.as_non_null());
-
-                    let sig = self.type_index(store.store_data());
-                    module
-                        .wasm_to_array_trampoline(sig)
-                        .expect(
-                            "if the wasm is importing a function of a given type, it must have the \
-                         type's trampoline",
-                        )
-                        .into()
-                },
+                // Note that this is a load-bearing assertion here, but is
+                // never expected to trip at runtime. The general problem is
+                // that host functions do not have a `wasm_call` function so
+                // the `VMFuncRef` type has an optional pointer there. This is
+                // only able to be filled out when a function is "paired" with
+                // a module where trampolines are present to fill out
+                // `wasm_call` pointers.
+                //
+                // This pairing of modules doesn't happen explicitly but is
+                // instead managed lazily throughout Wasmtime. Specifically the
+                // way this works is one of:
+                //
+                // * When a host function is created the store's list of
+                //   modules are searched for a wasm trampoline. If not found
+                //   the `wasm_call` field is left blank.
+                //
+                // * When a module instantiation happens, which uses this
+                //   function, the module will be used to fill any outstanding
+                //   holes that it has trampolines for.
+                //
+                // This means that by the time we get to this point any
+                // relevant holes should be filled out. Thus if this panic
+                // actually triggers then it's indicative of a missing `fill`
+                // call somewhere else.
+                wasm_call: f.as_ref().wasm_call.unwrap(),
                 array_call: f.as_ref().array_call,
                 vmctx: f.as_ref().vmctx,
             }
@@ -1354,7 +1259,7 @@ impl Func {
     }
 
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
-        store.store_data().contains(self.0)
+        self.store == store.id()
     }
 
     fn invoke_host_func_for_wasm<T>(
@@ -2570,8 +2475,9 @@ impl HostFunc {
     /// this `HostFunc` was first created.
     pub unsafe fn to_func(self: &Arc<Self>, store: &mut StoreOpaque) -> Func {
         self.validate_store(store);
-        let me = self.clone();
-        Func::from_func_kind(FuncKind::SharedHost(me), store)
+        let (funcrefs, modules) = store.func_refs_and_modules();
+        let funcref = funcrefs.push_arc_host(self.clone(), modules);
+        Func::from_vm_func_ref(store, funcref)
     }
 
     /// Inserts this `HostFunc` into a `Store`, returning the `Func` pointing to
@@ -2602,21 +2508,24 @@ impl HostFunc {
     ) -> Func {
         self.validate_store(store);
 
-        if rooted_func_ref.is_some() {
-            debug_assert!(self.func_ref().wasm_call.is_none());
-            debug_assert!(matches!(self.ctx, HostContext::Array(_)));
+        match rooted_func_ref {
+            Some(funcref) => {
+                debug_assert!(funcref.as_ref().wasm_call.is_some());
+                Func::from_vm_func_ref(store, funcref)
+            }
+            None => {
+                debug_assert!(self.func_ref().wasm_call.is_some());
+                Func::from_vm_func_ref(store, self.func_ref().into())
+            }
         }
-
-        Func::from_func_kind(
-            FuncKind::RootedHost(RootedHostFunc::new(self, rooted_func_ref)),
-            store,
-        )
     }
 
     /// Same as [`HostFunc::to_func`], different ownership.
     unsafe fn into_func(self, store: &mut StoreOpaque) -> Func {
         self.validate_store(store);
-        Func::from_func_kind(FuncKind::Host(Box::new(self)), store)
+        let (funcrefs, modules) = store.func_refs_and_modules();
+        let funcref = funcrefs.push_box_host(Box::new(self), modules);
+        Func::from_vm_func_ref(store, funcref)
     }
 
     fn validate_store(&self, store: &mut StoreOpaque) {
@@ -2643,98 +2552,12 @@ impl HostFunc {
     pub(crate) fn host_ctx(&self) -> &HostContext {
         &self.ctx
     }
-
-    fn export_func(&self) -> ExportFunction {
-        ExportFunction {
-            func_ref: NonNull::from(self.func_ref()),
-        }
-    }
-}
-
-impl FuncData {
-    #[inline]
-    fn export(&self) -> ExportFunction {
-        self.kind.export()
-    }
-
-    pub(crate) fn sig_index(&self) -> VMSharedTypeIndex {
-        unsafe { self.export().func_ref.as_ref().type_index }
-    }
-}
-
-impl FuncKind {
-    #[inline]
-    fn export(&self) -> ExportFunction {
-        match self {
-            FuncKind::StoreOwned { export, .. } => *export,
-            FuncKind::SharedHost(host) => host.export_func(),
-            FuncKind::RootedHost(rooted) => ExportFunction {
-                func_ref: NonNull::from(rooted.func_ref()),
-            },
-            FuncKind::Host(host) => host.export_func(),
-        }
-    }
-}
-
-use self::rooted::*;
-
-/// An inner module is used here to force unsafe construction of
-/// `RootedHostFunc` instead of accidentally safely allowing access to its
-/// constructor.
-mod rooted {
-    use super::HostFunc;
-    use crate::runtime::vm::{SendSyncPtr, VMFuncRef};
-    use alloc::sync::Arc;
-    use core::ptr::NonNull;
-
-    /// A variant of a pointer-to-a-host-function used in `FuncKind::RootedHost`
-    /// above.
-    ///
-    /// For more documentation see `FuncKind::RootedHost`, `InstancePre`, and
-    /// `HostFunc::to_func_store_rooted`.
-    pub(crate) struct RootedHostFunc {
-        func: SendSyncPtr<HostFunc>,
-        func_ref: Option<SendSyncPtr<VMFuncRef>>,
-    }
-
-    impl RootedHostFunc {
-        /// Note that this is `unsafe` because this wrapper type allows safe
-        /// access to the pointer given at any time, including outside the
-        /// window of validity of `func`, so callers must not use the return
-        /// value past the lifetime of the provided `func`.
-        ///
-        /// Similarly, callers must ensure that the given `func_ref` is valid
-        /// for the lifetime of the return value.
-        pub(crate) unsafe fn new(
-            func: &Arc<HostFunc>,
-            func_ref: Option<NonNull<VMFuncRef>>,
-        ) -> RootedHostFunc {
-            RootedHostFunc {
-                func: NonNull::from(&**func).into(),
-                func_ref: func_ref.map(|p| p.into()),
-            }
-        }
-
-        pub(crate) fn func(&self) -> &HostFunc {
-            // Safety invariants are upheld by the `RootedHostFunc::new` caller.
-            unsafe { self.func.as_ref() }
-        }
-
-        pub(crate) fn func_ref(&self) -> &VMFuncRef {
-            if let Some(f) = self.func_ref {
-                // Safety invariants are upheld by the `RootedHostFunc::new` caller.
-                unsafe { f.as_ref() }
-            } else {
-                self.func().func_ref()
-            }
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Store;
+    use crate::{Module, Store};
 
     #[test]
     fn hash_key_is_stable_across_duplicate_store_data_entries() -> Result<()> {

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -546,7 +546,7 @@ unsafe impl WasmTy for Func {
 
     #[inline]
     fn compatible_with_store(&self, store: &StoreOpaque) -> bool {
-        store.store_data().contains(self.0)
+        self.store == store.id()
     }
 
     #[inline]
@@ -584,7 +584,7 @@ unsafe impl WasmTy for Option<Func> {
     #[inline]
     fn compatible_with_store(&self, store: &StoreOpaque) -> bool {
         if let Some(f) = self {
-            store.store_data().contains(f.0)
+            f.compatible_with_store(store)
         } else {
             true
         }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -166,13 +166,28 @@ impl Instance {
                 bail!("cross-`Store` instantiation is not currently supported");
             }
         }
+
         typecheck(module, imports, |cx, ty, item| {
             let item = DefinitionType::from(store, item);
             cx.definition(ty, &item)
         })?;
+
+        // When pushing functions into `OwnedImports` it's required that their
+        // `wasm_call` fields are all filled out. This `module` is guaranteed
+        // to have any trampolines necessary for functions so register the
+        // module with the store and then attempt to fill out any outstanding
+        // holes.
+        //
+        // Note that under normal operation this shouldn't do much as the list
+        // of funcs-with-holes should generally be empty. As a result the
+        // process of filling this out is not super optimized at this point.
+        store.modules_mut().register_module(module);
+        let (funcrefs, modules) = store.func_refs_and_modules();
+        funcrefs.fill(modules);
+
         let mut owned_imports = OwnedImports::new(module);
         for import in imports {
-            owned_imports.push(import, store, module);
+            owned_imports.push(import, store);
         }
         Ok(owned_imports)
     }
@@ -265,7 +280,6 @@ impl Instance {
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
         let module_id = store.modules_mut().register_module(module);
-        store.fill_func_refs();
 
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an
@@ -676,10 +690,10 @@ impl OwnedImports {
         self.tags.clear();
     }
 
-    fn push(&mut self, item: &Extern, store: &mut StoreOpaque, module: &Module) {
+    fn push(&mut self, item: &Extern, store: &mut StoreOpaque) {
         match item {
             Extern::Func(i) => {
-                self.functions.push(i.vmimport(store, module));
+                self.functions.push(i.vmimport(store));
             }
             Extern::Global(i) => {
                 self.globals.push(i.vmimport(store));
@@ -927,19 +941,25 @@ fn pre_instantiate_raw(
     host_funcs: usize,
     func_refs: &Arc<[VMFuncRef]>,
 ) -> Result<OwnedImports> {
+    // Register this module and use it to fill out any funcref wasm_call holes
+    // we can. For more comments on this see `typecheck_externs`.
+    store.modules_mut().register_module(module);
+    let (funcrefs, modules) = store.func_refs_and_modules();
+    funcrefs.fill(modules);
+
     if host_funcs > 0 {
         // Any linker-defined function of the `Definition::HostFunc` variant
         // will insert a function into the store automatically as part of
         // instantiation, so reserve space here to make insertion more efficient
         // as it won't have to realloc during the instantiation.
-        store.store_data_mut().reserve_funcs(host_funcs);
+        funcrefs.reserve_storage(host_funcs);
 
         // The usage of `to_extern_store_rooted` requires that the items are
         // rooted via another means, which happens here by cloning the list of
         // items into the store once. This avoids cloning each individual item
         // below.
-        store.push_rooted_funcs(items.clone());
-        store.push_instance_pre_func_refs(func_refs.clone());
+        funcrefs.push_instance_pre_definitions(items.clone());
+        funcrefs.push_instance_pre_func_refs(func_refs.clone());
     }
 
     let mut func_refs = func_refs.iter().map(|f| NonNull::from(f));
@@ -966,7 +986,7 @@ fn pre_instantiate_raw(
                 .into()
             },
         };
-        imports.push(&item, store, module);
+        imports.push(&item, store);
     }
 
     Ok(imports)

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1421,7 +1421,7 @@ impl DefinitionType {
     pub(crate) fn from(store: &StoreOpaque, item: &Extern) -> DefinitionType {
         let data = store.store_data();
         match item {
-            Extern::Func(f) => DefinitionType::Func(f.type_index(data)),
+            Extern::Func(f) => DefinitionType::Func(f.type_index(store)),
             Extern::Table(t) => DefinitionType::Table(*t.wasmtime_ty(data), t.internal_size(store)),
             Extern::Global(t) => DefinitionType::Global(*t.wasmtime_ty(data)),
             Extern::Memory(t) => {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -78,7 +78,6 @@
 
 use crate::RootSet;
 use crate::instance::InstanceData;
-use crate::linker::Definition;
 use crate::module::RegisteredModuleId;
 use crate::prelude::*;
 #[cfg(feature = "gc")]
@@ -358,11 +357,7 @@ pub struct StoreOpaque {
     fuel_yield_interval: Option<NonZeroU64>,
     /// Indexed data within this `Store`, used to store information about
     /// globals, functions, memories, etc.
-    ///
-    /// Note that this is `ManuallyDrop` because it needs to be dropped before
-    /// `rooted_host_funcs` below. This structure contains pointers which are
-    /// otherwise kept alive by the `Arc` references in `rooted_host_funcs`.
-    store_data: ManuallyDrop<StoreData>,
+    store_data: StoreData,
     traitobj: StorePtr,
     default_caller_vmctx: SendSyncPtr<VMContext>,
 
@@ -373,20 +368,6 @@ pub struct StoreOpaque {
     /// Same as `hostcall_val_storage`, but for the direction of the host
     /// calling wasm.
     wasm_val_raw_storage: Vec<ValRaw>,
-
-    /// A list of lists of definitions which have been used to instantiate
-    /// within this `Store`.
-    ///
-    /// Note that not all instantiations end up pushing to this list. At the
-    /// time of this writing only the `InstancePre<T>` type will push to this
-    /// list. Pushes to this list are typically accompanied with
-    /// `HostFunc::to_func_store_rooted` to clone an `Arc` here once which
-    /// preserves a strong reference to the `Arc` for each `HostFunc` stored
-    /// within the list of `Definition`s.
-    ///
-    /// Note that this is `ManuallyDrop` as it must be dropped after
-    /// `store_data` above, where the function pointers are stored.
-    rooted_host_funcs: ManuallyDrop<Vec<Arc<[Definition]>>>,
 
     /// Keep track of what protection key is being used during allocation so
     /// that the right memory pages can be enabled when entering WebAssembly
@@ -567,12 +548,11 @@ impl<T> Store<T> {
             async_state: AsyncState::default(),
             fuel_reserve: 0,
             fuel_yield_interval: None,
-            store_data: ManuallyDrop::new(store_data),
+            store_data,
             traitobj: StorePtr::empty(),
             default_caller_vmctx: SendSyncPtr::new(NonNull::dangling()),
             hostcall_val_storage: Vec::new(),
             wasm_val_raw_storage: Vec::new(),
-            rooted_host_funcs: ManuallyDrop::new(Vec::new()),
             pkey,
             #[cfg(feature = "component-model")]
             component_host_table: Default::default(),
@@ -1236,16 +1216,8 @@ impl StoreOpaque {
         &mut self.modules
     }
 
-    pub(crate) fn func_refs(&mut self) -> &mut FuncRefs {
-        &mut self.func_refs
-    }
-
-    pub(crate) fn fill_func_refs(&mut self) {
-        self.func_refs.fill(&self.modules);
-    }
-
-    pub(crate) fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[VMFuncRef]>) {
-        self.func_refs.push_instance_pre_func_refs(func_refs);
+    pub(crate) fn func_refs_and_modules(&mut self) -> (&mut FuncRefs, &ModuleRegistry) {
+        (&mut self.func_refs, &self.modules)
     }
 
     pub(crate) fn host_globals(&mut self) -> &mut Vec<StoreBox<VMHostGlobalContext>> {
@@ -1781,10 +1753,6 @@ impl StoreOpaque {
         if storage.capacity() > self.wasm_val_raw_storage.capacity() {
             self.wasm_val_raw_storage = storage;
         }
-    }
-
-    pub(crate) fn push_rooted_funcs(&mut self, funcs: Arc<[Definition]>) {
-        self.rooted_host_funcs.push(funcs);
     }
 
     /// Translates a WebAssembly fault at the native `pc` and native `addr` to a
@@ -2355,11 +2323,6 @@ impl Drop for StoreOpaque {
                     allocator.decrement_component_instance_count();
                 }
             }
-
-            // See documentation for these fields on `StoreOpaque` for why they
-            // must be dropped in this order.
-            ManuallyDrop::drop(&mut self.store_data);
-            ManuallyDrop::drop(&mut self.rooted_host_funcs);
         }
     }
 }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -25,7 +25,6 @@ impl InstanceId {
 
 pub struct StoreData {
     id: StoreId,
-    funcs: Vec<crate::func::FuncData>,
     tables: Vec<crate::runtime::vm::ExportTable>,
     globals: Vec<crate::runtime::vm::ExportGlobal>,
     instances: Vec<crate::instance::InstanceData>,
@@ -51,7 +50,6 @@ macro_rules! impl_store_data {
 }
 
 impl_store_data! {
-    funcs => crate::func::FuncData,
     tables => crate::runtime::vm::ExportTable,
     globals => crate::runtime::vm::ExportGlobal,
     instances => crate::instance::InstanceData,
@@ -62,7 +60,6 @@ impl StoreData {
     pub fn new() -> StoreData {
         StoreData {
             id: StoreId::allocate(),
-            funcs: Vec::new(),
             tables: Vec::new(),
             globals: Vec::new(),
             instances: Vec::new(),
@@ -112,10 +109,6 @@ impl StoreData {
     {
         let id = self.id;
         (0..T::list(self).len()).map(move |i| Stored::new(id, i))
-    }
-
-    pub(crate) fn reserve_funcs(&mut self, count: usize) {
-        self.funcs.reserve(count);
     }
 }
 

--- a/crates/wasmtime/src/runtime/store/func_refs.rs
+++ b/crates/wasmtime/src/runtime/store/func_refs.rs
@@ -1,8 +1,10 @@
 //! Lifetime management of `VMFuncRef`s inside of stores, and filling in their
 //! trampolines.
 
+use crate::Definition;
 use crate::module::ModuleRegistry;
 use crate::prelude::*;
+use crate::runtime::HostFunc;
 use crate::runtime::vm::{SendSyncPtr, VMArrayCallHostFuncContext, VMFuncRef};
 use alloc::sync::Arc;
 use core::ptr::NonNull;
@@ -22,10 +24,57 @@ pub struct FuncRefs {
     /// in.
     with_holes: Vec<SendSyncPtr<VMFuncRef>>,
 
+    /// General-purpose storage of "function things" that need to live as long
+    /// as the entire store.
+    storage: Vec<Storage>,
+}
+
+/// Various items to place in `FuncRefs::storage`
+///
+/// Note that each field has its own heap-level indirection to be resistant to
+/// `FuncRefs::storage` having its own backing storage reallocated.
+enum Storage {
+    /// Pinned arbitrary `Linker` definitions that must be kept alive for the
+    /// entire duration of the store. This can include host functions, funcrefs
+    /// inside them, etc.
+    InstancePreDefinitions {
+        #[expect(dead_code, reason = "only here to keep the original value alive")]
+        defs: Arc<[Definition]>,
+    },
+
     /// Pinned `VMFuncRef`s that had their `wasm_call` field
     /// pre-patched when constructing an `InstancePre`, and which we need to
     /// keep alive for our owning store's lifetime.
-    instance_pre_func_refs: Vec<Arc<[VMFuncRef]>>,
+    InstancePreFuncRefs {
+        #[expect(dead_code, reason = "only here to keep the original value alive")]
+        funcs: Arc<[VMFuncRef]>,
+    },
+
+    /// A uniquely-owned host function within a `Store`. This comes about with
+    /// `Func::new` or similar APIs. The `HostFunc` internally owns the
+    /// `InstanceHandle` and that will get dropped when this `HostFunc` itself
+    /// is dropped.
+    ///
+    /// Note that this contains the vmctx that the `VMFuncRef` points to for
+    /// this host function.
+    BoxHost {
+        #[expect(dead_code, reason = "only here to keep the original value alive")]
+        func: Box<HostFunc>,
+    },
+
+    /// A function is shared across possibly other stores, hence the `Arc`. This
+    /// variant happens when a `Linker`-defined function is instantiated within
+    /// a `Store` (e.g. via `Linker::get` or similar APIs). The `Arc` here
+    /// indicates that there's some number of other stores holding this function
+    /// too, so dropping this may not deallocate the underlying
+    /// `InstanceHandle`.
+    ///
+    /// Note that this contains the vmctx that the `VMFuncRef` points to for
+    /// this host function.
+    ArcHost {
+        #[expect(dead_code, reason = "only here to keep the original value alive")]
+        func: Arc<HostFunc>,
+    },
 }
 
 use send_sync_bump::SendSyncBump;
@@ -53,40 +102,108 @@ impl FuncRefs {
     ///
     /// You may only access the return value on the same thread as this
     /// `FuncRefs` and only while the store holding this `FuncRefs` exists.
-    pub unsafe fn push(&mut self, func_ref: VMFuncRef) -> NonNull<VMFuncRef> {
+    pub unsafe fn push(
+        &mut self,
+        func_ref: VMFuncRef,
+        modules: &ModuleRegistry,
+    ) -> NonNull<VMFuncRef> {
         debug_assert!(func_ref.wasm_call.is_none());
-        // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
-        // that is the only kind that can have holes.
-        let _ = unsafe { VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx.as_non_null()) };
-
         let func_ref = self.bump.alloc(func_ref);
+        let has_hole = !try_fill(func_ref, modules);
         let unpatched = SendSyncPtr::from(func_ref);
-        let ret = unpatched.as_non_null();
-        self.with_holes.push(unpatched);
-        ret
+        if has_hole {
+            self.with_holes.push(unpatched);
+        }
+        unpatched.as_non_null()
     }
 
     /// Patch any `VMFuncRef::wasm_call`s that need filling in.
     pub fn fill(&mut self, modules: &ModuleRegistry) {
-        self.with_holes.retain_mut(|f| {
-            unsafe {
-                let func_ref = f.as_mut();
-                debug_assert!(func_ref.wasm_call.is_none());
+        self.with_holes
+            .retain_mut(|f| unsafe { !try_fill(f.as_mut(), modules) });
+    }
 
-                // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
-                // that is the only kind that can have holes.
-                let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx.as_non_null());
-
-                func_ref.wasm_call = modules
-                    .wasm_to_array_trampoline(func_ref.type_index)
-                    .map(|f| f.into());
-                func_ref.wasm_call.is_none()
-            }
-        });
+    /// Reserves `amt` space for extra items in "storage" for this store.
+    pub fn reserve_storage(&mut self, amt: usize) {
+        self.storage.reserve(amt);
     }
 
     /// Push pre-patched `VMFuncRef`s from an `InstancePre`.
-    pub fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[VMFuncRef]>) {
-        self.instance_pre_func_refs.push(func_refs);
+    ///
+    /// This is used to ensure that the store itself persists the entire list of
+    /// `funcs` for the entire lifetime of the store.
+    pub fn push_instance_pre_func_refs(&mut self, funcs: Arc<[VMFuncRef]>) {
+        self.storage.push(Storage::InstancePreFuncRefs { funcs });
     }
+
+    /// Push linker definitions into storage, keeping them alive for the entire
+    /// lifetime of the store.
+    ///
+    /// This is used to keep linker-defined functions' vmctx values alive, for
+    /// example.
+    pub fn push_instance_pre_definitions(&mut self, defs: Arc<[Definition]>) {
+        self.storage.push(Storage::InstancePreDefinitions { defs });
+    }
+
+    /// Pushes a shared host function into this store.
+    ///
+    /// This will create a store-local `VMFuncRef` with a hole to fill in where
+    /// the `wasm_call` will get filled in as needed.
+    ///
+    /// This function returns a `VMFuncRef` which is store-local and will have
+    /// `wasm_call` filled in eventually if needed.
+    ///
+    /// # Safety
+    ///
+    /// You may only access the return value on the same thread as this
+    /// `FuncRefs` and only while the store holding this `FuncRefs` exists.
+    pub unsafe fn push_arc_host(
+        &mut self,
+        func: Arc<HostFunc>,
+        modules: &ModuleRegistry,
+    ) -> NonNull<VMFuncRef> {
+        debug_assert!(func.func_ref().wasm_call.is_none());
+        let ret = self.push(func.func_ref().clone(), modules);
+        self.storage.push(Storage::ArcHost { func });
+        ret
+    }
+
+    /// Same as `push_arc_host`, but for owned host functions.
+    pub unsafe fn push_box_host(
+        &mut self,
+        func: Box<HostFunc>,
+        modules: &ModuleRegistry,
+    ) -> NonNull<VMFuncRef> {
+        debug_assert!(func.func_ref().wasm_call.is_none());
+        let ret = self.push(func.func_ref().clone(), modules);
+        self.storage.push(Storage::BoxHost { func });
+        ret
+    }
+}
+
+/// Attempts to fill the `wasm_call` field of `func_ref` given `modules`
+/// registered.
+///
+/// # Panics
+///
+/// Panics if `func_ref.wasm_call.is_some()`
+///
+/// # Safety
+///
+/// This relies on `func_ref` being a valid pointer with a valid `vmctx` field.
+unsafe fn try_fill(func_ref: &mut VMFuncRef, modules: &ModuleRegistry) -> bool {
+    debug_assert!(func_ref.wasm_call.is_none());
+
+    // Debug assert that the vmctx is a `VMArrayCallHostFuncContext` as
+    // that is the only kind that can have holes.
+    //
+    // SAFETY: the validity of `vmctx` is a contract of this function itself.
+    unsafe {
+        let _ = VMArrayCallHostFuncContext::from_opaque(func_ref.vmctx.as_non_null());
+    }
+
+    func_ref.wasm_call = modules
+        .wasm_to_array_trampoline(func_ref.type_index)
+        .map(|f| f.into());
+    func_ref.wasm_call.is_some()
 }

--- a/crates/wasmtime/src/runtime/store/func_refs.rs
+++ b/crates/wasmtime/src/runtime/store/func_refs.rs
@@ -182,7 +182,7 @@ impl FuncRefs {
 }
 
 /// Attempts to fill the `wasm_call` field of `func_ref` given `modules`
-/// registered.
+/// registered and returns `true` if the field was filled, `false` otherwise.
 ///
 /// # Panics
 ///

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -37,7 +37,7 @@ pub fn generate_global_export(
             Val::V128(x) => global.set_u128(x.into()),
             Val::FuncRef(f) => {
                 *global.as_func_ref_mut() =
-                    f.map_or(ptr::null_mut(), |f| f.vm_func_ref(&mut store).as_ptr());
+                    f.map_or(ptr::null_mut(), |f| f.vm_func_ref(&store).as_ptr());
             }
             Val::ExternRef(x) => {
                 let new = match x {

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -983,7 +983,7 @@ impl Ref {
                     f.comes_from_same_store(&store),
                     "checked in `ensure_matches_ty`"
                 );
-                Ok(TableElement::FuncRef(Some(f.vm_func_ref(&mut store))))
+                Ok(TableElement::FuncRef(Some(f.vm_func_ref(&store))))
             }
 
             (Ref::Extern(e), HeapType::Extern) => match e {


### PR DESCRIPTION
This commit rewrites the internals of `wasmtime::Func`. The `Stored` type is no longer used meaning that it's now free to create a `wasmtime::Func` at any time. It is effectively a store-tagged `NonNull<VMFuncRef>`. This required a few internal changes to how functions are passed around:

* Previously the insertion of a `wasm_call`-less `VMFuncRef` was deferred until the raw pointer was loaded. Now the insertion happens immediately as soon as the function is placed within a store. This is done to ensure that a `Func` corresponds to one exact `VMFuncRef` and that's it, and lazily filled in versions within the store are still lazily filled in but they're more eagerly allocated. This isn't expected to have much of an impact perf-wise since all these lazily allocated functions were already almost guaranteed to get lazily allocated anyway.

* Filling in "holes" in `VMFuncRef`, notably the `wasm_call` field, no longer happens lazily when the `VMFuncRef` is demanded. Instead during instantiation a pass is made to fill in holes with the new module being instantiated (after registration). Additionally when a lazily-allocated `VMFuncRef` is created the module registry is checked immediately. This means that all store-local `VMFuncRef` values are either filled in immediately or filled in during instantiation. This notably means that the previous logic in `Func::vmimport` is now "just" an `.unwrap()` with a lot of comments saying why the unwrap shouldn't panic.

* To implement this commit a previous optimization for the `Func` API was removed as well, namely `Func::call` will become slower after this commit. The `Func::call` API is a dynamically-typed API which requires run-time type-checking of arguments. Previously a `FuncType` was loaded into a cache once-per-`Func` which helped amortize the cost of using `Func::call` repeatedly. Now, though, there's no natural place to put such a cache since `Func` no longer has dedicated storage within a `Store`. Historically this optimization was added for the C API before the `*_call_unchecked` APIs existed, but nowadays the `*_call_unchecked` APIs should suffice for performance-critical applications where needed. In the future it might also be possible to have a hash map in the `Store` of a `VMSharedTypeIndex` to `FuncType` which is lazily populated based on calls to `Func::call`, but that feels a bit overkill nowadays for a possibly rarely-used map.

* The no-longer-necessary `RootedHostFunc` type is now gone as its unsafety and various contracts are subsumed by other preexisting `unsafe` blocks.

* The specific drop order between `StoreOpaque::store_data` and `StoreOpaque::rooted_host_funcs` is removed. The `rooted_host_funcs` field now lives in the `func_refs` field and the `FuncKind` type, where the destructors came from before, is no more.

* The `func_refs` field has grown storage locations for a variety of "keep this thing alive as long as the store" related to functions and such.

Closes #10868

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
