### PR TITLE
Add intial porting of table_ops from arbitrary to mutatis

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 wasmtime-test-util = { workspace = true, features = ['wast'] }
 
 [dependencies]
+mutatis = "0.3.1"
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This is the initial porting of `table_ops` from `arbitrary` to `mutatis`.

No new features are added. This is a direct port of the existing implementation using the `arbitrary` crate to the `mutatis` framework.

Open to review and feedback.

Initial work towards: bytecodealliance/wasmtime#10327  
cc @ospencer @fitzgen

