### PR TITLE
 Remove Stored from wasmtime::Instance 

### DIFF
--- a/crates/c-api/include/wasmtime/instance.h
+++ b/crates/c-api/include/wasmtime/instance.h
@@ -26,8 +26,8 @@ extern "C" {
 typedef struct wasmtime_instance {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  /// Private data for use in Wasmtime.
+  size_t __private;
 } wasmtime_instance_t;
 
 /**

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -466,7 +466,7 @@ impl InstanceData {
             // investigated if this becomes a performance issue though.
             ExportItem::Name(name) => instance.module().exports[name],
         };
-        instance.get_export_by_index(idx)
+        instance.instance().get_export_by_index(idx)
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -121,7 +121,7 @@ impl Extern {
 
     pub(crate) unsafe fn from_wasmtime_export(
         wasmtime_export: crate::runtime::vm::Export,
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
     ) -> Extern {
         match wasmtime_export {
             crate::runtime::vm::Export::Function(f) => {

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -167,7 +167,7 @@ impl Table {
         unsafe {
             match (*table).get(gc_store, index)? {
                 runtime::TableElement::FuncRef(f) => {
-                    let func = f.map(|f| Func::from_vm_func_ref(&mut store, f));
+                    let func = f.map(|f| Func::from_vm_func_ref(&store, f));
                     Some(func.into())
                 }
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -527,7 +527,7 @@ impl Func {
     }
 
     pub(crate) unsafe fn from_vm_func_ref(
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
         func_ref: NonNull<VMFuncRef>,
     ) -> Func {
         debug_assert!(func_ref.as_ref().type_index != VMSharedTypeIndex::default());
@@ -1218,12 +1218,12 @@ impl Func {
 
     pub(crate) unsafe fn from_wasmtime_function(
         export: ExportFunction,
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
     ) -> Self {
         Self::from_vm_func_ref(store, export.func_ref)
     }
 
-    pub(crate) fn vmimport(&self, store: &mut StoreOpaque) -> VMFunctionImport {
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> VMFunctionImport {
         unsafe {
             let f = self.vm_func_ref(store);
             VMFunctionImport {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -4,7 +4,7 @@ use crate::runtime::vm::{
     Imports, ModuleRuntimeInfo, VMFuncRef, VMFunctionImport, VMGlobalImport, VMMemoryImport,
     VMOpaqueContext, VMTableImport, VMTagImport,
 };
-use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque, Stored};
+use crate::store::{AllocateInstanceKind, InstanceId, StoreInstanceId, StoreOpaque};
 use crate::types::matching;
 use crate::{
     AsContextMut, Engine, Export, Extern, Func, Global, Memory, Module, ModuleExport, SharedMemory,
@@ -32,20 +32,20 @@ use wasmtime_environ::{
 /// [`Linker`](crate::Linker) methods, but a more low-level constructor is also
 /// available as [`Instance::new`].
 #[derive(Copy, Clone, Debug)]
-#[repr(transparent)]
-pub struct Instance(Stored<InstanceData>);
-
-pub(crate) struct InstanceData {
-    /// The id of the instance within the store, used to find the original
-    /// `InstanceHandle`.
-    id: InstanceId,
+#[repr(C)]
+pub struct Instance {
+    id: StoreInstanceId,
 }
 
-impl InstanceData {
-    pub fn from_id(id: InstanceId) -> InstanceData {
-        InstanceData { id }
-    }
-}
+// Double-check that the C representation in `instance.h` matches our in-Rust
+// representation here in terms of size/alignment/etc.
+const _: () = {
+    #[repr(C)]
+    struct C(u64, usize);
+    assert!(core::mem::size_of::<C>() == core::mem::size_of::<Instance>());
+    assert!(core::mem::align_of::<C>() == core::mem::align_of::<Instance>());
+    assert!(core::mem::offset_of!(Instance, id) == 0);
+};
 
 impl Instance {
     /// Creates a new [`Instance`] from the previously compiled [`Module`] and
@@ -277,19 +277,10 @@ impl Instance {
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an
         // instance handle.
-        //
-        // Note that the `host_state` here is a pointer back to the
-        // `Instance` we'll be returning from this function. This is a
-        // circular reference so we can't construct it before we construct
-        // this instance, so we determine what the ID is and then assert
-        // it's the same later when we do actually insert it.
-        let instance_to_be = store.store_data().next_id::<InstanceData>();
-
         let id = store.allocate_instance(
             AllocateInstanceKind::Module(module_id),
             &ModuleRuntimeInfo::Module(module.clone()),
             imports,
-            Box::new(Instance(instance_to_be)),
         )?;
 
         // Additionally, before we start doing fallible instantiation, we
@@ -304,14 +295,7 @@ impl Instance {
         // For module/instance exports, though, those aren't actually
         // stored in the instance handle so we need to immediately handle
         // those here.
-        let instance = {
-            let data = InstanceData { id };
-            Instance::from_wasmtime(data, store)
-        };
-
-        // double-check our guess of what the new instance's ID would be
-        // was actually correct.
-        assert_eq!(instance.0, instance_to_be);
+        let instance = Instance::from_wasmtime(id, store);
 
         // Now that we've recorded all information we need to about this
         // instance within a `Store` we can start performing fallible
@@ -335,15 +319,16 @@ impl Instance {
         Ok((instance, compiled_module.module().start_func))
     }
 
-    pub(crate) fn from_wasmtime(handle: InstanceData, store: &mut StoreOpaque) -> Instance {
-        Instance(store.store_data_mut().insert(handle))
+    pub(crate) fn from_wasmtime(id: InstanceId, store: &mut StoreOpaque) -> Instance {
+        Instance {
+            id: StoreInstanceId::new(store.id(), id),
+        }
     }
 
     fn start_raw<T>(&self, store: &mut StoreContextMut<'_, T>, start: FuncIndex) -> Result<()> {
-        let id = store.0.store_data()[self.0].id;
         // If a start function is present, invoke it. Make sure we use all the
         // trap-handling configuration in `store` as well.
-        let instance = store.0.instance_mut(id);
+        let instance = &mut store.0[self.id];
         let f = instance.get_exported_func(start);
         let caller_vmctx = instance.vmctx();
         unsafe {
@@ -364,8 +349,7 @@ impl Instance {
     }
 
     fn _module<'a>(&self, store: &'a StoreOpaque) -> &'a Module {
-        let InstanceData { id, .. } = store[self.0];
-        store.module_for_instance(id).unwrap()
+        store.module_for_instance(self.id).unwrap()
     }
 
     /// Returns the list of exported items from this [`Instance`].
@@ -384,9 +368,8 @@ impl Instance {
         &'a self,
         store: &'a mut StoreOpaque,
     ) -> impl ExactSizeIterator<Item = Export<'a>> + 'a {
-        let data = &store.store_data()[self.0];
-        let module = store.instance(data.id).module();
-        module
+        store[self.id]
+            .env_module()
             .exports
             .iter()
             .map(|(name, entity)| Export::new(name, self._get_export(store, *entity)))
@@ -411,9 +394,7 @@ impl Instance {
     /// mutable context.
     pub fn get_export(&self, mut store: impl AsContextMut, name: &str) -> Option<Extern> {
         let store = store.as_context_mut().0;
-        let data = &store[self.0];
-        let instance = store.instance(data.id);
-        let entity = *instance.module().exports.get(name)?;
+        let entity = *store[self.id].env_module().exports.get(name)?;
         Some(self._get_export(store, entity))
     }
 
@@ -446,13 +427,8 @@ impl Instance {
     }
 
     fn _get_export(&self, store: &StoreOpaque, entity: EntityIndex) -> Extern {
-        // Instantiated instances will lazily fill in exports, so we process
-        // all that lazy logic here.
-        let data = &store[self.0];
-
-        let instance = store.instance(data.id); // Reborrow the &mut InstanceHandle
-
-        unsafe { Extern::from_wasmtime_export(instance.get_export_by_index(entity), store) }
+        let export = store[self.id].get_export_by_index(entity);
+        unsafe { Extern::from_wasmtime_export(export, store) }
     }
 
     /// Looks up an exported [`Func`] value by name.
@@ -562,7 +538,7 @@ impl Instance {
 
     #[cfg(feature = "component-model")]
     pub(crate) fn id(&self, store: &StoreOpaque) -> InstanceId {
-        store[self.0].id
+        store[self.id].id()
     }
 
     /// Get all globals within this instance.
@@ -577,9 +553,7 @@ impl Instance {
         &'a self,
         store: &'a mut StoreOpaque,
     ) -> impl ExactSizeIterator<Item = (GlobalIndex, Global)> + 'a {
-        let data = &store[self.0];
-        let instance = store.instance_mut(data.id);
-        instance
+        store[self.id]
             .all_globals()
             .collect::<Vec<_>>()
             .into_iter()
@@ -598,9 +572,7 @@ impl Instance {
         &'a self,
         store: &'a mut StoreOpaque,
     ) -> impl ExactSizeIterator<Item = (MemoryIndex, Memory)> + 'a {
-        let data = &store[self.0];
-        let instance = store.instance_mut(data.id);
-        instance
+        store[self.id]
             .all_memories()
             .collect::<Vec<_>>()
             .into_iter()

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -1030,7 +1030,7 @@ impl SharedMemory {
     /// shared memory and the user wants host-side access to it.
     pub(crate) unsafe fn from_wasmtime_memory(
         wasmtime_export: crate::runtime::vm::ExportMemory,
-        store: &mut StoreOpaque,
+        store: &StoreOpaque,
     ) -> Self {
         #[cfg_attr(not(feature = "threads"), allow(unused_variables, unreachable_code))]
         crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |handle| {

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -862,14 +862,11 @@ impl Module {
     pub fn get_export_index(&self, name: &str) -> Option<ModuleExport> {
         let compiled_module = self.compiled_module();
         let module = compiled_module.module();
-        module
-            .exports
-            .get_full(name)
-            .map(|(export_name_index, _, &entity)| ModuleExport {
-                module: self.id(),
-                entity,
-                export_name_index,
-            })
+        let entity = *module.exports.get(name)?;
+        Some(ModuleExport {
+            module: self.id(),
+            entity,
+        })
     }
 
     /// Returns the [`Engine`] that this [`Module`] was compiled by.
@@ -1152,8 +1149,6 @@ pub struct ModuleExport {
     pub(crate) module: CompiledModuleId,
     /// A raw index into the wasm module.
     pub(crate) entity: EntityIndex,
-    /// The index of the export name.
-    pub(crate) export_name_index: usize,
 }
 
 fn _assert_send_sync() {

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -29,7 +29,6 @@ impl InstanceId {
 
 pub struct StoreData {
     id: StoreId,
-    instances: Vec<crate::instance::InstanceData>,
     #[cfg(feature = "component-model")]
     pub(crate) components: crate::component::ComponentStoreData,
 }
@@ -39,26 +38,10 @@ pub trait StoredData: Sized {
     fn list_mut(data: &mut StoreData) -> &mut Vec<Self>;
 }
 
-macro_rules! impl_store_data {
-    ($($field:ident => $t:ty,)*) => ($(
-        impl StoredData for $t {
-            #[inline]
-            fn list(data: &StoreData) -> &Vec<Self> { &data.$field }
-            #[inline]
-            fn list_mut(data: &mut StoreData) -> &mut Vec<Self> { &mut data.$field }
-        }
-    )*)
-}
-
-impl_store_data! {
-    instances => crate::instance::InstanceData,
-}
-
 impl StoreData {
     pub fn new() -> StoreData {
         StoreData {
             id: StoreId::allocate(),
-            instances: Vec::new(),
             #[cfg(feature = "component-model")]
             components: Default::default(),
         }
@@ -341,7 +324,7 @@ pub struct StoreInstanceId {
 }
 
 impl StoreInstanceId {
-    pub(super) fn new(store_id: StoreId, instance: InstanceId) -> StoreInstanceId {
+    pub(crate) fn new(store_id: StoreId, instance: InstanceId) -> StoreInstanceId {
         StoreInstanceId { store_id, instance }
     }
 
@@ -353,6 +336,11 @@ impl StoreInstanceId {
     #[inline]
     pub fn store_id(&self) -> StoreId {
         self.store_id
+    }
+
+    #[inline]
+    pub(crate) fn instance(&self) -> InstanceId {
+        self.instance
     }
 }
 

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -18,13 +18,11 @@ use crate::runtime::vm::{
 use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque};
 use crate::{MemoryType, TableType};
 use alloc::sync::Arc;
-use core::any::Any;
 use wasmtime_environ::{MemoryIndex, Module, TableIndex, VMSharedTypeIndex};
 
 fn create_handle(
     module: Module,
     store: &mut StoreOpaque,
-    host_state: Box<dyn Any + Send + Sync>,
     func_imports: &[VMFunctionImport],
     one_signature: Option<VMSharedTypeIndex>,
 ) -> Result<InstanceId> {
@@ -41,7 +39,6 @@ fn create_handle(
             },
             &ModuleRuntimeInfo::bare_maybe_imported_func(module, one_signature),
             imports,
-            host_state,
         )
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -58,7 +58,6 @@ pub fn create_memory(
             },
             &ModuleRuntimeInfo::bare_maybe_imported_func(Arc::new(module), None),
             Default::default(),
-            Box::new(()),
         )
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -22,5 +22,5 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
         .exports
         .insert(String::new(), EntityIndex::Table(table_id));
 
-    create_handle(module, store, Box::new(()), &[], None)
+    create_handle(module, store, &[], None)
 }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -713,7 +713,7 @@ impl Instance {
         NonNull::new(ret).unwrap()
     }
 
-    fn get_exported_func(&mut self, index: FuncIndex) -> ExportFunction {
+    fn get_exported_func(&self, index: FuncIndex) -> ExportFunction {
         let func_ref = self.get_func_ref(index).unwrap();
         ExportFunction { func_ref }
     }
@@ -739,7 +739,7 @@ impl Instance {
         }
     }
 
-    fn get_exported_memory(&mut self, index: MemoryIndex) -> ExportMemory {
+    fn get_exported_memory(&self, index: MemoryIndex) -> ExportMemory {
         let (definition, vmctx, def_index) =
             if let Some(def_index) = self.env_module().defined_memory_index(index) {
                 (self.memory_ptr(def_index), self.vmctx(), def_index)
@@ -772,7 +772,7 @@ impl Instance {
         }
     }
 
-    fn get_exported_tag(&mut self, index: TagIndex) -> ExportTag {
+    fn get_exported_tag(&self, index: TagIndex) -> ExportTag {
         let tag = self.env_module().tags[index];
         let (vmctx, definition, index) =
             if let Some(def_index) = self.env_module().defined_tag_index(index) {
@@ -936,7 +936,7 @@ impl Instance {
     /// before, because resetting that state on (re)instantiation is
     /// very expensive if there are many funcrefs.
     fn construct_func_ref(
-        &mut self,
+        &self,
         index: FuncIndex,
         type_index: VMSharedTypeIndex,
         into: *mut VMFuncRef,
@@ -975,7 +975,7 @@ impl Instance {
     ///
     /// The returned reference is a stable reference that won't be moved and can
     /// be passed into JIT code.
-    pub(crate) fn get_func_ref(&mut self, index: FuncIndex) -> Option<NonNull<VMFuncRef>> {
+    pub(crate) fn get_func_ref(&self, index: FuncIndex) -> Option<NonNull<VMFuncRef>> {
         if index == FuncIndex::reserved_value() {
             return None;
         }
@@ -1600,32 +1600,32 @@ impl InstanceHandle {
     }
 
     /// Lookup a function by index.
-    pub fn get_exported_func(&mut self, export: FuncIndex) -> ExportFunction {
-        self.instance_mut().get_exported_func(export)
+    pub fn get_exported_func(&self, export: FuncIndex) -> ExportFunction {
+        self.instance().get_exported_func(export)
     }
 
     /// Lookup a global by index.
-    pub fn get_exported_global(&mut self, export: GlobalIndex) -> ExportGlobal {
-        self.instance_mut().get_exported_global(export)
+    pub fn get_exported_global(&self, export: GlobalIndex) -> ExportGlobal {
+        self.instance().get_exported_global(export)
     }
 
     /// Lookup a tag by index.
-    pub fn get_exported_tag(&mut self, export: TagIndex) -> ExportTag {
-        self.instance_mut().get_exported_tag(export)
+    pub fn get_exported_tag(&self, export: TagIndex) -> ExportTag {
+        self.instance().get_exported_tag(export)
     }
 
     /// Lookup a memory by index.
-    pub fn get_exported_memory(&mut self, export: MemoryIndex) -> ExportMemory {
-        self.instance_mut().get_exported_memory(export)
+    pub fn get_exported_memory(&self, export: MemoryIndex) -> ExportMemory {
+        self.instance().get_exported_memory(export)
     }
 
     /// Lookup a table by index.
-    pub fn get_exported_table(&mut self, export: TableIndex) -> ExportTable {
-        self.instance_mut().get_exported_table(export)
+    pub fn get_exported_table(&self, export: TableIndex) -> ExportTable {
+        self.instance().get_exported_table(export)
     }
 
     /// Lookup an item with the given index.
-    pub fn get_export_by_index(&mut self, export: EntityIndex) -> Export {
+    pub fn get_export_by_index(&self, export: EntityIndex) -> Export {
         match export {
             EntityIndex::Function(i) => Export::Function(self.get_exported_func(i)),
             EntityIndex::Global(i) => Export::Global(self.get_exported_global(i)),

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -20,7 +20,6 @@ use crate::store::{InstanceId, StoreInner, StoreOpaque};
 use crate::{StoreContextMut, prelude::*};
 use alloc::sync::Arc;
 use core::alloc::Layout;
-use core::any::Any;
 use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(target_has_atomic = "64")]
@@ -222,12 +221,6 @@ pub struct Instance {
     /// If the index is present in the set, the segment has been dropped.
     dropped_data: EntitySet<DataIndex>,
 
-    /// Hosts can store arbitrary per-instance information here.
-    ///
-    /// Most of the time from Wasmtime this is `Box::new(())`, a noop
-    /// allocation, but some host-defined objects will store their state here.
-    host_state: Box<dyn Any + Send + Sync>,
-
     /// A pointer to the `vmctx` field at the end of the `Instance`.
     ///
     /// If you're looking at this a reasonable question would be "why do we need
@@ -326,7 +319,6 @@ impl Instance {
                 tables,
                 dropped_elements,
                 dropped_data,
-                host_state: req.host_state,
                 vmctx_self_reference: SendSyncPtr::new(NonNull::new(ptr.add(1).cast()).unwrap()),
                 vmctx: VMContext {
                     _marker: core::marker::PhantomPinned,
@@ -713,7 +705,12 @@ impl Instance {
         NonNull::new(ret).unwrap()
     }
 
-    fn get_exported_func(&self, index: FuncIndex) -> ExportFunction {
+    /// Lookup a function by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds for this instance.
+    pub fn get_exported_func(&self, index: FuncIndex) -> ExportFunction {
         let func_ref = self.get_func_ref(index).unwrap();
         ExportFunction { func_ref }
     }
@@ -800,12 +797,6 @@ impl Instance {
     /// resolved `lookup_by_declaration`.
     pub fn exports(&self) -> wasmparser::collections::index_map::Iter<String, EntityIndex> {
         self.env_module().exports.iter()
-    }
-
-    /// Return a reference to the custom state attached to this instance.
-    #[inline]
-    pub fn host_state(&self) -> &dyn Any {
-        &*self.host_state
     }
 
     /// Return the table index for the given `VMTableDefinition`.
@@ -1573,6 +1564,47 @@ impl Instance {
     pub fn id(&self) -> InstanceId {
         self.id
     }
+
+    /// Get all memories within this instance.
+    ///
+    /// Returns both import and defined memories.
+    ///
+    /// Returns both exported and non-exported memories.
+    ///
+    /// Gives access to the full memories space.
+    pub fn all_memories<'a>(
+        &'a self,
+    ) -> impl ExactSizeIterator<Item = (MemoryIndex, ExportMemory)> + 'a {
+        let indices = (0..self.env_module().memories.len())
+            .map(|i| MemoryIndex::new(i))
+            .collect::<Vec<_>>();
+        indices
+            .into_iter()
+            .map(|i| (i, self.get_exported_memory(i)))
+    }
+
+    /// Return the memories defined in this instance (not imported).
+    pub fn defined_memories<'a>(&'a self) -> impl ExactSizeIterator<Item = ExportMemory> + 'a {
+        let num_imported = self.env_module().num_imported_memories;
+        self.all_memories()
+            .skip(num_imported)
+            .map(|(_i, memory)| memory)
+    }
+
+    /// Lookup an item with the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `export` is not valid for this instance.
+    pub fn get_export_by_index(&self, export: EntityIndex) -> Export {
+        match export {
+            EntityIndex::Function(i) => Export::Function(self.get_exported_func(i)),
+            EntityIndex::Global(i) => Export::Global(self.get_exported_global(i)),
+            EntityIndex::Table(i) => Export::Table(self.get_exported_table(i)),
+            EntityIndex::Memory(i) => Export::Memory(self.get_exported_memory(i)),
+            EntityIndex::Tag(i) => Export::Tag(self.get_exported_tag(i)),
+        }
+    }
 }
 
 /// A handle holding an `Instance` of a WebAssembly module.
@@ -1624,17 +1656,6 @@ impl InstanceHandle {
         self.instance().get_exported_table(export)
     }
 
-    /// Lookup an item with the given index.
-    pub fn get_export_by_index(&self, export: EntityIndex) -> Export {
-        match export {
-            EntityIndex::Function(i) => Export::Function(self.get_exported_func(i)),
-            EntityIndex::Global(i) => Export::Global(self.get_exported_global(i)),
-            EntityIndex::Table(i) => Export::Table(self.get_exported_table(i)),
-            EntityIndex::Memory(i) => Export::Memory(self.get_exported_memory(i)),
-            EntityIndex::Tag(i) => Export::Tag(self.get_exported_tag(i)),
-        }
-    }
-
     /// Return an iterator over the exports of this instance.
     ///
     /// Specifically, it provides access to the key-value pairs, where the keys
@@ -1642,11 +1663,6 @@ impl InstanceHandle {
     /// resolved `lookup_by_declaration`.
     pub fn exports(&self) -> wasmparser::collections::index_map::Iter<String, EntityIndex> {
         self.instance().exports()
-    }
-
-    /// Return a reference to the custom state attached to this instance.
-    pub fn host_state(&self) -> &dyn Any {
-        self.instance().host_state()
     }
 
     /// Get a table defined locally within this module.
@@ -1687,32 +1703,6 @@ impl InstanceHandle {
         self.all_tables()
             .skip(num_imported)
             .map(|(_i, table)| table)
-    }
-
-    /// Get all memories within this instance.
-    ///
-    /// Returns both import and defined memories.
-    ///
-    /// Returns both exported and non-exported memories.
-    ///
-    /// Gives access to the full memories space.
-    pub fn all_memories<'a>(
-        &'a mut self,
-    ) -> impl ExactSizeIterator<Item = (MemoryIndex, ExportMemory)> + 'a {
-        let indices = (0..self.module().memories.len())
-            .map(|i| MemoryIndex::new(i))
-            .collect::<Vec<_>>();
-        indices
-            .into_iter()
-            .map(|i| (i, self.get_exported_memory(i)))
-    }
-
-    /// Return the memories defined in this instance (not imported).
-    pub fn defined_memories<'a>(&'a mut self) -> impl ExactSizeIterator<Item = ExportMemory> + 'a {
-        let num_imported = self.module().num_imported_memories;
-        self.all_memories()
-            .skip(num_imported)
-            .map(|(_i, memory)| memory)
     }
 
     /// Get all globals within this instance.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -9,7 +9,7 @@ use crate::runtime::vm::{CompiledModuleId, ModuleRuntimeInfo, VMFuncRef, VMGcRef
 use crate::store::{AutoAssertNoGc, InstanceId, StoreOpaque};
 use crate::vm::VMGlobalDefinition;
 use core::ptr::NonNull;
-use core::{any::Any, mem, ptr};
+use core::{mem, ptr};
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, InitMemory, MemoryInitialization,
     MemoryInitializer, Module, PrimaryMap, SizeOverflow, TableInitialValue, Trap, Tunables,
@@ -51,9 +51,6 @@ pub struct InstanceAllocationRequest<'a> {
 
     /// The imports to use for the instantiation.
     pub imports: Imports<'a>,
-
-    /// The host state to associate with the instance.
-    pub host_state: Box<dyn Any + Send + Sync>,
 
     /// A pointer to the "store" for this instance to be allocated. The store
     /// correlates with the `Store` in wasmtime itself, and lots of contextual

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -911,7 +911,7 @@ unsafe fn array_init_elem(
             .iter()
             .map(|f| {
                 let raw_func_ref = instance.get_func_ref(*f);
-                let func = raw_func_ref.map(|p| Func::from_vm_func_ref(&mut store, p));
+                let func = raw_func_ref.map(|p| Func::from_vm_func_ref(&store, p));
                 Val::FuncRef(func)
             })
             .collect::<Vec<_>>(),


### PR DESCRIPTION
Powered by all previous commits this is a near-trivial change where an
`Instance` is now more-or-less "just" an `InstanceId`. Additionally the
`host_state: Box<dyn Any>` is no longer needed within `vm::Instance` so
that was removed as well.