### PR TITLE
x64: Migrate `UnaryRmRVex*` instructions to new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -1086,6 +1086,21 @@ impl Vex {
         }
     }
 
+    /// Set the digit extending the opcode; equivalent to `/<digit>` in the
+    /// reference manual.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `extension` is too large.
+    #[must_use]
+    pub fn digit(self, extension: u8) -> Self {
+        assert!(extension <= 0b111, "must fit in 3 bits");
+        Self {
+            modrm: Some(ModRmKind::Digit(extension)),
+            ..self
+        }
+    }
+
     fn validate(&self, _operands: &[Operand]) {
         assert!(self.opcode != u8::MAX);
         assert!(self.mmmmm.is_some());

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -218,6 +218,17 @@ impl dsl::Format {
                     rm: *rm,
                 }
             }
+            [Reg(vvvv), RegMem(rm)] => {
+                let digit = vex.modrm.unwrap().unwrap_digit();
+                fmtln!(f, "let reg = {digit:#x};");
+                fmtln!(f, "let vvvv = self.{vvvv}.enc();");
+                fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
+                fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                ModRmStyle::RegMem {
+                    reg: ModRmReg::Digit(digit),
+                    rm: *rm,
+                }
+            }
             unknown => unimplemented!("unknown pattern: {unknown:?}"),
         };
 

--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -43,6 +43,15 @@ pub fn list() -> Vec<Inst> {
         inst("bswapl", fmt("O", [rw(r32)]), rex([0x0F, 0xC8]).rd(), _64b | compat),
         inst("bswapq", fmt("O", [rw(r64)]), rex([0x0F, 0xC8]).w().ro(), _64b),
 
+        // BMI1 instructions
+        inst("blsrl", fmt("VM", [w(r32), r(rm32)]), vex(LZ)._0f38().w0().op(0xF3).digit(1), _64b | compat | bmi1),
+        inst("blsrq", fmt("VM", [w(r64), r(rm64)]), vex(LZ)._0f38().w1().op(0xF3).digit(1), _64b | bmi1),
+        inst("blsmskl", fmt("VM", [w(r32), r(rm32)]), vex(LZ)._0f38().w0().op(0xF3).digit(2), _64b | compat | bmi1),
+        inst("blsmskq", fmt("VM", [w(r64), r(rm64)]), vex(LZ)._0f38().w1().op(0xF3).digit(2), _64b | bmi1),
+        inst("blsil", fmt("VM", [w(r32), r(rm32)]), vex(LZ)._0f38().w0().op(0xF3).digit(3), _64b | compat | bmi1),
+        inst("blsiq", fmt("VM", [w(r64), r(rm64)]), vex(LZ)._0f38().w1().op(0xF3).digit(3), _64b | compat | bmi1),
+
+        // BMI2 instructions
         inst("bzhil", fmt("RMV", [w(r32a), r(rm32), r(r32b)]), vex(LZ)._0f38().w0().op(0xF5), _64b | compat | bmi2),
         inst("bzhiq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._0f38().w1().op(0xF5), _64b | bmi2),
     ]

--- a/cranelift/assembler-x64/meta/src/instructions/shift.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/shift.rs
@@ -65,6 +65,8 @@ pub fn list() -> Vec<Inst> {
         inst("sarxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._f3()._0f38().w1().op(0xF7), _64b | bmi2),
         inst("shlxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._66()._0f38().w1().op(0xF7), _64b | bmi2),
         inst("shrxq", fmt("RMV", [w(r64a), r(rm64), r(r64b)]), vex(LZ)._f2()._0f38().w1().op(0xF7), _64b | bmi2),
+        inst("rorxl", fmt("RMI", [w(r32), r(rm32), r(imm8)]), vex(LZ)._f2()._0f3a().w0().op(0xF0).r().ib(), _64b | compat | bmi2),
+        inst("rorxq", fmt("RMI", [w(r64), r(rm64), r(imm8)]), vex(LZ)._f2()._0f3a().w1().op(0xF0).r().ib(), _64b | bmi2),
 
         // Vector instructions (shift left).
         inst("psllw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0xF1]).r(), _64b | compat | sse2),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -13,19 +13,6 @@
        ;; =========================================
        ;; Integer instructions.
 
-       ;; Same as `UnaryRmR` but with the VEX prefix for BMI1 instructions.
-       (UnaryRmRVex (size OperandSize)
-                    (op UnaryRmRVexOpcode)
-                    (src GprMem)
-                    (dst WritableGpr))
-
-       ;; Same as `UnaryRmRVex` but with an immediate
-       (UnaryRmRImmVex (size OperandSize)
-                       (op UnaryRmRImmVexOpcode)
-                       (src GprMem)
-                       (dst WritableGpr)
-                       (imm u8))
-
        ;; A synthetic instruction sequence used as part of the lowering of the
        ;; `srem` instruction which returns 0 if the divisor is -1 and
        ;; otherwise executes an `idiv` instruction.
@@ -678,21 +665,6 @@
 (rule (operand_size_bits (OperandSize.Size16)) 16)
 (rule (operand_size_bits (OperandSize.Size32)) 32)
 (rule (operand_size_bits (OperandSize.Size64)) 64)
-
-(type UnaryRmROpcode extern
-      (enum Bsr
-            Bsf
-            Lzcnt
-            Tzcnt
-            Popcnt))
-
-(type UnaryRmRVexOpcode
-      (enum Blsi
-            Blsmsk
-            Blsr))
-
-(type UnaryRmRImmVexOpcode
-      (enum Rorx))
 
 (type SseOpcode extern
       (enum Blendvpd
@@ -1876,20 +1848,6 @@
 (rule (xmm_rmr_vex3 op src1 src2 src3)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmRVex3 op src1 src2 src3 dst))))
-        dst))
-
-;; Helper for creating `MInst.UnaryRmRVex` instructions.
-(decl unary_rm_r_vex (UnaryRmRVexOpcode GprMem OperandSize) Gpr)
-(rule (unary_rm_r_vex op src size)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.UnaryRmRVex size op src dst))))
-        dst))
-
-;; Helper for creating `MInst.UnaryRmRImmVex` instructions.
-(decl unary_rm_r_imm_vex (UnaryRmRImmVexOpcode GprMem OperandSize u8) Gpr)
-(rule (unary_rm_r_imm_vex op src size imm)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.UnaryRmRImmVex size op src dst imm))))
         dst))
 
 (decl cvt_int_to_float_vex (AvxOpcode Xmm GprMem OperandSize) Xmm)
