### PR TITLE
x64: generate rules to pick between SSE or AVX instructions

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -59,6 +59,21 @@ impl Encoding {
             Encoding::Vex(vex) => vex.validate(operands),
         }
     }
+
+    /// Return the primary opcode for this encoding.
+    ///
+    /// Note that [`Rex`]-encoded instructions have a more complex opcode scheme
+    /// (see [`Opcodes`]), and this returns the last opcode: the secondary
+    /// opcode if one is available and the primary otherwise.
+    pub fn opcode(&self) -> u8 {
+        match self {
+            Encoding::Rex(rex) => match rex.opcodes.secondary {
+                Some(secondary) => secondary,
+                None => rex.opcodes.primary,
+            },
+            Encoding::Vex(vex) => vex.opcode,
+        }
+    }
 }
 
 impl fmt::Display for Encoding {

--- a/cranelift/assembler-x64/meta/src/dsl/features.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/features.rs
@@ -32,6 +32,10 @@ impl Features {
     pub fn iter(&self) -> impl Iterator<Item = &Feature> {
         self.0.iter()
     }
+
+    pub fn contains(&self, feature: Feature) -> bool {
+        self.0.contains(&feature)
+    }
 }
 
 impl fmt::Display for Features {

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -20,7 +20,8 @@ mod sub;
 mod unpack;
 mod xor;
 
-use crate::dsl::Inst;
+use crate::dsl::{Feature, Inst, Mutability, OperandKind};
+use std::collections::HashMap;
 
 #[must_use]
 pub fn list() -> Vec<Inst> {
@@ -44,5 +45,104 @@ pub fn list() -> Vec<Inst> {
     all.extend(sub::list());
     all.extend(xor::list());
     all.extend(unpack::list());
+
+    // Automatically assign AVX alternates to SSE instructions (see
+    // `Inst::alternate`). This allows later code generation to
+    // instruction-select between the AVX and SSE versions of an instruction.
+    assign_avx_alternates(&mut all);
+
     all
+}
+
+/// Assigns AVX alternates to SSE instructions.
+///
+/// This works by:
+/// - finding the mnemonics of all AVX instructions
+/// - finding the mnemonics of all SSE* instructions
+/// - looking up each AVX mnemonic, minus its 'v' prefix, to see if an SSE
+///   version exists
+/// - checking that the SSE and AVX instructions have the same opcode
+/// - assigning the AVX instruction name as the alternate for the SSE
+///   instruction
+fn assign_avx_alternates(all: &mut [Inst]) {
+    let sse = map_mnemonic_to_index(&all, is_sse);
+    let avx = map_mnemonic_to_index(&all, is_avx);
+
+    for (avx_mnemonic, avx_index) in avx {
+        let sse_mnemonic = &avx_mnemonic[1..]; // Remove the 'v' prefix.
+        if let Some(sse_index) = sse.get(sse_mnemonic) {
+            if let Some(avx_name) = sse_matches_avx(*sse_index, avx_index, all) {
+                let sse_inst = &mut all[*sse_index];
+                sse_inst.alternate = Some(avx_name);
+            }
+        }
+    }
+}
+
+/// Check if `inst` is an SSE instructions (any SSE-based feature).
+fn is_sse((_, inst): &(usize, &Inst)) -> bool {
+    inst.features.contains(Feature::sse)
+        || inst.features.contains(Feature::sse2)
+        || inst.features.contains(Feature::ssse3)
+        || inst.features.contains(Feature::sse41)
+}
+
+/// Check if `inst` is an AVX instructions.
+fn is_avx((_, inst): &(usize, &Inst)) -> bool {
+    inst.features.contains(Feature::avx)
+}
+
+/// Create a map of an instruction mnemonic to its index in `insts`; this speeds
+/// up lookups and avoids borrowing from a `Vec` we are attempting to modify.
+fn map_mnemonic_to_index(
+    insts: &[Inst],
+    filter: impl Fn(&(usize, &Inst)) -> bool,
+) -> HashMap<String, usize> {
+    insts
+        .iter()
+        .enumerate()
+        .filter(filter)
+        .map(|(index, inst)| (inst.mnemonic.clone(), index))
+        .collect()
+}
+
+/// Checks if the SSE instruction at `sse_index` matches the AVX instruction at
+/// `avx_index` in terms of operands and opcode, and returns the AVX mnemonic if
+/// they match.
+fn sse_matches_avx(sse_index: usize, avx_index: usize, insts: &[Inst]) -> Option<String> {
+    use crate::dsl::{Mutability::*, OperandKind::*};
+
+    let sse_inst = &insts[sse_index];
+    let avx_inst = &insts[avx_index];
+
+    // Just to double-check:
+    debug_assert_eq!(&format!("v{}", sse_inst.mnemonic), &avx_inst.mnemonic);
+
+    if sse_inst.encoding.opcode() != avx_inst.encoding.opcode() {
+        panic!("the following instructions should have the same opcode:\n{sse_inst}\n{avx_inst}");
+    }
+
+    match (list_ops(sse_inst).as_slice(), list_ops(avx_inst).as_slice()) {
+        // For now, we only really want to tie together SSE instructions that
+        // look like `rw(xmm), r(xmm_m*)` with their AVX counterpart that looks
+        // like `w(xmm), r(xmm), r(xmm_m*)`. This is because the relationship
+        // between these kinds of instructions is quite regular. Other formats
+        // may have slightly different operand semantics (e.g., `roundss` ->
+        // `vroundss`) and we want to be careful about matching too freely.
+        (
+            [(ReadWrite, Reg(_)), (Read, RegMem(_))],
+            [(Write, Reg(_)), (Read, Reg(_)), (Read, RegMem(_))],
+        ) => Some(avx_inst.name()),
+        // We ignore other formats for now.
+        _ => None,
+    }
+}
+
+/// Collect the mutability and kind of each operand in an instruction.
+fn list_ops(inst: &Inst) -> Vec<(Mutability, OperandKind)> {
+    inst.format
+        .operands
+        .iter()
+        .map(|o| (o.mutability, o.location.kind()))
+        .collect()
 }

--- a/cranelift/assembler-x64/meta/src/instructions/round.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/round.rs
@@ -14,6 +14,5 @@ pub fn list() -> Vec<Inst> {
         inst("vroundps", fmt("RMI", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._66()._0f3a().ib().op(0x08), _64b | compat | avx),
         inst("vroundsd", fmt("RVMI", [w(xmm1), r(xmm2), r(xmm_m64), r(imm8)]), vex(LIG)._66()._0f3a().ib().op(0x0b), _64b | compat | avx),
         inst("vroundss", fmt("RVMI", [w(xmm1), r(xmm2), r(xmm_m32), r(imm8)]), vex(LIG)._66()._0f3a().ib().op(0x0a), _64b | compat | avx),
-
-        ]
+    ]
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3367,17 +3367,11 @@
 
 ;; Helper for creating `addps` instructions.
 (decl x64_addps (Xmm XmmMem) Xmm)
-(rule 1 (x64_addps src1 src2)
-      (if-let true (use_avx))
-      (x64_vaddps_b src1 src2))
-(rule 0 (x64_addps src1 src2) (x64_addps_a src1 src2))
+(rule (x64_addps src1 src2) (x64_addps_a_or_avx src1 src2))
 
 ;; Helper for creating `addpd` instructions.
 (decl x64_addpd (Xmm XmmMem) Xmm)
-(rule 1 (x64_addpd src1 src2)
-      (if-let true (use_avx))
-      (xmm_rmir_vex (AvxOpcode.Vaddpd) src1 src2))
-(rule 0 (x64_addpd src1 src2) (x64_addpd_a src1 src2))
+(rule (x64_addpd src1 src2) (x64_addpd_a_or_avx src1 src2))
 
 ;; Helper for creating `subss` instructions.
 (decl x64_subss (Xmm XmmMem) Xmm)

--- a/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
@@ -128,7 +128,7 @@ block0(v0: i64x2):
 ;   vpsrlq  %xmm0, $32, %xmm6
 ;   vpor    %xmm6, const(2), %xmm0
 ;   vsubpd  %xmm0, const(3), %xmm2
-;   vaddpd  %xmm4, %xmm2, %xmm0
+;   vaddpd %xmm2, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -739,7 +739,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vaddpd  %xmm0, %xmm1, %xmm0
+;   vaddpd %xmm1, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1346,7 +1346,7 @@ block0(v0: f64x2):
 ;   vmaxpd  %xmm0, %xmm4, %xmm6
 ;   vminpd  %xmm6, const(0), %xmm0
 ;   vroundpd $3, %xmm0, %xmm2
-;   vaddpd  %xmm2, const(1), %xmm5
+;   vaddpd (%rip), %xmm2, %xmm5
 ;   vshufps $136, %xmm5, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
The new assembler gives us the opportunity to generate some extra ISLE rules to eliminate boilerplate like the following, hand-written around 180 times throughout `inst.isle`:

```
(decl x64_... (Xmm XmmMem) Xmm)
(rule 1 (x64_... src1 src2)
        (if-let true (use_avx))
        (<emit avx version>))
(rule 0 (x64_... src1 src2) (<emit sse version>))
```

This PR only attempts to solve that exact pattern (i.e., `Xmm XmmMem`) but the approach could scale to more patterns in the future.