### PR TITLE
More clearly flag internal crates as such

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -446,7 +446,7 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - run: cargo test -p wasmtime-fiber --no-default-features
+    - run: cargo test -p wasmtime-internal-fiber --no-default-features
     - run: cargo test -p cranelift-tools --test logged-filetests
 
     # common logic to cancel the entire run if this job fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -380,9 +380,9 @@ jobs:
 
           - name: wasmtime-fiber
             checks: |
-              -p wasmtime-fiber --no-default-features
-              -p wasmtime-fiber --no-default-features --features std
-              -p wasmtime-fiber --all-features
+              -p wasmtime-internal-fiber --no-default-features
+              -p wasmtime-internal-fiber --no-default-features --features std
+              -p wasmtime-internal-fiber --all-features
 
           - name: wasmtime-cli
             checks: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
  "smallvec",
  "souper-ir",
  "target-lexicon",
- "wasmtime-math",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -796,7 +796,7 @@ dependencies = [
  "target-lexicon",
  "thiserror 2.0.12",
  "toml",
- "wasmtime-unwinder",
+ "wasmtime-internal-unwinder",
  "wat",
 ]
 
@@ -864,8 +864,8 @@ dependencies = [
  "memmap2",
  "region",
  "target-lexicon",
- "wasmtime-jit-icache-coherence",
- "wasmtime-unwinder",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
  "windows-sys 0.59.0",
 ]
 
@@ -2642,7 +2642,7 @@ dependencies = [
  "log",
  "pulley-macros",
  "termcolor",
- "wasmtime-math",
+ "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -4182,31 +4182,24 @@ dependencies = [
  "wasm-encoder 0.233.0",
  "wasm-wave",
  "wasmparser 0.233.0",
- "wasmtime-asm-macros",
- "wasmtime-cache",
- "wasmtime-component-macro",
- "wasmtime-component-util",
- "wasmtime-cranelift",
  "wasmtime-environ",
- "wasmtime-fiber",
- "wasmtime-jit-debug",
- "wasmtime-jit-icache-coherence",
- "wasmtime-math",
- "wasmtime-slab",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wasmtime-internal-wmemcheck",
  "wasmtime-test-util",
- "wasmtime-unwinder",
- "wasmtime-versioned-export-macros",
- "wasmtime-winch",
- "wasmtime-wmemcheck",
  "wat",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-asm-macros"
-version = "35.0.0"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4244,38 +4237,9 @@ dependencies = [
  "tokio",
  "tracing",
  "wasmtime",
- "wasmtime-c-api-macros",
+ "wasmtime-internal-c-api-macros",
  "wasmtime-wasi",
  "wat",
-]
-
-[[package]]
-name = "wasmtime-c-api-macros"
-version = "35.0.0"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "base64",
- "directories-next",
- "env_logger 0.11.5",
- "filetime",
- "log",
- "postcard",
- "rustix 1.0.3",
- "serde",
- "serde_derive",
- "sha2",
- "tempfile",
- "toml",
- "windows-sys 0.59.0",
- "zstd 0.13.0",
 ]
 
 [[package]]
