### PR TITLE
Update the definition of `wasmtime::Table`

### DIFF
--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -41,10 +41,14 @@ typedef struct wasmtime_func {
 /// wrong table is passed to the wrong store then it may trigger an assertion
 /// to abort the process.
 typedef struct wasmtime_table {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
+  struct {
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Private field for Wasmtime.
+    size_t __private1;
+  };
   /// Private field for Wasmtime.
-  size_t __private;
+  uint32_t __private2;
 } wasmtime_table_t;
 
 /// \brief Representation of a memory in Wasmtime.

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -150,7 +150,7 @@ impl Extern {
             Extern::Global(g) => g.comes_from_same_store(store),
             Extern::Memory(m) => m.comes_from_same_store(store),
             Extern::SharedMemory(m) => Engine::same(m.engine(), store.engine()),
-            Extern::Table(t) => store.store_data().contains(t.0),
+            Extern::Table(t) => t.comes_from_same_store(store),
             Extern::Tag(t) => t.comes_from_same_store(store),
         }
     }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -1,11 +1,10 @@
 use crate::prelude::*;
 use crate::runtime::vm::{self as runtime};
-use crate::store::{AutoAssertNoGc, StoreData, StoreOpaque, Stored};
+use crate::store::{AutoAssertNoGc, StoreInstanceId, StoreOpaque};
 use crate::trampoline::generate_table_export;
-use crate::vm::ExportTable;
 use crate::{AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, Ref, TableType};
 use core::iter;
-use wasmtime_environ::TypeTrace;
+use wasmtime_environ::{DefinedTableIndex, TypeTrace};
 
 /// A WebAssembly `table`, or an array of values.
 ///
@@ -21,8 +20,23 @@ use wasmtime_environ::TypeTrace;
 /// store it belongs to, and if another store is passed in by accident then
 /// methods will panic.
 #[derive(Copy, Clone, Debug)]
