### PR TITLE
Add a `disas` test for conditional traps

### DIFF
--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -1,0 +1,63 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module
+  ;; This function body should ideally get compiled down into a single `trapz`
+  ;; CLIF instruction.
+  (func (export "trapnz") (param i32)
+    local.get 0
+    if
+      unreachable
+    end
+  )
+
+  ;; And this one into a single `trapnz` instruction.
+  (func (export "trapz") (param i32)
+    local.get 0
+    i32.eqz
+    if
+      unreachable
+    end
+  )
+)
+
+;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @002f                               brif v2, block2, block3
+;;
+;;                                 block2:
+;; @0031                               trap user11
+;;
+;;                                 block3:
+;; @0033                               jump block1
+;;
+;;                                 block1:
+;; @0033                               return
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v5 = iconst.i32 0
+;; @0038                               v3 = icmp eq v2, v5  ; v5 = 0
+;; @0038                               v4 = uextend.i32 v3
+;; @0039                               brif v4, block2, block3
+;;
+;;                                 block2:
+;; @003b                               trap user11
+;;
+;;                                 block3:
+;; @003d                               jump block1
+;;
+;;                                 block1:
+;; @003d                               return
+;; }


### PR DESCRIPTION
The Wasm-to-CLIF translation is currently suboptimal / we don't have a way to fuse the control-flow equivalent of `trap[n]z` instructions into their single CLIF instruction, which results in worse optimizations and poor codegen. This new test will at least help us track this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
