### PR TITLE
asm: follow up on DSL nits

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/avg.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/avg.rs
@@ -10,7 +10,5 @@ pub fn list() -> Vec<Inst> {
         // AVX versions
         inst("vpavgb", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0xE0), _64b | compat | avx),
         inst("vpavgw", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0xE3), _64b | compat | avx),
-
-
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/div.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/div.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*, align};
-use crate::dsl::{fmt, implicit, inst, r, rex, rw, vex};
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{align, fmt, implicit, inst, r, rex, rw, vex};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -19,7 +19,7 @@ pub fn list() -> Vec<Inst> {
         inst("divsd", fmt("A", [rw(xmm1), r(xmm_m64)]), rex([0xF2, 0xF, 0x5E]).r(), _64b | compat | sse2),
         inst("vdivps", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._0f().op(0x5E).r(), _64b | compat | avx),
         inst("vdivpd", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0x5E).r(), _64b | compat | avx),
-        inst("vdivss", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m32)]), vex(L128)._f3()._0f().op(0x5E).r(), _64b | compat | avx),
-        inst("vdivsd", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m64)]), vex(L128)._f2()._0f().op(0x5E).r(), _64b | compat | avx),
+        inst("vdivss", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m32)]), vex(LIG)._f3()._0f().op(0x5E).r(), _64b | compat | avx),
+        inst("vdivsd", fmt("B", [rw(xmm1), r(xmm2), r(xmm_m64)]), vex(LIG)._f2()._0f().op(0x5E).r(), _64b | compat | avx),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/round.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/round.rs
@@ -14,6 +14,5 @@ pub fn list() -> Vec<Inst> {
         inst("vroundps", fmt("RMI", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._66()._0f3a().ib().op(0x08), _64b | compat | avx),
         inst("vroundsd", fmt("RVMI", [w(xmm1), r(xmm2), r(xmm_m64), r(imm8)]), vex(LIG)._66()._0f3a().ib().op(0x0b), _64b | compat | avx),
         inst("vroundss", fmt("RVMI", [w(xmm1), r(xmm2), r(xmm_m32), r(imm8)]), vex(LIG)._66()._0f3a().ib().op(0x0a), _64b | compat | avx),
-
-        ]
+   ]
 }


### PR DESCRIPTION
Some final review comments went unaddressed in #10855 that this change resolve, primarily using `LIG` for non-vector definitions. I was going to add `.wig()` everywhere but, after thinking about it, it _is_ the default value for `vex()` and leaving it out reduces the amount of information one has to parse. This also cleans up a few extra lines I saw lying around.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
