### PR TITLE
Refactor `wasmtime::Tag`'s representation

### DIFF
--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -151,7 +151,7 @@ impl Extern {
             Extern::Memory(m) => m.comes_from_same_store(store),
             Extern::SharedMemory(m) => Engine::same(m.engine(), store.engine()),
             Extern::Table(t) => store.store_data().contains(t.0),
-            Extern::Tag(t) => store.store_data().contains(t.0),
+            Extern::Tag(t) => t.comes_from_same_store(store),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -1,25 +1,31 @@
 use crate::runtime::types::TagType;
 use crate::{
     AsContext,
-    store::{StoreData, StoreOpaque, Stored},
+    store::{StoreInstanceId, StoreOpaque},
 };
-use wasmtime_environ::VMSharedTypeIndex;
+use wasmtime_environ::{DefinedTagIndex, VMSharedTypeIndex};
 
 /// A WebAssembly `tag`.
 #[derive(Copy, Clone, Debug)]
-#[repr(transparent)] // here for the C API
-pub struct Tag(pub(super) Stored<crate::runtime::vm::ExportTag>);
+#[repr(C)] // here for the C API in the future
+pub struct Tag {
+    instance: StoreInstanceId,
+    index: DefinedTagIndex,
+}
 
 impl Tag {
     pub(crate) unsafe fn from_wasmtime_tag(
         wasmtime_export: crate::runtime::vm::ExportTag,
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
     ) -> Self {
         debug_assert!(
             wasmtime_export.tag.signature.unwrap_engine_type_index()
                 != VMSharedTypeIndex::default()
         );
-        Tag(store.store_data_mut().insert(wasmtime_export))
+        Tag {
+            instance: store.vmctx_id(wasmtime_export.vmctx),
+            index: wasmtime_export.index,
+        }
     }
 
     /// Returns the underlying type of this `tag`.
@@ -32,21 +38,26 @@ impl Tag {
     }
 
     pub(crate) fn _ty(&self, store: &StoreOpaque) -> TagType {
-        let ty = &store[self.0].tag;
-        TagType::from_wasmtime_tag(store.engine(), &ty)
+        TagType::from_wasmtime_tag(store.engine(), self.wasmtime_ty(store))
     }
 
-    pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Tag {
-        &data[self.0].tag
+    pub(crate) fn wasmtime_ty<'a>(&self, store: &'a StoreOpaque) -> &'a wasmtime_environ::Tag {
+        let module = store[self.instance].env_module();
+        let index = module.tag_index(self.index);
+        &module.tags[index]
     }
 
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTagImport {
-        let export = &store[self.0];
+        let instance = &store[self.instance];
         crate::runtime::vm::VMTagImport {
-            from: export.definition.into(),
-            vmctx: export.vmctx.into(),
-            index: export.index,
+            from: instance.tag_ptr(self.index).into(),
+            vmctx: instance.vmctx().into(),
+            index: self.index,
         }
+    }
+
+    pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
+        store.id() == self.instance.store_id()
     }
 
     /// Determines whether this tag is reference equal to the other
@@ -56,9 +67,12 @@ impl Tag {
     ///
     /// Panics if either tag do not belong to the given `store`.
     pub fn eq(a: &Tag, b: &Tag, store: impl AsContext) -> bool {
-        let store = store.as_context().0;
-        let a = &store[a.0];
-        let b = &store[b.0];
-        a.definition.eq(&b.definition)
+        // make sure both tags belong to the store
+        let store = store.as_context();
+        let _ = &store[a.instance];
+        let _ = &store[b.instance];
+
+        // then compare to see if they have the same definition
+        a.instance == b.instance && a.index == b.index
     }
 }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1428,7 +1428,7 @@ impl DefinitionType {
                 DefinitionType::Memory(*t.wasmtime_ty(store), t.internal_size(store))
             }
             Extern::SharedMemory(t) => DefinitionType::Memory(*t.ty().wasmtime_memory(), t.size()),
-            Extern::Tag(t) => DefinitionType::Tag(*t.wasmtime_ty(data)),
+            Extern::Tag(t) => DefinitionType::Tag(*t.wasmtime_ty(store)),
         }
     }
 

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -29,7 +29,6 @@ pub struct StoreData {
     tables: Vec<crate::runtime::vm::ExportTable>,
     globals: Vec<crate::runtime::vm::ExportGlobal>,
     instances: Vec<crate::instance::InstanceData>,
-    tags: Vec<crate::runtime::vm::ExportTag>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
 }
@@ -55,7 +54,6 @@ impl_store_data! {
     tables => crate::runtime::vm::ExportTable,
     globals => crate::runtime::vm::ExportGlobal,
     instances => crate::instance::InstanceData,
-    tags => crate::runtime::vm::ExportTag,
 }
 
 impl StoreData {
@@ -66,7 +64,6 @@ impl StoreData {
             tables: Vec::new(),
             globals: Vec::new(),
             instances: Vec::new(),
-            tags: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),
         }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -502,7 +502,7 @@ impl Instance {
     }
 
     /// Return the indexed `VMTagDefinition`.
-    fn tag_ptr(&mut self, index: DefinedTagIndex) -> NonNull<VMTagDefinition> {
+    pub fn tag_ptr(&self, index: DefinedTagIndex) -> NonNull<VMTagDefinition> {
         unsafe { self.vmctx_plus_offset_raw(self.offsets().vmctx_vmtag_definition(index)) }
     }
 


### PR DESCRIPTION
Removes the use of `Stored` to ensure that creating an external `Tag` is a free operation with just some indices into store-internal data.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
