### PR TITLE
stack-switching: update vmoffsets naming for VMHostArray

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -276,25 +276,25 @@ pub trait PtrSize {
         self.size()
     }
 
-    // Offsets within `VMArray`
+    // Offsets within `VMHostArray`
 
-    /// Return the offset of `VMArray::length`.
-    fn vmarray_length(&self) -> u8 {
+    /// Return the offset of `VMHostArray::length`.
+    fn vmhostarray_length(&self) -> u8 {
         0
     }
 
-    /// Return the offset of `VMArray::capacity`.
-    fn vmarray_capacity(&self) -> u8 {
+    /// Return the offset of `VMHostArray::capacity`.
+    fn vmhostarray_capacity(&self) -> u8 {
         4
     }
 
-    /// Return the offset of `VMArray::data`.
-    fn vmarray_data(&self) -> u8 {
+    /// Return the offset of `VMHostArray::data`.
+    fn vmhostarray_data(&self) -> u8 {
         8
     }
 
-    /// Return the size of `VMArray`.
-    fn size_of_vmarray(&self) -> u8 {
+    /// Return the size of `VMHostArray`.
+    fn size_of_vmhostarray(&self) -> u8 {
         8 + self.size()
     }
 
@@ -321,7 +321,7 @@ pub trait PtrSize {
 
     /// Return the offset of `VMCommonStackInformation::first_switch_handler_index`.
     fn vmcommon_stack_information_first_switch_handler_index(&self) -> u8 {
-        self.vmcommon_stack_information_handlers() + self.size_of_vmarray()
+        self.vmcommon_stack_information_handlers() + self.size_of_vmhostarray()
     }
 
     /// Return the size of `VMCommonStackInformation`.
@@ -372,7 +372,7 @@ pub trait PtrSize {
 
     /// Return the offset of `VMContRef::values`.
     fn vmcontref_values(&self) -> u8 {
-        self.vmcontref_args() + self.size_of_vmarray()
+        self.vmcontref_args() + self.size_of_vmhostarray()
     }
 
     /// Return the offset to the `magic` value in this `VMContext`.

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -633,19 +633,19 @@ mod tests {
         let offsets = VMOffsets::new(HostPtr, &module);
         assert_eq!(
             size_of::<VMHostArray<()>>(),
-            usize::from(offsets.ptr.size_of_vmarray())
+            usize::from(offsets.ptr.size_of_vmhostarray())
         );
         assert_eq!(
             offset_of!(VMHostArray<()>, length),
-            usize::from(offsets.ptr.vmarray_length())
+            usize::from(offsets.ptr.vmhostarray_length())
         );
         assert_eq!(
             offset_of!(VMHostArray<()>, capacity),
-            usize::from(offsets.ptr.vmarray_capacity())
+            usize::from(offsets.ptr.vmhostarray_capacity())
         );
         assert_eq!(
             offset_of!(VMHostArray<()>, data),
-            usize::from(offsets.ptr.vmarray_data())
+            usize::from(offsets.ptr.vmhostarray_data())
         );
     }
 


### PR DESCRIPTION
VMArray from the original stack switching impl was renamed to VMHostArray, but the prefixes used in vmoffsets didn't get updated.

Original Discussion:
https://github.com/bytecodealliance/wasmtime/pull/10388#discussion_r2114329856

Original (incomplete) Change: 22bf039e801f0e92048a2ce508dc27289fbb27ae

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