@@ -4329,12 +4293,12 @@ dependencies = [
  "wasm-encoder 0.233.0",
  "wasmparser 0.233.0",
  "wasmtime",
- "wasmtime-cache",
  "wasmtime-cli-flags",
- "wasmtime-component-util",
- "wasmtime-cranelift",
  "wasmtime-environ",
- "wasmtime-explorer",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-explorer",
  "wasmtime-test-macros",
  "wasmtime-test-util",
  "wasmtime-wasi",
@@ -4367,55 +4331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "component-macro-test-helpers",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "similar",
- "syn 2.0.100",
- "tracing",
- "wasmtime",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser 0.233.0",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "35.0.0"
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.12",
- "wasmparser 0.233.0",
- "wasmtime-environ",
- "wasmtime-math",
- "wasmtime-versioned-export-macros",
-]
-
-[[package]]
 name = "wasmtime-environ"
 version = "35.0.0"
 dependencies = [
@@ -4439,7 +4354,7 @@ dependencies = [
  "wasm-encoder 0.233.0",
  "wasmparser 0.233.0",
  "wasmprinter",
- "wasmtime-component-util",
+ "wasmtime-internal-component-util",
  "wat",
 ]
 
@@ -4455,36 +4370,6 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-test-util",
  "wat",
-]
-
-[[package]]
-name = "wasmtime-explorer"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "capstone",
- "serde",
- "serde_derive",
- "serde_json",
- "target-lexicon",
- "wasmprinter",
- "wasmtime",
- "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "backtrace",
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.0.3",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4546,17 +4431,132 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-jit-debug"
+name = "wasmtime-internal-asm-macros"
+version = "35.0.0"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-c-api-macros"
+version = "35.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "env_logger 0.11.5",
+ "filetime",
+ "log",
+ "postcard",
+ "rustix 1.0.3",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "tempfile",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd 0.13.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "component-macro-test-helpers",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "similar",
+ "syn 2.0.100",
+ "tracing",
+ "wasmtime",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.233.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "35.0.0"
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser 0.233.0",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-explorer"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "capstone",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-lexicon",
+ "wasmprinter",
+ "wasmtime",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.3",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
 version = "35.0.0"
 dependencies = [
  "cc",
  "object",
  "rustix 1.0.3",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
+name = "wasmtime-internal-jit-icache-coherence"
 version = "35.0.0"
 dependencies = [
  "anyhow",
@@ -4566,14 +4566,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-math"
+name = "wasmtime-internal-math"
 version = "35.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
-name = "wasmtime-slab"
+name = "wasmtime-internal-slab"
+version = "35.0.0"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "35.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.233.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "35.0.0"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.7.0",
+ "wit-parser 0.233.0",
+]
+
+[[package]]
+name = "wasmtime-internal-wmemcheck"
 version = "35.0.0"
 
 [[package]]
@@ -4601,28 +4650,8 @@ dependencies = [
  "target-lexicon",
  "toml",
  "wasmtime",
- "wasmtime-component-util",
  "wasmtime-environ",
-]
-
-[[package]]
-name = "wasmtime-unwinder"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "log",
- "object",
-]
-
-[[package]]
-name = "wasmtime-versioned-export-macros"
-version = "35.0.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "wasmtime-internal-component-util",
 ]
 
 [[package]]
@@ -4778,35 +4807,6 @@ dependencies = [
  "wasmtime",
  "wast 233.0.0",
 ]
-
-[[package]]
-name = "wasmtime-winch"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "object",
- "target-lexicon",
- "wasmparser 0.233.0",
- "wasmtime-cranelift",
- "wasmtime-environ",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "35.0.0"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.7.0",
- "wit-parser 0.233.0",
-]
-
-[[package]]
-name = "wasmtime-wmemcheck"
-version = "35.0.0"
 
 [[package]]
 name = "wast"
@@ -4968,9 +4968,9 @@ dependencies = [
  "target-lexicon",
  "thiserror 2.0.12",
  "wasmparser 0.233.0",
- "wasmtime-cranelift",
  "wasmtime-environ",
- "wasmtime-math",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,19 +215,17 @@ allow_attributes_without_reason = 'warn'
 from_over_into = 'warn'
 
 [workspace.dependencies]
-arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=35.0.0" }
+# Public crates related to Wasmtime.
+#
+# These crates are intended to be depended upon publicly to varying degrees. For
+# example `wasmtime` is very much intended to be used, as well as WASI crates
+# like `wasmtime-wasi`. Crates like `wasmtime-environ` are useful for ecosystem
+# tooling but aren't intended to be widely depended on.
+#
+# All of these crates are supported though in the sense that
 wasmtime = { path = "crates/wasmtime", version = "35.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=35.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=35.0.0" }
 wasmtime-cli-flags = { path = "crates/cli-flags", version = "=35.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=35.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=35.0.0" }
 wasmtime-environ = { path = "crates/environ", version = "=35.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=35.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=35.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=35.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=35.0.0" }
 wasmtime-wasi = { path = "crates/wasi", version = "35.0.0", default-features = false }
 wasmtime-wasi-io = { path = "crates/wasi-io", version = "35.0.0", default-features = false }
 wasmtime-wasi-http = { path = "crates/wasi-http", version = "35.0.0", default-features = false }
@@ -235,28 +233,44 @@ wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "35.0.0" }
 wasmtime-wasi-config = { path = "crates/wasi-config", version = "35.0.0" }
 wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "35.0.0" }
 wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "35.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=35.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=35.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=35.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=35.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=35.0.0" }
 wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "35.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=35.0.0" }
