### PR TITLE
Disable memory64 fuzzing in wasmi temporarily

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -22,6 +22,9 @@ impl WasmiEngine {
         // FIXME: once the active fuzz bug for wasmi's simd differential fuzzing
         // has been fixed and we've updated then this should be re-enabled.
         config.simd_enabled = false;
+        // FIXME: requires updating to a wasmi that contains
+        // wasmi-labs/wasmi#1531.
+        config.memory64_enabled = false;
 
         let mut wasmi_config = wasmi::Config::default();
         wasmi_config


### PR DESCRIPTION
Until it's updated to include wasmi-labs/wasmi#1531

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
