### PR TITLE
Remove `Stored` usage from `wasmtime::component::Instance`

### DIFF
--- a/crates/c-api/include/wasmtime/component/instance.h
+++ b/crates/c-api/include/wasmtime/component/instance.h
@@ -25,7 +25,7 @@ typedef struct wasmtime_component_instance {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
   /// Internal index within the store.
-  size_t index;
+  size_t __private;
 } wasmtime_component_instance_t;
 
 /**

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -2,7 +2,6 @@ use crate::component::InstanceExportLookup;
 use crate::component::matching::InstanceType;
 use crate::component::types;
 use crate::prelude::*;
-use crate::runtime::vm::component::ComponentRuntimeInfo;
 #[cfg(feature = "std")]
 use crate::runtime::vm::open_file_for_mmap;
 use crate::runtime::vm::{
@@ -14,7 +13,6 @@ use crate::{
 };
 use crate::{FuncType, ValType};
 use alloc::sync::Arc;
-use core::any::Any;
 use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
@@ -93,7 +91,7 @@ struct ComponentInner {
     /// A cached handle to the `wasmtime::FuncType` for the canonical ABI's
     /// `realloc`, to avoid the need to look up types in the registry and take
     /// locks when calling `realloc` via `TypedFunc::call_raw`.
-    realloc_func_type: Arc<dyn Any + Send + Sync>,
+    realloc_func_type: Arc<FuncType>,
 }
 
 pub(crate) struct AllCallFuncPointers {
@@ -443,7 +441,7 @@ impl Component {
             engine,
             [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
             [ValType::I32],
-        )) as _;
+        ));
 
         Ok(Component {
             inner: Arc::new(ComponentInner {
@@ -477,7 +475,12 @@ impl Component {
 
     #[inline]
     pub(crate) fn types(&self) -> &Arc<ComponentTypes> {
-        self.inner.component_types()
+        match self.inner.code.types() {
+            crate::code::Types::Component(types) => types,
+            // The only creator of a `Component` is itself which uses the other
+            // variant, so this shouldn't be possible.
+            crate::code::Types::Module(_) => unreachable!(),
+        }
     }
 
     pub(crate) fn signatures(&self) -> &TypeCollection {
@@ -519,10 +522,6 @@ impl Component {
     /// [`Module`]: crate::Module
     pub fn serialize(&self) -> Result<Vec<u8>> {
         Ok(self.code_object().code_memory().mmap().to_vec())
-    }
-
-    pub(crate) fn runtime_info(&self) -> Arc<dyn ComponentRuntimeInfo> {
-        self.inner.clone()
     }
 
     /// Creates a new `VMFuncRef` with all fields filled out for the destructor
@@ -824,6 +823,10 @@ impl Component {
     pub fn engine(&self) -> &Engine {
         &self.inner.engine
     }
+
+    pub(crate) fn realloc_func_ty(&self) -> &Arc<FuncType> {
+        &self.inner.realloc_func_type
+    }
 }
 
 /// A value which represents a known export of a component.
@@ -844,25 +847,6 @@ impl InstanceExportLookup for ComponentExportIndex {
         } else {
             None
         }
-    }
-}
-
-impl ComponentRuntimeInfo for ComponentInner {
-    fn component(&self) -> &wasmtime_environ::component::Component {
-        &self.info.component
-    }
-
-    fn component_types(&self) -> &Arc<ComponentTypes> {
-        match self.code.types() {
-            crate::code::Types::Component(types) => types,
-            // The only creator of a `Component` is itself which uses the other
-            // variant, so this shouldn't be possible.
-            crate::code::Types::Module(_) => unreachable!(),
-        }
-    }
-
-    fn realloc_func_type(&self) -> &Arc<dyn Any + Send + Sync> {
-        &self.realloc_func_type
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -59,7 +59,7 @@ impl Func {
         func: &CoreDef,
         options: &CanonicalOptions,
     ) -> Func {
-        let export = match data.lookup_def(store, func) {
+        let export = match data.instance().lookup_def(store, func) {
             Export::Function(f) => f,
             _ => unreachable!(),
         };

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -319,7 +319,7 @@ where
 {
     let cx = VMComponentContext::from_opaque(cx);
     let instance = cx.as_ref().instance();
-    let types = (*instance).component_types();
+    let types = (*instance).component().types();
     let raw_store = (*instance).store();
     let mut store = StoreContextMut(&mut *raw_store.cast());
 

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -247,8 +247,7 @@ impl<'a, T: 'static> LowerContext<'a, T> {
         old_align: u32,
         new_size: usize,
     ) -> Result<usize> {
-        let realloc_func_ty = Arc::clone(unsafe { (*self.instance).realloc_func_ty() });
-        let realloc_func_ty = realloc_func_ty.downcast_ref::<FuncType>().unwrap();
+        let realloc_func_ty = Arc::clone(unsafe { (*self.instance).component().realloc_func_ty() });
         self.options
             .realloc(
                 &mut self.store,

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -201,7 +201,7 @@ impl Instance {
         name: impl InstanceExportLookup,
     ) -> Option<Module> {
         let store = store.as_context_mut().0;
-        let (instance, export, _) = self.lookup_export(store, name)?;
+        let (instance, export) = self.lookup_export(store, name)?;
         match export {
             Export::ModuleStatic { index, .. } => {
                 Some(instance.component().static_module(*index).clone())
@@ -236,7 +236,7 @@ impl Instance {
         name: impl InstanceExportLookup,
     ) -> Option<ResourceType> {
         let store = store.as_context_mut().0;
-        let (instance, export, _) = self.lookup_export(store, name)?;
+        let (instance, export) = self.lookup_export(store, name)?;
         match export {
             Export::Type(TypeDef::Resource(id)) => {
                 Some(InstanceType::new(instance).resource_type(*id))
@@ -327,13 +327,12 @@ impl Instance {
         &self,
         store: &'a StoreOpaque,
         name: impl InstanceExportLookup,
-    ) -> Option<(&'a ComponentInstance, &'a Export, ExportIndex)> {
+    ) -> Option<(&'a ComponentInstance, &'a Export)> {
         let data = store[self.0].as_ref().unwrap();
         let index = name.lookup(data.state.component())?;
         Some((
             &data.state,
             &data.state.component().env_component().export_items[index],
-            index,
         ))
     }
 

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -186,7 +186,7 @@ impl Definition {
 impl<'a> InstanceType<'a> {
     pub fn new(instance: &'a ComponentInstance) -> InstanceType<'a> {
         InstanceType {
-            types: instance.component_types(),
+            types: instance.component().types(),
             resources: instance.resource_types(),
         }
     }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -130,6 +130,7 @@ pub use self::resources::{Resource, ResourceAny};
 pub use self::types::{ResourceType, Type};
 pub use self::values::Val;
 
+pub(crate) use self::instance::RuntimeImport;
 pub(crate) use self::resources::HostResourceData;
 pub(crate) use self::store::ComponentInstanceId;
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -537,8 +537,8 @@ impl Instance {
     }
 
     #[cfg(feature = "component-model")]
-    pub(crate) fn id(&self, store: &StoreOpaque) -> InstanceId {
-        store[self.id].id()
+    pub(crate) fn id(&self) -> InstanceId {
+        self.id.instance()
     }
 
     /// Get all globals within this instance.

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -941,8 +941,8 @@ impl OwnedComponentInstance {
     }
 
     /// Returns the underlying component instance's raw pointer.
-    pub fn instance_ptr(&self) -> *mut ComponentInstance {
-        self.ptr.as_ptr()
+    pub fn instance_ptr(&self) -> NonNull<ComponentInstance> {
+        self.ptr.as_non_null()
     }
 
     /// See `ComponentInstance::set_runtime_memory`


### PR DESCRIPTION
This is a continuation of the work from https://github.com/bytecodealliance/wasmtime/pull/10870 to remove the usage of `Stored<T>` from Wasmtime entirely. Next on the chopping block is component instances as they feed into a number of other locations. This work is split across a number of commits to be more bite-sized as the integration of `InstanceData` was a bit sprawling. With this removal some other refactorings are now unblocked to use more first-class index types within a Store and eventual removal of `Stored` entirely with its final user, component functions.