+
+# Internal Wasmtime-specific crates.
+#
+# Note that all crates here are actually named `wasmtime-internal-*` as their
+# package name which is what will show up on crates.io. This is done to signal
+# that these are internal unsupported crates for external use. These exist as
+# part of the project organization of other public crates in Wasmtime and are
+# otherwise not supported in terms of CVEs for example.
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=35.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=35.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=35.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=35.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=35.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=35.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=35.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=35.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=35.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=35.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=35.0.0", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=35.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=35.0.0", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=35.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=35.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=35.0.0", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=35.0.0", package = 'wasmtime-internal-unwinder' }
+
+# Miscellaneous crates without a `wasmtime-*` prefix in their name but still
+# used in the `wasmtime-*` family of crates depending on various features/etc.
 wiggle = { path = "crates/wiggle", version = "=35.0.0", default-features = false }
 wiggle-macro = { path = "crates/wiggle/macro", version = "=35.0.0" }
 wiggle-generate = { path = "crates/wiggle/generate", version = "=35.0.0" }
 wasi-common = { path = "crates/wasi-common", version = "=35.0.0", default-features = false }
-wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=35.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=35.0.0" }
-wasmtime-math = { path = "crates/math", version = "=35.0.0" }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=35.0.0" }
-test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
-wasmtime-test-util = { path = "crates/test-util" }
-
 pulley-interpreter = { path = 'pulley', version = "=35.0.0" }
-pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 pulley-macros = { path = 'pulley/macros', version = "=35.0.0" }
 
+# Cranelift crates in this workspace
 cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.122.0" }
 cranelift-codegen = { path = "cranelift/codegen", version = "0.122.0", default-features = false, features = ["std", "unwind"] }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.122.0" }
@@ -275,10 +289,16 @@ cranelift-control = { path = "cranelift/control", version = "0.122.0" }
 cranelift-srcgen = { path = "cranelift/srcgen", version = "0.122.0" }
 cranelift = { path = "cranelift/umbrella", version = "0.122.0" }
 
+# Winch crates in this workspace.
 winch-codegen = { path = "winch/codegen", version = "=35.0.0" }
 
+# Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
+wasmtime-fuzzing = { path = "crates/fuzzing" }
+test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
+wasmtime-test-util = { path = "crates/test-util" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }
+pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
@@ -315,6 +335,7 @@ wasm-wave = "0.233.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
+arbitrary = "1.4.0"
 cc = "1.0"
 object = { version = "0.36.5", default-features = false, features = ['read_core', 'elf'] }
 gimli = { version = "0.31.0", default-features = false, features = ['read'] }

--- a/crates/asm-macros/Cargo.toml
+++ b/crates/asm-macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["The Wasmtime Project Developers"]
-description = "Macros for defining asm functions in Wasmtime"
+description = "INTERNAL: Macros for defining asm functions in Wasmtime"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
-name = "wasmtime-asm-macros"
+name = "wasmtime-internal-asm-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true
 

--- a/crates/asm-macros/src/lib.rs
+++ b/crates/asm-macros/src/lib.rs
@@ -5,6 +5,13 @@
 //! attributes correct (e.g. ELF symbols get a size and are flagged as a
 //! function) and additionally handles visibility across platforms. All symbols
 //! should be visible to Rust but not visible externally outside of a `*.so`.
+//!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
 
 #![no_std]
 

--- a/crates/c-api-macros/Cargo.toml
+++ b/crates/c-api-macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "wasmtime-c-api-macros"
+name = "wasmtime-internal-c-api-macros"
 version.workspace = true
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
-description = "Support macros for `wasmtime-c-api`"
+description = "INTERNAL: Support macros for `wasmtime-c-api`"
 repository = "https://github.com/bytecodealliance/wasmtime"
 
 [lints]

--- a/crates/c-api-macros/src/lib.rs
+++ b/crates/c-api-macros/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! These are intended to mirror the macros in the `wasm.h` header file and
 //! largely facilitate the `declare_ref` macro.
+//!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
 
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::quote;

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-cache"
+name = "wasmtime-internal-cache"
 version.workspace = true
 authors.workspace = true
-description = "Support for automatic module caching with Wasmtime"
+description = "INTERNAL: Support for automatic module caching with Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cache/"

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 use anyhow::Result;
 use base64::Engine;
 use log::{debug, trace, warn};

