### PR TITLE
Change component/instance maps to `PrimaryMap`

### DIFF
--- a/crates/c-api/include/wasmtime/component/instance.h
+++ b/crates/c-api/include/wasmtime/component/instance.h
@@ -25,7 +25,7 @@ typedef struct wasmtime_component_instance {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
   /// Internal index within the store.
-  size_t __private;
+  uint32_t __private;
 } wasmtime_component_instance_t;
 
 /**

--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -45,7 +45,7 @@ typedef struct wasmtime_table {
     /// Internal identifier of what store this belongs to, never zero.
     uint64_t store_id;
     /// Private field for Wasmtime.
-    size_t __private1;
+    uint32_t __private1;
   };
   /// Private field for Wasmtime.
   uint32_t __private2;
@@ -63,7 +63,7 @@ typedef struct wasmtime_memory {
     /// Internal identifier of what store this belongs to, never zero.
     uint64_t store_id;
     /// Private field for Wasmtime.
-    size_t __private1;
+    uint32_t __private1;
   };
   /// Private field for Wasmtime.
   uint32_t __private2;
@@ -80,7 +80,7 @@ typedef struct wasmtime_global {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
   /// Private field for Wasmtime.
-  size_t __private1;
+  uint32_t __private1;
   /// Private field for Wasmtime.
   uint32_t __private2;
   /// Private field for Wasmtime.

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -42,7 +42,7 @@ pub struct Instance {
 // in-Rust representation here in terms of size/alignment/etc.
 const _: () = {
     #[repr(C)]
-    struct C(u64, usize);
+    struct C(u64, u32);
     assert!(core::mem::size_of::<C>() == core::mem::size_of::<Instance>());
     assert!(core::mem::align_of::<C>() == core::mem::align_of::<Instance>());
     assert!(core::mem::offset_of!(Instance, id) == 0);

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -31,7 +31,7 @@ pub struct Global {
     store: StoreId,
     /// Either `InstanceId` or `ComponentInstanceId` internals depending on
     /// `kind` below.
-    instance: usize,
+    instance: u32,
     /// Which method of definition was used when creating this global.
     kind: VMGlobalKind,
 }
@@ -40,7 +40,7 @@ pub struct Global {
 // representation here in terms of size/alignment/etc.
 const _: () = {
     #[repr(C)]
-    struct C(u64, usize, u32, u32);
+    struct C(u64, u32, u32, u32);
     assert!(core::mem::size_of::<C>() == core::mem::size_of::<Global>());
     assert!(core::mem::align_of::<C>() == core::mem::align_of::<Global>());
     assert!(core::mem::offset_of!(Global, store) == 0);
@@ -120,7 +120,7 @@ impl Global {
     ) -> Global {
         Global {
             store: store.id(),
-            instance: instance.index(),
+            instance: instance.as_u32(),
             kind: VMGlobalKind::Instance(index),
         }
     }
@@ -277,12 +277,12 @@ impl Global {
         let (instance, kind) = match wasmtime_export.kind {
             ExportGlobalKind::Host(index) => (0, VMGlobalKind::Host(index)),
             ExportGlobalKind::Instance(vmctx, index) => (
-                vm::Instance::from_vmctx(vmctx, |i| i.id().index()),
+                vm::Instance::from_vmctx(vmctx, |i| i.id().as_u32()),
                 VMGlobalKind::Instance(index),
             ),
             #[cfg(feature = "component-model")]
             ExportGlobalKind::ComponentFlags(vmctx, index) => (
-                vm::component::ComponentInstance::from_vmctx(vmctx, |i| i.id().index()),
+                vm::component::ComponentInstance::from_vmctx(vmctx, |i| i.id().as_u32()),
                 VMGlobalKind::ComponentFlags(index),
             ),
         };
@@ -297,7 +297,7 @@ impl Global {
         self.store.assert_belongs_to(store.id());
         match self.kind {
             VMGlobalKind::Instance(index) => {
-                let instance = InstanceId::from_index(self.instance);
+                let instance = InstanceId::from_u32(self.instance);
                 let module = store.instance(instance).module();
                 let index = module.global_index(index);
                 &module.globals[index]
@@ -317,13 +317,13 @@ impl Global {
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> vm::VMGlobalImport {
         let vmctx = match self.kind {
             VMGlobalKind::Instance(_) => {
-                let instance = InstanceId::from_index(self.instance);
+                let instance = InstanceId::from_u32(self.instance);
                 Some(VMOpaqueContext::from_vmcontext(store.instance(instance).vmctx()).into())
             }
             VMGlobalKind::Host(_) => None,
             #[cfg(feature = "component-model")]
             VMGlobalKind::ComponentFlags(_) => {
-                let instance = crate::component::ComponentInstanceId::from_index(self.instance);
+                let instance = crate::component::ComponentInstanceId::from_u32(self.instance);
                 Some(
                     VMOpaqueContext::from_vmcomponent(store.component_instance(instance).vmctx())
                         .into(),
@@ -355,7 +355,7 @@ impl Global {
         self.store.assert_belongs_to(store.id());
         match self.kind {
             VMGlobalKind::Instance(index) => {
-                let instance = InstanceId::from_index(self.instance);
+                let instance = InstanceId::from_u32(self.instance);
                 store.instance(instance).instance().global_ptr(index)
             }
             VMGlobalKind::Host(index) => unsafe {
@@ -363,7 +363,7 @@ impl Global {
             },
             #[cfg(feature = "component-model")]
             VMGlobalKind::ComponentFlags(index) => {
-                let instance = crate::component::ComponentInstanceId::from_index(self.instance);
+                let instance = crate::component::ComponentInstanceId::from_u32(self.instance);
                 store
                     .component_instance(instance)
                     .instance_flags(index)

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -30,7 +30,7 @@ pub struct Table {
 // representation here in terms of size/alignment/etc.
 const _: () = {
     #[repr(C)]
-    struct Tmp(u64, usize);
+    struct Tmp(u64, u32);
     #[repr(C)]
     struct C(Tmp, u32);
     assert!(core::mem::size_of::<C>() == core::mem::size_of::<Table>());

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -222,7 +222,7 @@ pub struct Memory {
 // representation here in terms of size/alignment/etc.
 const _: () = {
     #[repr(C)]
-    struct Tmp(u64, usize);
+    struct Tmp(u64, u32);
     #[repr(C)]
     struct C(Tmp, u32);
     assert!(core::mem::size_of::<C>() == core::mem::size_of::<Memory>());

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -97,7 +97,6 @@ use core::mem::{self, ManuallyDrop};
 use core::num::NonZeroU64;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
-use wasmtime_environ::packed_option::ReservedValue;
 use wasmtime_environ::{DefinedGlobalIndex, DefinedTableIndex, EntityRef, PrimaryMap, TripleExt};
 
 mod context;
@@ -1347,6 +1346,8 @@ impl StoreOpaque {
             vmstore: NonNull<dyn vm::VMStore>,
             pkey: Option<ProtectionKey>,
         ) -> Result<GcStore> {
+            use wasmtime_environ::packed_option::ReservedValue;
+
             ensure!(
                 engine.features().gc_types(),
                 "cannot allocate a GC store when GC is disabled at configuration time"

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -97,6 +97,7 @@ use core::mem::{self, ManuallyDrop};
 use core::num::NonZeroU64;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
+use wasmtime_environ::packed_option::ReservedValue;
 use wasmtime_environ::{DefinedGlobalIndex, DefinedTableIndex, EntityRef, PrimaryMap, TripleExt};
 
 mod context;
@@ -319,7 +320,7 @@ pub struct StoreOpaque {
 
     engine: Engine,
     vm_store_context: VMStoreContext,
-    instances: Vec<StoreInstance>,
+    instances: PrimaryMap<InstanceId, StoreInstance>,
     #[cfg(feature = "component-model")]
     num_component_instances: usize,
     signal_handler: Option<SignalHandler>,
@@ -521,7 +522,7 @@ impl<T> Store<T> {
             _marker: marker::PhantomPinned,
             engine: engine.clone(),
             vm_store_context: Default::default(),
-            instances: Vec::new(),
+            instances: PrimaryMap::new(),
             #[cfg(feature = "component-model")]
             num_component_instances: 0,
             signal_handler: None,
@@ -1229,7 +1230,7 @@ impl StoreOpaque {
 
     pub fn module_for_instance(&self, instance: StoreInstanceId) -> Option<&'_ Module> {
         instance.store_id().assert_belongs_to(self.id());
-        match self.instances[instance.instance().0].kind {
+        match self.instances[instance.instance()].kind {
             StoreInstanceKind::Dummy => None,
             StoreInstanceKind::Real { module_id } => {
                 let module = self
@@ -1242,11 +1243,11 @@ impl StoreOpaque {
     }
 
     pub fn instance(&self, id: InstanceId) -> &InstanceHandle {
-        &self.instances[id.0].handle
+        &self.instances[id].handle
     }
 
     pub fn instance_mut(&mut self, id: InstanceId) -> &mut InstanceHandle {
-        &mut self.instances[id.0].handle
+        &mut self.instances[id].handle
     }
 
     /// Get all instances (ignoring dummy instances) within this store.
@@ -1254,9 +1255,7 @@ impl StoreOpaque {
         let instances = self
             .instances
             .iter()
-            .enumerate()
-            .filter_map(|(idx, inst)| {
-                let id = InstanceId::from_index(idx);
+            .filter_map(|(id, inst)| {
                 if let StoreInstanceKind::Dummy = inst.kind {
                     None
                 } else {
@@ -1277,7 +1276,7 @@ impl StoreOpaque {
         let mems = self
             .instances
             .iter_mut()
-            .flat_map(|instance| instance.handle.instance().defined_memories())
+            .flat_map(|(_, instance)| instance.handle.instance().defined_memories())
             .collect::<Vec<_>>();
         mems.into_iter()
             .map(|memory| unsafe { Memory::from_wasmtime_memory(memory, self) })
@@ -1288,8 +1287,7 @@ impl StoreOpaque {
         // NB: Host-created tables have dummy instances. Therefore, we can get
         // all tables in the store by iterating over all instances (including
         // dummy instances) and getting each of their defined memories.
-        for id in 0..self.instances.len() {
-            let id = InstanceId(id);
+        for id in self.instances.keys() {
             let instance = StoreInstanceId::new(self.id(), id);
             for table in 0..self.instance(id).module().num_defined_tables() {
                 let table = DefinedTableIndex::new(table);
@@ -1307,8 +1305,7 @@ impl StoreOpaque {
         }
 
         // Then enumerate all instances' defined globals.
-        for id in 0..self.instances.len() {
-            let id = InstanceId(id);
+        for id in self.instances.keys() {
             for index in 0..self.instance(id).module().num_defined_globals() {
                 let index = DefinedGlobalIndex::new(index);
                 let global = Global::new_instance(self, id, index);
@@ -1357,7 +1354,7 @@ impl StoreOpaque {
 
             // First, allocate the memory that will be our GC heap's storage.
             let mut request = InstanceAllocationRequest {
-                id: InstanceId::INVALID,
+                id: InstanceId::reserved_value(),
                 runtime_info: &ModuleRuntimeInfo::bare(Arc::new(
                     wasmtime_environ::Module::default(),
                 )),
@@ -1751,7 +1748,7 @@ impl StoreOpaque {
         // possible to precompute maps about linear memories in a store and have
         // a quicker lookup.
         let mut fault = None;
-        for instance in self.instances.iter() {
+        for (_, instance) in self.instances.iter() {
             if let Some(f) = instance.handle.wasm_fault(addr) {
                 assert!(fault.is_none());
                 fault = Some(f);
@@ -1886,7 +1883,7 @@ at https://bytecodealliance.org/security.
         runtime_info: &ModuleRuntimeInfo,
         imports: Imports<'_>,
     ) -> Result<InstanceId> {
-        let id = InstanceId(self.instances.len());
+        let id = self.instances.next_key();
 
         let allocator = match kind {
             AllocateInstanceKind::Module(_) => self.engine().allocator(),
@@ -1902,7 +1899,7 @@ at https://bytecodealliance.org/security.
             tunables: self.engine().tunables(),
         })?;
 
-        match kind {
+        let actual = match kind {
             AllocateInstanceKind::Module(module_id) => {
                 log::trace!(
                     "Adding instance to store: store={:?}, module={module_id:?}, instance={id:?}",
@@ -1911,7 +1908,7 @@ at https://bytecodealliance.org/security.
                 self.instances.push(StoreInstance {
                     handle,
                     kind: StoreInstanceKind::Real { module_id },
-                });
+                })
             }
             AllocateInstanceKind::Dummy { .. } => {
                 log::trace!(
@@ -1921,13 +1918,13 @@ at https://bytecodealliance.org/security.
                 self.instances.push(StoreInstance {
                     handle,
                     kind: StoreInstanceKind::Dummy,
-                });
+                })
             }
-        }
+        };
 
         // double-check we didn't accidentally allocate two instances and our
         // prediction of what the id would be is indeed the id it should be.
-        assert_eq!(self.instances.len(), id.0 + 1);
+        assert_eq!(id, actual);
 
         Ok(id)
     }
@@ -2256,8 +2253,7 @@ impl Drop for StoreOpaque {
                 allocator.deallocate_memory(None, mem_alloc_index, mem);
             }
 
-            for (idx, instance) in self.instances.iter_mut().enumerate() {
-                let id = InstanceId::from_index(idx);
+            for (id, instance) in self.instances.iter_mut() {
                 log::trace!("store {store_id:?} is deallocating {id:?}");
                 if let StoreInstanceKind::Dummy = instance.kind {
                     ondemand.deallocate_module(&mut instance.handle);

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -12,20 +12,8 @@ use core::ops::{Index, IndexMut};
 // crate-private-type-in-public-interface errors that aren't really too
 // interesting to deal with.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct InstanceId(pub(super) usize);
-
-impl InstanceId {
-    pub const INVALID: InstanceId = InstanceId(usize::MAX);
-
-    pub fn from_index(idx: usize) -> InstanceId {
-        debug_assert!(idx != Self::INVALID.0);
-        InstanceId(idx)
-    }
-
-    pub fn index(&self) -> usize {
-        self.0
-    }
-}
+pub struct InstanceId(u32);
+wasmtime_environ::entity_impl!(InstanceId);
 
 pub struct StoreData {
     id: StoreId,


### PR DESCRIPTION
This switches to using typed keys for these maps to be more idiomatic with the rest of Wasmtime and this has the additional benefit of compressing indices to 32-bits instead of the previous pointer-sized-bits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
