### PR TITLE
Remove DeleteMeDebugAssertion trap

### DIFF
--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -99,10 +99,6 @@ pub enum Trap {
     /// Attempt to resume a continuation twice.
     ContinuationAlreadyConsumed,
 
-    /// FIXME(frank-emrich) Only used for stack switching debugging code, to be
-    /// removed from final upstreamed code.
-    DeleteMeDebugAssertion,
-
     /// A Pulley opcode was executed at runtime when the opcode was disabled at
     /// compile time.
     DisabledOpcode,
@@ -145,7 +141,6 @@ impl Trap {
             NoAsyncResult
             UnhandledTag
             ContinuationAlreadyConsumed
-            DeleteMeDebugAssertion
             DisabledOpcode
         }
 
@@ -180,7 +175,6 @@ impl fmt::Display for Trap {
             NoAsyncResult => "async-lifted export failed to produce a result",
             UnhandledTag => "unhandled tag",
             ContinuationAlreadyConsumed => "continuation already consumed",
-            DeleteMeDebugAssertion => "triggered debug assertion",
             DisabledOpcode => "pulley opcode disabled at compile time was executed",
         };
         write!(f, "wasm trap: {desc}")


### PR DESCRIPTION
This trap was used during wasmfxtime development and was missed in the cleanup of #10388.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
