### PR TITLE
Start reducing unsafety of `ComponentInstance`

### DIFF
--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -377,7 +377,7 @@ impl Func {
         LowerParams: Copy,
         LowerReturn: Copy,
     {
-        let vminstance = self.instance.instance(store.0);
+        let vminstance = &store[self.instance.id()];
         let (ty, def, options) = vminstance.component().export_lifted_function(self.index);
         let export = match vminstance.lookup_def(store.0, def) {
             Export::Function(f) => f,
@@ -427,7 +427,7 @@ impl Func {
             debug_assert!(flags.may_leave());
             flags.set_may_leave(false);
             let instance_ptr = self.instance.instance_ptr(store.0).as_ptr();
-            let mut cx = LowerContext::new(store.as_context_mut(), &options, &types, instance_ptr);
+            let mut cx = LowerContext::new(store.as_context_mut(), &options, &types, self.instance);
             cx.enter_call();
             let result = lower(
                 &mut cx,
@@ -474,7 +474,7 @@ impl Func {
             // later get used in post-return.
             flags.set_needs_post_return(true);
             let val = lift(
-                &mut LiftContext::new(store.0, &options, &types, instance_ptr),
+                &mut LiftContext::new(store.0, &options, &types, self.instance),
                 InterfaceType::Tuple(types[ty].results),
                 ret,
             )?;

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -1,6 +1,6 @@
-use crate::component::ResourceType;
 use crate::component::matching::InstanceType;
 use crate::component::resources::{HostResourceData, HostResourceIndex, HostResourceTables};
+use crate::component::{Instance, ResourceType};
 use crate::prelude::*;
 use crate::runtime::vm::component::{
     CallContexts, ComponentInstance, InstanceFlags, ResourceTable, ResourceTables,
@@ -22,7 +22,7 @@ use wasmtime_environ::component::{ComponentTypes, StringEncoding, TypeResourceTa
 /// reference to actually use the pointers.
 #[derive(Copy, Clone)]
 pub struct Options {
-    /// The store from which this options originated from.
+    /// The store from which this options originated.
     store_id: StoreId,
 
     /// An optional pointer for the memory that this set of options is referring
@@ -193,27 +193,18 @@ pub struct LowerContext<'a, T: 'static> {
     /// lifting/lowering process.
     pub types: &'a ComponentTypes,
 
-    /// A raw unsafe pointer to the component instance that's being lowered
-    /// into.
-    ///
-    /// This pointer is required to be owned by the `store` provided.
-    instance: *mut ComponentInstance,
+    /// Index of the component instance that's being lowered into.
+    instance: Instance,
 }
 
 #[doc(hidden)]
 impl<'a, T: 'static> LowerContext<'a, T> {
     /// Creates a new lowering context from the specified parameters.
-    ///
-    /// # Unsafety
-    ///
-    /// This function is unsafe as it needs to be guaranteed by the caller that
-    /// the `instance` here is valid within `store` and is a valid component
-    /// instance.
-    pub unsafe fn new(
+    pub fn new(
         store: StoreContextMut<'a, T>,
         options: &'a Options,
         types: &'a ComponentTypes,
-        instance: *mut ComponentInstance,
+        instance: Instance,
     ) -> LowerContext<'a, T> {
         LowerContext {
             store,
@@ -221,6 +212,16 @@ impl<'a, T: 'static> LowerContext<'a, T> {
             types,
             instance,
         }
+    }
+
+    /// Returns the `&ComponentInstance` that's being lowered into.
+    pub fn instance(&self) -> &ComponentInstance {
+        &self.store[self.instance.id()]
+    }
+
+    /// Returns the `&mut ComponentInstance` that's being lowered into.
+    pub fn instance_mut(&mut self) -> &mut ComponentInstance {
+        &mut self.store[self.instance.id()]
     }
 
     /// Returns a view into memory as a mutable slice of bytes.
@@ -247,7 +248,7 @@ impl<'a, T: 'static> LowerContext<'a, T> {
         old_align: u32,
         new_size: usize,
     ) -> Result<usize> {
-        let realloc_func_ty = Arc::clone(unsafe { (*self.instance).component().realloc_func_ty() });
+        let realloc_func_ty = Arc::clone(self.instance().component().realloc_func_ty());
         self.options
             .realloc(
                 &mut self.store,
@@ -311,10 +312,7 @@ impl<'a, T: 'static> LowerContext<'a, T> {
         // This check is performed by comparing the owning instance of `ty`
         // against the owning instance of the resource that `ty` is working
         // with.
-        //
-        // Note that the unsafety here should be valid given the contract of
-        // `LowerContext::new`.
-        if unsafe { (*self.instance).resource_owned_by_own_instance(ty) } {
+        if self.instance().resource_owned_by_own_instance(ty) {
             return Ok(rep);
         }
         self.resource_tables().guest_resource_lower_borrow(rep, ty)
@@ -355,20 +353,19 @@ impl<'a, T: 'static> LowerContext<'a, T> {
     /// Returns the instance type information corresponding to the instance that
     /// this context is lowering into.
     pub fn instance_type(&self) -> InstanceType<'_> {
-        // Note that the unsafety here should be valid given the contract of
-        // `LowerContext::new`.
-        InstanceType::new(unsafe { &*self.instance })
+        InstanceType::new(self.instance())
     }
 
     fn resource_tables(&mut self) -> HostResourceTables<'_> {
-        let (calls, host_table, host_resource_data) = self.store.0.component_resource_state();
+        let (calls, host_table, host_resource_data, instance) = self
+            .store
+            .0
+            .component_resource_state_with_instance(self.instance);
         HostResourceTables::from_parts(
             ResourceTables {
                 host_table: Some(host_table),
                 calls,
-                // Note that the unsafety here should be valid given the contract of
-                // `LowerContext::new`.
-                guest: Some(unsafe { (*self.instance).guest_tables() }),
+                guest: Some(instance.guest_tables()),
             },
             host_resource_data,
         )
@@ -402,7 +399,8 @@ pub struct LiftContext<'a> {
 
     memory: Option<&'a [u8]>,
 
-    instance: *mut ComponentInstance,
+    instance: &'a mut ComponentInstance,
+    instance_handle: Instance,
 
     host_table: &'a mut ResourceTable,
     host_resource_data: &'a mut HostResourceData,
@@ -413,17 +411,12 @@ pub struct LiftContext<'a> {
 #[doc(hidden)]
 impl<'a> LiftContext<'a> {
     /// Creates a new lifting context given the provided context.
-    ///
-    /// # Unsafety
-    ///
-    /// This is unsafe for the same reasons as `LowerContext::new` where the
-    /// validity of `instance` is required to be upheld by the caller.
     #[inline]
-    pub unsafe fn new(
+    pub fn new(
         store: &'a mut StoreOpaque,
         options: &'a Options,
         types: &'a Arc<ComponentTypes>,
-        instance: *mut ComponentInstance,
+        instance_handle: Instance,
     ) -> LiftContext<'a> {
         // From `&mut StoreOpaque` provided the goal here is to project out
         // three different disjoint fields owned by the store: memory,
@@ -431,8 +424,10 @@ impl<'a> LiftContext<'a> {
         // so it's hacked around a bit. This unsafe pointer cast could be fixed
         // with more methods in more places, but it doesn't seem worth doing it
         // at this time.
-        let (calls, host_table, host_resource_data) =
-            (&mut *(store as *mut StoreOpaque)).component_resource_state();
+        let (calls, host_table, host_resource_data, instance) = unsafe {
+            (&mut *(store as *mut StoreOpaque))
+                .component_resource_state_with_instance(instance_handle)
+        };
         let memory = options.memory.map(|_| options.memory(store));
 
         LiftContext {
@@ -440,6 +435,7 @@ impl<'a> LiftContext<'a> {
             options,
             types,
             instance,
+            instance_handle,
             calls,
             host_table,
             host_resource_data,
@@ -463,9 +459,13 @@ impl<'a> LiftContext<'a> {
         self.options.store_id
     }
 
-    /// Returns the component instance raw pointer that is being lifted from.
-    pub fn instance_ptr(&self) -> *mut ComponentInstance {
+    /// Returns the component instance that is being lifted from.
+    pub fn instance_mut(&mut self) -> &mut ComponentInstance {
         self.instance
+    }
+    /// Returns the component instance that is being lifted from.
+    pub fn instance_handle(&self) -> Instance {
+        self.instance_handle
     }
 
     /// Lifts an `own` resource from the guest at the `idx` specified into its
@@ -479,9 +479,7 @@ impl<'a> LiftContext<'a> {
         idx: u32,
     ) -> Result<(u32, Option<NonNull<VMFuncRef>>, Option<InstanceFlags>)> {
         let idx = self.resource_tables().guest_resource_lift_own(idx, ty)?;
-        // Note that the unsafety here should be valid given the contract of
-        // `LiftContext::new`.
-        let (dtor, flags) = unsafe { (*self.instance).dtor_and_flags(ty) };
+        let (dtor, flags) = self.instance.dtor_and_flags(ty);
         Ok((idx, dtor, flags))
     }
 
@@ -520,9 +518,7 @@ impl<'a> LiftContext<'a> {
     /// Returns instance type information for the component instance that is
     /// being lifted from.
     pub fn instance_type(&self) -> InstanceType<'_> {
-        // Note that the unsafety here should be valid given the contract of
-        // `LiftContext::new`.
-        InstanceType::new(unsafe { &*self.instance })
+        InstanceType::new(self.instance)
     }
 
     fn resource_tables(&mut self) -> HostResourceTables<'_> {
@@ -532,7 +528,7 @@ impl<'a> LiftContext<'a> {
                 calls: self.calls,
                 // Note that the unsafety here should be valid given the contract of
                 // `LiftContext::new`.
-                guest: Some(unsafe { (*self.instance).guest_tables() }),
+                guest: Some(self.instance.guest_tables()),
             },
             self.host_resource_data,
         )

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -304,7 +304,7 @@ impl Instance {
         instance: Option<&ComponentExportIndex>,
         name: &str,
     ) -> Option<(ComponentItem, ComponentExportIndex)> {
-        let data = self.instance(store);
+        let data = &store[self.id()];
         let component = data.component();
         let index = component.lookup_export_index(instance, name)?;
         let item = ComponentItem::from_export(
@@ -340,7 +340,7 @@ impl Instance {
         instance: Option<&ComponentExportIndex>,
         name: &str,
     ) -> Option<ComponentExportIndex> {
-        let data = self.instance(store.as_context_mut().0);
+        let data = &store.as_context_mut()[self.id()];
         let index = data.component().lookup_export_index(instance, name)?;
         Some(ComponentExportIndex {
             id: data.component().id(),
@@ -353,7 +353,7 @@ impl Instance {
         store: &'a StoreOpaque,
         name: impl InstanceExportLookup,
     ) -> Option<(&'a ComponentInstance, &'a Export)> {
-        let data = self.instance(store);
+        let data = &store[self.id()];
         let index = name.lookup(data.component())?;
         Some((data, &data.component().env_component().export_items[index]))
     }
@@ -362,19 +362,13 @@ impl Instance {
     pub fn instance_pre<T>(&self, store: impl AsContext<Data = T>) -> InstancePre<T> {
         // This indexing operation asserts the Store owns the Instance.
         // Therefore, the InstancePre<T> must match the Store<T>.
-        let data = self.instance(store.as_context().0);
+        let data = &store.as_context()[self.id()];
 
         // SAFETY: calling this method safely here relies on matching the `T`
         // in `InstancePre<T>` to the store itself, which is happening in the
         // type signature just above by ensuring the store's data is `T` which
         // matches the return value.
         unsafe { data.instance_pre() }
-    }
-
-    /// Returns the VM/runtime state for this instance as belonging to the
-    /// store provided.
-    pub(crate) fn instance<'a>(&self, store: &'a StoreOpaque) -> &'a ComponentInstance {
-        &store[self.id]
     }
 
     /// Returns the VM/runtime state for this instance as belonging to the
@@ -432,7 +426,7 @@ impl InstanceExportLookup for String {
 
 struct Instantiator<'a> {
     component: &'a Component,
-    instance: OwnedComponentInstance,
+    id: ComponentInstanceId,
     core_imports: OwnedImports,
     imports: &'a PrimaryMap<RuntimeImportIndex, RuntimeImport>,
 }
@@ -473,17 +467,21 @@ impl<'a> Instantiator<'a> {
         store.modules_mut().register_component(component);
         let imported_resources: ImportedResources =
             PrimaryMap::with_capacity(env_component.imported_resources.len());
+
+        let instance = OwnedComponentInstance::new(
+            store.store_data().components.next_component_instance_id(),
+            component,
+            Arc::new(imported_resources),
+            imports,
+            store.traitobj(),
+        );
+        let id = store.store_data_mut().push_component_instance(instance);
+
         Instantiator {
             component,
             imports,
             core_imports: OwnedImports::empty(),
-            instance: OwnedComponentInstance::new(
-                store.store_data().components.next_component_instance_id(),
-                component,
-                Arc::new(imported_resources),
-                imports,
-                store.traitobj(),
-            ),
+            id,
         }
     }
 
@@ -500,9 +498,10 @@ impl<'a> Instantiator<'a> {
                 } => (*ty, NonNull::from(dtor_funcref)),
                 _ => unreachable!(),
             };
-            let i = self.instance_resource_types_mut().push(ty);
+            let i = self.instance_resource_types_mut(store.0).push(ty);
             assert_eq!(i, idx);
-            self.instance.set_resource_destructor(idx, Some(func_ref));
+            self.instance_mut(store.0)
+                .set_resource_destructor(idx, Some(func_ref));
         }
 
         // Next configure all `VMFuncRef`s for trampolines that this component
@@ -516,8 +515,12 @@ impl<'a> Instantiator<'a> {
                 None => panic!("found unregistered signature: {sig:?}"),
             };
 
-            self.instance
-                .set_trampoline(idx, ptrs.wasm_call, ptrs.array_call, signature);
+            self.instance_mut(store.0).set_trampoline(
+                idx,
+                ptrs.wasm_call,
+                ptrs.array_call,
+                signature,
+            );
         }
 
         for initializer in env_component.initializers.iter() {
@@ -564,7 +567,7 @@ impl<'a> Instantiator<'a> {
                     let i = unsafe {
                         crate::Instance::new_started_impl(store, module, imports.as_ref())?
                     };
-                    self.instance.push_instance_id(i.id());
+                    self.instance_mut(store.0).push_instance_id(i.id());
                 }
 
                 GlobalInitializer::LowerImport { import, index } => {
@@ -572,7 +575,8 @@ impl<'a> Instantiator<'a> {
                         RuntimeImport::Func(func) => func,
                         _ => unreachable!(),
                     };
-                    self.instance.set_lowering(*index, func.lowering());
+                    self.instance_mut(store.0)
+                        .set_lowering(*index, func.lowering());
                 }
 
                 GlobalInitializer::ExtractTable(table) => self.extract_table(store.0, table),
@@ -597,11 +601,12 @@ impl<'a> Instantiator<'a> {
         Ok(())
     }
 
-    fn resource(&mut self, store: &StoreOpaque, resource: &Resource) {
+    fn resource(&mut self, store: &mut StoreOpaque, resource: &Resource) {
+        let instance = self.instance(store);
         let dtor = resource
             .dtor
             .as_ref()
-            .map(|dtor| self.instance.lookup_def(store, dtor));
+            .map(|dtor| instance.lookup_def(store, dtor));
         let dtor = dtor.map(|export| match export {
             crate::runtime::vm::Export::Function(f) => f.func_ref,
             _ => unreachable!(),
@@ -610,53 +615,60 @@ impl<'a> Instantiator<'a> {
             .component
             .env_component()
             .resource_index(resource.index);
-        self.instance.set_resource_destructor(index, dtor);
-        let ty = ResourceType::guest(store.id(), &self.instance, resource.index);
-        let i = self.instance_resource_types_mut().push(ty);
+        let ty = ResourceType::guest(store.id(), instance, resource.index);
+        self.instance_mut(store)
+            .set_resource_destructor(index, dtor);
+        let i = self.instance_resource_types_mut(store).push(ty);
         debug_assert_eq!(i, index);
     }
 
-    fn extract_memory(&mut self, store: &StoreOpaque, memory: &ExtractMemory) {
-        let mem = match self.instance.lookup_export(store, &memory.export) {
+    fn extract_memory(&mut self, store: &mut StoreOpaque, memory: &ExtractMemory) {
+        let mem = match self.instance(store).lookup_export(store, &memory.export) {
             crate::runtime::vm::Export::Memory(m) => m,
             _ => unreachable!(),
         };
-        self.instance
+        self.instance_mut(store)
             .set_runtime_memory(memory.index, mem.definition);
     }
 
-    fn extract_realloc(&mut self, store: &StoreOpaque, realloc: &ExtractRealloc) {
-        let func_ref = match self.instance.lookup_def(store, &realloc.def) {
+    fn extract_realloc(&mut self, store: &mut StoreOpaque, realloc: &ExtractRealloc) {
+        let func_ref = match self.instance(store).lookup_def(store, &realloc.def) {
             crate::runtime::vm::Export::Function(f) => f.func_ref,
             _ => unreachable!(),
         };
-        self.instance.set_runtime_realloc(realloc.index, func_ref);
+        self.instance_mut(store)
+            .set_runtime_realloc(realloc.index, func_ref);
     }
 
-    fn extract_callback(&mut self, store: &StoreOpaque, callback: &ExtractCallback) {
-        let func_ref = match self.instance.lookup_def(store, &callback.def) {
+    fn extract_callback(&mut self, store: &mut StoreOpaque, callback: &ExtractCallback) {
+        let func_ref = match self.instance(store).lookup_def(store, &callback.def) {
             crate::runtime::vm::Export::Function(f) => f.func_ref,
             _ => unreachable!(),
         };
-        self.instance.set_runtime_callback(callback.index, func_ref);
+        self.instance_mut(store)
+            .set_runtime_callback(callback.index, func_ref);
     }
 
-    fn extract_post_return(&mut self, store: &StoreOpaque, post_return: &ExtractPostReturn) {
-        let func_ref = match self.instance.lookup_def(store, &post_return.def) {
+    fn extract_post_return(&mut self, store: &mut StoreOpaque, post_return: &ExtractPostReturn) {
+        let func_ref = match self.instance(store).lookup_def(store, &post_return.def) {
             crate::runtime::vm::Export::Function(f) => f.func_ref,
             _ => unreachable!(),
         };
-        self.instance
+        self.instance_mut(store)
             .set_runtime_post_return(post_return.index, func_ref);
     }
 
-    fn extract_table(&mut self, store: &StoreOpaque, table: &ExtractTable) {
-        let export = match self.instance.lookup_export(store, &table.export) {
+    fn extract_table(&mut self, store: &mut StoreOpaque, table: &ExtractTable) {
+        let export = match self.instance(store).lookup_export(store, &table.export) {
             crate::runtime::vm::Export::Table(t) => t,
             _ => unreachable!(),
         };
-        self.instance
-            .set_runtime_table(table.index, export.definition, export.vmctx, export.index);
+        self.instance_mut(store).set_runtime_table(
+            table.index,
+            export.definition,
+            export.vmctx,
+            export.index,
+        );
     }
 
     fn build_imports<'b>(
@@ -683,7 +695,7 @@ impl<'a> Instantiator<'a> {
             // The unsafety here should be ok since the `export` is loaded
             // directly from an instance which should only give us valid export
             // items.
-            let export = self.instance.lookup_def(store, arg);
+            let export = self.instance(store).lookup_def(store, arg);
             unsafe {
                 self.core_imports.push_export(&export);
             }
@@ -702,7 +714,7 @@ impl<'a> Instantiator<'a> {
         imp_name: &str,
         expected: EntityType,
     ) {
-        let export = self.instance.lookup_def(store, arg);
+        let export = self.instance(store).lookup_def(store, arg);
 
         // If this value is a core wasm function then the type check is inlined
         // here. This can otherwise fail `Extern::from_wasmtime_export` because
@@ -734,13 +746,27 @@ impl<'a> Instantiator<'a> {
             .expect("unexpected typecheck failure");
     }
 
+    /// Convenience helper to return the `&ComponentInstance` that's being
+    /// instantiated.
+    fn instance<'b>(&self, store: &'b StoreOpaque) -> &'b ComponentInstance {
+        store.store_data().component_instance(self.id)
+    }
+
+    /// Same as [`Self::instance`], but for mutability.
+    fn instance_mut<'b>(&self, store: &'b mut StoreOpaque) -> &'b mut ComponentInstance {
+        store.store_data_mut().component_instance_mut(self.id)
+    }
+
     // NB: This method is only intended to be called during the instantiation
     // process because the `Arc::get_mut` here is fallible and won't generally
     // succeed once the instance has been handed to the embedder. Before that
     // though it should be guaranteed that the single owning reference currently
     // lives within the `ComponentInstance` that's being built.
-    fn instance_resource_types_mut(&mut self) -> &mut ImportedResources {
-        Arc::get_mut(self.instance.resource_types_mut()).unwrap()
+    fn instance_resource_types_mut<'b>(
+        &self,
+        store: &'b mut StoreOpaque,
+    ) -> &'b mut ImportedResources {
+        Arc::get_mut(self.instance_mut(store).resource_types_mut()).unwrap()
     }
 }
 
@@ -857,14 +883,10 @@ impl<T: 'static> InstancePre<T> {
                 .decrement_component_instance_count();
             e
         })?;
-        let id = store
-            .0
-            .store_data_mut()
-            .push_component_instance(instantiator.instance);
         // SAFETY: `from_wasmtime` requires that `id` belongs to the store
         // provided, and it was just inserted above so the condition should be
         // satisfied.
-        let instance = unsafe { Instance::from_wasmtime(store.0, id) };
+        let instance = unsafe { Instance::from_wasmtime(store.0, instantiator.id) };
         store.0.push_component_instance(instance);
         Ok(instance)
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1896,6 +1896,24 @@ at https://bytecodealliance.org/security.
         self.num_component_instances += 1;
     }
 
+    #[cfg(feature = "component-model")]
+    pub(crate) fn component_resource_state_with_instance(
+        &mut self,
+        instance: crate::component::Instance,
+    ) -> (
+        &mut vm::component::CallContexts,
+        &mut vm::component::ResourceTable,
+        &mut crate::component::HostResourceData,
+        &mut vm::component::ComponentInstance,
+    ) {
+        (
+            &mut self.component_calls,
+            &mut self.component_host_table,
+            &mut self.host_resource_data,
+            &mut self.store_data[instance.id()],
+        )
+    }
+
     #[cfg(not(feature = "async"))]
     pub(crate) fn async_guard_range(&self) -> core::ops::Range<*mut u8> {
         core::ptr::null_mut()..core::ptr::null_mut()

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -1,4 +1,4 @@
-use crate::runtime::vm;
+use crate::runtime::vm::{self, VMStore};
 use crate::store::StoreOpaque;
 use crate::{StoreContext, StoreContextMut};
 use core::num::NonZeroU64;
@@ -29,6 +29,29 @@ impl StoreData {
 
     pub fn id(&self) -> StoreId {
         self.id
+    }
+}
+
+// forward StoreOpaque => StoreData
+impl<I> Index<I> for StoreOpaque
+where
+    StoreData: Index<I>,
+{
+    type Output = <StoreData as Index<I>>::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        self.store_data.index(index)
+    }
+}
+
+impl<I> IndexMut<I> for StoreOpaque
+where
+    StoreData: IndexMut<I>,
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        self.store_data.index_mut(index)
     }
 }
 
@@ -65,6 +88,27 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         self.0.index_mut(index)
+    }
+}
+
+// forward dyn VMStore => StoreOpaque
+impl<I> Index<I> for dyn VMStore + '_
+where
+    StoreOpaque: Index<I>,
+{
+    type Output = <StoreOpaque as Index<I>>::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        self.store_opaque().index(index)
+    }
+}
+
+impl<I> IndexMut<I> for dyn VMStore + '_
+where
+    StoreOpaque: IndexMut<I>,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        self.store_opaque_mut().index_mut(index)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -637,6 +637,11 @@ impl ComponentInstance {
         &self.resource_types
     }
 
+    /// Returns mutable a reference to the resource type information.
+    pub fn resource_types_mut(&mut self) -> &mut Arc<PrimaryMap<ResourceIndex, ResourceType>> {
+        &mut self.resource_types
+    }
+
     /// Returns whether the resource that `ty` points to is owned by the
     /// instance that `ty` correspond to.
     ///
@@ -976,97 +981,9 @@ impl OwnedComponentInstance {
         }
     }
 
-    // Note that this is technically unsafe due to the fact that it enables
-    // `mem::swap`-ing two component instances which would get all the offsets
-    // mixed up and cause issues. This is scoped to just this module though as a
-    // convenience to forward to `&mut` methods on `ComponentInstance`.
-    unsafe fn instance_mut(&mut self) -> &mut ComponentInstance {
-        &mut *self.ptr.as_ptr()
-    }
-
     /// Returns the underlying component instance's raw pointer.
     pub fn instance_ptr(&self) -> NonNull<ComponentInstance> {
         self.ptr.as_non_null()
-    }
-
-    /// See `ComponentInstance::set_runtime_memory`
-    pub fn set_runtime_memory(
-        &mut self,
-        idx: RuntimeMemoryIndex,
-        ptr: NonNull<VMMemoryDefinition>,
-    ) {
-        unsafe { self.instance_mut().set_runtime_memory(idx, ptr) }
-    }
-
-    /// See `ComponentInstance::set_runtime_realloc`
-    pub fn set_runtime_realloc(&mut self, idx: RuntimeReallocIndex, ptr: NonNull<VMFuncRef>) {
-        unsafe { self.instance_mut().set_runtime_realloc(idx, ptr) }
-    }
-
-    /// See `ComponentInstance::set_runtime_callback`
-    pub fn set_runtime_callback(&mut self, idx: RuntimeCallbackIndex, ptr: NonNull<VMFuncRef>) {
-        unsafe { self.instance_mut().set_runtime_callback(idx, ptr) }
-    }
-
-    /// See `ComponentInstance::set_runtime_post_return`
-    pub fn set_runtime_post_return(
-        &mut self,
-        idx: RuntimePostReturnIndex,
-        ptr: NonNull<VMFuncRef>,
-    ) {
-        unsafe { self.instance_mut().set_runtime_post_return(idx, ptr) }
-    }
-
-    /// See `ComponentInstance::set_runtime_table`
-    pub fn set_runtime_table(
-        &mut self,
-        idx: RuntimeTableIndex,
-        ptr: NonNull<VMTableDefinition>,
-        vmctx: NonNull<VMContext>,
-        index: DefinedTableIndex,
-    ) {
-        unsafe {
-            self.instance_mut()
-                .set_runtime_table(idx, ptr, vmctx, index)
-        }
-    }
-
-    /// See `ComponentInstance::set_lowering`
-    pub fn set_lowering(&mut self, idx: LoweredIndex, lowering: VMLowering) {
-        unsafe { self.instance_mut().set_lowering(idx, lowering) }
-    }
-
-    /// See `ComponentInstance::set_resource_drop`
-    pub fn set_trampoline(
-        &mut self,
-        idx: TrampolineIndex,
-        wasm_call: NonNull<VMWasmCallFunction>,
-        array_call: NonNull<VMArrayCallFunction>,
-        type_index: VMSharedTypeIndex,
-    ) {
-        unsafe {
-            self.instance_mut()
-                .set_trampoline(idx, wasm_call, array_call, type_index)
-        }
-    }
-
-    /// See `ComponentInstance::set_resource_destructor`
-    pub fn set_resource_destructor(
-        &mut self,
-        idx: ResourceIndex,
-        dtor: Option<NonNull<VMFuncRef>>,
-    ) {
-        unsafe { self.instance_mut().set_resource_destructor(idx, dtor) }
-    }
-
-    /// See `ComponentInstance::resource_types`
-    pub fn resource_types_mut(&mut self) -> &mut Arc<PrimaryMap<ResourceIndex, ResourceType>> {
-        unsafe { &mut (*self.ptr.as_ptr()).resource_types }
-    }
-
-    /// See `ComponentInstance::push_instance_id`
-    pub fn push_instance_id(&mut self, id: InstanceId) -> RuntimeInstanceIndex {
-        unsafe { self.instance_mut().push_instance_id(id) }
     }
 }
 


### PR DESCRIPTION
Work recently in the wasip3-prototyping repository has focused on reducing the amount of `unsafe` code and improving internal abstractions to facilitate this. One major thrust that's manifested in is the removal of the usage of `*mut ComponentInstance` where possible and instead using an index to safely borrow from the store to get the entire instance. This commit does not fully realize this vision just yet but lays some groundwork leading up to this.

This commit specifically removes the `*mut ComponentInstance` pointers in lift/lower contexts in favor of directly storing a `wasmtime::component::Instance`. When the raw `ComponentInstance` is needed it's acquired from the `StoreOpaque` in a safe fashion that borrows the entire store for the duration of the returned borrow. This in turn required pushing instances into the store earlier during instantiation because during instantiation an instance could call out to host APIs which do lifts/lowers.

There's still more work to be done to plumb this fully into libcalls and host function invocations but I wanted to upstream the wasip3 work piecemeal a chunk at a time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
