### PR TITLE
x64: Migrate `XmmVexPinsr` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/lanes.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/lanes.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex, rw, w};
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{fmt, inst, r, rex, rw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -25,5 +25,10 @@ pub fn list() -> Vec<Inst> {
         inst("movmskps", fmt("RM", [w(r32), r(xmm2)]), rex([0x0F, 0x50]).r(), _64b | compat | sse),
         inst("movmskpd", fmt("RM", [w(r32), r(xmm2)]), rex([0x66, 0x0F, 0x50]).r(), _64b | compat | sse2),
         inst("pmovmskb", fmt("RM", [w(r32), r(xmm2)]), rex([0x66, 0x0F, 0xD7]).r(), _64b | compat | sse2),
+
+        inst("vpinsrb", fmt("B", [w(xmm1), r(xmm2), r(r32m8), r(imm8)]), vex(L128)._66()._0f3a().w0().op(0x20).r().ib(), _64b | compat | avx),
+        inst("vpinsrw", fmt("B", [w(xmm1), r(xmm2), r(r32m16), r(imm8)]), vex(L128)._66()._0f().w0().op(0xC4).r().ib(), _64b | compat | avx),
+        inst("vpinsrd", fmt("B", [w(xmm1), r(xmm2), r(rm32), r(imm8)]), vex(L128)._66()._0f3a().w0().op(0x22).r().ib(), _64b | compat | avx),
+        inst("vpinsrq", fmt("B", [w(xmm1), r(xmm2), r(rm64), r(imm8)]), vex(L128)._66()._0f3a().w1().op(0x22).r().ib(), _64b | avx),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -152,14 +152,6 @@
                      (dst WritableXmm)
                      (imm u8))
 
-       ;; XMM instruction for `vpinsr{b,w,d,q}` which is separate from
-       ;; `XmmRmRImmVex` because `src2` is a gpr, not xmm register.
-       (XmmVexPinsr (op AvxOpcode)
-                   (src1 Xmm)
-                   (src2 GprMem)
-                   (dst WritableXmm)
-                   (imm u8))
-
        ;; XMM (scalar or vector) ternary op that relies on the VEX prefix and
        ;; has three dynamic inputs.
        (XmmRmRVex3 (op AvxOpcode)
@@ -1121,10 +1113,6 @@
             Vpackuswb
             Vpackusdw
             Vpalignr
-            Vpinsrb
-            Vpinsrw
-            Vpinsrd
-            Vpinsrq
             Vpmaddwd
             Vpmaddubsw
             Vinsertps
@@ -1728,13 +1716,6 @@
                                            dst
                                            imm
                                            size))))
-        dst))
-
-;; Helper for constructing `XmmVexPinsr` instructions.
-(decl xmm_vex_pinsr (AvxOpcode Xmm GprMem u8) Xmm)
-(rule (xmm_vex_pinsr op src1 src2 imm)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmVexPinsr op src1 src2 dst imm))))
         dst))
 
 ;; Helper for constructing `XmmUnaryRmRImm` instructions.
