### PR TITLE
Adjust lint warning reason

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -43,7 +43,7 @@ pub(crate) struct IsleContext<'a, 'b, 'c> {
 }
 
 impl IsleContext<'_, '_, '_> {
-    #[allow(dead_code, reason = "FIXME(rust-lang/rust#141407)")]
+    #[allow(dead_code, reason = "dead code, only on nightly rust at this time")]
     pub(crate) fn dfg(&self) -> &crate::ir::DataFlowGraph {
         &self.ctx.func.dfg
     }


### PR DESCRIPTION
After digging into this more I was confused by compiler diagnostics (or lack thereof). This is indeed dead code but it's required due to how we use macros/generated code/etc, so just suppress the warning for now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
