### PR TITLE
Enable `allow_attributes_without_reason` in fuzzer

### DIFF
--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -138,7 +138,7 @@ mod component {
         }
 
         let module = quote! {
-            #[allow(unused_imports)]
+            #[allow(unused_imports, reason = "macro-generated code")]
             fn static_component_api_target(input: &mut libfuzzer_sys::arbitrary::Unstructured) -> libfuzzer_sys::arbitrary::Result<()> {
                 use anyhow::Result;
                 use wasmtime_test_util::component_fuzz::Declarations;

--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -1,12 +1,10 @@
 #![no_main]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
 use wasmtime_fuzzing::oracles;
 
 include!(concat!(env!("OUT_DIR"), "/static_component_api.rs"));
 
-#[allow(unused_imports)]
 fn target(input: &mut arbitrary::Unstructured) -> arbitrary::Result<()> {
     if input.arbitrary()? {
         static_component_api_target(input)


### PR DESCRIPTION
This was a holdover from the initial migration, no reason to exclude the fuzzer any more.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
