### PR TITLE
Cranelift: Refactor legalization such that traversal is separate from legalizing a particular instruction

### DIFF
--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -73,8 +73,11 @@ fn forward_walk(
 ) {
     let mut pos = FuncCursor::new(func);
     while let Some(_block) = pos.next_block() {
-        let prev_pos = pos.position();
-        while let Some(inst) = pos.next_inst() {
+        let mut prev_pos;
+        while let Some(inst) = {
+            prev_pos = pos.position();
+            pos.next_inst()
+        } {
             match f(pos.func, inst) {
                 WalkCommand::Continue => continue,
                 WalkCommand::Revisit => pos.set_position(prev_pos),


### PR DESCRIPTION
Notably, make sure that we aren't using the same `FuncCursor` for traversal and modification, as that makes it hard to follow when the traversal is being moved forward and backed up.

Additionally, this makes it so that when we legalize an instruction, we only back up the cursor to continue legalization until we reach a fixed-point when said legalization resulted in something that actually requires further legalization. This should be mildly more efficient, since we can avoid an unnecessary loop iteration and its `match` on the just-legalized instruction data and opcode.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
