### PR TITLE
Change compilation settings for ASAN with rustdoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -778,7 +778,7 @@ jobs:
         echo CARGO_PROFILE_DEV_OPT_LEVEL=2 >> $GITHUB_ENV
         echo CARGO_PROFILE_TEST_OPT_LEVEL=2 >> $GITHUB_ENV
         echo RUSTFLAGS=-Zsanitizer=address >> $GITHUB_ENV
-        echo RUSTDOCFLAGS=-Zsanitizer=address >> $GITHUB_ENV
+        echo RUSTDOCFLAGS="-Zsanitizer=address -Copt-level=2 -Ccodegen-units=16" >> $GITHUB_ENV
       if: ${{ contains(matrix.name, 'ASAN') }}
 
     # Record some CPU details; this is helpful information if tests fail due


### PR DESCRIPTION
It appears that rustdoc tests do not inherit profile settings nor default codegen unit settings. This means that an ASAN build of doc tests would use 1 CGU with no optimizations. Locally this balooned the doc tests for `wasmtime-wasi` to a whopping 16G of memory in one process locally. This was found in the wasip3-prototyping repository where more doc tests were added.

This commit, for ASAN builds, updates the opt-level and codegen-units settings used for rustdoc. This gets the LLVM memory usage under control to avoid OOM-ing the github actions runner we're running on.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