@@ -3735,28 +3716,28 @@
 (rule 0 (x64_pinsrb src1 src2 lane) (x64_pinsrb_a src1 src2 lane))
 (rule 1 (x64_pinsrb src1 src2 lane)
       (if-let true (use_avx))
-      (xmm_vex_pinsr (AvxOpcode.Vpinsrb) src1 src2 lane))
+      (x64_vpinsrb_b src1 src2 lane))
 
 ;; Helper for creating `pinsrw` instructions.
 (decl x64_pinsrw (Xmm GprMem u8) Xmm)
 (rule 0 (x64_pinsrw src1 src2 lane) (x64_pinsrw_a src1 src2 lane))
 (rule 1 (x64_pinsrw src1 src2 lane)
       (if-let true (use_avx))
-      (xmm_vex_pinsr (AvxOpcode.Vpinsrw) src1 src2 lane))
+      (x64_vpinsrw_b src1 src2 lane))
 
 ;; Helper for creating `pinsrd` instructions.
 (decl x64_pinsrd (Xmm GprMem u8) Xmm)
 (rule 0 (x64_pinsrd src1 src2 lane) (x64_pinsrd_a src1 src2 lane))
 (rule 1 (x64_pinsrd src1 src2 lane)
       (if-let true (use_avx))
-      (xmm_vex_pinsr (AvxOpcode.Vpinsrd) src1 src2 lane))
+      (x64_vpinsrd_b src1 src2 lane))
 
 ;; Helper for creating `pinsrq` instructions.
 (decl x64_pinsrq (Xmm GprMem u8) Xmm)
 (rule (x64_pinsrq src1 src2 lane) (x64_pinsrq_a src1 src2 lane))
 (rule 1 (x64_pinsrq src1 src2 lane)
       (if-let true (use_avx))
-      (xmm_vex_pinsr (AvxOpcode.Vpinsrq) src1 src2 lane))
+      (x64_vpinsrq_b src1 src2 lane))
 
 ;; Helper for creating `roundss` instructions.
 (decl x64_roundss (XmmMem RoundImm) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1076,10 +1076,6 @@ impl AvxOpcode {
             | AvxOpcode::Vpackuswb
             | AvxOpcode::Vpackusdw
             | AvxOpcode::Vpalignr
-            | AvxOpcode::Vpinsrb
-            | AvxOpcode::Vpinsrw
-            | AvxOpcode::Vpinsrd
-            | AvxOpcode::Vpinsrq
             | AvxOpcode::Vpmaddwd
             | AvxOpcode::Vpmaddubsw
             | AvxOpcode::Vinsertps

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1733,45 +1733,6 @@ pub(crate) fn emit(
                 .encode(sink);
         }
 
-        Inst::XmmVexPinsr {
-            op,
-            src1,
-            src2,
-            dst,
-            imm,
-        } => {
-            let dst = dst.to_reg().to_reg();
-            let src1 = src1.to_reg();
-            let src2 = match src2.clone().to_reg_mem().clone() {
-                RegMem::Reg { reg } => {
-                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
-                }
-                RegMem::Mem { addr } => {
-                    RegisterOrAmode::Amode(addr.finalize(state.frame_layout(), sink))
-                }
-            };
-
-            let (w, map, opcode) = match op {
-                AvxOpcode::Vpinsrb => (false, OpcodeMap::_0F3A, 0x20),
-                AvxOpcode::Vpinsrw => (false, OpcodeMap::_0F, 0xC4),
-                AvxOpcode::Vpinsrd => (false, OpcodeMap::_0F3A, 0x22),
-                AvxOpcode::Vpinsrq => (true, OpcodeMap::_0F3A, 0x22),
-                _ => panic!("unexpected vex_pinsr opcode {op:?}"),
-            };
-
-            VexInstruction::new()
-                .length(VexVectorLength::V128)
-                .prefix(LegacyPrefixes::_66)
-                .map(map)
-                .w(w)
-                .opcode(opcode)
-                .reg(dst.to_real_reg().unwrap().hw_enc())
-                .vvvv(src1.to_real_reg().unwrap().hw_enc())
-                .rm(src2)
-                .imm(*imm)
-                .encode(sink);
-        }
-
         Inst::XmmRmRVex3 {
             op,
             src1,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -1615,20 +1615,6 @@ fn test_x64_emit() {
     ));
 
     // ========================================================
-    // XmmRmRImmVex
-    insns.push((
-        Inst::XmmVexPinsr {
-            op: AvxOpcode::Vpinsrb,
-            dst: Writable::from_reg(Xmm::unwrap_new(xmm13)),
-            src1: Xmm::unwrap_new(xmm14),
-            src2: GprMem::unwrap_new(RegMem::reg(r15)),
-            imm: 2,
-        },
-        "C4430920EF02",
-        "vpinsrb $2, %xmm14, %r15, %xmm13",
-    ));
-
-    // ========================================================
     // Pertaining to atomics.
     let am1: SyntheticAmode =
         Amode::imm_reg_reg_shift(321, Gpr::unwrap_new(r10), Gpr::unwrap_new(rdx), 2).into();

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -153,7 +153,6 @@ impl Inst {
             | Inst::XmmRmRVex3 { op, .. }
             | Inst::XmmRmRImmVex { op, .. }
             | Inst::XmmRmRBlendVex { op, .. }
-            | Inst::XmmVexPinsr { op, .. }
             | Inst::XmmUnaryRmRVex { op, .. }
             | Inst::XmmUnaryRmRImmVex { op, .. }
             | Inst::XmmMovRMVex { op, .. }
@@ -751,21 +750,6 @@ impl PrettyPrint for Inst {
             }
 
             Inst::XmmRmRImmVex {
-                op,
-                src1,
-                src2,
-                dst,
-                imm,
-                ..
-            } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
-                let src1 = pretty_print_reg(src1.to_reg(), 8);
-                let src2 = src2.pretty_print(8);
-                let op = ljustify(op.to_string());
-                format!("{op} ${imm}, {src1}, {src2}, {dst}")
-            }
-
-            Inst::XmmVexPinsr {
                 op,
                 src1,
                 src2,
@@ -1627,13 +1611,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             src2.get_operands(collector);
         }
         Inst::XmmRmRImmVex {
-            src1, src2, dst, ..
-        } => {
-            collector.reg_def(dst);
-            collector.reg_use(src1);
-            src2.get_operands(collector);
-        }
-        Inst::XmmVexPinsr {
             src1, src2, dst, ..
         } => {
             collector.reg_def(dst);

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -279,10 +279,6 @@ pub(crate) fn check(
             let (ty, size) = match op {
                 AvxOpcode::Vmovss => (F32, 32),
                 AvxOpcode::Vmovsd => (F64, 64),
-                AvxOpcode::Vpinsrb => (I8, 8),
-                AvxOpcode::Vpinsrw => (I16, 16),
-                AvxOpcode::Vpinsrd => (I32, 32),
-                AvxOpcode::Vpinsrq => (I64, 64),
 
                 // We assume all other operations happen on 128-bit values.
                 _ => (I8X16, 128),
@@ -303,16 +299,6 @@ pub(crate) fn check(
                     check_load(ctx, None, addr, vcode, I8X16, 128)?;
                 }
                 RegMemImm::Reg { .. } | RegMemImm::Imm { .. } => {}
-            }
-            ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
-        }
-
-        Inst::XmmVexPinsr { dst, ref src2, .. } => {
-            match <&RegMem>::from(src2) {
-                RegMem::Mem { addr } => {
-                    check_load(ctx, None, addr, vcode, I64, 64)?;
-                }
-                RegMem::Reg { .. } => {}
             }
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
         }

--- a/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
@@ -90,7 +90,7 @@ block0(v0: i8x16, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrb $1, %xmm0, 0(%rdi), %xmm0
+;   vpinsrb $0x1, (%rdi), %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -116,7 +116,7 @@ block0(v0: i16x8, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrw $1, %xmm0, 0(%rdi), %xmm0
+;   vpinsrw $0x1, (%rdi), %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -142,7 +142,7 @@ block0(v0: i32x4, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrd $1, %xmm0, 0(%rdi), %xmm0
+;   vpinsrd $0x1, (%rdi), %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -168,7 +168,7 @@ block0(v0: i64x2, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrq $1, %xmm0, 0(%rdi), %xmm0
+;   vpinsrq $0x1, (%rdi), %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
@@ -579,7 +579,7 @@ block0(v0: i8x16, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrb $1, %xmm0, %rdi, %xmm0
+;   vpinsrb $0x1, %edi, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -604,7 +604,7 @@ block0(v0: i16x8, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrw $1, %xmm0, %rdi, %xmm0
+;   vpinsrw $0x1, %edi, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -629,7 +629,7 @@ block0(v0: i32x4, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrd $1, %xmm0, %rdi, %xmm0
+;   vpinsrd $0x1, %edi, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -654,7 +654,7 @@ block0(v0: i64x2, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpinsrq $1, %xmm0, %rdi, %xmm0
+;   vpinsrq $0x1, %rdi, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-make-vectors-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-make-vectors-avx.clif
@@ -40,7 +40,7 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm3
 ;   vpxor   %xmm3, %xmm3, %xmm5
-;   vpinsrq $0, %xmm5, %rdi, %xmm0
+;   vpinsrq $0x0, %rdi, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -68,7 +68,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovq   %rdi, %xmm3
-;   vpinsrq $1, %xmm3, %rsi, %xmm0
+;   vpinsrq $0x1, %rsi, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -176,7 +176,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   uninit  %xmm2
-;   vpinsrb $0, %xmm2, 0(%rdi), %xmm4
+;   vpinsrb $0x0, (%rdi), %xmm2, %xmm4
 ;   uninit  %xmm6
 ;   vpxor   %xmm6, %xmm6, %xmm0
 ;   vpshufb %xmm4, %xmm0, %xmm0
@@ -208,7 +208,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   uninit  %xmm2
-;   vpinsrw $0, %xmm2, 0(%rdi), %xmm4
+;   vpinsrw $0x0, (%rdi), %xmm2, %xmm4
 ;   vpshuflw $0, %xmm4, %xmm6
 ;   vpshufd $0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp


### PR DESCRIPTION
Hack-and-slash all these assorted instruction shapes...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