-#[repr(transparent)] // here for the C API
-pub struct Table(pub(super) Stored<crate::runtime::vm::ExportTable>);
+#[repr(C)] // here for the C API
+pub struct Table {
+    instance: StoreInstanceId,
+    index: DefinedTableIndex,
+}
+
+// Double-check that the C representation in `extern.h` matches our in-Rust
+// representation here in terms of size/alignment/etc.
+const _: () = {
+    #[repr(C)]
+    struct Tmp(u64, usize);
+    #[repr(C)]
+    struct C(Tmp, u32);
+    assert!(core::mem::size_of::<C>() == core::mem::size_of::<Table>());
+    assert!(core::mem::align_of::<C>() == core::mem::align_of::<Table>());
+    assert!(core::mem::offset_of!(Table, instance) == 0);
+};
 
 impl Table {
     /// Creates a new [`Table`] with the given parameters.
@@ -122,8 +136,7 @@ impl Table {
     }
 
     fn _ty(&self, store: &StoreOpaque) -> TableType {
-        let ty = &store[self.0].table;
-        TableType::from_wasmtime_table(store.engine(), ty)
+        TableType::from_wasmtime_table(store.engine(), self.wasmtime_ty(store))
     }
 
     fn wasmtime_table(
@@ -132,12 +145,10 @@ impl Table {
         lazy_init_range: impl Iterator<Item = u64>,
     ) -> *mut runtime::Table {
         unsafe {
-            let ExportTable {
-                vmctx, definition, ..
-            } = store[self.0];
+            let instance = &store[self.instance];
+            let vmctx = instance.vmctx();
             crate::runtime::vm::Instance::from_vmctx(vmctx, |handle| {
-                let idx = handle.table_index(definition.as_ref());
-                handle.get_defined_table_with_lazy_init(idx, lazy_init_range)
+                handle.get_defined_table_with_lazy_init(self.index, lazy_init_range)
             })
         }
     }
@@ -224,7 +235,7 @@ impl Table {
     pub(crate) fn internal_size(&self, store: &StoreOpaque) -> u64 {
         // unwrap here should be ok because the runtime should always guarantee
         // that we can fit the number of elements in a 64-bit integer.
-        unsafe { u64::try_from(store[self.0].definition.as_ref().current_elements).unwrap() }
+        u64::try_from(store[self.instance].table(self.index).current_elements).unwrap()
     }
 
     /// Grows the size of this table by `delta` more elements, initialization
@@ -257,7 +268,7 @@ impl Table {
             match (*table).grow(delta, init, store)? {
                 Some(size) => {
                     let vm = (*table).vmtable();
-                    store[self.0].definition.write(vm);
+                    store[self.instance].table_ptr(self.index).write(vm);
                     // unwrap here should be ok because the runtime should always guarantee
                     // that we can fit the table size in a 64-bit integer.
                     Ok(u64::try_from(size).unwrap())
@@ -392,9 +403,13 @@ impl Table {
         }
     }
 
+    pub(crate) fn from_raw(instance: StoreInstanceId, index: DefinedTableIndex) -> Table {
+        Table { instance, index }
+    }
+
     pub(crate) unsafe fn from_wasmtime_table(
         wasmtime_export: crate::runtime::vm::ExportTable,
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
     ) -> Table {
         debug_assert!(
             wasmtime_export
@@ -402,21 +417,29 @@ impl Table {
                 .ref_type
                 .is_canonicalized_for_runtime_usage()
         );
-
-        Table(store.store_data_mut().insert(wasmtime_export))
+        Table {
+            instance: store.vmctx_id(wasmtime_export.vmctx),
+            index: wasmtime_export.index,
+        }
     }
 
-    pub(crate) fn wasmtime_ty<'a>(&self, data: &'a StoreData) -> &'a wasmtime_environ::Table {
-        &data[self.0].table
+    pub(crate) fn wasmtime_ty<'a>(&self, store: &'a StoreOpaque) -> &'a wasmtime_environ::Table {
+        let module = store[self.instance].env_module();
+        let index = module.table_index(self.index);
+        &module.tables[index]
     }
 
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTableImport {
-        let export = &store[self.0];
+        let instance = &store[self.instance];
         crate::runtime::vm::VMTableImport {
-            from: export.definition.into(),
-            vmctx: export.vmctx.into(),
-            index: export.index,
+            from: instance.table_ptr(self.index).into(),
+            vmctx: instance.vmctx().into(),
+            index: self.index,
         }
+    }
+
+    pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
+        store.id() == self.instance.store_id()
     }
 
     /// Get a stable hash key for this table.
@@ -426,7 +449,7 @@ impl Table {
     /// this hash key will be consistent across all of these tables.
     #[allow(dead_code)] // Not used yet, but added for consistency.
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<'_> {
-        store[self.0].definition.as_ptr() as usize
+        store[self.instance].table_ptr(self.index).as_ptr() as usize
     }
 }
 

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1419,10 +1419,11 @@ impl Definition {
 
 impl DefinitionType {
     pub(crate) fn from(store: &StoreOpaque, item: &Extern) -> DefinitionType {
-        let data = store.store_data();
         match item {
             Extern::Func(f) => DefinitionType::Func(f.type_index(store)),
-            Extern::Table(t) => DefinitionType::Table(*t.wasmtime_ty(data), t.internal_size(store)),
+            Extern::Table(t) => {
+                DefinitionType::Table(*t.wasmtime_ty(store), t.internal_size(store))
+            }
             Extern::Global(t) => DefinitionType::Global(*t.wasmtime_ty(store)),
             Extern::Memory(t) => {
                 DefinitionType::Memory(*t.wasmtime_ty(store), t.internal_size(store))

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -29,7 +29,6 @@ impl InstanceId {
 
 pub struct StoreData {
     id: StoreId,
-    tables: Vec<crate::runtime::vm::ExportTable>,
     instances: Vec<crate::instance::InstanceData>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
@@ -52,7 +51,6 @@ macro_rules! impl_store_data {
 }
 
 impl_store_data! {
-    tables => crate::runtime::vm::ExportTable,
     instances => crate::instance::InstanceData,
 }
 
@@ -60,7 +58,6 @@ impl StoreData {
     pub fn new() -> StoreData {
         StoreData {
             id: StoreId::allocate(),
-            tables: Vec::new(),
             instances: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -507,8 +507,7 @@ impl Instance {
     }
 
     /// Return the indexed `VMTableDefinition`.
-    #[allow(dead_code)]
-    fn table(&mut self, index: DefinedTableIndex) -> VMTableDefinition {
+    pub fn table(&self, index: DefinedTableIndex) -> VMTableDefinition {
         unsafe { self.table_ptr(index).read() }
     }
 
@@ -519,8 +518,9 @@ impl Instance {
         }
     }
 
-    /// Return the indexed `VMTableDefinition`.
-    fn table_ptr(&self, index: DefinedTableIndex) -> NonNull<VMTableDefinition> {
+    /// Return a pointer to the `index`'th table within this instance, stored
+    /// in vmctx memory.
+    pub fn table_ptr(&self, index: DefinedTableIndex) -> NonNull<VMTableDefinition> {
         unsafe { self.vmctx_plus_offset_raw(self.offsets().vmctx_vmtable_definition(index)) }
     }
 
@@ -718,7 +718,7 @@ impl Instance {
         ExportFunction { func_ref }
     }
 
-    fn get_exported_table(&mut self, index: TableIndex) -> ExportTable {
+    fn get_exported_table(&self, index: TableIndex) -> ExportTable {
         let ty = self.env_module().tables[index];
         let (definition, vmctx, index) =
             if let Some(def_index) = self.env_module().defined_table_index(index) {


### PR DESCRIPTION
This commit is similar to a prior commit modifying memories which refactors the internals of `wasmtime::Table` to not longer use a `Stored` index. Instead a `StoreInstanceId` and a `DefinedTableIndex` is used instead. This enables construction of external-facing types to be trivial and zero-cost.

This additionally notably fixes an issue where triggering a GC in a store would unconditionally create a `Table`, pushing onto an internal vector in the store. This then would never be deallocated because the internal table lived as long as the `Store`. In effect this meant that triggering a GC would end up leaking memory by pushing more items onto internal `Store` table. This is fixed through this commit because creating a `wasmtime::Table` is now "free" and no longer requires any allocations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
