### PR TITLE
Don't pass vmctx to component libcalls

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1547,6 +1547,7 @@ impl TrampolineCompiler<'_> {
         let to_base = self.load_runtime_memory_base(vmctx, to);
 
         let mut args = Vec::new();
+        args.push(vmctx);
 
         let uses_retptr = match op {
             Transcode::Utf16ToUtf8

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -156,18 +156,18 @@ macro_rules! foreach_builtin_component_function {
 
             trap(vmctx: vmctx, code: u8);
 
-            utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8) -> bool;
-            utf16_to_utf16(src: ptr_u16, len: size, dst: ptr_u16) -> bool;
-            latin1_to_latin1(src: ptr_u8, len: size, dst: ptr_u8) -> bool;
-            latin1_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> bool;
-            utf8_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> size;
-            utf16_to_utf8(src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
-            latin1_to_utf8(src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
-            utf16_to_compact_probably_utf16(src: ptr_u16, len: size, dst: ptr_u16) -> size;
-            utf8_to_latin1(src: ptr_u8, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
-            utf16_to_latin1(src: ptr_u16, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
-            utf8_to_compact_utf16(src: ptr_u8, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
-            utf16_to_compact_utf16(src: ptr_u16, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
+            utf8_to_utf8(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u8) -> bool;
+            utf16_to_utf16(vmctx: vmctx, src: ptr_u16, len: size, dst: ptr_u16) -> bool;
+            latin1_to_latin1(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u8) -> bool;
+            latin1_to_utf16(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u16) -> bool;
+            utf8_to_utf16(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u16) -> size;
+            utf16_to_utf8(vmctx: vmctx, src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
+            latin1_to_utf8(vmctx: vmctx, src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
+            utf16_to_compact_probably_utf16(vmctx: vmctx, src: ptr_u16, len: size, dst: ptr_u16) -> size;
+            utf8_to_latin1(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
+            utf16_to_latin1(vmctx: vmctx, src: ptr_u16, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
+            utf8_to_compact_utf16(vmctx: vmctx, src: ptr_u8, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
+            utf16_to_compact_utf16(vmctx: vmctx, src: ptr_u16, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
         }
     };
 }

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -91,7 +91,10 @@ mod trampolines {
                     }
                     $(
                         #[cfg(not($attr))]
-                        unreachable!();
+                        {
+                            let _ = vmctx;
+                            unreachable!();
+                        }
                     )?
                 }
             )*

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -63,26 +63,29 @@ wasmtime_environ::foreach_builtin_component_function!(define_builtins);
 /// implementation following this submodule.
 #[allow(improper_ctypes_definitions)]
 mod trampolines {
-    use super::VMComponentContext;
+    use super::{ComponentInstance, VMComponentContext};
     use core::ptr::NonNull;
 
     macro_rules! shims {
         (
             $(
                 $( #[cfg($attr:meta)] )?
-                $name:ident( $( $pname:ident: $param:ident ),* ) $( -> $result:ident )?;
+                $name:ident( vmctx: vmctx $(, $pname:ident: $param:ident )* ) $( -> $result:ident )?;
             )*
         ) => (
             $(
                 pub unsafe extern "C" fn $name(
-                    $($pname : signature!(@ty $param),)*
+                    vmctx: NonNull<VMComponentContext>
+                    $(,$pname : signature!(@ty $param))*
                 ) $( -> signature!(@ty $result))? {
                     $(#[cfg($attr)])?
                     {
                         $(shims!(@validate_param $pname $param);)*
 
                         let ret = crate::runtime::vm::traphandlers::catch_unwind_and_record_trap(|| {
-                            shims!(@invoke $name() $($pname)*)
+                            ComponentInstance::from_vmctx(vmctx, |instance| {
+                                shims!(@invoke $name(instance,) $($pname)*)
+                            })
                         });
                         shims!(@convert_ret ret $($pname: $param)*)
                     }
@@ -153,7 +156,12 @@ fn assert_no_overlap<T, U>(a: &[T], b: &[U]) {
 /// The length provided is length of both the source and the destination
 /// buffers. No value is returned other than whether an invalid string was
 /// found.
-unsafe fn utf8_to_utf8(src: *mut u8, len: usize, dst: *mut u8) -> Result<()> {
+unsafe fn utf8_to_utf8(
+    _: &mut ComponentInstance,
+    src: *mut u8,
+    len: usize,
+    dst: *mut u8,
+) -> Result<()> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -168,7 +176,12 @@ unsafe fn utf8_to_utf8(src: *mut u8, len: usize, dst: *mut u8) -> Result<()> {
 /// The length provided is length of both the source and the destination
 /// buffers. No value is returned other than whether an invalid string was
 /// found.
-unsafe fn utf16_to_utf16(src: *mut u16, len: usize, dst: *mut u16) -> Result<()> {
+unsafe fn utf16_to_utf16(
+    _: &mut ComponentInstance,
+    src: *mut u16,
+    len: usize,
+    dst: *mut u16,
+) -> Result<()> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -198,7 +211,12 @@ fn run_utf16_to_utf16(src: &[u16], mut dst: &mut [u16]) -> Result<bool> {
 ///
 /// Given that all byte sequences are valid latin1 strings this is simply a
 /// memory copy.
-unsafe fn latin1_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<()> {
+unsafe fn latin1_to_latin1(
+    _: &mut ComponentInstance,
+    src: *mut u8,
+    len: usize,
+    dst: *mut u8,
+) -> Result<()> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -211,7 +229,12 @@ unsafe fn latin1_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<()>
 ///
 /// This simply inflates the latin1 characters to the u16 code points. The
 /// length provided is the same length of the source and destination buffers.
-unsafe fn latin1_to_utf16(src: *mut u8, len: usize, dst: *mut u16) -> Result<()> {
+unsafe fn latin1_to_utf16(
+    _: &mut ComponentInstance,
+    src: *mut u8,
+    len: usize,
+    dst: *mut u16,
+) -> Result<()> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -236,7 +259,12 @@ unsafe impl HostResultHasUnwindSentinel for CopySizeReturn {
 ///
 /// The length provided is the same unit length of both buffers, and the
 /// returned value from this function is how many u16 units were written.
-unsafe fn utf8_to_utf16(src: *mut u8, len: usize, dst: *mut u16) -> Result<CopySizeReturn> {
+unsafe fn utf8_to_utf16(
+    _: &mut ComponentInstance,
+    src: *mut u8,
+    len: usize,
+    dst: *mut u16,
+) -> Result<CopySizeReturn> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -276,6 +304,7 @@ unsafe impl HostResultHasUnwindSentinel for SizePair {
 /// a partial transcode if the destination buffer is not large enough to hold
 /// the entire contents.
 unsafe fn utf16_to_utf8(
+    _: &mut ComponentInstance,
     src: *mut u16,
     src_len: usize,
     dst: *mut u8,
@@ -329,6 +358,7 @@ unsafe fn utf16_to_utf8(
 ///
 /// This may perform a partial encoding if the destination is not large enough.
 unsafe fn latin1_to_utf8(
+    _: &mut ComponentInstance,
     src: *mut u8,
     src_len: usize,
     dst: *mut u8,
@@ -353,6 +383,7 @@ unsafe fn latin1_to_utf8(
 /// returned. Otherwise the string is "deflated" from a utf16 string to a latin1
 /// string and the latin1 length is returned.
 unsafe fn utf16_to_compact_probably_utf16(
+    _: &mut ComponentInstance,
     src: *mut u16,
     len: usize,
     dst: *mut u16,
@@ -386,7 +417,12 @@ unsafe fn utf16_to_compact_probably_utf16(
 ///
 /// Note that this may not convert the entire source into the destination if the
 /// original utf8 string has usvs not representable in latin1.
-unsafe fn utf8_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<SizePair> {
+unsafe fn utf8_to_latin1(
+    _: &mut ComponentInstance,
+    src: *mut u8,
+    len: usize,
+    dst: *mut u8,
+) -> Result<SizePair> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -402,7 +438,12 @@ unsafe fn utf8_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<SizeP
 /// Converts a utf16 string to latin1
 ///
 /// This is the same as `utf8_to_latin1` in terms of parameters/results.
-unsafe fn utf16_to_latin1(src: *mut u16, len: usize, dst: *mut u8) -> Result<SizePair> {
+unsafe fn utf16_to_latin1(
+    _: &mut ComponentInstance,
+    src: *mut u16,
+    len: usize,
+    dst: *mut u8,
+) -> Result<SizePair> {
     let src = slice::from_raw_parts(src, len);
     let dst = slice::from_raw_parts_mut(dst, len);
     assert_no_overlap(src, dst);
@@ -439,6 +480,7 @@ unsafe fn utf16_to_latin1(src: *mut u16, len: usize, dst: *mut u8) -> Result<Siz
 /// After the initial latin1 code units have been inflated the entirety of `src`
 /// is then transcoded into the remaining space within `dst`.
 unsafe fn utf8_to_compact_utf16(
+    _: &mut ComponentInstance,
     src: *mut u8,
     src_len: usize,
     dst: *mut u16,
@@ -457,6 +499,7 @@ unsafe fn utf8_to_compact_utf16(
 
 /// Same as `utf8_to_compact_utf16` but for utf16 source strings.
 unsafe fn utf16_to_compact_utf16(
+    _: &mut ComponentInstance,
     src: *mut u16,
     src_len: usize,
     dst: *mut u16,
@@ -499,33 +542,23 @@ fn inflate_latin1_bytes(dst: &mut [u16], latin1_bytes_so_far: usize) -> &mut [u1
     return rest;
 }
 
-unsafe fn resource_new32(
-    vmctx: NonNull<VMComponentContext>,
-    resource: u32,
-    rep: u32,
-) -> Result<u32> {
+fn resource_new32(instance: &mut ComponentInstance, resource: u32, rep: u32) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_new32(resource, rep))
+    instance.resource_new32(resource, rep)
 }
 
-unsafe fn resource_rep32(
-    vmctx: NonNull<VMComponentContext>,
-    resource: u32,
-    idx: u32,
-) -> Result<u32> {
+fn resource_rep32(instance: &mut ComponentInstance, resource: u32, idx: u32) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_rep32(resource, idx))
+    instance.resource_rep32(resource, idx)
 }
 
-unsafe fn resource_drop(
-    vmctx: NonNull<VMComponentContext>,
+fn resource_drop(
+    instance: &mut ComponentInstance,
     resource: u32,
     idx: u32,
 ) -> Result<ResourceDropRet> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        Ok(ResourceDropRet(instance.resource_drop(resource, idx)?))
-    })
+    Ok(ResourceDropRet(instance.resource_drop(resource, idx)?))
 }
 
 struct ResourceDropRet(Option<u32>);
@@ -541,209 +574,174 @@ unsafe impl HostResultHasUnwindSentinel for ResourceDropRet {
     }
 }
 
-unsafe fn resource_transfer_own(
-    vmctx: NonNull<VMComponentContext>,
+fn resource_transfer_own(
+    instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = TypeResourceTableIndex::from_u32(src_table);
     let dst_table = TypeResourceTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.resource_transfer_own(src_idx, src_table, dst_table)
-    })
+    instance.resource_transfer_own(src_idx, src_table, dst_table)
 }
 
-unsafe fn resource_transfer_borrow(
-    vmctx: NonNull<VMComponentContext>,
+fn resource_transfer_borrow(
+    instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = TypeResourceTableIndex::from_u32(src_table);
     let dst_table = TypeResourceTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.resource_transfer_borrow(src_idx, src_table, dst_table)
-    })
+    instance.resource_transfer_borrow(src_idx, src_table, dst_table)
 }
 
-unsafe fn resource_enter_call(vmctx: NonNull<VMComponentContext>) {
-    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_enter_call())
+fn resource_enter_call(instance: &mut ComponentInstance) {
+    instance.resource_enter_call()
 }
 
-unsafe fn resource_exit_call(vmctx: NonNull<VMComponentContext>) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_exit_call())
+fn resource_exit_call(instance: &mut ComponentInstance) -> Result<()> {
+    instance.resource_exit_call()
 }
 
-unsafe fn trap(_vmctx: NonNull<VMComponentContext>, code: u8) -> Result<Infallible> {
+fn trap(_instance: &mut ComponentInstance, code: u8) -> Result<Infallible> {
     Err(wasmtime_environ::Trap::from_u8(code).unwrap().into())
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn backpressure_set(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     enabled: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .backpressure_set(
-                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
-                    caller_instance,
-                ),
-                enabled,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .backpressure_set(
+            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+            enabled,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn task_return(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().task_return(
-            instance,
-            wasmtime_environ::component::TypeTupleIndex::from_u32(ty),
-            storage.cast::<crate::ValRaw>(),
-            storage_len,
-        )
-    })
+    (*instance.store()).component_async_store().task_return(
+        instance,
+        wasmtime_environ::component::TypeTupleIndex::from_u32(ty),
+        storage.cast::<crate::ValRaw>(),
+        storage_len,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn waitable_set_new(
-    vmctx: NonNull<VMComponentContext>,
-    caller_instance: u32,
-) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .waitable_set_new(
-                instance,
-                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
-                    caller_instance,
-                ),
-            )
-    })
+unsafe fn waitable_set_new(instance: &mut ComponentInstance, caller_instance: u32) -> Result<u32> {
+    (*instance.store())
+        .component_async_store()
+        .waitable_set_new(
+            instance,
+            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_wait(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     set: u32,
     async_: u8,
     memory: *mut u8,
     payload: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .waitable_set_wait(
-                instance,
-                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
-                    caller_instance,
-                ),
-                set,
-                async_ != 0,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                payload,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .waitable_set_wait(
+            instance,
+            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+            set,
+            async_ != 0,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            payload,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_poll(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     set: u32,
     async_: u8,
     memory: *mut u8,
     payload: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .waitable_set_poll(
-                instance,
-                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
-                    caller_instance,
-                ),
-                set,
-                async_ != 0,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                payload,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .waitable_set_poll(
+            instance,
+            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+            set,
+            async_ != 0,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            payload,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_drop(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     set: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .waitable_set_drop(
-                instance,
-                wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(
-                    caller_instance,
-                ),
-                set,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .waitable_set_drop(
+            instance,
+            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+            set,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_join(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     set: u32,
     waitable: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().waitable_join(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
-            waitable,
-        )
-    })
+    (*instance.store()).component_async_store().waitable_join(
+        instance,
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        set,
+        waitable,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn yield_(vmctx: NonNull<VMComponentContext>, async_: u8) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .yield_(instance, async_ != 0)
-    })
+unsafe fn yield_(instance: &mut ComponentInstance, async_: u8) -> Result<()> {
+    (*instance.store())
+        .component_async_store()
+        .yield_(instance, async_ != 0)
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn subtask_drop(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     caller_instance: u32,
     task_id: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().subtask_drop(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            task_id,
-        )
-    })
+    (*instance.store()).component_async_store().subtask_drop(
+        instance,
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        task_id,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn sync_enter(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     start: *mut u8,
     return_: *mut u8,
     caller_instance: u32,
@@ -752,22 +750,20 @@ unsafe fn sync_enter(
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().sync_enter(
-            start.cast::<crate::vm::VMFuncRef>(),
-            return_.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
-            result_count,
-            storage.cast::<crate::ValRaw>(),
-            storage_len,
-        )
-    })
+    (*instance.store()).component_async_store().sync_enter(
+        start.cast::<crate::vm::VMFuncRef>(),
+        return_.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
+        result_count,
+        storage.cast::<crate::ValRaw>(),
+        storage_len,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn sync_exit(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     callback: *mut u8,
     caller_instance: u32,
     callee: *mut u8,
@@ -776,23 +772,21 @@ unsafe fn sync_exit(
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().sync_exit(
-            instance,
-            callback.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            callee.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
-            param_count,
-            storage.cast::<std::mem::MaybeUninit<crate::ValRaw>>(),
-            storage_len,
-        )
-    })
+    (*instance.store()).component_async_store().sync_exit(
+        instance,
+        callback.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        callee.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
+        param_count,
+        storage.cast::<std::mem::MaybeUninit<crate::ValRaw>>(),
+        storage_len,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn async_enter(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     start: *mut u8,
     return_: *mut u8,
     caller_instance: u32,
@@ -800,21 +794,19 @@ unsafe fn async_enter(
     params: u32,
     results: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().async_enter(
-            start.cast::<crate::vm::VMFuncRef>(),
-            return_.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
-            params,
-            results,
-        )
-    })
+    (*instance.store()).component_async_store().async_enter(
+        start.cast::<crate::vm::VMFuncRef>(),
+        return_.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
+        params,
+        results,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn async_exit(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     callback: *mut u8,
     post_return: *mut u8,
     caller_instance: u32,
@@ -824,52 +816,46 @@ unsafe fn async_exit(
     result_count: u32,
     flags: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().async_exit(
-            instance,
-            callback.cast::<crate::vm::VMFuncRef>(),
-            post_return.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            callee.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
-            param_count,
-            result_count,
-            flags,
-        )
-    })
+    (*instance.store()).component_async_store().async_exit(
+        instance,
+        callback.cast::<crate::vm::VMFuncRef>(),
+        post_return.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        callee.cast::<crate::vm::VMFuncRef>(),
+        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
+        param_count,
+        result_count,
+        flags,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_transfer(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(src_table);
     let dst_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.future_transfer(src_idx, src_table, dst_table)
-    })
+    instance.future_transfer(src_idx, src_table, dst_table)
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_transfer(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(src_table);
     let dst_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.stream_transfer(src_idx, src_table, dst_table)
-    })
+    instance.stream_transfer(src_idx, src_table, dst_table)
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_transfer(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -878,24 +864,20 @@ unsafe fn error_context_transfer(
         wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(src_table);
     let dst_table =
         wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(dst_table);
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.error_context_transfer(src_idx, src_table, dst_table)
-    })
+    instance.error_context_transfer(src_idx, src_table, dst_table)
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_new(vmctx: NonNull<VMComponentContext>, ty: u32) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().future_new(
-            instance,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-        )
-    })
+unsafe fn future_new(instance: &mut ComponentInstance, ty: u32) -> Result<u32> {
+    (*instance.store()).component_async_store().future_new(
+        instance,
+        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_write(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -903,22 +885,20 @@ unsafe fn future_write(
     future: u32,
     address: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().future_write(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            future,
-            address,
-        )
-    })
+    (*instance.store()).component_async_store().future_write(
+        instance,
+        memory.cast::<crate::vm::VMMemoryDefinition>(),
+        realloc.cast::<crate::vm::VMFuncRef>(),
+        string_encoding,
+        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+        future,
+        address,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_read(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -926,104 +906,92 @@ unsafe fn future_read(
     future: u32,
     address: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().future_read(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            future,
-            address,
-        )
-    })
+    (*instance.store()).component_async_store().future_read(
+        instance,
+        memory.cast::<crate::vm::VMMemoryDefinition>(),
+        realloc.cast::<crate::vm::VMFuncRef>(),
+        string_encoding,
+        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+        future,
+        address,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_cancel_write(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .future_cancel_write(
-                instance,
-                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-                async_ != 0,
-                writer,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .future_cancel_write(
+            instance,
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+            async_ != 0,
+            writer,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_cancel_read(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .future_cancel_read(
-                instance,
-                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-                async_ != 0,
-                reader,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .future_cancel_read(
+            instance,
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+            async_ != 0,
+            reader,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_close_writable(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .future_close_writable(
-                instance,
-                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-                writer,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .future_close_writable(
+            instance,
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+            writer,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_close_readable(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .future_close_readable(
-                instance,
-                wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-                reader,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .future_close_readable(
+            instance,
+            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
+            reader,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_new(vmctx: NonNull<VMComponentContext>, ty: u32) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().stream_new(
-            instance,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-        )
-    })
+unsafe fn stream_new(instance: &mut ComponentInstance, ty: u32) -> Result<u32> {
+    (*instance.store()).component_async_store().stream_new(
+        instance,
+        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_write(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -1032,23 +1000,21 @@ unsafe fn stream_write(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().stream_write(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            stream,
-            address,
-            count,
-        )
-    })
+    (*instance.store()).component_async_store().stream_write(
+        instance,
+        memory.cast::<crate::vm::VMMemoryDefinition>(),
+        realloc.cast::<crate::vm::VMFuncRef>(),
+        string_encoding,
+        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+        stream,
+        address,
+        count,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_read(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -1057,95 +1023,85 @@ unsafe fn stream_read(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store()).component_async_store().stream_read(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            stream,
-            address,
-            count,
-        )
-    })
+    (*instance.store()).component_async_store().stream_read(
+        instance,
+        memory.cast::<crate::vm::VMMemoryDefinition>(),
+        realloc.cast::<crate::vm::VMFuncRef>(),
+        string_encoding,
+        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+        stream,
+        address,
+        count,
+    )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_cancel_write(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .stream_cancel_write(
-                instance,
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                async_ != 0,
-                writer,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .stream_cancel_write(
+            instance,
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            async_ != 0,
+            writer,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_cancel_read(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .stream_cancel_read(
-                instance,
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                async_ != 0,
-                reader,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .stream_cancel_read(
+            instance,
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            async_ != 0,
+            reader,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_close_writable(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     writer: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .stream_close_writable(
-                instance,
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                writer,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .stream_close_writable(
+            instance,
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            writer,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_close_readable(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     reader: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .stream_close_readable(
-                instance,
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                reader,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .stream_close_readable(
+            instance,
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            reader,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn flat_stream_write(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     ty: u32,
@@ -1155,26 +1111,24 @@ unsafe fn flat_stream_write(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .flat_stream_write(
-                instance,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                realloc.cast::<crate::vm::VMFuncRef>(),
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                payload_size,
-                payload_align,
-                stream,
-                address,
-                count,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .flat_stream_write(
+            instance,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            realloc.cast::<crate::vm::VMFuncRef>(),
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            payload_size,
+            payload_align,
+            stream,
+            address,
+            count,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn flat_stream_read(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     ty: u32,
@@ -1184,26 +1138,24 @@ unsafe fn flat_stream_read(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .flat_stream_read(
-                instance,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                realloc.cast::<crate::vm::VMFuncRef>(),
-                wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-                payload_size,
-                payload_align,
-                stream,
-                address,
-                count,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .flat_stream_read(
+            instance,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            realloc.cast::<crate::vm::VMFuncRef>(),
+            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
+            payload_size,
+            payload_align,
+            stream,
+            address,
+            count,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_new(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -1211,24 +1163,22 @@ unsafe fn error_context_new(
     debug_msg_address: u32,
     debug_msg_len: u32,
 ) -> Result<u32> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .error_context_new(
-                instance,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                realloc.cast::<crate::vm::VMFuncRef>(),
-                string_encoding,
-                wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-                debug_msg_address,
-                debug_msg_len,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .error_context_new(
+            instance,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            realloc.cast::<crate::vm::VMFuncRef>(),
+            string_encoding,
+            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
+            debug_msg_address,
+            debug_msg_len,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_debug_message(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -1236,34 +1186,30 @@ unsafe fn error_context_debug_message(
     err_ctx_handle: u32,
     debug_msg_address: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .error_context_debug_message(
-                instance,
-                memory.cast::<crate::vm::VMMemoryDefinition>(),
-                realloc.cast::<crate::vm::VMFuncRef>(),
-                string_encoding,
-                wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-                err_ctx_handle,
-                debug_msg_address,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .error_context_debug_message(
+            instance,
+            memory.cast::<crate::vm::VMMemoryDefinition>(),
+            realloc.cast::<crate::vm::VMFuncRef>(),
+            string_encoding,
+            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
+            err_ctx_handle,
+            debug_msg_address,
+        )
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_drop(
-    vmctx: NonNull<VMComponentContext>,
+    instance: &mut ComponentInstance,
     ty: u32,
     err_ctx_handle: u32,
 ) -> Result<()> {
-    ComponentInstance::from_vmctx(vmctx, |instance| {
-        (*instance.store())
-            .component_async_store()
-            .error_context_drop(
-                instance,
-                wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-                err_ctx_handle,
-            )
-    })
+    (*instance.store())
+        .component_async_store()
+        .error_context_drop(
+            instance,
+            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
+            err_ctx_handle,
+        )
 }


### PR DESCRIPTION
Take a leaf out of the core libcalls book where the `from_vmctx` call is baked in as part of each libcall so libcalls can receive safer arguments by default. There's still much `unsafe` in the libcalls due to their arguments or accessing `*instance.store()`, but this latter part will be fixed in a follow-up commit soon.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
