### PR TITLE
Refactor component host/libcalls

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -4,7 +4,7 @@ use crate::component::storage::slice_to_storage_mut;
 use crate::component::{ComponentNamedList, ComponentType, Instance, Lift, Lower, Val};
 use crate::prelude::*;
 use crate::runtime::vm::component::{
-    InstanceFlags, VMComponentContext, VMLowering, VMLoweringCallee,
+    ComponentInstance, InstanceFlags, VMComponentContext, VMLowering, VMLoweringCallee,
 };
 use crate::runtime::vm::{VMFuncRef, VMGlobalDefinition, VMMemoryDefinition, VMOpaqueContext};
 use crate::{AsContextMut, CallHook, StoreContextMut, ValRaw};
@@ -13,8 +13,8 @@ use core::any::Any;
 use core::mem::{self, MaybeUninit};
 use core::ptr::NonNull;
 use wasmtime_environ::component::{
-    CanonicalAbiInfo, ComponentTypes, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
-    StringEncoding, TypeFuncIndex,
+    CanonicalAbiInfo, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS, StringEncoding,
+    TypeFuncIndex,
 };
 
 pub struct HostFunc {
@@ -66,11 +66,10 @@ impl HostFunc {
     {
         let data = data.as_ptr() as *const F;
         unsafe {
-            call_host_and_handle_result::<T>(cx, |store, instance, types| {
+            call_host_and_handle_result::<T>(cx, |store, instance| {
                 call_host(
                     store,
                     instance,
-                    types,
                     TypeFuncIndex::from_u32(ty),
                     InstanceFlags::from_raw(flags),
                     memory,
@@ -148,7 +147,6 @@ where
 unsafe fn call_host<T, Params, Return, F>(
     mut cx: StoreContextMut<'_, T>,
     instance: Instance,
-    types: &Arc<ComponentTypes>,
     ty: TypeFuncIndex,
     mut flags: InstanceFlags,
     memory: *mut VMMemoryDefinition,
@@ -199,6 +197,7 @@ where
         bail!("cannot leave component instance");
     }
 
+    let types = cx[instance.id()].component().types().clone();
     let ty = &types[ty];
     let param_tys = InterfaceType::Tuple(ty.params);
     let result_tys = InterfaceType::Tuple(ty.results);
@@ -225,13 +224,13 @@ where
             Storage::Indirect(slice_to_storage_mut(storage).assume_init_ref())
         }
     };
-    let mut lift = LiftContext::new(cx.0, &options, types, instance);
+    let mut lift = LiftContext::new(cx.0, &options, &types, instance);
     lift.enter_call();
     let params = storage.lift_params(&mut lift, param_tys)?;
 
     let ret = closure(cx.as_context_mut(), params)?;
     flags.set_may_leave(false);
-    let mut lower = LowerContext::new(cx, &options, types, instance);
+    let mut lower = LowerContext::new(cx, &options, &types, instance);
     storage.lower_results(&mut lower, result_tys, ret)?;
     flags.set_may_leave(true);
 
@@ -308,30 +307,27 @@ fn validate_inbounds<T: ComponentType>(memory: &[u8], ptr: &ValRaw) -> Result<us
 
 unsafe fn call_host_and_handle_result<T>(
     cx: NonNull<VMOpaqueContext>,
-    func: impl FnOnce(StoreContextMut<'_, T>, Instance, &Arc<ComponentTypes>) -> Result<()>,
+    func: impl FnOnce(StoreContextMut<'_, T>, Instance) -> Result<()>,
 ) -> bool
 where
     T: 'static,
 {
     let cx = VMComponentContext::from_opaque(cx);
-    let instance = cx.as_ref().instance();
-    let types = (*instance).component().types();
-    let raw_store = (*instance).store();
-    let mut store = StoreContextMut(&mut *raw_store.cast());
-    let instance = Instance::from_wasmtime(store.0, (*instance).id());
+    ComponentInstance::from_vmctx(cx, |store, instance| {
+        let mut store = store.unchecked_context_mut();
 
-    crate::runtime::vm::catch_unwind_and_record_trap(|| {
-        store.0.call_hook(CallHook::CallingHost)?;
-        let res = func(store.as_context_mut(), instance, types);
-        store.0.call_hook(CallHook::ReturningFromHost)?;
-        res
+        crate::runtime::vm::catch_unwind_and_record_trap(|| {
+            store.0.call_hook(CallHook::CallingHost)?;
+            let res = func(store.as_context_mut(), instance);
+            store.0.call_hook(CallHook::ReturningFromHost)?;
+            res
+        })
     })
 }
 
 unsafe fn call_host_dynamic<T, F>(
     mut store: StoreContextMut<'_, T>,
     instance: Instance,
-    types: &Arc<ComponentTypes>,
     ty: TypeFuncIndex,
     mut flags: InstanceFlags,
     memory: *mut VMMemoryDefinition,
@@ -366,10 +362,11 @@ where
     let args;
     let ret_index;
 
+    let types = store[instance.id()].component().types().clone();
     let func_ty = &types[ty];
     let param_tys = &types[func_ty.params];
     let result_tys = &types[func_ty.results];
-    let mut cx = LiftContext::new(store.0, &options, types, instance);
+    let mut cx = LiftContext::new(store.0, &options, &types, instance);
     cx.enter_call();
     if let Some(param_count) = param_tys.abi.flat_count(MAX_FLAT_PARAMS) {
         // NB: can use `MaybeUninit::slice_assume_init_ref` when that's stable
@@ -405,7 +402,7 @@ where
     closure(store.as_context_mut(), &args, &mut result_vals)?;
     flags.set_may_leave(false);
 
-    let mut cx = LowerContext::new(store, &options, types, instance);
+    let mut cx = LowerContext::new(store, &options, &types, instance);
     if let Some(cnt) = result_tys.abi.flat_count(MAX_FLAT_RESULTS) {
         let mut dst = storage[..cnt].iter_mut();
         for (val, ty) in result_vals.iter().zip(result_tys.types.iter()) {
@@ -463,11 +460,10 @@ where
 {
     let data = data.as_ptr() as *const F;
     unsafe {
-        call_host_and_handle_result(cx, |store, instance, types| {
+        call_host_and_handle_result(cx, |store, instance| {
             call_host_dynamic::<T, _>(
                 store,
                 instance,
-                types,
                 TypeFuncIndex::from_u32(ty),
                 InstanceFlags::from_raw(flags),
                 memory,

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -287,7 +287,9 @@ impl Global {
             ),
             #[cfg(feature = "component-model")]
             ExportGlobalKind::ComponentFlags(vmctx, index) => (
-                vm::component::ComponentInstance::from_vmctx(vmctx, |i| i.id().as_u32()),
+                vm::component::ComponentInstance::from_vmctx(vmctx, |_, i| {
+                    i.id().instance().as_u32()
+                }),
                 VMGlobalKind::ComponentFlags(index),
             ),
         };

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2048,7 +2048,8 @@ impl<T> Caller<'_, T> {
         R: 'static,
     {
         crate::runtime::vm::InstanceAndStore::from_vmctx(caller, |pair| {
-            let (instance, mut store) = pair.unpack_context_mut::<T>();
+            let (instance, store) = pair.unpack_mut();
+            let mut store = store.unchecked_context_mut::<T>();
             let caller = Instance::from_wasmtime(instance.id(), store.0);
 
             let (gc_lifo_scope, ret) = {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -33,7 +33,9 @@ pub(crate) struct f32x4(crate::uninhabited::Uninhabited);
 #[derive(Copy, Clone)]
 pub(crate) struct f64x2(crate::uninhabited::Uninhabited);
 
+use crate::StoreContextMut;
 use crate::prelude::*;
+use crate::store::StoreInner;
 use crate::store::StoreOpaque;
 use alloc::sync::Arc;
 use core::fmt;
@@ -166,13 +168,21 @@ cfg_if::cfg_if! {
 ///
 /// This trait is used to store a raw pointer trait object within each
 /// `VMContext`. This raw pointer trait object points back to the
-/// `wasmtime::Store` internally but is type-erased so this `wasmtime-runtime`
-/// crate doesn't need the entire `wasmtime` crate to build.
+/// `wasmtime::Store` internally but is type-erased to avoid needing to
+/// monomorphize the entire runtime on the `T` in `Store<T>`
 ///
-/// Note that this is an extra-unsafe trait because no heed is paid to the
-/// lifetime of this store or the Send/Sync-ness of this store. All of that must
-/// be respected by embedders (e.g. the `wasmtime::Store` structure). The theory
-/// is that `wasmtime::Store` handles all this correctly.
+/// # Safety
+///
+/// This trait should be implemented by nothing other than `StoreInner<T>` in
+/// this crate. It's not sound to implement it for anything else due to
+/// `unchecked_context_mut` below.
+///
+/// It's also worth nothing that there are various locations where a `*mut dyn
+/// VMStore` is asserted to be both `Send` and `Sync` which disregards the `T`
+/// that's actually stored in the store itself. It's assume that the high-level
+/// APIs using `Store<T>` are correctly inferring send/sync on the returned
+/// values (e.g. futures) and that internally in the runtime we aren't doing
+/// anything "weird" with threads for example.
 pub unsafe trait VMStore {
     /// Get a shared borrow of this store's `StoreOpaque`.
     fn store_opaque(&self) -> &StoreOpaque;
@@ -262,6 +272,19 @@ impl Deref for dyn VMStore + '_ {
 impl DerefMut for dyn VMStore + '_ {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.store_opaque_mut()
+    }
+}
+
+impl dyn VMStore + '_ {
+    /// Asserts that this `VMStore` was originally paired with `StoreInner<T>`
+    /// and then casts to the `StoreContextMut` type.
+    ///
+    /// # Unsafety
+    ///
+    /// This method is not safe as there's no static guarantee that `T` is
+    /// correct for this store.
+    pub(crate) unsafe fn unchecked_context_mut<T>(&mut self) -> StoreContextMut<'_, T> {
+        StoreContextMut(&mut *(self as *mut dyn VMStore as *mut StoreInner<T>))
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -5,11 +5,12 @@
     expect(unused_variables, reason = "trying to reduce merge conflicts")
 )]
 
+use crate::component::Instance;
 use crate::prelude::*;
 #[cfg(feature = "component-model-async")]
 use crate::runtime::component::concurrent::ResourcePair;
 use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
-use crate::runtime::vm::{HostResultHasUnwindSentinel, VmSafe};
+use crate::runtime::vm::{HostResultHasUnwindSentinel, VMStore, VmSafe};
 use core::cell::Cell;
 use core::convert::Infallible;
 use core::ptr::NonNull;
@@ -90,8 +91,8 @@ mod trampolines {
                         $(shims!(@validate_param $pname $param);)*
 
                         let ret = crate::runtime::vm::traphandlers::catch_unwind_and_record_trap(|| {
-                            ComponentInstance::from_vmctx(vmctx, |instance| {
-                                shims!(@invoke $name(instance,) $($pname)*)
+                            ComponentInstance::from_vmctx(vmctx, |store, instance| {
+                                shims!(@invoke $name(store, instance,) $($pname)*)
                             })
                         });
                         shims!(@convert_ret ret $($pname: $param)*)
@@ -167,7 +168,8 @@ fn assert_no_overlap<T, U>(a: &[T], b: &[U]) {
 /// buffers. No value is returned other than whether an invalid string was
 /// found.
 unsafe fn utf8_to_utf8(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     len: usize,
     dst: *mut u8,
@@ -187,7 +189,8 @@ unsafe fn utf8_to_utf8(
 /// buffers. No value is returned other than whether an invalid string was
 /// found.
 unsafe fn utf16_to_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u16,
     len: usize,
     dst: *mut u16,
@@ -222,7 +225,8 @@ fn run_utf16_to_utf16(src: &[u16], mut dst: &mut [u16]) -> Result<bool> {
 /// Given that all byte sequences are valid latin1 strings this is simply a
 /// memory copy.
 unsafe fn latin1_to_latin1(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     len: usize,
     dst: *mut u8,
@@ -240,7 +244,8 @@ unsafe fn latin1_to_latin1(
 /// This simply inflates the latin1 characters to the u16 code points. The
 /// length provided is the same length of the source and destination buffers.
 unsafe fn latin1_to_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     len: usize,
     dst: *mut u16,
@@ -270,7 +275,8 @@ unsafe impl HostResultHasUnwindSentinel for CopySizeReturn {
 /// The length provided is the same unit length of both buffers, and the
 /// returned value from this function is how many u16 units were written.
 unsafe fn utf8_to_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     len: usize,
     dst: *mut u16,
@@ -314,7 +320,8 @@ unsafe impl HostResultHasUnwindSentinel for SizePair {
 /// a partial transcode if the destination buffer is not large enough to hold
 /// the entire contents.
 unsafe fn utf16_to_utf8(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u16,
     src_len: usize,
     dst: *mut u8,
@@ -368,7 +375,8 @@ unsafe fn utf16_to_utf8(
 ///
 /// This may perform a partial encoding if the destination is not large enough.
 unsafe fn latin1_to_utf8(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     src_len: usize,
     dst: *mut u8,
@@ -393,7 +401,8 @@ unsafe fn latin1_to_utf8(
 /// returned. Otherwise the string is "deflated" from a utf16 string to a latin1
 /// string and the latin1 length is returned.
 unsafe fn utf16_to_compact_probably_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u16,
     len: usize,
     dst: *mut u16,
@@ -428,7 +437,8 @@ unsafe fn utf16_to_compact_probably_utf16(
 /// Note that this may not convert the entire source into the destination if the
 /// original utf8 string has usvs not representable in latin1.
 unsafe fn utf8_to_latin1(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     len: usize,
     dst: *mut u8,
@@ -449,7 +459,8 @@ unsafe fn utf8_to_latin1(
 ///
 /// This is the same as `utf8_to_latin1` in terms of parameters/results.
 unsafe fn utf16_to_latin1(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u16,
     len: usize,
     dst: *mut u8,
@@ -490,7 +501,8 @@ unsafe fn utf16_to_latin1(
 /// After the initial latin1 code units have been inflated the entirety of `src`
 /// is then transcoded into the remaining space within `dst`.
 unsafe fn utf8_to_compact_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u8,
     src_len: usize,
     dst: *mut u16,
@@ -509,7 +521,8 @@ unsafe fn utf8_to_compact_utf16(
 
 /// Same as `utf8_to_compact_utf16` but for utf16 source strings.
 unsafe fn utf16_to_compact_utf16(
-    _: &mut ComponentInstance,
+    _: &mut dyn VMStore,
+    _: Instance,
     src: *mut u16,
     src_len: usize,
     dst: *mut u16,
@@ -552,23 +565,36 @@ fn inflate_latin1_bytes(dst: &mut [u16], latin1_bytes_so_far: usize) -> &mut [u1
     return rest;
 }
 
-fn resource_new32(instance: &mut ComponentInstance, resource: u32, rep: u32) -> Result<u32> {
+fn resource_new32(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    resource: u32,
+    rep: u32,
+) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    instance.resource_new32(resource, rep)
+    instance.resource_new32(store, resource, rep)
 }
 
-fn resource_rep32(instance: &mut ComponentInstance, resource: u32, idx: u32) -> Result<u32> {
+fn resource_rep32(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    resource: u32,
+    idx: u32,
+) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    instance.resource_rep32(resource, idx)
+    instance.resource_rep32(store, resource, idx)
 }
 
 fn resource_drop(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     resource: u32,
     idx: u32,
 ) -> Result<ResourceDropRet> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    Ok(ResourceDropRet(instance.resource_drop(resource, idx)?))
+    Ok(ResourceDropRet(
+        instance.resource_drop(store, resource, idx)?,
+    ))
 }
 
 struct ResourceDropRet(Option<u32>);
@@ -585,42 +611,45 @@ unsafe impl HostResultHasUnwindSentinel for ResourceDropRet {
 }
 
 fn resource_transfer_own(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = TypeResourceTableIndex::from_u32(src_table);
     let dst_table = TypeResourceTableIndex::from_u32(dst_table);
-    instance.resource_transfer_own(src_idx, src_table, dst_table)
+    instance.resource_transfer_own(store, src_idx, src_table, dst_table)
 }
 
 fn resource_transfer_borrow(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
 ) -> Result<u32> {
     let src_table = TypeResourceTableIndex::from_u32(src_table);
     let dst_table = TypeResourceTableIndex::from_u32(dst_table);
-    instance.resource_transfer_borrow(src_idx, src_table, dst_table)
+    instance.resource_transfer_borrow(store, src_idx, src_table, dst_table)
 }
 
-fn resource_enter_call(instance: &mut ComponentInstance) {
-    instance.resource_enter_call()
+fn resource_enter_call(store: &mut dyn VMStore, instance: Instance) {
+    instance.resource_enter_call(store)
 }
 
-fn resource_exit_call(instance: &mut ComponentInstance) -> Result<()> {
-    instance.resource_exit_call()
+fn resource_exit_call(store: &mut dyn VMStore, instance: Instance) -> Result<()> {
+    instance.resource_exit_call(store)
 }
 
-fn trap(_instance: &mut ComponentInstance, code: u8) -> Result<Infallible> {
+fn trap(_store: &mut dyn VMStore, _instance: Instance, code: u8) -> Result<Infallible> {
     Err(wasmtime_environ::Trap::from_u8(code).unwrap().into())
 }
 
 #[cfg(feature = "component-model-async")]
 fn backpressure_set(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     enabled: u32,
 ) -> Result<()> {
@@ -629,7 +658,8 @@ fn backpressure_set(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn task_return(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     memory: *mut u8,
     string_encoding: u8,
@@ -640,18 +670,23 @@ unsafe fn task_return(
 }
 
 #[cfg(feature = "component-model-async")]
-fn task_cancel(instance: &mut ComponentInstance, caller_instance: u32) -> Result<()> {
+fn task_cancel(store: &mut dyn VMStore, instance: Instance, caller_instance: u32) -> Result<()> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-fn waitable_set_new(instance: &mut ComponentInstance, caller_instance: u32) -> Result<u32> {
+fn waitable_set_new(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    caller_instance: u32,
+) -> Result<u32> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_wait(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     async_: u8,
     memory: *mut u8,
@@ -663,7 +698,8 @@ unsafe fn waitable_set_wait(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn waitable_set_poll(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     async_: u8,
     memory: *mut u8,
@@ -675,7 +711,8 @@ unsafe fn waitable_set_poll(
 
 #[cfg(feature = "component-model-async")]
 fn waitable_set_drop(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     set: u32,
 ) -> Result<()> {
@@ -684,7 +721,8 @@ fn waitable_set_drop(
 
 #[cfg(feature = "component-model-async")]
 fn waitable_join(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     waitable: u32,
     set: u32,
@@ -693,13 +731,14 @@ fn waitable_join(
 }
 
 #[cfg(feature = "component-model-async")]
-fn yield_(instance: &mut ComponentInstance, async_: u8) -> Result<bool> {
+fn yield_(store: &mut dyn VMStore, instance: Instance, async_: u8) -> Result<bool> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 fn subtask_drop(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     task_id: u32,
 ) -> Result<()> {
@@ -708,7 +747,8 @@ fn subtask_drop(
 
 #[cfg(feature = "component-model-async")]
 fn subtask_cancel(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     caller_instance: u32,
     async_: u8,
     task_id: u32,
@@ -718,7 +758,8 @@ fn subtask_cancel(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn prepare_call(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     start: *mut u8,
     return_: *mut u8,
@@ -735,7 +776,8 @@ unsafe fn prepare_call(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn sync_start(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     callback: *mut u8,
     callee: *mut u8,
     param_count: u32,
@@ -747,7 +789,8 @@ unsafe fn sync_start(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn async_start(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     callback: *mut u8,
     post_return: *mut u8,
     callee: *mut u8,
@@ -760,7 +803,8 @@ unsafe fn async_start(
 
 #[cfg(feature = "component-model-async")]
 fn future_transfer(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -770,7 +814,8 @@ fn future_transfer(
 
 #[cfg(feature = "component-model-async")]
 fn stream_transfer(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -780,7 +825,8 @@ fn stream_transfer(
 
 #[cfg(feature = "component-model-async")]
 fn error_context_transfer(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     src_idx: u32,
     src_table: u32,
     dst_table: u32,
@@ -800,13 +846,14 @@ unsafe impl HostResultHasUnwindSentinel for ResourcePair {
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_new(instance: &mut ComponentInstance, ty: u32) -> Result<ResourcePair> {
+fn future_new(store: &mut dyn VMStore, instance: Instance, ty: u32) -> Result<ResourcePair> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_write(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -820,7 +867,8 @@ unsafe fn future_write(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn future_read(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -834,7 +882,8 @@ unsafe fn future_read(
 
 #[cfg(feature = "component-model-async")]
 fn future_cancel_write(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     async_: u8,
     writer: u32,
@@ -844,7 +893,8 @@ fn future_cancel_write(
 
 #[cfg(feature = "component-model-async")]
 fn future_cancel_read(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     async_: u8,
     reader: u32,
@@ -853,23 +903,34 @@ fn future_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_writable(instance: &mut ComponentInstance, ty: u32, writer: u32) -> Result<()> {
+fn future_close_writable(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    ty: u32,
+    writer: u32,
+) -> Result<()> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-fn future_close_readable(instance: &mut ComponentInstance, ty: u32, reader: u32) -> Result<()> {
+fn future_close_readable(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    ty: u32,
+    reader: u32,
+) -> Result<()> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_new(instance: &mut ComponentInstance, ty: u32) -> Result<ResourcePair> {
+fn stream_new(store: &mut dyn VMStore, instance: Instance, ty: u32) -> Result<ResourcePair> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_write(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -884,7 +945,8 @@ unsafe fn stream_write(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn stream_read(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -899,7 +961,8 @@ unsafe fn stream_read(
 
 #[cfg(feature = "component-model-async")]
 fn stream_cancel_write(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     async_: u8,
     writer: u32,
@@ -909,7 +972,8 @@ fn stream_cancel_write(
 
 #[cfg(feature = "component-model-async")]
 fn stream_cancel_read(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     async_: u8,
     reader: u32,
@@ -918,18 +982,29 @@ fn stream_cancel_read(
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_writable(instance: &mut ComponentInstance, ty: u32, writer: u32) -> Result<()> {
+fn stream_close_writable(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    ty: u32,
+    writer: u32,
+) -> Result<()> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-fn stream_close_readable(instance: &mut ComponentInstance, ty: u32, reader: u32) -> Result<()> {
+fn stream_close_readable(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    ty: u32,
+    reader: u32,
+) -> Result<()> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
 unsafe fn flat_stream_write(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     async_: u8,
@@ -945,7 +1020,8 @@ unsafe fn flat_stream_write(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn flat_stream_read(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     async_: u8,
@@ -961,7 +1037,8 @@ unsafe fn flat_stream_read(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_new(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -974,7 +1051,8 @@ unsafe fn error_context_new(
 
 #[cfg(feature = "component-model-async")]
 unsafe fn error_context_debug_message(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     memory: *mut u8,
     realloc: *mut u8,
     string_encoding: u8,
@@ -987,7 +1065,8 @@ unsafe fn error_context_debug_message(
 
 #[cfg(feature = "component-model-async")]
 fn error_context_drop(
-    instance: &mut ComponentInstance,
+    store: &mut dyn VMStore,
+    instance: Instance,
     ty: u32,
     err_ctx_handle: u32,
 ) -> Result<()> {
@@ -995,11 +1074,11 @@ fn error_context_drop(
 }
 
 #[cfg(feature = "component-model-async")]
-fn context_get(instance: &mut ComponentInstance, slot: u32) -> Result<u32> {
+fn context_get(store: &mut dyn VMStore, instance: Instance, slot: u32) -> Result<u32> {
     todo!()
 }
 
 #[cfg(feature = "component-model-async")]
-fn context_set(instance: &mut ComponentInstance, slot: u32, val: u32) -> Result<()> {
+fn context_set(store: &mut dyn VMStore, instance: Instance, slot: u32, val: u32) -> Result<()> {
     todo!()
 }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -2,6 +2,7 @@
 //! wasm module (except its callstack and register state). An
 //! `InstanceHandle` is a reference-counting handle for an `Instance`.
 
+use crate::prelude::*;
 use crate::runtime::vm::const_expr::{ConstEvalContext, ConstExprEvaluator};
 use crate::runtime::vm::export::Export;
 use crate::runtime::vm::memory::{Memory, RuntimeMemoryCreator};
@@ -16,8 +17,7 @@ use crate::runtime::vm::{
     Imports, ModuleRuntimeInfo, SendSyncPtr, VMFunctionBody, VMGcRef, VMStore, VMStoreRawPtr,
     VmPtr, VmSafe, WasmFault,
 };
-use crate::store::{InstanceId, StoreInner, StoreOpaque};
-use crate::{StoreContextMut, prelude::*};
+use crate::store::{InstanceId, StoreOpaque};
 use alloc::sync::Arc;
 use core::alloc::Layout;
 use core::ops::Range;
@@ -140,24 +140,6 @@ impl InstanceAndStore {
             let store = &mut *self.store_ptr();
             (Pin::new_unchecked(&mut self.instance), store)
         }
-    }
-
-    /// Unpacks this `InstanceAndStore` into its underlying `Instance` and
-    /// `StoreInner<T>`.
-    ///
-    /// # Safety
-    ///
-    /// The `T` must be the same `T` that was used to define this store's
-    /// instance.
-    #[inline]
-    pub(crate) unsafe fn unpack_context_mut<T>(
-        &mut self,
-    ) -> (Pin<&mut Instance>, StoreContextMut<'_, T>) {
-        let store_ptr = self.store_ptr().cast::<StoreInner<T>>();
-        (
-            Pin::new_unchecked(&mut self.instance),
-            StoreContextMut(&mut *store_ptr),
-        )
     }
 
     /// Gets a pointer to this instance's `Store` which was originally


### PR DESCRIPTION
In the spirit of making Wasmtime's internals safer this is a step forward for components to a new paradigm for how libcalls/host functions are implemented. Previously `*mut ComponentInstance` was liberally used but this meant that situations would often simultaneously have `&mut ComponentInstance` and `&mut StoreOpaque` accessible in the same function and there was no prevention of going from the store to the component instance, acquiring two aliasing mutable references (which would be unsound). The refactoring applied here is to redefine the entrypoints from the guest back into the host to operate on `&mut dyn VMStore` (or `StoreContextMut<'_, T>`) plus
`wasmtime::component::Instance`. This index-based approach means that there's no aliasing of component instances and stores and the `Instance` type can be used to look up anything within the store that's necessary.

This refactoring originated in the wasip3-prototyping repository and has been used to remove a good deal of `unsafe` code now that `Instance` is effectively safe to pass around and the store was already passed around anyway everywhere.

In the future I plan to apply a similar paradigm shift for core instances as well, but that'll require some more finesse for all the bits and bobs that core wasm does.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
