### PR TITLE
Align symbol names with `--emit-clif`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1454,6 +1454,7 @@ impl ComponentCompiler for Compiler {
         types: &ComponentTypesBuilder,
         index: TrampolineIndex,
         tunables: &Tunables,
+        symbol: &str,
     ) -> Result<AllCallFunc<CompiledFunctionBody>> {
         let compile = |abi: Abi| -> Result<_> {
             let mut compiler = self.function_compiler();
@@ -1499,9 +1500,7 @@ impl ComponentCompiler for Compiler {
             c.builder.finalize();
 
             Ok(CompiledFunctionBody {
-                code: Box::new(
-                    compiler.finish(&format!("component_trampoline_{}_{abi:?}", index.as_u32()))?,
-                ),
+                code: Box::new(compiler.finish(symbol)?),
                 needs_gc_heap: false,
             })
         };

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -200,6 +200,7 @@ pub trait Compiler: Send + Sync {
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
         types: &ModuleTypesBuilder,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError>;
 
     /// Compile a trampoline for an array-call host function caller calling the
@@ -212,6 +213,7 @@ pub trait Compiler: Send + Sync {
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError>;
 
     /// Compile a trampoline for a Wasm caller calling a array callee with the
@@ -222,6 +224,7 @@ pub trait Compiler: Send + Sync {
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &WasmFuncType,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError>;
 
     /// Creates a trampoline that can be used to call Wasmtime's implementation
@@ -236,6 +239,7 @@ pub trait Compiler: Send + Sync {
     fn compile_wasm_to_builtin(
         &self,
         index: BuiltinFunctionIndex,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError>;
 
     /// Returns the list of relocations required for a function from one of the

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -16,5 +16,6 @@ pub trait ComponentCompiler: Send + Sync {
         types: &ComponentTypesBuilder,
         trampoline: TrampolineIndex,
         tunables: &Tunables,
+        symbol: &str,
     ) -> Result<AllCallFunc<CompiledFunctionBody>>;
 }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -95,6 +95,7 @@ impl wasmtime_environ::Compiler for Compiler {
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
         types: &ModuleTypesBuilder,
+        _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let index = translation.module.func_index(index);
         let sig = translation.module.functions[index]
@@ -144,17 +145,19 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         self.trampolines
-            .compile_array_to_wasm_trampoline(translation, types, index)
+            .compile_array_to_wasm_trampoline(translation, types, index, symbol)
     }
 
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &wasmtime_environ::WasmFuncType,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         self.trampolines
-            .compile_wasm_to_array_trampoline(wasm_func_ty)
+            .compile_wasm_to_array_trampoline(wasm_func_ty, symbol)
     }
 
     fn append_code(
@@ -234,8 +237,9 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_builtin(
         &self,
         index: BuiltinFunctionIndex,
+        symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
-        self.trampolines.compile_wasm_to_builtin(index)
+        self.trampolines.compile_wasm_to_builtin(index, symbol)
     }
 
     fn compiled_function_relocation_targets<'a>(


### PR DESCRIPTION
This commit fixes two issues: (1) is that `--emit-clif` generates file names that are different from symbol names and (2) is that `--emit-clif` for components today has collisions on filenames which means that output files can get corrupted. Currently (2) is causing spurious failures in CI due to the test added in #10939 being the first test with a component and functions in modules where they clash to emit the same file.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
