### PR TITLE
Synchronize p3 intrinsics/translation

### DIFF
--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -32,10 +32,25 @@
 /// for transferring parameters.
 pub const MAX_FLAT_PARAMS: usize = 16;
 
+/// Similar to `MAX_FLAT_PARAMS`, but used for async-lowered imports instead of
+/// sync ones.
+pub const MAX_FLAT_ASYNC_PARAMS: usize = 4;
+
 /// Canonical ABI-defined constant for the maximum number of "flat" results.
 /// This number of results are returned directly from wasm and otherwise results
 /// are transferred through memory.
 pub const MAX_FLAT_RESULTS: usize = 1;
+
+/// Sentinel value in `result_count_or_max_if_async` as part of the
+/// `prepare_call` libcall which indicates that preparation is being done for an
+/// async function that produces no result, aka there is no return pointer.
+pub const PREPARE_ASYNC_NO_RESULT: u32 = u32::MAX;
+
+/// Sentinel value in `result_count_or_max_if_async` as part of the
+/// `prepare_call` libcall which indicates that preparation is being done for an
+/// async function that produces at least one result, aka there is a return
+/// pointer.
+pub const PREPARE_ASYNC_WITH_RESULT: u32 = u32::MAX - 1;
 
 mod artifacts;
 mod info;