--- a/crates/cache/tests/cache_write_default_config.rs
+++ b/crates/cache/tests/cache_write_default_config.rs
@@ -1,4 +1,4 @@
-use wasmtime_cache::create_new_config;
+use wasmtime_internal_cache::create_new_config;
 
 #[test]
 fn test_cache_write_default_config() {

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-component-macro"
+name = "wasmtime-internal-component-macro"
 version.workspace = true
 authors.workspace = true
-description = "Macros for deriving component interface types from Rust types"
+description = "INTERNAL: Macros for deriving component interface types from Rust types"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-component-macro/"

--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 use syn::{DeriveInput, Error, parse_macro_input};
 
 mod bindgen;

--- a/crates/component-util/Cargo.toml
+++ b/crates/component-util/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-component-util"
+name = "wasmtime-internal-component-util"
 version.workspace = true
 authors.workspace = true
-description = "Utility types and functions to support the component model in Wasmtime"
+description = "INTERNAL: Utility types and functions to support the component model in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-component-util/"

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 #![no_std]
 
 /// Represents the possible sizes in bytes of the discriminant of a variant type in the component model

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-cranelift"
+name = "wasmtime-internal-cranelift"
 version.workspace = true
 authors.workspace = true
-description = "Integration between Cranelift and Wasmtime"
+description = "INTERNAL: Integration between Cranelift and Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cranelift/"

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! This crate provides an implementation of the `wasmtime_environ::Compiler`
 //! and `wasmtime_environ::CompilerBuilder` traits.
+//!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
 
 // See documentation in crates/wasmtime/src/runtime.rs for why this is
 // selectively enabled here.

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "wasmtime-explorer"
+name = "wasmtime-internal-explorer"
 authors.workspace = true
-description = "Compiler explorer for Wasmtime and Cranelift"
+description = "INTERNAL: Compiler explorer for Wasmtime and Cranelift"
 documentation = "https://docs.rs/wasmtime-explorer/"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 use anyhow::Result;
 use capstone::arch::BuildsCapstone;
 use serde_derive::Serialize;

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-fiber"
+name = "wasmtime-internal-fiber"
 version.workspace = true
 authors.workspace = true
-description = "Fiber support for Wasmtime"
+description = "INTERNAL: Fiber support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 #![no_std]
 
 #[cfg(any(feature = "std", unix, windows))]

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-jit-debug"
+name = "wasmtime-internal-jit-debug"
 version.workspace = true
 authors.workspace = true
-description = "JIT debug interfaces support for Wasmtime"
+description = "INTERNAL: JIT debug interfaces support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 categories = ["development-tools::debugging"]
 keywords = ["gdb", "jit"]

--- a/crates/jit-debug/src/lib.rs
+++ b/crates/jit-debug/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 #[cfg(feature = "gdb_jit_int")]
 pub mod gdb_jit_int;
 

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-jit-icache-coherence"
+name = "wasmtime-internal-jit-icache-coherence"
 version.workspace = true
 authors.workspace = true
-description = "Utilities for JIT icache maintenance"
+description = "INTERNAL: Utilities for JIT icache maintenance"
 documentation = "https://docs.rs/jit-icache-coherence"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -1,5 +1,12 @@
 //! This crate provides utilities for instruction cache maintenance for JIT authors.
 //!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+//!
 //! In self modifying codes such as when writing a JIT, special care must be taken when marking the
 //! code as ready for execution. On fully coherent architectures (X86, S390X) the data cache (D-Cache)
 //! and the instruction cache (I-Cache) are always in sync. However this is not guaranteed for all

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -34,7 +34,7 @@
 //! ```
 //! # use std::ffi::c_void;
 //! # use std::io;
-//! # use wasmtime_jit_icache_coherence::*;
+//! # use wasmtime_internal_jit_icache_coherence::*;
 //! #
 //! # struct Page {
 //! #   addr: *const c_void,

--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-math"
+name = "wasmtime-internal-math"
 version.workspace = true
 authors.workspace = true
-description = "Low-level math routines used in Wasmtime"
+description = "INTERNAL: Low-level math routines used in Wasmtime"
 documentation = "https://docs.rs/wasmtime-math"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -1,6 +1,13 @@
 //! A minimal helper crate for implementing float-related operations for
 //! WebAssembly in terms of the native platform primitives.
 //!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+//!
 //! This crate is intended to assist with solving the portability issues such
 //! as:
 //!

--- a/crates/slab/Cargo.toml
+++ b/crates/slab/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["The Wasmtime Project Developers"]
-description = "Uni-typed slab with a free list for use in Wasmtime"
+description = "INTERNAL: Uni-typed slab with a free list for use in Wasmtime"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
-name = "wasmtime-slab"
+name = "wasmtime-internal-slab"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true
 

--- a/crates/slab/src/lib.rs
+++ b/crates/slab/src/lib.rs
@@ -14,7 +14,7 @@
 //! # Example
 //!
 //! ```
-//! use wasmtime_slab::{Id, Slab};
+//! use wasmtime_internal_slab::{Id, Slab};
 //!
 //! let mut slab = Slab::new();
 //!
@@ -79,7 +79,7 @@
 //!
 //! ```rust
 //! pub struct GenerationalId {
-//!     id: wasmtime_slab::Id,
+//!     id: wasmtime_internal_slab::Id,
 //!     generation: u32,
 //! }
 //!
@@ -89,7 +89,7 @@
 //! }
 //!
 //! pub struct GenerationalSlab<T> {
-//!     slab: wasmtime_slab::Slab<GenerationalEntry<T>>,
+//!     slab: wasmtime_internal_slab::Slab<GenerationalEntry<T>>,
 //!     generation: u32,
 //! }
 //!

--- a/crates/slab/src/lib.rs
+++ b/crates/slab/src/lib.rs
@@ -1,6 +1,13 @@
 //! A very simple, uniformly-typed slab arena that supports deallocation and
 //! reusing deallocated entries' space.
 //!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+//!
 //! The free list of vacant entries in the slab are stored inline in the slab's
 //! existing storage.
 //!

--- a/crates/unwinder/Cargo.toml
+++ b/crates/unwinder/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-unwinder"
+name = "wasmtime-internal-unwinder"
 authors.workspace = true
 version.workspace = true
-description = "Wasmtime's unwind format and unwinder"
+description = "INTERNAL: Wasmtime's unwind format and unwinder"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/wasmtime-unwinder"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/crates/unwinder/src/lib.rs
+++ b/crates/unwinder/src/lib.rs
@@ -1,4 +1,12 @@
-//! Cranelift unwinder.
+//! Wasmtime unwinder.
+//!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]

--- a/crates/versioned-export-macros/Cargo.toml
+++ b/crates/versioned-export-macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["The Wasmtime Project Developers"]
-description = "Macros for defining versioned exports in Wasmtime"
+description = "INTERNAL: Macros for defining versioned exports in Wasmtime"
 edition.workspace = true
 rust-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
-name = "wasmtime-versioned-export-macros"
+name = "wasmtime-internal-versioned-export-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true
 

--- a/crates/versioned-export-macros/src/lib.rs
+++ b/crates/versioned-export-macros/src/lib.rs
@@ -1,6 +1,13 @@
 //! This crate defines macros to easily define and use functions with a
 //! versioned suffix, to facilitate using multiple versions of the same
 //! crate that generate assembly.
+//!
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
 
 use quote::ToTokens;
 

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "wasmtime-winch"
-description = "Integration between Wasmtime and Winch"
+name = "wasmtime-internal-winch"
+description = "INTERNAL: Integration between Wasmtime and Winch"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/crates/winch/src/lib.rs
+++ b/crates/winch/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 pub use builder::builder;
 
 mod builder;

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-wit-bindgen"
+name = "wasmtime-internal-wit-bindgen"
 version.workspace = true
 authors.workspace = true
-description = "Internal `*.wit` support for the `wasmtime` crate's macros"
+description = "INTERNAL: `*.wit` support for the `wasmtime` crate's macros"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-wit-bindgen/"

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 use crate::rust::{RustGenerator, TypeMode, to_rust_ident, to_rust_upper_camel_case};
 use crate::types::{TypeInfo, Types};
 use anyhow::bail;

--- a/crates/wmemcheck/Cargo.toml
+++ b/crates/wmemcheck/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wasmtime-wmemcheck"
+name = "wasmtime-internal-wmemcheck"
 version.workspace = true
 authors.workspace = true
-description = "Memcheck implementation for Wasmtime"
+description = "INTERNAL: Memcheck implementation for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cranelift/"

--- a/crates/wmemcheck/src/lib.rs
+++ b/crates/wmemcheck/src/lib.rs
@@ -1,3 +1,10 @@
+//! > **⚠️ Warning ⚠️**: this crate is an internal-only crate for the Wasmtime
+//! > project and is not intended for general use. APIs are not strictly
+//! > reviewed for safety and usage outside of Wasmtime may have bugs. If
+//! > you're interested in using this feel free to file an issue on the
+//! > Wasmtime repository to start a discussion about doing so, but otherwise
+//! > be aware that your usage of this crate is not supported.
+
 use std::cmp::*;
 use std::collections::HashMap;
 

--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -234,3 +234,30 @@ above can be used to update an `exemptions` entry or add a new entry. Note that
 when the "popular threshold" is used **do not add a vet entry** because the
 crate is, in fact, not vetted. This is required to go through an
 `[[exemptions]]` entry.
+
+### Crate Organization
+
+The Wasmtime repository is a bit of a monorepo with lots of crates internally
+within it. The Wasmtime project and `wasmtime` crate also consists of a variety
+of crates intended for various purposes. As such not all crates are treated
+exactly the same and so there are some rough guidelines here about adding new
+crates to the repository and where to place/name them:
+
+* Wasmtime-related crates live in `crates/foo/Cargo.toml` where the crate name
+  is typically `wasmtime-foo` or `wasmtime-internal-foo`.
+
+* Cranelift-related crates live in `cranelift/foo/Cargo.toml` where the crate is
+  named `cranelift-foo`.
+
+* Some projects such as Winch, Pulley, and Wiggle are exceptions to the above
+  rules and live in `winch/*`, `pulley/*` and `crates/wiggle/*`.
+
+* Some crates are "internal" to Wasmtime. This means that they only exist for
+  crate organization purposes (such as optional dependencies, or code
+  organization). These crates are not intended for public consumption and are
+  intended for exclusively being used by the `wasmtime` crate, for example, or
+  other public crates. These crates should be named `wasmtime-internal-foo` and
+  live in `crates/foo`. The `[workspace.dependencies]` directive in `Cargo.toml`
+  at the root of the repository should rename it to `wasmtime-foo` in
+  workspace-local usage, meaning that the "internal" part is only relevant on
+  crates.io.

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 const CRATES_TO_PUBLISH: &[&str] = &[
     // pulley
     "cranelift-bitset",
-    "wasmtime-math",
+    "wasmtime-internal-math",
     "pulley-macros",
     "pulley-interpreter",
     // cranelift
@@ -41,9 +41,9 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "cranelift-native",
     "cranelift-object",
     "cranelift-interpreter",
-    "wasmtime-jit-icache-coherence",
+    "wasmtime-internal-jit-icache-coherence",
     // Wasmtime unwinder, used by both `cranelift-jit` (optionally) and filetests, and by Wasmtime.
-    "wasmtime-unwinder",
+    "wasmtime-internal-unwinder",
     // Cranelift crates that use Wasmtime unwinder.
     "cranelift-jit",
     "cranelift",
@@ -53,20 +53,20 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     // winch
     "winch",
     // wasmtime
-    "wasmtime-asm-macros",
-    "wasmtime-versioned-export-macros",
-    "wasmtime-slab",
-    "wasmtime-component-util",
-    "wasmtime-wit-bindgen",
-    "wasmtime-component-macro",
-    "wasmtime-jit-debug",
-    "wasmtime-fiber",
+    "wasmtime-internal-asm-macros",
+    "wasmtime-internal-versioned-export-macros",
+    "wasmtime-internal-slab",
+    "wasmtime-internal-component-util",
+    "wasmtime-internal-wit-bindgen",
+    "wasmtime-internal-component-macro",
+    "wasmtime-internal-jit-debug",
+    "wasmtime-internal-fiber",
     "wasmtime-environ",
-    "wasmtime-wmemcheck",
-    "wasmtime-cranelift",
-    "wasmtime-cache",
+    "wasmtime-internal-wmemcheck",
+    "wasmtime-internal-cranelift",
+    "wasmtime-internal-cache",
     "winch-codegen",
-    "wasmtime-winch",
+    "wasmtime-internal-winch",
     "wasmtime",
     // wasi-common/wiggle
     "wiggle",
@@ -81,10 +81,10 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasmtime-wasi-threads",
     "wasmtime-wasi-tls",
     "wasmtime-wast",
-    "wasmtime-c-api-macros",
+    "wasmtime-internal-c-api-macros",
     "wasmtime-c-api-impl",
     "wasmtime-cli-flags",
-    "wasmtime-explorer",
+    "wasmtime-internal-explorer",
     "wasmtime-cli",
 ];
 
@@ -340,7 +340,10 @@ fn bump_version(krate: &Crate, crates: &[Crate], patch: bool) {
             if !other.publish {
                 continue;
             }
-            if !is_deps || !line.starts_with(&format!("{} ", other.name)) {
+            if !is_deps
+                || (!line.starts_with(&format!("{} ", other.name))
+                    && !line.contains(&format!("package = '{}'", other.name)))
+            {
                 continue;
             }
             if !line.contains(&other.version) {

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -103,31 +103,13 @@ audit-as-crates-io = true
 [policy.wasmtime]
 audit-as-crates-io = true
 
-[policy.wasmtime-asm-macros]
-audit-as-crates-io = true
-
 [policy.wasmtime-c-api-impl]
 audit-as-crates-io = false
-
-[policy.wasmtime-c-api-macros]
-audit-as-crates-io = false
-
-[policy.wasmtime-cache]
-audit-as-crates-io = true
 
 [policy.wasmtime-cli]
 audit-as-crates-io = true
 
 [policy.wasmtime-cli-flags]
-audit-as-crates-io = true
-
-[policy.wasmtime-component-macro]
-audit-as-crates-io = true
-
-[policy.wasmtime-component-util]
-audit-as-crates-io = true
-
-[policy.wasmtime-cranelift]
 audit-as-crates-io = true
 
 [policy.wasmtime-environ]
@@ -136,32 +118,11 @@ audit-as-crates-io = true
 [policy.wasmtime-environ-fuzz]
 criteria = []
 
-[policy.wasmtime-explorer]
-audit-as-crates-io = true
-
-[policy.wasmtime-fiber]
-audit-as-crates-io = true
-
 [policy.wasmtime-fuzz]
 criteria = []
 
 [policy.wasmtime-fuzzing]
 criteria = []
-
-[policy.wasmtime-jit-debug]
-audit-as-crates-io = true
-
-[policy.wasmtime-jit-icache-coherence]
-audit-as-crates-io = true
-
-[policy.wasmtime-math]
-audit-as-crates-io = true
-
-[policy.wasmtime-slab]
-audit-as-crates-io = true
-
-[policy.wasmtime-versioned-export-macros]
-audit-as-crates-io = false
 
 [policy.wasmtime-wasi]
 audit-as-crates-io = true
@@ -188,15 +149,6 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-wast]
-audit-as-crates-io = true
-
-[policy.wasmtime-winch]
-audit-as-crates-io = true
-
-[policy.wasmtime-wit-bindgen]
-audit-as-crates-io = true
-
-[policy.wasmtime-wmemcheck]
 audit-as-crates-io = true
 
 [policy.wiggle]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1308,18 +1308,6 @@ when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
-[[publisher.wasmtime-asm-macros]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-cache]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
 [[publisher.wasmtime-cli]]
 version = "33.0.0"
 when = "2025-05-20"
@@ -1332,61 +1320,7 @@ when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
-[[publisher.wasmtime-component-macro]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-component-util]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-cranelift]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
 [[publisher.wasmtime-environ]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-explorer]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-fiber]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-jit-debug]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-jit-icache-coherence]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-math]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-slab]]
 version = "33.0.0"
 when = "2025-05-20"
 user-id = 73222
@@ -1441,24 +1375,6 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-winch]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-wit-bindgen]]
-version = "33.0.0"
-when = "2025-05-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-wmemcheck]]
 version = "33.0.0"
 when = "2025-05-20"
 user-id = 73222


### PR DESCRIPTION
This commit is an attempt to more clearly flag internal crates in this project as internal and not intended for external use. Specifically:

* Many crates are renamed from `wasmtime-foo` to `wasmtime-internal-foo`.
* All of these crates now have `INTERNAL: ...` in their crates.io description.
* All of these crates now have a warning at the top of their documentation discouraging use.

This change is a result of rustsec/advisory-db#1999 where the goal is to be crystal clear from a project perspective that usage of these crates are highly discouraged and not supported. We'll still probably get such advisories but we won't be considering them CVEs from the project itself due to the internal nature of these crates and the discouraging warnings.

Some concrete changes used here are:

* Inter-crate dependencies still use `wasmtime_foo` for naming and do so with Cargo's package-renaming features.
* Crate renames are specified at the workspace level so the rename is only in one locations and all other inherit it.
* Contribution documentation now has some brief guidelines about crate organization.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
