### PR TITLE
Refactor globals to no longer use `Stored`

### DIFF
--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -76,7 +76,11 @@ typedef struct wasmtime_global {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
   /// Private field for Wasmtime.
-  size_t __private;
+  size_t __private1;
+  /// Private field for Wasmtime.
+  uint32_t __private2;
+  /// Private field for Wasmtime.
+  uint32_t __private3;
 } wasmtime_global_t;
 
 /// \brief Discriminant of #wasmtime_extern_t

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -588,6 +588,12 @@ impl Module {
         self.memories.len() - self.num_imported_memories
     }
 
+    /// Returns the number of globals defined by this module itself: all
+    /// globals minus imported globals.
+    pub fn num_defined_globals(&self) -> usize {
+        self.globals.len() - self.num_imported_globals
+    }
+
     /// Returns the number of tags defined by this module itself: all tags
     /// minus imported tags.
     pub fn num_defined_tags(&self) -> usize {

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -663,7 +663,8 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the size of `VMGlobalImport`.
     #[inline]
     pub fn size_of_vmglobal_import(&self) -> u8 {
-        1 * self.pointer_size()
+        // `VMGlobalImport` has two pointers plus 8 bytes for `VMGlobalKind`
+        2 * self.pointer_size() + 8
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -8,7 +8,7 @@ use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
 use crate::prelude::*;
 use crate::runtime::vm::component::{ComponentInstance, OwnedComponentInstance};
-use crate::runtime::vm::{CompiledModuleId, VMFuncRef};
+use crate::runtime::vm::{CompiledModuleId, ExportGlobalKind, VMFuncRef};
 use crate::store::{StoreOpaque, Stored};
 use crate::{AsContext, AsContextMut, Engine, Module, StoreContextMut};
 use alloc::sync::Arc;
@@ -431,11 +431,11 @@ impl InstanceData {
             CoreDef::InstanceFlags(idx) => {
                 crate::runtime::vm::Export::Global(crate::runtime::vm::ExportGlobal {
                     definition: self.state.instance_flags(*idx).as_raw(),
-                    vmctx: None,
                     global: Global {
                         wasm_ty: WasmValType::I32,
                         mutability: true,
                     },
+                    kind: ExportGlobalKind::ComponentFlags(self.state.vmctx(), *idx),
                 })
             }
         }

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -37,6 +37,10 @@ impl ComponentInstanceId {
     pub fn from_index(idx: usize) -> ComponentInstanceId {
         ComponentInstanceId(idx)
     }
+
+    pub(crate) fn index(&self) -> usize {
+        self.0
+    }
 }
 
 impl ComponentStoreData {
@@ -59,7 +63,6 @@ impl StoreData {
 }
 
 impl StoreOpaque {
-    #[expect(dead_code, reason = "to be used soon")]
     pub(crate) fn component_instance(&self, id: ComponentInstanceId) -> &ComponentInstance {
         self.store_data().components.instances[id.0]
             .as_ref()

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -147,7 +147,7 @@ impl Extern {
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
             Extern::Func(f) => f.comes_from_same_store(store),
-            Extern::Global(g) => store.store_data().contains(g.0),
+            Extern::Global(g) => g.comes_from_same_store(store),
             Extern::Memory(m) => m.comes_from_same_store(store),
             Extern::SharedMemory(m) => Engine::same(m.engine(), store.engine()),
             Extern::Table(t) => store.store_data().contains(t.0),

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -1,12 +1,16 @@
 use crate::prelude::*;
+use crate::runtime::vm::{
+    self, ExportGlobalKind, VMGlobalDefinition, VMGlobalKind, VMOpaqueContext,
+};
 use crate::{
     AnyRef, AsContext, AsContextMut, ExternRef, Func, GlobalType, HeapType, Mutability, Ref,
     RootedGcRefImpl, Val, ValType,
-    store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored},
+    store::{AutoAssertNoGc, InstanceId, StoreId, StoreOpaque},
     trampoline::generate_global_export,
 };
 use core::ptr;
-use wasmtime_environ::TypeTrace;
+use core::ptr::NonNull;
+use wasmtime_environ::{DefinedGlobalIndex, TypeTrace};
 
 /// A WebAssembly `global` value which can be read and written to.
 ///
@@ -21,8 +25,26 @@ use wasmtime_environ::TypeTrace;
 /// store it belongs to, and if another store is passed in by accident then
 /// methods will panic.
 #[derive(Copy, Clone, Debug)]
-#[repr(transparent)] // here for the C API
-pub struct Global(pub(super) Stored<crate::runtime::vm::ExportGlobal>);
+#[repr(C)] // here for the C API
+pub struct Global {
+    /// The store that this global belongs to.
+    store: StoreId,
+    /// Either `InstanceId` or `ComponentInstanceId` internals depending on
+    /// `kind` below.
+    instance: usize,
+    /// Which method of definition was used when creating this global.
+    kind: VMGlobalKind,
+}
+
+// Double-check that the C representation in `extern.h` matches our in-Rust
+// representation here in terms of size/alignment/etc.
+const _: () = {
+    #[repr(C)]
+    struct C(u64, usize, u32, u32);
+    assert!(core::mem::size_of::<C>() == core::mem::size_of::<Global>());
+    assert!(core::mem::align_of::<C>() == core::mem::align_of::<Global>());
+    assert!(core::mem::offset_of!(Global, store) == 0);
+};
 
 impl Global {
     /// Creates a new WebAssembly `global` value with the provide type `ty` and
@@ -83,6 +105,26 @@ impl Global {
         }
     }
 
+    pub(crate) fn new_host(store: &StoreOpaque, index: DefinedGlobalIndex) -> Global {
+        Global {
+            store: store.id(),
+            instance: 0,
+            kind: VMGlobalKind::Host(index),
+        }
+    }
+
+    pub(crate) fn new_instance(
+        store: &StoreOpaque,
+        instance: InstanceId,
+        index: DefinedGlobalIndex,
+    ) -> Global {
+        Global {
+            store: store.id(),
+            instance: instance.index(),
+            kind: VMGlobalKind::Instance(index),
+        }
+    }
+
     /// Returns the underlying type of this `global`.
     ///
     /// # Panics
@@ -93,8 +135,7 @@ impl Global {
     }
 
     pub(crate) fn _ty(&self, store: &StoreOpaque) -> GlobalType {
-        let ty = &store[self.0].global;
-        GlobalType::from_wasmtime_global(store.engine(), &ty)
+        GlobalType::from_wasmtime_global(store.engine(), self.wasmtime_ty(store))
     }
 
     /// Returns the current [`Val`] of this global.
@@ -105,8 +146,8 @@ impl Global {
     pub fn get(&self, mut store: impl AsContextMut) -> Val {
         unsafe {
             let store = store.as_context_mut();
+            let definition = self.definition(store.0).as_ref();
             let mut store = AutoAssertNoGc::new(store.0);
-            let definition = store[self.0].definition.as_ref();
             match self._ty(&store).content() {
                 ValType::I32 => Val::from(*definition.as_i32()),
                 ValType::I64 => Val::from(*definition.as_i64()),
@@ -174,7 +215,7 @@ impl Global {
         val.ensure_matches_ty(&store, global_ty.content())
             .context("type mismatch: attempt to set global to value of wrong type")?;
         unsafe {
-            let definition = store[self.0].definition.as_mut();
+            let definition = self.definition(&store).as_mut();
             match val {
                 Val::I32(i) => *definition.as_i32_mut() = i,
                 Val::I64(i) => *definition.as_i64_mut() = i,
@@ -210,17 +251,13 @@ impl Global {
     }
 
     #[cfg(feature = "gc")]
-    pub(crate) fn trace_root(
-        &self,
-        store: &mut StoreOpaque,
-        gc_roots_list: &mut crate::runtime::vm::GcRootsList,
-    ) {
+    pub(crate) fn trace_root(&self, store: &mut StoreOpaque, gc_roots_list: &mut vm::GcRootsList) {
         if let Some(ref_ty) = self._ty(store).content().as_ref() {
             if !ref_ty.is_vmgcref_type_and_points_to_object() {
                 return;
             }
 
-            if let Some(gc_ref) = unsafe { store[self.0].definition.as_ref().as_gc_ref() } {
+            if let Some(gc_ref) = unsafe { self.definition(store).as_ref().as_gc_ref() } {
                 unsafe {
                     gc_roots_list.add_root(gc_ref.into(), "Wasm global");
                 }
@@ -229,8 +266,8 @@ impl Global {
     }
 
     pub(crate) unsafe fn from_wasmtime_global(
-        wasmtime_export: crate::runtime::vm::ExportGlobal,
-        store: &mut StoreOpaque,
+        wasmtime_export: vm::ExportGlobal,
+        store: &StoreOpaque,
     ) -> Global {
         debug_assert!(
             wasmtime_export
@@ -238,17 +275,71 @@ impl Global {
                 .wasm_ty
                 .is_canonicalized_for_runtime_usage()
         );
-        Global(store.store_data_mut().insert(wasmtime_export))
-    }
-
-    pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Global {
-        &data[self.0].global
-    }
-
-    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMGlobalImport {
-        crate::runtime::vm::VMGlobalImport {
-            from: store[self.0].definition.into(),
+        let (instance, kind) = match wasmtime_export.kind {
+            ExportGlobalKind::Host(index) => (0, VMGlobalKind::Host(index)),
+            ExportGlobalKind::Instance(vmctx, index) => (
+                vm::Instance::from_vmctx(vmctx, |i| i.id().index()),
+                VMGlobalKind::Instance(index),
+            ),
+            #[cfg(feature = "component-model")]
+            ExportGlobalKind::ComponentFlags(vmctx, index) => (
+                vm::component::ComponentInstance::from_vmctx(vmctx, |i| i.id().index()),
+                VMGlobalKind::ComponentFlags(index),
+            ),
+        };
+        Global {
+            store: store.id(),
+            instance,
+            kind,
         }
+    }
+
+    pub(crate) fn wasmtime_ty<'a>(&self, store: &'a StoreOpaque) -> &'a wasmtime_environ::Global {
+        self.store.assert_belongs_to(store.id());
+        match self.kind {
+            VMGlobalKind::Instance(index) => {
+                let instance = InstanceId::from_index(self.instance);
+                let module = store.instance(instance).module();
+                let index = module.global_index(index);
+                &module.globals[index]
+            }
+            VMGlobalKind::Host(index) => unsafe { &store.host_globals()[index].get().as_ref().ty },
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::ComponentFlags(_) => {
+                const TY: wasmtime_environ::Global = wasmtime_environ::Global {
+                    mutability: true,
+                    wasm_ty: wasmtime_environ::WasmValType::I32,
+                };
+                &TY
+            }
+        }
+    }
+
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> vm::VMGlobalImport {
+        let vmctx = match self.kind {
+            VMGlobalKind::Instance(_) => {
+                let instance = InstanceId::from_index(self.instance);
+                Some(VMOpaqueContext::from_vmcontext(store.instance(instance).vmctx()).into())
+            }
+            VMGlobalKind::Host(_) => None,
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::ComponentFlags(_) => {
+                let instance = crate::component::ComponentInstanceId::from_index(self.instance);
+                Some(
+                    VMOpaqueContext::from_vmcomponent(store.component_instance(instance).vmctx())
+                        .into(),
+                )
+            }
+        };
+        vm::VMGlobalImport {
+            from: self.definition(store).into(),
+            vmctx,
+            kind: self.kind,
+        }
+    }
+
+    pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
+        store.id() == self.store
     }
 
     /// Get a stable hash key for this global.
@@ -258,7 +349,28 @@ impl Global {
     /// this hash key will be consistent across all of these globals.
     #[cfg(feature = "coredump")]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
-        store[self.0].definition.as_ptr() as usize
+        self.definition(store).as_ptr() as usize
+    }
+
+    fn definition(&self, store: &StoreOpaque) -> NonNull<VMGlobalDefinition> {
+        self.store.assert_belongs_to(store.id());
+        match self.kind {
+            VMGlobalKind::Instance(index) => {
+                let instance = InstanceId::from_index(self.instance);
+                store.instance(instance).instance().global_ptr(index)
+            }
+            VMGlobalKind::Host(index) => unsafe {
+                NonNull::from(&mut store.host_globals()[index].get().as_mut().global)
+            },
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::ComponentFlags(index) => {
+                let instance = crate::component::ComponentInstanceId::from_index(self.instance);
+                store
+                    .component_instance(instance)
+                    .instance_flags(index)
+                    .as_raw()
+            }
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -713,9 +713,7 @@ impl OwnedImports {
                 });
             }
             crate::runtime::vm::Export::Global(g) => {
-                self.globals.push(VMGlobalImport {
-                    from: g.definition.into(),
-                });
+                self.globals.push(g.vmimport());
             }
             crate::runtime::vm::Export::Table(t) => {
                 self.tables.push(VMTableImport {

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1423,7 +1423,7 @@ impl DefinitionType {
         match item {
             Extern::Func(f) => DefinitionType::Func(f.type_index(data)),
             Extern::Table(t) => DefinitionType::Table(*t.wasmtime_ty(data), t.internal_size(store)),
-            Extern::Global(t) => DefinitionType::Global(*t.wasmtime_ty(data)),
+            Extern::Global(t) => DefinitionType::Global(*t.wasmtime_ty(store)),
             Extern::Memory(t) => {
                 DefinitionType::Memory(*t.wasmtime_ty(store), t.internal_size(store))
             }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -21,13 +21,16 @@ impl InstanceId {
         debug_assert!(idx != Self::INVALID.0);
         InstanceId(idx)
     }
+
+    pub fn index(&self) -> usize {
+        self.0
+    }
 }
 
 pub struct StoreData {
     id: StoreId,
     funcs: Vec<crate::func::FuncData>,
     tables: Vec<crate::runtime::vm::ExportTable>,
-    globals: Vec<crate::runtime::vm::ExportGlobal>,
     instances: Vec<crate::instance::InstanceData>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
@@ -52,7 +55,6 @@ macro_rules! impl_store_data {
 impl_store_data! {
     funcs => crate::func::FuncData,
     tables => crate::runtime::vm::ExportTable,
-    globals => crate::runtime::vm::ExportGlobal,
     instances => crate::instance::InstanceData,
 }
 
@@ -62,7 +64,6 @@ impl StoreData {
             id: StoreId::allocate(),
             funcs: Vec::new(),
             tables: Vec::new(),
-            globals: Vec::new(),
             instances: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -2483,15 +2483,6 @@ impl GlobalType {
         self.mutability
     }
 
-    pub(crate) fn to_wasm_type(&self) -> Global {
-        let wasm_ty = self.content().to_wasm_type();
-        let mutability = matches!(self.mutability(), Mutability::Var);
-        Global {
-            wasm_ty,
-            mutability,
-        }
-    }
-
     /// Returns `None` if the wasmtime global has a type that we can't
     /// represent, but that should only very rarely happen and indicate a bug.
     pub(crate) fn from_wasmtime_global(engine: &Engine, global: &Global) -> GlobalType {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -122,8 +122,9 @@ pub use crate::runtime::vm::unwind::*;
 pub use crate::runtime::vm::vmcontext::VMTableDefinition;
 pub use crate::runtime::vm::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
-    VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
-    VMOpaqueContext, VMStoreContext, VMTableImport, VMTagImport, VMWasmCallFunction, ValRaw,
+    VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMGlobalKind, VMMemoryDefinition,
+    VMMemoryImport, VMOpaqueContext, VMStoreContext, VMTableImport, VMTagImport,
+    VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -244,7 +244,7 @@ impl ComponentInstance {
         (*ptr.as_ptr()).initialize_vmctx();
     }
 
-    fn vmctx(&self) -> NonNull<VMComponentContext> {
+    pub fn vmctx(&self) -> NonNull<VMComponentContext> {
         let addr = &raw const self.vmctx;
         let ret = self.vmctx_self_reference.as_ptr().with_addr(addr.addr());
         NonNull::new(ret).unwrap()

--- a/crates/wasmtime/src/runtime/vm/export.rs
+++ b/crates/wasmtime/src/runtime/vm/export.rs
@@ -1,10 +1,15 @@
+#[cfg(feature = "component-model")]
+use crate::runtime::vm::component::VMComponentContext;
 use crate::runtime::vm::vmcontext::{
-    VMContext, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
-    VMTagDefinition,
+    VMContext, VMFuncRef, VMGlobalDefinition, VMGlobalImport, VMGlobalKind, VMMemoryDefinition,
+    VMOpaqueContext, VMTableDefinition, VMTagDefinition,
 };
 use core::ptr::NonNull;
+#[cfg(feature = "component-model")]
+use wasmtime_environ::component::RuntimeComponentInstanceIndex;
 use wasmtime_environ::{
-    DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, Global, Memory, Table, Tag,
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, Global, Memory,
+    Table, Tag,
 };
 
 /// The value of an export passed from one instance to another.
@@ -98,11 +103,70 @@ impl From<ExportMemory> for Export {
 pub struct ExportGlobal {
     /// The address of the global storage.
     pub definition: NonNull<VMGlobalDefinition>,
-    /// Pointer to the containing `VMContext`. May be null for host-created
-    /// globals.
-    pub vmctx: Option<NonNull<VMContext>>,
+
+    /// Kind of exported global, or what's owning this global and how to find
+    /// it.
+    pub kind: ExportGlobalKind,
+
     /// The global declaration, used for compatibility checking.
     pub global: Global,
+}
+
+/// A global export value.
+#[derive(Debug, Clone)]
+pub enum ExportGlobalKind {
+    /// This global was created by the host or embedder and is stored within the
+    /// `Store` at the provided offset.
+    Host(DefinedGlobalIndex),
+
+    /// This global was created as part of a core wasm instance.
+    Instance(NonNull<VMContext>, DefinedGlobalIndex),
+
+    /// This global was created as flags for a component instance.
+    #[cfg(feature = "component-model")]
+    ComponentFlags(NonNull<VMComponentContext>, RuntimeComponentInstanceIndex),
+}
+
+impl ExportGlobal {
+    pub fn from_vmimport(import: &VMGlobalImport, ty: Global) -> ExportGlobal {
+        let kind = match import.kind {
+            VMGlobalKind::Host(index) => ExportGlobalKind::Host(index),
+            VMGlobalKind::Instance(index) => ExportGlobalKind::Instance(
+                unsafe { VMContext::from_opaque(import.vmctx.unwrap().as_non_null()) },
+                index,
+            ),
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::ComponentFlags(index) => ExportGlobalKind::ComponentFlags(
+                unsafe { VMComponentContext::from_opaque(import.vmctx.unwrap().as_non_null()) },
+                index,
+            ),
+        };
+        ExportGlobal {
+            definition: import.from.as_non_null(),
+            kind,
+            global: ty,
+        }
+    }
+
+    pub fn vmimport(&self) -> VMGlobalImport {
+        let (vmctx, kind) = match self.kind {
+            ExportGlobalKind::Host(index) => (None, VMGlobalKind::Host(index)),
+            ExportGlobalKind::Instance(vmctx, index) => (
+                Some(VMOpaqueContext::from_vmcontext(vmctx).into()),
+                VMGlobalKind::Instance(index),
+            ),
+            #[cfg(feature = "component-model")]
+            ExportGlobalKind::ComponentFlags(vmctx, index) => (
+                Some(VMOpaqueContext::from_vmcomponent(vmctx).into()),
+                VMGlobalKind::ComponentFlags(index),
+            ),
+        };
+        VMGlobalImport {
+            from: self.definition.into(),
+            vmctx,
+            kind,
+        }
+    }
 }
 
 // See docs on send/sync for `ExportFunction` above.


### PR DESCRIPTION
This commit refactors the `wasmtime::Global` to avoid the usage of `Stored<T>` internally. This makes conversion from internal global state to external global state a noop along the lines of previous commits. The end goal is to remove `Stored` entirely and enable more pervasively using external types internally within Wasmtime as well.

Globals were different than the prior iterations of memories, tags, and tables. Globals have three different ways of defining them: wasm instances, the host embedder, and component flags. Representing these in all the various locations required a bit of finesse in how everything is represented and stored at rest and such. In the end there's a small amount of "type punning" in a few instance/vmctx fields related to globals now since everything is squeezed into one slot. This is required because the `VMGlobalImport` structure must have a size known to wasm-compiled code and `wasmtime::Global` must have a known layout for C code.

In the end while this is more code to manage globals my hope is that the end result will be a net negative in terms of complexity by ensuring that the embedder API is additionally suitable for use internally within Wasmtime as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