@@ -4226,18 +4184,18 @@
 
 ;; Helper for creating `blsi` instructions.
 (decl x64_blsi (Type GprMem) Gpr)
-(rule (x64_blsi ty src)
-      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsi) src (operand_size_of_type_32_64 ty)))
+(rule (x64_blsi $I32 src) (x64_blsil_vm src))
+(rule (x64_blsi $I64 src) (x64_blsiq_vm src))
 
 ;; Helper for creating `blsmsk` instructions.
 (decl x64_blsmsk (Type GprMem) Gpr)
-(rule (x64_blsmsk ty src)
-      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsmsk) src (operand_size_of_type_32_64 ty)))
+(rule (x64_blsmsk $I32 src) (x64_blsmskl_vm src))
+(rule (x64_blsmsk $I64 src) (x64_blsmskq_vm src))
 
 ;; Helper for creating `blsr` instructions.
 (decl x64_blsr (Type GprMem) Gpr)
-(rule (x64_blsr ty src)
-      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsr) src (operand_size_of_type_32_64 ty)))
+(rule (x64_blsr $I32 src) (x64_blsrl_vm src))
+(rule (x64_blsr $I64 src) (x64_blsrq_vm src))
 
 ;; Helper for creating `sarx` instructions.
 (decl x64_sarx (Type GprMem Gpr) Gpr)
@@ -4256,11 +4214,8 @@
 
 ;; Helper for creating `rorx` instructions.
 (decl x64_rorx (Type GprMem u8) Gpr)
-(rule (x64_rorx ty src imm)
-      (unary_rm_r_imm_vex (UnaryRmRImmVexOpcode.Rorx)
-                          src
-                          (operand_size_of_type_32_64 ty)
-                          imm))
+(rule (x64_rorx $I32 src imm) (x64_rorxl_rmi src imm))
+(rule (x64_rorx $I64 src imm) (x64_rorxq_rmi src imm))
 
 ;; Helper for creating `popcnt` instructions.
 (decl x64_popcnt (Type GprMem) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -729,42 +729,6 @@ impl PrettyPrint for RegMem {
     }
 }
 
