### PR TITLE
Minor updates to the `wasmtime-unwinder` crate

### DIFF
--- a/crates/unwinder/src/arch/aarch64.rs
+++ b/crates/unwinder/src/arch/aarch64.rs
@@ -1,7 +1,6 @@
 //! Arm64-specific definitions of architecture-specific functions in Wasmtime.
 
 #[inline]
-#[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {
     let stack_pointer: usize;
     unsafe {
@@ -26,25 +25,27 @@ pub fn get_stack_pointer() -> usize {
 //
 // - AAPCS64 section 6.2.3 The Frame Pointer[0]
 pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
-    let mut pc = *(fp as *mut usize).offset(1);
+    unsafe {
+        let mut pc = *(fp as *mut usize).offset(1);
 
-    // The return address might be signed, so we need to strip the highest bits
-    // (where the authentication code might be located) in order to obtain a
-    // valid address. We use the `XPACLRI` instruction, which is executed as a
-    // no-op by processors that do not support pointer authentication, so that
-    // the implementation is backward-compatible and there is no duplication.
-    // However, this instruction requires the LR register for both its input and
-    // output.
-    core::arch::asm!(
-        "mov lr, {pc}",
-        "xpaclri",
-        "mov {pc}, lr",
-        pc = inout(reg) pc,
-        out("lr") _,
-        options(nomem, nostack, preserves_flags, pure),
-    );
+        // The return address might be signed, so we need to strip the highest bits
+        // (where the authentication code might be located) in order to obtain a
+        // valid address. We use the `XPACLRI` instruction, which is executed as a
+        // no-op by processors that do not support pointer authentication, so that
+        // the implementation is backward-compatible and there is no duplication.
+        // However, this instruction requires the LR register for both its input and
+        // output.
+        core::arch::asm!(
+            "mov lr, {pc}",
+            "xpaclri",
+            "mov {pc}, lr",
+            pc = inout(reg) pc,
+            out("lr") _,
+            options(nomem, nostack, preserves_flags, pure),
+        );
 
-    pc
+        pc
+    }
 }
 
 pub unsafe fn resume_to_exception_handler(

--- a/crates/unwinder/src/arch/mod.rs
+++ b/crates/unwinder/src/arch/mod.rs
@@ -99,7 +99,9 @@ cfg_if::cfg_if! {
                 NEXT_OLDER_SP_FROM_FP_OFFSET
             }
             unsafe fn get_next_older_pc_from_fp(&self, fp: usize) -> usize {
-                get_next_older_pc_from_fp(fp)
+                unsafe {
+                    get_next_older_pc_from_fp(fp)
+                }
             }
             fn assert_fp_is_aligned(&self, fp: usize) {
                 assert_fp_is_aligned(fp)

--- a/crates/unwinder/src/arch/riscv64.rs
+++ b/crates/unwinder/src/arch/riscv64.rs
@@ -1,7 +1,6 @@
 //! Riscv64-specific definitions of architecture-specific functions in Wasmtime.
 
 #[inline]
-#[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {
     let stack_pointer: usize;
     unsafe {
@@ -15,7 +14,7 @@ pub fn get_stack_pointer() -> usize {
 }
 
 pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
-    *(fp as *mut usize).offset(1)
+    unsafe { *(fp as *mut usize).offset(1) }
 }
 
 pub unsafe fn resume_to_exception_handler(

--- a/crates/unwinder/src/arch/s390x.rs
+++ b/crates/unwinder/src/arch/s390x.rs
@@ -1,7 +1,6 @@
 //! s390x-specific definitions of architecture-specific functions in Wasmtime.
 
 #[inline]
-#[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {
     let mut sp;
     unsafe {
@@ -18,7 +17,7 @@ pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
     // The next older PC can be found in register %r14 at function entry, which
     // was saved into slot 14 of the register save area pointed to by "FP" (the
     // backchain pointer).
-    *(fp as *mut usize).offset(14)
+    unsafe { *(fp as *mut usize).offset(14) }
 }
 
 pub unsafe fn resume_to_exception_handler(

--- a/crates/unwinder/src/arch/x86.rs
+++ b/crates/unwinder/src/arch/x86.rs
@@ -2,7 +2,6 @@
 //! Wasmtime.
 
 #[inline]
-#[allow(missing_docs)]
 pub fn get_stack_pointer() -> usize {
     let stack_pointer: usize;
     unsafe {
@@ -18,7 +17,7 @@ pub fn get_stack_pointer() -> usize {
 pub unsafe fn get_next_older_pc_from_fp(fp: usize) -> usize {
     // The calling convention always pushes the return pointer (aka the PC of
     // the next older frame) just before this frame.
-    *(fp as *mut usize).offset(1)
+    unsafe { *(fp as *mut usize).offset(1) }
 }
 
 pub unsafe fn resume_to_exception_handler(

--- a/crates/unwinder/src/lib.rs
+++ b/crates/unwinder/src/lib.rs
@@ -1,8 +1,6 @@
 //! Cranelift unwinder.
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 #[cfg(feature = "cranelift")]
 extern crate alloc;
@@ -10,7 +8,10 @@ extern crate alloc;
 mod stackwalk;
 pub use stackwalk::*;
 mod arch;
-#[allow(unused_imports)] // `arch` becomes empty on platforms without native-code backends.
+#[allow(
+    unused_imports,
+    reason = "`arch` is intentionally an empty module on some platforms"
+)]
 pub use arch::*;
 mod exception_table;
 pub use exception_table::*;


### PR DESCRIPTION
* Don't opt-out of the default set of lints.
* Minor changes to inline assembly which shouldn't affect functionality.