@@ -86,35 +101,49 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             backpressure_set(vmctx: vmctx, caller_instance: u32, enabled: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            task_return(vmctx: vmctx, ty: u32, storage: ptr_u8, storage_len: size) -> bool;
+            task_return(vmctx: vmctx, ty: u32, memory: ptr_u8, string_encoding: u8, storage: ptr_u8, storage_len: size) -> bool;
+            #[cfg(feature = "component-model-async")]
+            task_cancel(vmctx: vmctx, caller_instance: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             waitable_set_new(vmctx: vmctx, caller_instance: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            waitable_set_wait(vmctx: vmctx, caller_instance: u32, set: u32, async_: u8, memory: ptr_u8, payload: u32) -> u64;
+            waitable_set_wait(vmctx: vmctx, caller_instance: u32, async_: u8, memory: ptr_u8, set: u32, payload: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            waitable_set_poll(vmctx: vmctx, caller_instance: u32, set: u32, async_: u8, memory: ptr_u8, payload: u32) -> u64;
+            waitable_set_poll(vmctx: vmctx, caller_instance: u32, async_: u8, memory: ptr_u8, set: u32, payload: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             waitable_set_drop(vmctx: vmctx, caller_instance: u32, set: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             waitable_join(vmctx: vmctx, caller_instance: u32, set: u32, waitable: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            yield_(vmctx: vmctx, async_: u8) -> bool;
+            yield_(vmctx: vmctx, async_: u8) -> u32;
             #[cfg(feature = "component-model-async")]
             subtask_drop(vmctx: vmctx, caller_instance: u32, task_id: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            sync_enter(vmctx: vmctx, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, result_count: u32, storage: ptr_u8, storage_len: size) -> bool;
+            subtask_cancel(vmctx: vmctx, caller_instance: u32, async_: u8, task_id: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            sync_exit(vmctx: vmctx, callback: ptr_u8, caller_instance: u32, callee: ptr_u8, callee_instance: u32, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
+            prepare_call(
+                vmctx: vmctx,
+                memory: ptr_u8,
+                start: ptr_u8,
+                return_: ptr_u8,
+                caller_instance: u32,
+                callee_instance: u32,
+                task_return_type: u32,
+                string_encoding: u32,
+                result_count_or_max_if_async: u32,
+                storage: ptr_u8,
+                torage_len: size
+            ) -> bool;
             #[cfg(feature = "component-model-async")]
-            async_enter(vmctx: vmctx, start: ptr_u8, return_: ptr_u8, caller_instance: u32, task_return_type: u32, params: u32, results: u32) -> bool;
+            sync_start(vmctx: vmctx, callback: ptr_u8, callee: ptr_u8, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
-            async_exit(vmctx: vmctx, callback: ptr_u8, post_return: ptr_u8, caller_instance: u32, callee: ptr_u8, callee_instance: u32, param_count: u32, result_count: u32, flags: u32) -> u64;
+            async_start(vmctx: vmctx, callback: ptr_u8, post_return: ptr_u8, callee: ptr_u8, param_count: u32, result_count: u32, flags: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             future_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, future: u32, address: u32) -> u64;
+            future_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, future: u32, address: u32) -> u64;
+            future_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             future_cancel_write(vmctx: vmctx, ty: u32, async_: u8, writer: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -126,9 +155,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
+            stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
+            stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             stream_cancel_write(vmctx: vmctx, ty: u32, async_: u8, writer: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -138,9 +167,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_close_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            flat_stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
+            flat_stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            flat_stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
+            flat_stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             error_context_new(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, debug_msg_address: u32, debug_msg_len: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -153,6 +182,10 @@ macro_rules! foreach_builtin_component_function {
             stream_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             error_context_transfer(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u64;
+            #[cfg(feature = "component-model-async")]
+            context_get(vmctx: vmctx, slot: u32) -> u64;
+            #[cfg(feature = "component-model-async")]
+            context_set(vmctx: vmctx, slot: u32, val: u32) -> bool;
 
             trap(vmctx: vmctx, code: u8);
 

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -257,6 +257,16 @@ fn fact_import_to_core_def(
     import: &fact::Import,
     ty: EntityType,
 ) -> dfg::CoreDef {
+    fn unwrap_memory(def: &dfg::CoreDef) -> dfg::CoreExport<MemoryIndex> {
+        match def {
+            dfg::CoreDef::Export(e) => e.clone().map_index(|i| match i {
+                EntityIndex::Memory(i) => i,
+                _ => unreachable!(),
+            }),
+            _ => unreachable!(),
+        }
+    }
+
     let mut simple_intrinsic = |trampoline: dfg::Trampoline| {
         let signature = ty.unwrap_func();
         let index = dfg
@@ -273,16 +283,6 @@ fn fact_import_to_core_def(
             to,
             to64,
         } => {
-            fn unwrap_memory(def: &dfg::CoreDef) -> dfg::CoreExport<MemoryIndex> {
-                match def {
-                    dfg::CoreDef::Export(e) => e.clone().map_index(|i| match i {
-                        EntityIndex::Memory(i) => i,
-                        _ => unreachable!(),
-                    }),
-                    _ => unreachable!(),
-                }
-            }
-
             let from = dfg.memories.push(unwrap_memory(from));
             let to = dfg.memories.push(unwrap_memory(to));
             let signature = ty.unwrap_func();
@@ -304,17 +304,18 @@ fn fact_import_to_core_def(
         }
         fact::Import::ResourceEnterCall => simple_intrinsic(dfg::Trampoline::ResourceEnterCall),
         fact::Import::ResourceExitCall => simple_intrinsic(dfg::Trampoline::ResourceExitCall),
-        fact::Import::SyncEnterCall => simple_intrinsic(dfg::Trampoline::SyncEnterCall),
-        fact::Import::SyncExitCall { callback } => {
-            simple_intrinsic(dfg::Trampoline::SyncExitCall {
+        fact::Import::PrepareCall { memory } => simple_intrinsic(dfg::Trampoline::PrepareCall {
+            memory: memory.as_ref().map(|v| dfg.memories.push(unwrap_memory(v))),
+        }),
+        fact::Import::SyncStartCall { callback } => {
+            simple_intrinsic(dfg::Trampoline::SyncStartCall {
                 callback: callback.clone().map(|v| dfg.callbacks.push(v)),
             })
         }
-        fact::Import::AsyncEnterCall => simple_intrinsic(dfg::Trampoline::AsyncEnterCall),
-        fact::Import::AsyncExitCall {
+        fact::Import::AsyncStartCall {
             callback,
             post_return,
-        } => simple_intrinsic(dfg::Trampoline::AsyncExitCall {
+        } => simple_intrinsic(dfg::Trampoline::AsyncStartCall {
             callback: callback.clone().map(|v| dfg.callbacks.push(v)),
             post_return: post_return.clone().map(|v| dfg.post_returns.push(v)),
         }),

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -697,6 +697,15 @@ impl<'a> Inliner<'a> {
                     .push((*func, dfg::Trampoline::TaskReturn { results, options }));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
+            TaskCancel { func } => {
+                let index = self.result.trampolines.push((
+                    *func,
+                    dfg::Trampoline::TaskCancel {
+                        instance: frame.instance,
+                    },
+                ));
+                frame.funcs.push(dfg::CoreDef::Trampoline(index));
+            }
             WaitableSetNew { func } => {
                 let index = self.result.trampolines.push((
                     *func,
@@ -770,6 +779,16 @@ impl<'a> Inliner<'a> {
                     *func,
                     dfg::Trampoline::SubtaskDrop {
                         instance: frame.instance,
+                    },
+                ));
+                frame.funcs.push(dfg::CoreDef::Trampoline(index));
+            }
+            SubtaskCancel { func, async_ } => {
+                let index = self.result.trampolines.push((
+                    *func,
+                    dfg::Trampoline::SubtaskCancel {
+                        instance: frame.instance,
+                        async_: *async_,
                     },
                 ));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
@@ -988,6 +1007,20 @@ impl<'a> Inliner<'a> {
                     .result
                     .trampolines
                     .push((*func, dfg::Trampoline::ErrorContextDrop { ty }));
+                frame.funcs.push(dfg::CoreDef::Trampoline(index));
+            }
+            ContextGet { func, i } => {
+                let index = self
+                    .result
+                    .trampolines
+                    .push((*func, dfg::Trampoline::ContextGet(*i)));
+                frame.funcs.push(dfg::CoreDef::Trampoline(index));
+            }
+            ContextSet { func, i } => {
+                let index = self
+                    .result
+                    .trampolines
+                    .push((*func, dfg::Trampoline::ContextSet(*i)));
                 frame.funcs.push(dfg::CoreDef::Trampoline(index));
             }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -17,10 +17,11 @@
 
 use crate::component::{
     CanonicalAbiInfo, ComponentTypesBuilder, FLAG_MAY_ENTER, FLAG_MAY_LEAVE, FixedEncoding as FE,
-    FlatType, InterfaceType, MAX_FLAT_PARAMS, StringEncoding, Transcode,
-    TypeComponentLocalErrorContextTableIndex, TypeEnumIndex, TypeFlagsIndex, TypeFutureTableIndex,
-    TypeListIndex, TypeOptionIndex, TypeRecordIndex, TypeResourceTableIndex, TypeResultIndex,
-    TypeStreamTableIndex, TypeTupleIndex, TypeVariantIndex, VariantInfo,
+    FlatType, InterfaceType, MAX_FLAT_ASYNC_PARAMS, MAX_FLAT_PARAMS, PREPARE_ASYNC_NO_RESULT,
+    PREPARE_ASYNC_WITH_RESULT, StringEncoding, Transcode, TypeComponentLocalErrorContextTableIndex,
+    TypeEnumIndex, TypeFlagsIndex, TypeFutureTableIndex, TypeListIndex, TypeOptionIndex,
+    TypeRecordIndex, TypeResourceTableIndex, TypeResultIndex, TypeStreamTableIndex, TypeTupleIndex,
+    TypeVariantIndex, VariantInfo,
 };
 use crate::fact::signature::Signature;
 use crate::fact::transcode::Transcoder;
@@ -31,6 +32,7 @@ use crate::fact::{
 };
 use crate::prelude::*;
 use crate::{FuncIndex, GlobalIndex};
+use cranelift_entity::Signed;
 use std::collections::HashMap;
 use std::mem;
 use std::ops::Range;
@@ -186,12 +188,13 @@ pub(super) fn compile(module: &mut Module<'_>, adapter: &AdapterData) {
             // point a `STATUS_RETURNED` event will be delivered to the caller.
             let start = async_start_adapter(module);
             let return_ = async_return_adapter(module);
-            let (compiler, _, lift_sig) = compiler(module, adapter);
+            let (compiler, lower_sig, lift_sig) = compiler(module, adapter);
             compiler.compile_async_to_async_adapter(
                 adapter,
                 start,
                 return_,
                 i32::try_from(lift_sig.params.len()).unwrap(),
+                &lower_sig,
             );
         }
         (false, true) => {
@@ -241,13 +244,14 @@ pub(super) fn compile(module: &mut Module<'_>, adapter: &AdapterData) {
             let lift_sig = module.types.signature(&adapter.lift, Context::Lift);
             let start = async_start_adapter(module);
             let return_ = async_return_adapter(module);
-            let (compiler, ..) = compiler(module, adapter);
+            let (compiler, lower_sig, ..) = compiler(module, adapter);
             compiler.compile_async_to_sync_adapter(
                 adapter,
                 start,
                 return_,
                 i32::try_from(lift_sig.params.len()).unwrap(),
                 i32::try_from(lift_sig.results.len()).unwrap(),
+                &lower_sig,
             );
         }
     }
@@ -406,9 +410,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
     /// Compile an adapter function supporting an async-lowered import to an
     /// async-lifted export.
     ///
-    /// This uses a pair of `async-enter` and `async-exit` built-in functions to
-    /// set up and start a subtask, respectively.  `async-enter` accepts `start`
-    /// and `return_` functions which copy the parameters and results,
+    /// This uses a pair of `async-prepare` and `async-start` built-in functions
+    /// to set up and start a subtask, respectively.  `async-prepare` accepts
+    /// `start` and `return_` functions which copy the parameters and results,
     /// respectively; the host will call the former when the callee has cleared
     /// its backpressure flag and the latter when the callee has called
     /// `task.return`.
@@ -418,37 +422,18 @@ impl<'a, 'b> Compiler<'a, 'b> {
         start: FunctionId,
         return_: FunctionId,
         param_count: i32,
+        lower_sig: &Signature,
     ) {
-        let enter = self.module.import_async_enter_call();
-        let exit = self
-            .module
-            .import_async_exit_call(adapter.lift.options.callback, None);
+        let start_call =
+            self.module
+                .import_async_start_call(&adapter.name, adapter.lift.options.callback, None);
 
-        self.flush_code();
-        self.module.funcs[self.result]
-            .body
-            .push(Body::RefFunc(start));
-        self.module.funcs[self.result]
-            .body
-            .push(Body::RefFunc(return_));
-        self.instruction(I32Const(
-            i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
-        ));
-        self.instruction(I32Const(
-            i32::try_from(self.types[adapter.lift.ty].results.as_u32()).unwrap(),
-        ));
-        // Async-lowered imports pass params and receive results via linear
-        // memory, and those pointers are in the first and second params to
-        // this adapter.  We pass them on to the host so it can store them in
-        // the subtask for later use.
-        self.instruction(LocalGet(0));
-        self.instruction(LocalGet(1));
-        self.instruction(Call(enter.as_u32()));
+        self.call_prepare(adapter, start, return_, lower_sig, false);
 
         // TODO: As an optimization, consider checking the backpressure flag on
         // the callee instance and, if it's unset _and_ the callee uses a
         // callback, translate the params and call the callee function directly
-        // here (and make sure `exit` knows _not_ to call it in that case).
+        // here (and make sure `start_call` knows _not_ to call it in that case).
 
         // We export this function so we can pass a funcref to the host.
         //
@@ -458,48 +443,42 @@ impl<'a, 'b> Compiler<'a, 'b> {
             format!("[adapter-callee]{}", adapter.name),
         ));
 
-        self.instruction(I32Const(
-            i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
-        ));
         self.instruction(RefFunc(adapter.callee.as_u32()));
-        self.instruction(I32Const(
-            i32::try_from(adapter.lift.instance.as_u32()).unwrap(),
-        ));
         self.instruction(I32Const(param_count));
         // The result count for an async callee is either one (if there's a
         // callback) or zero (if there's no callback).  We conservatively use
         // one here to ensure the host provides room for the result, if any.
         self.instruction(I32Const(1));
-        self.instruction(I32Const(super::EXIT_FLAG_ASYNC_CALLEE));
-        self.instruction(Call(exit.as_u32()));
+        self.instruction(I32Const(super::START_FLAG_ASYNC_CALLEE));
+        self.instruction(Call(start_call.as_u32()));
 
         self.finish()
     }
 
-    /// Compile an adapter function supporting a sync-lowered import to an
-    /// async-lifted export.
+    /// Invokes the `prepare_call` builtin with the provided parameters for this
+    /// adapter.
     ///
-    /// This uses a pair of `sync-enter` and `sync-exit` built-in functions to
-    /// set up and start a subtask, respectively.  `sync-enter` accepts `start`
-    /// and `return_` functions which copy the parameters and results,
-    /// respectively; the host will call the former when the callee has cleared
-    /// its backpressure flag and the latter when the callee has called
-    /// `task.return`.
-    fn compile_sync_to_async_adapter(
-        mut self,
+    /// This is part of a async lower and/or async lift adapter. This is not
+    /// used for a sync->sync function call. This is done to create the task on
+    /// the host side of the runtime and such. This will notably invoke a
+    /// Cranelift builtin which will spill all wasm-level parameters to the
+    /// stack to handle variadic signatures.
+    ///
+    /// Note that the `prepare_sync` parameter here configures the
+    /// `result_count_or_max_if_async` parameter to indicate whether this is a
+    /// sync or async prepare.
+    fn call_prepare(
+        &mut self,
         adapter: &AdapterData,
         start: FunctionId,
         return_: FunctionId,
-        lift_param_count: i32,
         lower_sig: &Signature,
+        prepare_sync: bool,
     ) {
-        let enter = self
-            .module
-            .import_sync_enter_call(&adapter.name, &lower_sig.params);
-        let exit = self.module.import_sync_exit_call(
+        let prepare = self.module.import_prepare_call(
             &adapter.name,
-            adapter.lift.options.callback,
-            &lower_sig.results,
+            &lower_sig.params,
+            adapter.lift.options.memory,
         );
 
         self.flush_code();
@@ -513,35 +492,76 @@ impl<'a, 'b> Compiler<'a, 'b> {
             i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
         ));
         self.instruction(I32Const(
-            i32::try_from(self.types[adapter.lift.ty].results.as_u32()).unwrap(),
+            i32::try_from(adapter.lift.instance.as_u32()).unwrap(),
         ));
         self.instruction(I32Const(
-            i32::try_from(
-                self.types
-                    .flatten_types(
-                        &adapter.lower.options,
-                        usize::MAX,
-                        self.types[self.types[adapter.lower.ty].results]
-                            .types
-                            .iter()
-                            .copied(),
-                    )
-                    .map(|v| v.len())
-                    .unwrap_or(usize::try_from(i32::MAX).unwrap()),
-            )
-            .unwrap(),
+            i32::try_from(self.types[adapter.lift.ty].results.as_u32()).unwrap(),
         ));
+        self.instruction(I32Const(i32::from(
+            adapter.lift.options.string_encoding as u8,
+        )));
 
+        // flag this as a preparation for either an async call or sync call,
+        // depending on `prepare_sync`
+        let result_types = &self.types[self.types[adapter.lower.ty].results].types;
+        if prepare_sync {
+            self.instruction(I32Const(
+                i32::try_from(
+                    self.types
+                        .flatten_types(
+                            &adapter.lower.options,
+                            usize::MAX,
+                            result_types.iter().copied(),
+                        )
+                        .map(|v| v.len())
+                        .unwrap_or(usize::try_from(i32::MAX).unwrap()),
+                )
+                .unwrap(),
+            ));
+        } else {
+            if result_types.len() > 0 {
+                self.instruction(I32Const(PREPARE_ASYNC_WITH_RESULT.signed()));
+            } else {
+                self.instruction(I32Const(PREPARE_ASYNC_NO_RESULT.signed()));
+            }
+        }
+
+        // forward all our own arguments on to the host stub
         for index in 0..lower_sig.params.len() {
             self.instruction(LocalGet(u32::try_from(index).unwrap()));
         }
+        self.instruction(Call(prepare.as_u32()));
+    }
 
-        self.instruction(Call(enter.as_u32()));
+    /// Compile an adapter function supporting a sync-lowered import to an
+    /// async-lifted export.
+    ///
+    /// This uses a pair of `sync-prepare` and `sync-start` built-in functions
+    /// to set up and start a subtask, respectively.  `sync-prepare` accepts
+    /// `start` and `return_` functions which copy the parameters and results,
+    /// respectively; the host will call the former when the callee has cleared
+    /// its backpressure flag and the latter when the callee has called
+    /// `task.return`.
+    fn compile_sync_to_async_adapter(
+        mut self,
+        adapter: &AdapterData,
+        start: FunctionId,
+        return_: FunctionId,
+        lift_param_count: i32,
+        lower_sig: &Signature,
+    ) {
+        let start_call = self.module.import_sync_start_call(
+            &adapter.name,
+            adapter.lift.options.callback,
+            &lower_sig.results,
+        );
+
+        self.call_prepare(adapter, start, return_, lower_sig, true);
 
         // TODO: As an optimization, consider checking the backpressure flag on
         // the callee instance and, if it's unset _and_ the callee uses a
         // callback, translate the params and call the callee function directly
-        // here (and make sure `exit` knows _not_ to call it in that case).
+        // here (and make sure `start_call` knows _not_ to call it in that case).
 
         // We export this function so we can pass a funcref to the host.
         //
@@ -551,15 +571,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
             format!("[adapter-callee]{}", adapter.name),
         ));
 
-        self.instruction(I32Const(
-            i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
-        ));
         self.instruction(RefFunc(adapter.callee.as_u32()));
-        self.instruction(I32Const(
-            i32::try_from(adapter.lift.instance.as_u32()).unwrap(),
-        ));
         self.instruction(I32Const(lift_param_count));
-        self.instruction(Call(exit.as_u32()));
+        self.instruction(Call(start_call.as_u32()));
 
         self.finish()
     }
@@ -567,9 +581,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
     /// Compile an adapter function supporting an async-lowered import to a
     /// sync-lifted export.
     ///
-    /// This uses a pair of `async-enter` and `async-exit` built-in functions to
-    /// set up and start a subtask, respectively.  `async-enter` accepts `start`
-    /// and `return_` functions which copy the parameters and results,
+    /// This uses a pair of `async-prepare` and `async-start` built-in functions
+    /// to set up and start a subtask, respectively.  `async-prepare` accepts
+    /// `start` and `return_` functions which copy the parameters and results,
     /// respectively; the host will call the former when the callee has cleared
     /// its backpressure flag and the latter when the callee has returned its
     /// result(s).
@@ -580,28 +594,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
         return_: FunctionId,
         param_count: i32,
         result_count: i32,
+        lower_sig: &Signature,
     ) {
-        let enter = self.module.import_async_enter_call();
-        let exit = self
-            .module
-            .import_async_exit_call(None, adapter.lift.post_return);
+        let start_call =
+            self.module
+                .import_async_start_call(&adapter.name, None, adapter.lift.post_return);
 
-        self.flush_code();
-        self.module.funcs[self.result]
-            .body
-            .push(Body::RefFunc(start));
-        self.module.funcs[self.result]
-            .body
-            .push(Body::RefFunc(return_));
-        self.instruction(I32Const(
-            i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
-        ));
-        self.instruction(I32Const(
-            i32::try_from(self.types[adapter.lift.ty].results.as_u32()).unwrap(),
-        ));
-        self.instruction(LocalGet(0));
-        self.instruction(LocalGet(1));
-        self.instruction(Call(enter.as_u32()));
+        self.call_prepare(adapter, start, return_, lower_sig, false);
 
         // We export this function so we can pass a funcref to the host.
         //
@@ -611,17 +610,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
             format!("[adapter-callee]{}", adapter.name),
         ));
 
-        self.instruction(I32Const(
-            i32::try_from(adapter.lower.instance.as_u32()).unwrap(),
-        ));
         self.instruction(RefFunc(adapter.callee.as_u32()));
-        self.instruction(I32Const(
-            i32::try_from(adapter.lift.instance.as_u32()).unwrap(),
-        ));
         self.instruction(I32Const(param_count));
         self.instruction(I32Const(result_count));
         self.instruction(I32Const(0));
-        self.instruction(Call(exit.as_u32()));
+        self.instruction(Call(start_call.as_u32()));
 
         self.finish()
     }
@@ -803,12 +796,17 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // TODO: handle subtyping
         assert_eq!(src_tys.len(), dst_tys.len());
 
-        let src_flat = if adapter.lower.options.async_ {
-            None
+        // Async lowered functions have a smaller limit on flat parameters, but
+        // their destination, a lifted function, does not have a different limit
+        // than sync functions.
+        let max_flat_params = if adapter.lower.options.async_ {
+            MAX_FLAT_ASYNC_PARAMS
         } else {
-            self.types
-                .flatten_types(lower_opts, MAX_FLAT_PARAMS, src_tys.iter().copied())
+            MAX_FLAT_PARAMS
         };
+        let src_flat =
+            self.types
+                .flatten_types(lower_opts, max_flat_params, src_tys.iter().copied());
         let dst_flat =
             self.types
                 .flatten_types(lift_opts, MAX_FLAT_PARAMS, dst_tys.iter().copied());

--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -106,6 +106,11 @@ pub enum Trap {
     /// A Pulley opcode was executed at runtime when the opcode was disabled at
     /// compile time.
     DisabledOpcode,
+
+    /// Async event loop deadlocked; i.e. it cannot make further progress given
+    /// that all host tasks have completed and any/all host-owned stream/future
+    /// handles have been dropped.
+    AsyncDeadlock,
     // if adding a variant here be sure to update the `check!` macro below
 }
 
@@ -147,6 +152,7 @@ impl Trap {
             ContinuationAlreadyConsumed
             DeleteMeDebugAssertion
             DisabledOpcode
+            AsyncDeadlock
         }
 
         None
@@ -182,6 +188,7 @@ impl fmt::Display for Trap {
             ContinuationAlreadyConsumed => "continuation already consumed",
             DeleteMeDebugAssertion => "triggered debug assertion",
             DisabledOpcode => "pulley opcode disabled at compile time was executed",
+            AsyncDeadlock => "deadlock detected: event loop cannot make further progress",
         };
         write!(f, "wasm trap: {desc}")
     }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -13,6 +13,7 @@ use {
     },
 };
 
+pub(crate) use futures_and_streams::ResourcePair;
 pub use futures_and_streams::{ErrorContext, FutureReader, StreamReader};
 
 mod futures_and_streams;

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -12,3 +12,8 @@ pub struct StreamReader<T> {
 
 /// Represents a Component Model `error-context`.
 pub struct ErrorContext {}
+
+pub(crate) struct ResourcePair {
+    pub(crate) write: u32,
+    pub(crate) read: u32,
+}

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -764,39 +764,6 @@ impl ComponentInstance {
         self.resource_tables().exit_call()
     }
 
-    #[cfg(feature = "component-model-async")]
-    pub(crate) fn future_transfer(
-        &mut self,
-        src_idx: u32,
-        src: TypeFutureTableIndex,
-        dst: TypeFutureTableIndex,
-    ) -> Result<u32> {
-        _ = (src_idx, src, dst);
-        todo!()
-    }
-
-    #[cfg(feature = "component-model-async")]
-    pub(crate) fn stream_transfer(
-        &mut self,
-        src_idx: u32,
-        src: TypeStreamTableIndex,
-        dst: TypeStreamTableIndex,
-    ) -> Result<u32> {
-        _ = (src_idx, src, dst);
-        todo!()
-    }
-
-    #[cfg(feature = "component-model-async")]
-    pub(crate) fn error_context_transfer(
-        &mut self,
-        src_idx: u32,
-        src: TypeComponentLocalErrorContextTableIndex,
-        dst: TypeComponentLocalErrorContextTableIndex,
-    ) -> Result<u32> {
-        _ = (src_idx, src, dst);
-        todo!()
-    }
-
     /// Returns the store-local id that points to this component.
     pub fn id(&self) -> ComponentInstanceId {
         self.id

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -1,6 +1,13 @@
 //! Implementation of string transcoding required by the component model.
 
+#![cfg_attr(
+    feature = "component-model-async",
+    expect(unused_variables, reason = "trying to reduce merge conflicts")
+)]
+
 use crate::prelude::*;
+#[cfg(feature = "component-model-async")]
+use crate::runtime::component::concurrent::ResourcePair;
 use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
 use crate::runtime::vm::{HostResultHasUnwindSentinel, VmSafe};
 use core::cell::Cell;
@@ -612,270 +619,189 @@ fn trap(_instance: &mut ComponentInstance, code: u8) -> Result<Infallible> {
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn backpressure_set(
+fn backpressure_set(
     instance: &mut ComponentInstance,
     caller_instance: u32,
     enabled: u32,
 ) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .backpressure_set(
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            enabled,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn task_return(
     instance: &mut ComponentInstance,
     ty: u32,
+    memory: *mut u8,
+    string_encoding: u8,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    (*instance.store()).component_async_store().task_return(
-        instance,
-        wasmtime_environ::component::TypeTupleIndex::from_u32(ty),
-        storage.cast::<crate::ValRaw>(),
-        storage_len,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn waitable_set_new(instance: &mut ComponentInstance, caller_instance: u32) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .waitable_set_new(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        )
+fn task_cancel(instance: &mut ComponentInstance, caller_instance: u32) -> Result<()> {
+    todo!()
+}
+
+#[cfg(feature = "component-model-async")]
+fn waitable_set_new(instance: &mut ComponentInstance, caller_instance: u32) -> Result<u32> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_wait(
     instance: &mut ComponentInstance,
     caller_instance: u32,
-    set: u32,
     async_: u8,
     memory: *mut u8,
+    set: u32,
     payload: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .waitable_set_wait(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
-            async_ != 0,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            payload,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_poll(
     instance: &mut ComponentInstance,
     caller_instance: u32,
-    set: u32,
     async_: u8,
     memory: *mut u8,
+    set: u32,
     payload: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .waitable_set_poll(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
-            async_ != 0,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            payload,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn waitable_set_drop(
+fn waitable_set_drop(
     instance: &mut ComponentInstance,
     caller_instance: u32,
     set: u32,
 ) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .waitable_set_drop(
-            instance,
-            wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-            set,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn waitable_join(
+fn waitable_join(
     instance: &mut ComponentInstance,
     caller_instance: u32,
-    set: u32,
     waitable: u32,
+    set: u32,
 ) -> Result<()> {
-    (*instance.store()).component_async_store().waitable_join(
-        instance,
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        set,
-        waitable,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn yield_(instance: &mut ComponentInstance, async_: u8) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .yield_(instance, async_ != 0)
+fn yield_(instance: &mut ComponentInstance, async_: u8) -> Result<bool> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn subtask_drop(
+fn subtask_drop(
     instance: &mut ComponentInstance,
     caller_instance: u32,
     task_id: u32,
 ) -> Result<()> {
-    (*instance.store()).component_async_store().subtask_drop(
-        instance,
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        task_id,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn sync_enter(
+fn subtask_cancel(
     instance: &mut ComponentInstance,
+    caller_instance: u32,
+    async_: u8,
+    task_id: u32,
+) -> Result<u32> {
+    todo!()
+}
+
+#[cfg(feature = "component-model-async")]
+unsafe fn prepare_call(
+    instance: &mut ComponentInstance,
+    memory: *mut u8,
     start: *mut u8,
     return_: *mut u8,
     caller_instance: u32,
+    callee_instance: u32,
     task_return_type: u32,
-    result_count: u32,
+    string_encoding: u32,
+    result_count_or_max_if_async: u32,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    (*instance.store()).component_async_store().sync_enter(
-        start.cast::<crate::vm::VMFuncRef>(),
-        return_.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
-        result_count,
-        storage.cast::<crate::ValRaw>(),
-        storage_len,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn sync_exit(
+unsafe fn sync_start(
     instance: &mut ComponentInstance,
     callback: *mut u8,
-    caller_instance: u32,
     callee: *mut u8,
-    callee_instance: u32,
     param_count: u32,
     storage: *mut u8,
     storage_len: usize,
 ) -> Result<()> {
-    (*instance.store()).component_async_store().sync_exit(
-        instance,
-        callback.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        callee.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
-        param_count,
-        storage.cast::<std::mem::MaybeUninit<crate::ValRaw>>(),
-        storage_len,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn async_enter(
-    instance: &mut ComponentInstance,
-    start: *mut u8,
-    return_: *mut u8,
-    caller_instance: u32,
-    task_return_type: u32,
-    params: u32,
-    results: u32,
-) -> Result<()> {
-    (*instance.store()).component_async_store().async_enter(
-        start.cast::<crate::vm::VMFuncRef>(),
-        return_.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        wasmtime_environ::component::TypeTupleIndex::from_u32(task_return_type),
-        params,
-        results,
-    )
-}
-
-#[cfg(feature = "component-model-async")]
-unsafe fn async_exit(
+unsafe fn async_start(
     instance: &mut ComponentInstance,
     callback: *mut u8,
     post_return: *mut u8,
-    caller_instance: u32,
     callee: *mut u8,
-    callee_instance: u32,
     param_count: u32,
     result_count: u32,
     flags: u32,
 ) -> Result<u32> {
-    (*instance.store()).component_async_store().async_exit(
-        instance,
-        callback.cast::<crate::vm::VMFuncRef>(),
-        post_return.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        callee.cast::<crate::vm::VMFuncRef>(),
-        wasmtime_environ::component::RuntimeComponentInstanceIndex::from_u32(callee_instance),
-        param_count,
-        result_count,
-        flags,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_transfer(
+fn future_transfer(
     instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    let src_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(src_table);
-    let dst_table = wasmtime_environ::component::TypeFutureTableIndex::from_u32(dst_table);
-    instance.future_transfer(src_idx, src_table, dst_table)
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_transfer(
+fn stream_transfer(
     instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    let src_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(src_table);
-    let dst_table = wasmtime_environ::component::TypeStreamTableIndex::from_u32(dst_table);
-    instance.stream_transfer(src_idx, src_table, dst_table)
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn error_context_transfer(
+fn error_context_transfer(
     instance: &mut ComponentInstance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
-    let src_table =
-        wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(src_table);
-    let dst_table =
-        wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(dst_table);
-    instance.error_context_transfer(src_idx, src_table, dst_table)
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_new(instance: &mut ComponentInstance, ty: u32) -> Result<u32> {
-    (*instance.store()).component_async_store().future_new(
-        instance,
-        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-    )
+unsafe impl HostResultHasUnwindSentinel for ResourcePair {
+    type Abi = u64;
+    const SENTINEL: u64 = u64::MAX;
+
+    fn into_abi(self) -> Self::Abi {
+        assert!(self.write & (1 << 31) == 0);
+        (u64::from(self.write) << 32) | u64::from(self.read)
+    }
+}
+
+#[cfg(feature = "component-model-async")]
+fn future_new(instance: &mut ComponentInstance, ty: u32) -> Result<ResourcePair> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -884,19 +810,12 @@ unsafe fn future_write(
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
+    async_: u8,
     ty: u32,
     future: u32,
     address: u32,
 ) -> Result<u32> {
-    (*instance.store()).component_async_store().future_write(
-        instance,
-        memory.cast::<crate::vm::VMMemoryDefinition>(),
-        realloc.cast::<crate::vm::VMFuncRef>(),
-        string_encoding,
-        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-        future,
-        address,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -905,91 +824,47 @@ unsafe fn future_read(
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
+    async_: u8,
     ty: u32,
     future: u32,
     address: u32,
 ) -> Result<u32> {
-    (*instance.store()).component_async_store().future_read(
-        instance,
-        memory.cast::<crate::vm::VMMemoryDefinition>(),
-        realloc.cast::<crate::vm::VMFuncRef>(),
-        string_encoding,
-        wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-        future,
-        address,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_cancel_write(
+fn future_cancel_write(
     instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .future_cancel_write(
-            instance,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            async_ != 0,
-            writer,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_cancel_read(
+fn future_cancel_read(
     instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .future_cancel_read(
-            instance,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            async_ != 0,
-            reader,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_close_writable(
-    instance: &mut ComponentInstance,
-    ty: u32,
-    writer: u32,
-) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .future_close_writable(
-            instance,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            writer,
-        )
+fn future_close_writable(instance: &mut ComponentInstance, ty: u32, writer: u32) -> Result<()> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn future_close_readable(
-    instance: &mut ComponentInstance,
-    ty: u32,
-    reader: u32,
-) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .future_close_readable(
-            instance,
-            wasmtime_environ::component::TypeFutureTableIndex::from_u32(ty),
-            reader,
-        )
+fn future_close_readable(instance: &mut ComponentInstance, ty: u32, reader: u32) -> Result<()> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_new(instance: &mut ComponentInstance, ty: u32) -> Result<u32> {
-    (*instance.store()).component_async_store().stream_new(
-        instance,
-        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-    )
+fn stream_new(instance: &mut ComponentInstance, ty: u32) -> Result<ResourcePair> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -998,21 +873,13 @@ unsafe fn stream_write(
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
+    async_: u8,
     ty: u32,
     stream: u32,
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    (*instance.store()).component_async_store().stream_write(
-        instance,
-        memory.cast::<crate::vm::VMMemoryDefinition>(),
-        realloc.cast::<crate::vm::VMFuncRef>(),
-        string_encoding,
-        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-        stream,
-        address,
-        count,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -1021,85 +888,43 @@ unsafe fn stream_read(
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
+    async_: u8,
     ty: u32,
     stream: u32,
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    (*instance.store()).component_async_store().stream_read(
-        instance,
-        memory.cast::<crate::vm::VMMemoryDefinition>(),
-        realloc.cast::<crate::vm::VMFuncRef>(),
-        string_encoding,
-        wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-        stream,
-        address,
-        count,
-    )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_cancel_write(
+fn stream_cancel_write(
     instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     writer: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .stream_cancel_write(
-            instance,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            async_ != 0,
-            writer,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_cancel_read(
+fn stream_cancel_read(
     instance: &mut ComponentInstance,
     ty: u32,
     async_: u8,
     reader: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .stream_cancel_read(
-            instance,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            async_ != 0,
-            reader,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_close_writable(
-    instance: &mut ComponentInstance,
-    ty: u32,
-    writer: u32,
-) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .stream_close_writable(
-            instance,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            writer,
-        )
+fn stream_close_writable(instance: &mut ComponentInstance, ty: u32, writer: u32) -> Result<()> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn stream_close_readable(
-    instance: &mut ComponentInstance,
-    ty: u32,
-    reader: u32,
-) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .stream_close_readable(
-            instance,
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            reader,
-        )
+fn stream_close_readable(instance: &mut ComponentInstance, ty: u32, reader: u32) -> Result<()> {
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -1107,6 +932,7 @@ unsafe fn flat_stream_write(
     instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
+    async_: u8,
     ty: u32,
     payload_size: u32,
     payload_align: u32,
@@ -1114,19 +940,7 @@ unsafe fn flat_stream_write(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .flat_stream_write(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            payload_size,
-            payload_align,
-            stream,
-            address,
-            count,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -1134,6 +948,7 @@ unsafe fn flat_stream_read(
     instance: &mut ComponentInstance,
     memory: *mut u8,
     realloc: *mut u8,
+    async_: u8,
     ty: u32,
     payload_size: u32,
     payload_align: u32,
@@ -1141,19 +956,7 @@ unsafe fn flat_stream_read(
     address: u32,
     count: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .flat_stream_read(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            wasmtime_environ::component::TypeStreamTableIndex::from_u32(ty),
-            payload_size,
-            payload_align,
-            stream,
-            address,
-            count,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -1166,17 +969,7 @@ unsafe fn error_context_new(
     debug_msg_address: u32,
     debug_msg_len: u32,
 ) -> Result<u32> {
-    (*instance.store())
-        .component_async_store()
-        .error_context_new(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-            debug_msg_address,
-            debug_msg_len,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
@@ -1189,30 +982,24 @@ unsafe fn error_context_debug_message(
     err_ctx_handle: u32,
     debug_msg_address: u32,
 ) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .error_context_debug_message(
-            instance,
-            memory.cast::<crate::vm::VMMemoryDefinition>(),
-            realloc.cast::<crate::vm::VMFuncRef>(),
-            string_encoding,
-            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-            err_ctx_handle,
-            debug_msg_address,
-        )
+    todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-unsafe fn error_context_drop(
+fn error_context_drop(
     instance: &mut ComponentInstance,
     ty: u32,
     err_ctx_handle: u32,
 ) -> Result<()> {
-    (*instance.store())
-        .component_async_store()
-        .error_context_drop(
-            instance,
-            wasmtime_environ::component::TypeComponentLocalErrorContextTableIndex::from_u32(ty),
-            err_ctx_handle,
-        )
+    todo!()
+}
+
+#[cfg(feature = "component-model-async")]
+fn context_get(instance: &mut ComponentInstance, slot: u32) -> Result<u32> {
+    todo!()
+}
+
+#[cfg(feature = "component-model-async")]
+fn context_set(instance: &mut ComponentInstance, slot: u32, val: u32) -> Result<()> {
+    todo!()
 }

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -308,6 +308,14 @@ unsafe impl HostResultHasUnwindSentinel for core::convert::Infallible {
     }
 }
 
+unsafe impl HostResultHasUnwindSentinel for bool {
+    type Abi = u32;
+    const SENTINEL: Self::Abi = u32::MAX;
+    fn into_abi(self) -> Self::Abi {
+        u32::from(self)
+    }
+}
+
 /// Stores trace message with backtrace.
 #[derive(Debug)]
 pub struct Trap {


### PR DESCRIPTION
This commit synchronizes the list of intrinsics and notably libcalls with the wasip3-prototyping repository. This change alone does not really do all that much but the goal is to reduce the diff between this repository and the wasip3-prototyping repository. The main change included here is synchronizing the list of libcalls. That necessitates changing various concrete signatures of libcalls and all implementations are replaced with `todo!()` for now to get filled in in the future. Additionally this necessitates changes to the trampoline compilation as well which is brought wholesale from the wasip3-prototyping repository.

Note that this should all be well-tested and covered in the wasip3-prototyping repository so no extra tests are brought in at this time. The intention is that once the runtime bits start landing here upstream it'll be accompanied with appropriate tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
