### PR TITLE
Replace `as usize` with `.addr()`

### DIFF
--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -348,7 +348,7 @@ impl Global {
     /// this hash key will be consistent across all of these globals.
     #[cfg(feature = "coredump")]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
-        self.definition(store).as_ptr() as usize
+        self.definition(store).as_ptr().addr()
     }
 
     fn definition(&self, store: &StoreOpaque) -> NonNull<VMGlobalDefinition> {

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -449,7 +449,7 @@ impl Table {
     /// this hash key will be consistent across all of these tables.
     #[allow(dead_code)] // Not used yet, but added for consistency.
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<'_> {
-        store[self.instance].table_ptr(self.index).as_ptr() as usize
+        store[self.instance].table_ptr(self.index).as_ptr().addr()
     }
 }
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1499,7 +1499,7 @@ impl Func {
     /// will be consistent across all of these functions.
     #[allow(dead_code)] // Not used yet, but added for consistency.
     pub(crate) fn hash_key(&self, store: &mut StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
-        self.vm_func_ref(store).as_ptr() as usize
+        self.vm_func_ref(store).as_ptr().addr()
     }
 }
 

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -679,7 +679,7 @@ impl Memory {
     /// this hash key will be consistent across all of these memories.
     #[cfg(feature = "coredump")]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
-        store[self.instance].memory_ptr(self.index).as_ptr() as usize
+        store[self.instance].memory_ptr(self.index).as_ptr().addr()
     }
 }
 


### PR DESCRIPTION
Rust has since added provenance-related APIs so this is a more intent-ful way to cast a pointer to an integer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
