### PR TITLE
Classify more functions as trampolines in `objdump`

### DIFF
--- a/src/commands/objdump.rs
+++ b/src/commands/objdump.rs
@@ -152,7 +152,10 @@ impl ObjdumpCommand {
                 Func::Builtin
             } else if name.contains("]::function[") {
                 Func::Wasm
-            } else if name.contains("trampoline") {
+            } else if name.contains("trampoline")
+                || name.ends_with("_array_call")
+                || name.ends_with("_wasm_call")
+            {
                 Func::Trampoline
             } else if name.contains("libcall") || name.starts_with("component") {
                 Func::Libcall


### PR DESCRIPTION
Changes from wasip3-prototyping and peeling them off into this repo.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
