### PR TITLE
[34.0.0] Fix crash optimizing icmp with vectors

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -288,5 +288,5 @@
       (slt ty (iconcat $I64 a_lo a_hi) (iconcat $I64 b_lo b_hi)))
 
 
-(rule (simplify (eq cty x (bxor bty x y))) (subsume (eq cty y (iconst_u bty 0))))
-(rule (simplify (ne cty x (bxor bty x y))) (subsume (ne cty y (iconst_u bty 0))))
+(rule (simplify (eq cty x (bxor (ty_int bty) x y))) (subsume (eq cty y (iconst_u bty 0))))
+(rule (simplify (ne cty x (bxor (ty_int bty) x y))) (subsume (ne cty y (iconst_u bty 0))))

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -201,3 +201,25 @@ block0(v0: i32, v1: i32):
 ;     v5 = icmp ne v1, v4  ; v4 = 0
 ;     return v5
 ; }
+
+function %issue_10929_no_crash_on_icmp_vectors() -> i32x4 {
+  const0 = 0x40ad3fb47cb16076c8cb1fdd8189d40f
+
+block0():
+  v1 = vconst.i32x4 const0
+  v2 = bxor_not v1, v1
+  v3 = icmp.i32x4 ne v1, v2
+  return v3
+}
+
+; function %issue_10929_no_crash_on_icmp_vectors() -> i32x4 fast {
+;     const0 = 0x40ad3fb47cb16076c8cb1fdd8189d40f
+;
+; block0:
+;     v1 = vconst.i32x4 const0
+;     v4 = bnot v1  ; v1 = const0
+;     v2 = bxor v1, v4  ; v1 = const0
+;     v3 = icmp ne v1, v2  ; v1 = const0
+;     return v3
+; }
+

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -1,0 +1,27 @@
+;;! target = 'x86_64'
+;;! test = 'optimize'
+
+(module
+  (func (param v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 0
+    v128.not
+    v128.xor
+    i8x16.ne)
+)
+;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i8x16):
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @001f                               v4 = bnot.i8x16 v2
+;; @0021                               v5 = bxor.i8x16 v2, v4
+;; @0023                               v6 = icmp.i8x16 ne v2, v5
+;; @0025                               return v6
+;; }


### PR DESCRIPTION
This is a backport of #10948 to the 34.0.0 release branch.