### PR TITLE
Remove dead accessors for a field of `VM*Import`

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -592,12 +592,6 @@ impl<P: PtrSize> VMOffsets<P> {
         0 * self.pointer_size()
     }
 
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmtable_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
     /// Return the size of `VMTableImport`.
     #[inline]
     pub fn size_of_vmtable_import(&self) -> u8 {
@@ -637,12 +631,6 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmmemory_import_from(&self) -> u8 {
         0 * self.pointer_size()
-    }
-
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmmemory_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
     }
 
     /// Return the size of `VMMemoryImport`.
@@ -893,12 +881,6 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_vmmemory_import_from(&self, index: MemoryIndex) -> u32 {
         self.vmctx_vmmemory_import(index) + u32::from(self.vmmemory_import_from())
-    }
-
-    /// Return the offset to the `vmctx` field in `VMMemoryImport` index `index`.
-    #[inline]
-    pub fn vmctx_vmmemory_import_vmctx(&self, index: MemoryIndex) -> u32 {
-        self.vmctx_vmmemory_import(index) + u32::from(self.vmmemory_import_vmctx())
     }
 
     /// Return the offset to the `base` field in `VMMemoryDefinition` index `index`.

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -177,10 +177,6 @@ mod test_vmtable {
             offset_of!(VMTableImport, from),
             usize::from(offsets.vmtable_import_from())
         );
-        assert_eq!(
-            offset_of!(VMTableImport, vmctx),
-            usize::from(offsets.vmtable_import_vmctx())
-        );
     }
 
     #[test]
@@ -235,10 +231,6 @@ mod test_vmmemory_import {
         assert_eq!(
             offset_of!(VMMemoryImport, from),
             usize::from(offsets.vmmemory_import_from())
-        );
-        assert_eq!(
-            offset_of!(VMMemoryImport, vmctx),
-            usize::from(offsets.vmmemory_import_vmctx())
         );
     }
 }


### PR DESCRIPTION
These aren't actually read from compiled wasm code, only from the host.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
