### PR TITLE
 Refactor the representation of component::Func 

### DIFF
--- a/crates/c-api/include/wasmtime/component/func.h
+++ b/crates/c-api/include/wasmtime/component/func.h
@@ -22,10 +22,15 @@ extern "C" {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_component_func {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  struct {
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Private internal wasmtime information.
+    uint32_t __private1;
+  };
+
+  /// Private internal wasmtime information.
+  uint32_t __private2;
 } wasmtime_component_func_t;
 
 /**

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -19,9 +19,9 @@ use core::ptr::NonNull;
 use std::path::Path;
 use wasmtime_environ::TypeTrace;
 use wasmtime_environ::component::{
-    AllCallFunc, CompiledComponentInfo, ComponentArtifacts, ComponentTypes, Export, ExportIndex,
-    GlobalInitializer, InstantiateModule, NameMapNoIntern, StaticModuleIndex, TrampolineIndex,
-    TypeComponentIndex, VMComponentOffsets,
+    AllCallFunc, CanonicalOptions, CompiledComponentInfo, ComponentArtifacts, ComponentTypes,
+    CoreDef, Export, ExportIndex, GlobalInitializer, InstantiateModule, NameMapNoIntern,
+    StaticModuleIndex, TrampolineIndex, TypeComponentIndex, TypeFuncIndex, VMComponentOffsets,
 };
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
 
@@ -826,6 +826,21 @@ impl Component {
 
     pub(crate) fn realloc_func_ty(&self) -> &Arc<FuncType> {
         &self.inner.realloc_func_type
+    }
+
+    /// Returns the `Export::LiftedFunction` metadata associated with `export`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `export` is out of bounds or if it isn't a `LiftedFunction`.
+    pub(crate) fn export_lifted_function(
+        &self,
+        export: ExportIndex,
+    ) -> (TypeFuncIndex, &CoreDef, &CanonicalOptions) {
+        match &self.env_component().export_items[export] {
+            Export::LiftedFunction { ty, func, options } => (*ty, func, options),
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -11,7 +11,7 @@ use crate::{AsContext, AsContextMut, StoreContextMut, ValRaw};
 use core::mem::{self, MaybeUninit};
 use core::ptr::NonNull;
 use wasmtime_environ::component::{
-    CanonicalOptions, CoreDef, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
+    CanonicalOptions, CoreDef, ExportIndex, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
     RuntimeComponentInstanceIndex, TypeFuncIndex, TypeTuple,
 };
 
@@ -41,6 +41,8 @@ pub struct Func(Stored<FuncData>);
 #[doc(hidden)]
 pub struct FuncData {
     export: ExportFunction,
+    #[expect(dead_code, reason = "to be used soon")]
+    index: ExportIndex,
     ty: TypeFuncIndex,
     options: Options,
     instance: Instance,
@@ -52,6 +54,7 @@ pub struct FuncData {
 impl Func {
     pub(crate) unsafe fn from_lifted_func(
         store: &mut StoreOpaque,
+        index: ExportIndex,
         instance: &ComponentInstance,
         ty: TypeFuncIndex,
         func: &CoreDef,
@@ -74,6 +77,7 @@ impl Func {
         let instance = Instance::from_wasmtime(store, instance.id());
         Func(store.store_data_mut().insert(FuncData {
             export,
+            index,
             options,
             ty,
             instance,

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -174,7 +174,7 @@ impl Instance {
         let ret = name.lookup(&data.component()).and_then(|index| {
             match &data.component().env_component().export_items[index] {
                 Export::LiftedFunction { ty, func, options } => {
-                    Some(unsafe { Func::from_lifted_func(store, &data, *ty, func, options) })
+                    Some(unsafe { Func::from_lifted_func(store, index, &data, *ty, func, options) })
                 }
                 _ => None,
             }

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -173,9 +173,11 @@ impl Instance {
         };
         let ret = name.lookup(&data.component()).and_then(|index| {
             match &data.component().env_component().export_items[index] {
-                Export::LiftedFunction { ty, func, options } => {
-                    Some(unsafe { Func::from_lifted_func(store, index, &data, *ty, func, options) })
-                }
+                Export::LiftedFunction {
+                    ty: _,
+                    func,
+                    options,
+                } => Some(unsafe { Func::from_lifted_func(store, index, &data, func, options) }),
                 _ => None,
             }
         });

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -175,9 +175,9 @@ impl Instance {
             match &data.component().env_component().export_items[index] {
                 Export::LiftedFunction {
                     ty: _,
-                    func,
+                    func: _,
                     options,
-                } => Some(unsafe { Func::from_lifted_func(store, index, &data, func, options) }),
+                } => Some(unsafe { Func::from_lifted_func(store, index, &data, options) }),
                 _ => None,
             }
         });

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -173,11 +173,9 @@ impl Instance {
         };
         let ret = name.lookup(&data.component()).and_then(|index| {
             match &data.component().env_component().export_items[index] {
-                Export::LiftedFunction {
-                    ty: _,
-                    func: _,
-                    options,
-                } => Some(unsafe { Func::from_lifted_func(store, index, &data, options) }),
+                Export::LiftedFunction { .. } => {
+                    Some(unsafe { Func::from_lifted_func(store, index, &data) })
+                }
                 _ => None,
             }
         });

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -71,6 +71,14 @@ impl StoreOpaque {
     }
 
     // FIXME: this method should not exist, future refactorings should delete it
+    //
+    // Specifically we're in the process of requiring that all APIs, even
+    // libcalls and host functions, work with `&mut StoreThing` plus
+    // `ComponentInstanceId` (or a store-tagged index). When doing so there
+    // should be no need for raw pointers as access to a `ComponentInstance` is
+    // 100% delegated through the store itself. Until that happens though this
+    // will need to stick around as there's a few places that work with raw
+    // pointers instead of safe pointers.
     pub(crate) fn component_instance_ptr(
         &self,
         id: ComponentInstanceId,
@@ -82,6 +90,11 @@ impl StoreOpaque {
     }
 
     // FIXME: this method should not exist, future refactorings should delete it
+    //
+    // Specifically we're in the process of removing `Stored<T>` and the only
+    // location this API is required is for functions right now when they're
+    // being created. That needs to be refactored anyway and removing `Stored`
+    // should remove the need for this function.
     pub(crate) unsafe fn component_instance_replace(
         &mut self,
         id: ComponentInstanceId,


### PR DESCRIPTION
This commit updates the implementation of `component::Func` to be
index-based like all other exported items are now in Wasmtime. This
necessitated a new `StoreComponentInstanceId` abstraction similar to
`StoreInstanceId`. Additionally the `component_instance_replace`
function was entirely removed as it's no longer necessary.

This is more continuation of work from https://github.com/bytecodealliance/wasmtime/pull/10870 and removing `Stored` after this should effectively be trivial.