### PR TITLE
x64: Migrate `AluRmRVex` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -197,7 +197,8 @@ impl dsl::Format {
 
         let style = match self.operands_by_kind().as_slice() {
             [Reg(reg), Reg(vvvv), RegMem(rm)]
-            | [Reg(reg), Reg(vvvv), RegMem(rm), Imm(_) | FixedReg(_)] => {
+            | [Reg(reg), Reg(vvvv), RegMem(rm), Imm(_) | FixedReg(_)]
+            | [Reg(reg), RegMem(rm), Reg(vvvv)] => {
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");

--- a/cranelift/assembler-x64/meta/src/instructions/and.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/and.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq};
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -29,6 +29,9 @@ pub fn list() -> Vec<Inst> {
         inst("andw", fmt("RM", [rw(r16), r(rm16)]), rex([0x66, 0x23]).r(), _64b | compat),
         inst("andl", fmt("RM", [rw(r32), r(rm32)]), rex(0x23).r(), _64b | compat),
         inst("andq", fmt("RM", [rw(r64), r(rm64)]), rex(0x23).w().r(), _64b),
+        // BMI1 andn
+        inst("andnl", fmt("RVM", [w(r32a), r(r32b), r(rm32)]), vex(LZ)._0f38().w0().op(0xF2), _64b | compat | bmi1),
+        inst("andnq", fmt("RVM", [w(r64a), r(r64b), r(rm64)]), vex(LZ)._0f38().w1().op(0xF2), _64b | bmi1),
         // `LOCK`-prefixed memory-writing instructions.
         inst("lock_andb", fmt("MI", [rw(m8), r(imm8)]), rex([0xf0, 0x80]).digit(4).ib(), _64b | compat),
         inst("lock_andw", fmt("MI", [rw(m16), r(imm16)]), rex([0xf0, 0x66, 0x81]).digit(4).iw(), _64b | compat),

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, implicit, inst, r, rex, rw, w};
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{fmt, implicit, inst, r, rex, rw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -42,5 +42,8 @@ pub fn list() -> Vec<Inst> {
 
         inst("bswapl", fmt("O", [rw(r32)]), rex([0x0F, 0xC8]).rd(), _64b | compat),
         inst("bswapq", fmt("O", [rw(r64)]), rex([0x0F, 0xC8]).w().ro(), _64b),
+
+        inst("bzhil", fmt("RMV", [w(r32a), r(rm32), r(r32b)]), vex(LZ)._0f38().w0().op(0xF5), _64b | compat | bmi2),
+        inst("bzhiq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._0f38().w1().op(0xF5), _64b | bmi2),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/shift.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/shift.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{align, fmt, inst, r, rex, rw};
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{align, fmt, inst, r, rex, rw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -57,6 +57,15 @@ pub fn list() -> Vec<Inst> {
         inst("shldq", fmt("MRI", [rw(rm64), r(r64), r(imm8)]), rex([0x0F, 0xA4]).ib().w(), _64b),
         inst("shldl", fmt("MRC", [rw(rm32), r(r32), r(cl)]), rex([0x0F, 0xA5]).ib(), _64b | compat),
         inst("shldq", fmt("MRC", [rw(rm64), r(r64), r(cl)]), rex([0x0F, 0xA5]).ib().w(), _64b),
+
+        // BMI2 shifts
+        inst("sarxl", fmt("RMV", [w(r32a), r(rm32), r(r32b)]), vex(LZ)._f3()._0f38().w0().op(0xF7), _64b | compat | bmi2),
+        inst("shlxl", fmt("RMV", [w(r32a), r(rm32), r(r32b)]), vex(LZ)._66()._0f38().w0().op(0xF7), _64b | compat | bmi2),
+        inst("shrxl", fmt("RMV", [w(r32a), r(rm32), r(r32b)]), vex(LZ)._f2()._0f38().w0().op(0xF7), _64b | compat | bmi2),
+        inst("sarxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._f3()._0f38().w1().op(0xF7), _64b | bmi2),
+        inst("shlxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._66()._0f38().w1().op(0xF7), _64b | bmi2),
+        inst("shrxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._f2()._0f38().w1().op(0xF7), _64b | bmi2),
+
         // Vector instructions (shift left).
         inst("psllw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0xF1]).r(), _64b | compat | sse2),
         inst("psllw", fmt("B", [rw(xmm1), r(imm8)]), rex([0x66, 0x0F, 0x71]).digit(6).ib(), _64b | compat | sse2),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -13,15 +13,6 @@
        ;; =========================================
        ;; Integer instructions.
 
-       ;; Integer arithmetic binary op that relies on the VEX prefix.
-       ;; NOTE: we don't currently support emitting VEX instructions with memory
-       ;; arguments, so `src2` is artificially constrained to be a Gpr.
-       (AluRmRVex (size OperandSize)
-                  (op AluRmROpcode)
-                  (src1 Gpr)
-                  (src2 GprMem)
-                  (dst WritableGpr))
-
        ;; Same as `UnaryRmR` but with the VEX prefix for BMI1 instructions.
        (UnaryRmRVex (size OperandSize)
                     (op UnaryRmRVexOpcode)
@@ -702,13 +693,6 @@
 (rule (operand_size_bits (OperandSize.Size16)) 16)
 (rule (operand_size_bits (OperandSize.Size32)) 32)
 (rule (operand_size_bits (OperandSize.Size64)) 64)
-
-(type AluRmROpcode
-      (enum Andn
-            Sarx
-            Shrx
-            Shlx
-            Bzhi))
 
 (type UnaryRmROpcode extern
       (enum Bsr
@@ -1753,14 +1737,6 @@
             (_ Unit (emit (MInst.LoadExtName dst extname offset distance))))
         dst))
 
-;; Helper for emitting `MInst.AluRmRVex` instructions.
-(decl alu_rm_r_vex (Type AluRmROpcode Gpr GprMem) Gpr)
-(rule (alu_rm_r_vex ty opcode src1 src2)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (_ Unit (emit (MInst.AluRmRVex size opcode src1 src2 dst))))
-        dst))
-
 ;; Helper for creating `MInst.XmmRmR` instructions.
 (decl xmm_rm_r (SseOpcode Xmm XmmMemAligned) Xmm)
 (rule (xmm_rm_r op src1 src2)
@@ -2765,11 +2741,16 @@
 (rule 0 (x64_xor $I32 src1 (is_gpr_mem src2)) (x64_xorl_rm src1 src2))
 (rule 0 (x64_xor $I64 src1 (is_gpr_mem src2)) (x64_xorq_rm src1 src2))
 
-
-
+;; Helper for `andn` instructions
+;;
+;; Note that 8/16-bit versions of these instructions do not exist, so for
+;; those bit-widths the 32-bit version of the instruction is used which has the
+;; desired semantics for the lower bits of the register.
 (decl x64_andn (Type Gpr GprMem) Gpr)
-(rule (x64_andn ty src1 src2)
-      (alu_rm_r_vex ty (AluRmROpcode.Andn) src1 src2))
+(rule (x64_andn $I8 src1 src2) (x64_andnl_rvm src1 src2))
+(rule (x64_andn $I16 src1 src2) (x64_andnl_rvm src1 src2))
+(rule (x64_andn $I32 src1 src2) (x64_andnl_rvm src1 src2))
+(rule (x64_andn $I64 src1 src2) (x64_andnq_rvm src1 src2))
 
 ;; Helper for emitting immediates with an `i64` value. Note that
 ;; integer constants in ISLE are always parsed as `i128`s; this enables
@@ -2927,12 +2908,9 @@
 (rule (x64_shld $I64 src1 src2 amt) (x64_shldq_mri src1 src2 amt))
 
 ;; Helper for creating zeroing-of-high-bits instructions bzhi
-;;
-;; Note that the `src` operands are swapped here. The amount-to-shift-by
-;; is stored in `vvvv` which is `src1` in the `AluRmRVex` instruction shape.
 (decl x64_bzhi (Type GprMem Gpr) Gpr)
-(rule (x64_bzhi ty src1 src2)
-      (alu_rm_r_vex ty (AluRmROpcode.Bzhi) src2 src1))
+(rule (x64_bzhi $I32 src1 src2) (x64_bzhil_rmv src1 src2))
+(rule (x64_bzhi $I64 src1 src2) (x64_bzhiq_rmv src1 src2))
 
 ;; Helper for creating byteswap instructions.
 ;; In x64, 32- and 64-bit registers use BSWAP instruction, and
@@ -4271,18 +4249,18 @@
 
 ;; Helper for creating `sarx` instructions.
 (decl x64_sarx (Type GprMem Gpr) Gpr)
-(rule (x64_sarx ty val amt)
-      (alu_rm_r_vex ty (AluRmROpcode.Sarx) amt val))
+(rule (x64_sarx $I32 val amt) (x64_sarxl_rmv val amt))
+(rule (x64_sarx $I64 val amt) (x64_sarxq_rmv val amt))
 
 ;; Helper for creating `shrx` instructions.
 (decl x64_shrx (Type GprMem Gpr) Gpr)
-(rule (x64_shrx ty val amt)
-      (alu_rm_r_vex ty (AluRmROpcode.Shrx) amt val))
+(rule (x64_shrx $I32 val amt) (x64_shrxl_rmv val amt))
+(rule (x64_shrx $I64 val amt) (x64_shrxq_rmv val amt))
 
 ;; Helper for creating `shlx` instructions.
 (decl x64_shlx (Type GprMem Gpr) Gpr)
-(rule (x64_shlx ty val amt)
-      (alu_rm_r_vex ty (AluRmROpcode.Shlx) amt val))
+(rule (x64_shlx $I32 val amt) (x64_shlxl_rmv val amt))
+(rule (x64_shlx $I64 val amt) (x64_shlxq_rmv val amt))
 
 ;; Helper for creating `rorx` instructions.
 (decl x64_rorx (Type GprMem u8) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -729,25 +729,6 @@ impl PrettyPrint for RegMem {
     }
 }
 
-pub use crate::isa::x64::lower::isle::generated_code::AluRmROpcode;
-
-impl AluRmROpcode {
-    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
-        match self {
-            AluRmROpcode::Andn => smallvec![InstructionSet::BMI1],
-            AluRmROpcode::Sarx | AluRmROpcode::Shrx | AluRmROpcode::Shlx | AluRmROpcode::Bzhi => {
-                smallvec![InstructionSet::BMI2]
-            }
-        }
-    }
-}
-
-impl fmt::Display for AluRmROpcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("{self:?}").to_lowercase())
-    }
-}
-
 pub use crate::isa::x64::lower::isle::generated_code::UnaryRmRVexOpcode;
 
 impl UnaryRmRVexOpcode {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -62,21 +62,6 @@ pub(crate) fn check(
             Ok(())
         }
 
-        Inst::AluRmRVex {
-            size,
-            ref src2,
-            dst,
-            ..
-        } => match <&RegMem>::from(src2) {
-            RegMem::Mem { addr } => {
-                let loaded = check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
-                check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
-                    clamp_range(ctx, 64, size.to_bits().into(), loaded)
-                })
-            }
-            RegMem::Reg { .. } => undefined_result(ctx, vcode, dst, 64, size.to_bits().into()),
-        },
-
         Inst::UnaryRmRVex {
             size, ref src, dst, ..
         }

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andn    %edi, %esi, %eax
+;   andnl %edi, %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -38,7 +38,7 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andn    %esi, %edi, %eax
+;   andnl %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/bmi2.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi2.clif
@@ -12,7 +12,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   sarx    %edi, %esi, %eax
+;   sarxl %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -37,7 +37,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   sarx    %rdi, %rsi, %rax
+;   sarxq %rsi, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -62,7 +62,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   shrx    %edi, %esi, %eax
+;   shrxl %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -87,7 +87,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   shrx    %rdi, %rsi, %rax
+;   shrxq %rsi, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -112,7 +112,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   shlx    %edi, %esi, %eax
+;   shlxl %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -137,7 +137,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   shlx    %rdi, %rsi, %rax
+;   shlxq %rsi, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -270,7 +270,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   andl $0x1f, %esi
-;   bzhi    %edi, %esi, %eax
+;   bzhil %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -300,7 +300,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   andq $0x3f, %rsi
-;   bzhi    %rdi, %rsi, %rax
+;   bzhiq %rsi, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -331,7 +331,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   andl $0x1f, %esi
-;   bzhi    20(%rdi), %esi, %eax
+;   bzhil %esi, 0x14(%rdi), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
This includes the `bzhi`, `sarx`, `shlx`, `shrx`, and `andn` instructions. Everything pretty straightforward here, yay!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
