### PR TITLE
Remove `unsafe` from `Instance::from_wasmtime`

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -55,7 +55,7 @@ impl Instance {
     ///
     /// The safety of this function relies on `id` belonging to the instance
     /// within `store`.
-    pub(crate) unsafe fn from_wasmtime(store: &StoreOpaque, id: ComponentInstanceId) -> Instance {
+    pub(crate) fn from_wasmtime(store: &StoreOpaque, id: ComponentInstanceId) -> Instance {
         Instance {
             id: StoreComponentInstanceId::new(store.id(), id),
         }
@@ -883,10 +883,7 @@ impl<T: 'static> InstancePre<T> {
                 .decrement_component_instance_count();
             e
         })?;
-        // SAFETY: `from_wasmtime` requires that `id` belongs to the store
-        // provided, and it was just inserted above so the condition should be
-        // satisfied.
-        let instance = unsafe { Instance::from_wasmtime(store.0, instantiator.id) };
+        let instance = Instance::from_wasmtime(store.0, instantiator.id);
         store.0.push_component_instance(instance);
         Ok(instance)
     }

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -50,11 +50,6 @@ const _: () = {
 
 impl Instance {
     /// Creates a raw `Instance` from the internal identifiers within the store.
-    ///
-    /// # Safety
-    ///
-    /// The safety of this function relies on `id` belonging to the instance
-    /// within `store`.
     pub(crate) fn from_wasmtime(store: &StoreOpaque, id: ComponentInstanceId) -> Instance {
         Instance {
             id: StoreComponentInstanceId::new(store.id(), id),


### PR DESCRIPTION
I mistakenly thought that this would be an `unsafe` function due to reasons that aren't applicable, and I'm not aware of any reason why this function should be `unsafe`, so mark it safe.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