-pub use crate::isa::x64::lower::isle::generated_code::UnaryRmRVexOpcode;
-
-impl UnaryRmRVexOpcode {
-    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
-        match self {
-            UnaryRmRVexOpcode::Blsi | UnaryRmRVexOpcode::Blsmsk | UnaryRmRVexOpcode::Blsr => {
-                smallvec![InstructionSet::BMI1]
-            }
-        }
-    }
-}
-
-impl fmt::Display for UnaryRmRVexOpcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("{self:?}").to_lowercase())
-    }
-}
-
-pub use crate::isa::x64::lower::isle::generated_code::UnaryRmRImmVexOpcode;
-
-impl UnaryRmRImmVexOpcode {
-    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
-        match self {
-            UnaryRmRImmVexOpcode::Rorx => {
-                smallvec![InstructionSet::BMI2]
-            }
-        }
-    }
-}
-
-impl fmt::Display for UnaryRmRImmVexOpcode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&format!("{self:?}").to_lowercase())
-    }
-}
-
 #[derive(Clone, Copy, PartialEq)]
 /// Comparison operations.
 pub enum CmpOpcode {

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -141,65 +141,6 @@ pub(crate) fn emit(
         )
     }
     match inst {
-        Inst::UnaryRmRVex { size, op, src, dst } => {
-            let dst = dst.to_reg().to_reg();
-            let src = match src.clone().to_reg_mem().clone() {
-                RegMem::Reg { reg } => {
-                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
-                }
-                RegMem::Mem { addr } => {
-                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
-                }
-            };
-
-            let (opcode, opcode_ext) = match op {
-                UnaryRmRVexOpcode::Blsr => (0xF3, 1),
-                UnaryRmRVexOpcode::Blsmsk => (0xF3, 2),
-                UnaryRmRVexOpcode::Blsi => (0xF3, 3),
-            };
-
-            VexInstruction::new()
-                .map(OpcodeMap::_0F38)
-                .w(*size == OperandSize::Size64)
-                .opcode(opcode)
-                .reg(opcode_ext)
-                .vvvv(dst.to_real_reg().unwrap().hw_enc())
-                .rm(src)
-                .encode(sink);
-        }
-
-        Inst::UnaryRmRImmVex {
-            size,
-            op,
-            src,
-            dst,
-            imm,
-        } => {
-            let dst = dst.to_reg().to_reg();
-            let src = match src.clone().to_reg_mem().clone() {
-                RegMem::Reg { reg } => {
-                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
-                }
-                RegMem::Mem { addr } => {
-                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
-                }
-            };
-
-            let opcode = match op {
-                UnaryRmRImmVexOpcode::Rorx => 0xF0,
-            };
-
-            VexInstruction::new()
-                .prefix(LegacyPrefixes::_F2)
-                .map(OpcodeMap::_0F3A)
-                .w(*size == OperandSize::Size64)
-                .opcode(opcode)
-                .reg(dst.to_real_reg().unwrap().hw_enc())
-                .rm(src)
-                .imm(*imm)
-                .encode(sink);
-        }
-
         Inst::CheckedSRemSeq { divisor, .. } | Inst::CheckedSRemSeq8 { divisor, .. } => {
             // Validate that the register constraints of the dividend and the
             // destination are all as expected.

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -62,21 +62,6 @@ pub(crate) fn check(
             Ok(())
         }
 
-        Inst::UnaryRmRVex {
-            size, ref src, dst, ..
-        }
-        | Inst::UnaryRmRImmVex {
-            size, ref src, dst, ..
-        } => match <&RegMem>::from(src) {
-            RegMem::Mem { addr } => {
-                check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
-                check_output(ctx, vcode, dst.to_writable_reg(), &[], |_vcode| {
-                    clamp_range(ctx, 64, size.to_bits().into(), None)
-                })
-            }
-            RegMem::Reg { .. } => undefined_result(ctx, vcode, dst, 64, size.to_bits().into()),
-        },
-
         Inst::CheckedSRemSeq {
             dst_quotient,
             dst_remainder,

--- a/cranelift/filetests/filetests/isa/x64/bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi1.clif
@@ -13,7 +13,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrl   %edi, %eax
+;   blsrl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -40,7 +40,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrl   %edi, %eax
+;   blsrl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -67,7 +67,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrl   %edi, %eax
+;   blsrl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -94,7 +94,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrq   %rdi, %rax
+;   blsrq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -121,7 +121,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrl   %edi, %eax
+;   blsrl %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -148,7 +148,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsrq   %rdi, %rax
+;   blsrq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -174,7 +174,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsil   %edi, %eax
+;   blsil %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -200,7 +200,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsiq   %rdi, %rax
+;   blsiq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -226,7 +226,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsil   %edi, %eax
+;   blsil %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -252,7 +252,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   blsiq   %rdi, %rax
+;   blsiq %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/bmi2.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi2.clif
@@ -163,7 +163,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   rorxl   $3, %edi, %eax
+;   rorxl $0x3, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -189,7 +189,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   rorxq   $3, %rdi, %rax
+;   rorxq $0x3, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -215,7 +215,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   rorxl   $29, %edi, %eax
+;   rorxl $0x1d, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -241,7 +241,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   rorxq   $61, %rdi, %rax
+;   rorxq $0x3d, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
This migrates `blsi`, `blsmsk`, `blsr`, and `rorx` all to the new assembler. Some new formats but otherwise nothing major.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
