### PR TITLE
`cranelift-frontend`: Refactor how variables are declared

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -4,7 +4,7 @@ use crate::variable::Variable;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use cranelift_codegen::cursor::{Cursor, CursorPosition, FuncCursor};
-use cranelift_codegen::entity::{EntityRef, EntitySet, SecondaryMap};
+use cranelift_codegen::entity::{EntityRef, EntitySet, PrimaryMap, SecondaryMap};
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{
@@ -30,7 +30,7 @@ mod safepoints;
 pub struct FunctionBuilderContext {
     ssa: SSABuilder,
     status: SecondaryMap<Block, BlockStatus>,
-    types: SecondaryMap<Variable, Type>,
+    variables: PrimaryMap<Variable, Type>,
     stack_map_vars: EntitySet<Variable>,
     stack_map_values: EntitySet<Value>,
     safepoints: safepoints::SafepointSpiller,
@@ -71,21 +71,21 @@ impl FunctionBuilderContext {
         let FunctionBuilderContext {
             ssa,
             status,
-            types,
+            variables,
             stack_map_vars,
             stack_map_values,
             safepoints,
         } = self;
         ssa.clear();
         status.clear();
-        types.clear();
+        variables.clear();
         stack_map_values.clear();
         stack_map_vars.clear();
         safepoints.clear();
     }
 
     fn is_empty(&self) -> bool {
-        self.ssa.is_empty() && self.status.is_empty() && self.types.is_empty()
+        self.ssa.is_empty() && self.status.is_empty() && self.variables.is_empty()
     }
 }
 
@@ -243,29 +243,6 @@ impl fmt::Display for UseVariableError {
 }
 
 impl std::error::Error for UseVariableError {}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-/// An error encountered when calling [`FunctionBuilder::try_declare_var`].
-pub enum DeclareVariableError {
-    DeclaredMultipleTimes(Variable),
-}
-
-impl std::error::Error for DeclareVariableError {}
-
-impl fmt::Display for DeclareVariableError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DeclareVariableError::DeclaredMultipleTimes(variable) => {
-                write!(
-                    f,
-                    "variable {} was declared multiple times",
-                    variable.index()
-                )?;
-            }
-        }
-        Ok(())
-    }
-}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 /// An error encountered when defining the initial value of a variable.
@@ -432,29 +409,11 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Declares the type of a variable.
     ///
-    /// This allows the variable to be used later (by calling
-    /// [`FunctionBuilder::use_var`]).
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the variable has been previously
-    /// declared.
-    pub fn try_declare_var(&mut self, var: Variable, ty: Type) -> Result<(), DeclareVariableError> {
-        if self.func_ctx.types[var] != types::INVALID {
-            return Err(DeclareVariableError::DeclaredMultipleTimes(var));
-        }
-        self.func_ctx.types[var] = ty;
-        Ok(())
-    }
-
-    /// Declares the type of a variable, panicking if it is already declared.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the variable has already been declared.
-    pub fn declare_var(&mut self, var: Variable, ty: Type) {
-        self.try_declare_var(var, ty)
-            .unwrap_or_else(|_| panic!("the variable {var:?} has been declared multiple times"))
+    /// This allows the variable to be defined and used later (by calling
+    /// [`FunctionBuilder::def_var`] and [`FunctionBuilder::use_var`]
+    /// respectively).
+    pub fn declare_var(&mut self, ty: Type) -> Variable {
+        self.func_ctx.variables.push(ty)
     }
 
     /// Declare that all uses of the given variable must be included in stack
@@ -473,7 +432,7 @@ impl<'a> FunctionBuilder<'a> {
     /// variable has not been declared yet.
     pub fn declare_var_needs_stack_map(&mut self, var: Variable) {
         log::trace!("declare_var_needs_stack_map({var:?})");
-        let ty = self.func_ctx.types[var];
+        let ty = self.func_ctx.variables[var];
         assert!(ty != types::INVALID);
         assert!(ty.bytes() <= 16);
         self.func_ctx.stack_map_vars.insert(var);
@@ -491,7 +450,7 @@ impl<'a> FunctionBuilder<'a> {
         let (val, side_effects) = {
             let ty = *self
                 .func_ctx
-                .types
+                .variables
                 .get(var)
                 .ok_or(UseVariableError::UsedBeforeDeclared(var))?;
             debug_assert_ne!(
@@ -524,7 +483,7 @@ impl<'a> FunctionBuilder<'a> {
 
         let var_ty = *self
             .func_ctx
-            .types
+            .variables
             .get(var)
             .ok_or(DefVariableError::DefinedBeforeDeclared(var))?;
         if var_ty != self.func.dfg.value_type(val) {
@@ -748,7 +707,7 @@ impl<'a> FunctionBuilder<'a> {
         for var in self.func_ctx.stack_map_vars.iter() {
             for val in self.func_ctx.ssa.values_for_var(var) {
                 log::trace!("propagating needs-stack-map from {var:?} to {val:?}");
-                debug_assert_eq!(self.func.dfg.value_type(val), self.func_ctx.types[var]);
+                debug_assert_eq!(self.func.dfg.value_type(val), self.func_ctx.variables[var]);
                 self.func_ctx.stack_map_values.insert(val);
             }
         }
@@ -1233,11 +1192,9 @@ mod tests {
     use super::greatest_divisible_power_of_two;
     use crate::Variable;
     use crate::frontend::{
-        DeclareVariableError, DefVariableError, FunctionBuilder, FunctionBuilderContext,
-        UseVariableError,
+        DefVariableError, FunctionBuilder, FunctionBuilderContext, UseVariableError,
     };
     use alloc::string::ToString;
-    use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::condcodes::IntCC;
     use cranelift_codegen::ir::{
         AbiParam, BlockCall, ExceptionTableData, ExtFuncData, ExternalName, Function, InstBuilder,
@@ -1262,12 +1219,10 @@ mod tests {
             let block1 = builder.create_block();
             let block2 = builder.create_block();
             let block3 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(1);
-            let z = Variable::new(2);
-            builder.declare_var(x, I32);
-            builder.declare_var(y, I32);
-            builder.declare_var(z, I32);
+            let x = builder.declare_var(I32);
+            let y = builder.declare_var(I32);
+            let z = builder.declare_var(I32);
+
             builder.append_block_params_for_function_params(block0);
 
             builder.switch_to_block(block0);
@@ -1389,12 +1344,10 @@ mod tests {
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(1);
-            let z = Variable::new(2);
-            builder.declare_var(x, frontend_config.pointer_type());
-            builder.declare_var(y, frontend_config.pointer_type());
-            builder.declare_var(z, I32);
+            let x = builder.declare_var(frontend_config.pointer_type());
+            let y = builder.declare_var(frontend_config.pointer_type());
+            let _z = builder.declare_var(I32);
+
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1438,10 +1391,9 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(16);
-            builder.declare_var(x, frontend_config.pointer_type());
-            builder.declare_var(y, frontend_config.pointer_type());
+            let x = builder.declare_var(frontend_config.pointer_type());
+            let y = builder.declare_var(frontend_config.pointer_type());
+
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1492,10 +1444,8 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(16);
-            builder.declare_var(x, frontend_config.pointer_type());
-            builder.declare_var(y, frontend_config.pointer_type());
+            let x = builder.declare_var(frontend_config.pointer_type());
+            let y = builder.declare_var(frontend_config.pointer_type());
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1549,8 +1499,7 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let y = Variable::new(16);
-            builder.declare_var(y, frontend_config.pointer_type());
+            let y = builder.declare_var(frontend_config.pointer_type());
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1589,8 +1538,7 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let y = Variable::new(16);
-            builder.declare_var(y, frontend_config.pointer_type());
+            let y = builder.declare_var(frontend_config.pointer_type());
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1648,12 +1596,9 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(1);
-            let z = Variable::new(2);
-            builder.declare_var(x, target.pointer_type());
-            builder.declare_var(y, target.pointer_type());
-            builder.declare_var(z, target.pointer_type());
+            let x = builder.declare_var(target.pointer_type());
+            let y = builder.declare_var(target.pointer_type());
+            let z = builder.declare_var(target.pointer_type());
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1861,10 +1806,8 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let x = Variable::new(0);
-            let y = Variable::new(1);
-            builder.declare_var(x, target.pointer_type());
-            builder.declare_var(y, target.pointer_type());
+            let x = builder.declare_var(target.pointer_type());
+            let y = builder.declare_var(target.pointer_type());
             builder.append_block_params_for_function_params(block0);
             builder.switch_to_block(block0);
 
@@ -1896,12 +1839,9 @@ block0:
             let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
             let block0 = builder.create_block();
-            let a = Variable::new(0);
-            let b = Variable::new(1);
-            let c = Variable::new(2);
-            builder.declare_var(a, I8X16);
-            builder.declare_var(b, I8X16);
-            builder.declare_var(c, F32X4);
+            let a = builder.declare_var(I8X16);
+            let b = builder.declare_var(I8X16);
+            let c = builder.declare_var(F32X4);
             builder.switch_to_block(block0);
 
             let a = builder.use_var(a);
@@ -1966,14 +1906,6 @@ block0:
                     0
                 )))
             );
-
-            builder.declare_var(Variable::from_u32(0), cranelift_codegen::ir::types::I32);
-            assert_eq!(
-                builder.try_declare_var(Variable::from_u32(0), cranelift_codegen::ir::types::I32),
-                Err(DeclareVariableError::DeclaredMultipleTimes(
-                    Variable::from_u32(0)
-                ))
-            );
         }
     }
 
@@ -2030,8 +1962,7 @@ block0:
         let block2 = builder.create_block();
         let block3 = builder.create_block();
 
-        let my_var = Variable::from_u32(0);
-        builder.declare_var(my_var, I32);
+        let my_var = builder.declare_var(I32);
 
         builder.switch_to_block(block0);
         let branch_val = builder.append_block_param(block0, I8);

--- a/cranelift/frontend/src/frontend/safepoints.rs
+++ b/cranelift/frontend/src/frontend/safepoints.rs
@@ -1767,8 +1767,7 @@ block0:
         //                          call $foo(x)
         //                          return x
 
-        let x = Variable::from_u32(0);
-        builder.declare_var(x, ir::types::I32);
+        let x = builder.declare_var(ir::types::I32);
         builder.declare_var_needs_stack_map(x);
 
         let block0 = builder.create_block();
@@ -1884,8 +1883,7 @@ block3(v6: i32):
         let mut func = Function::with_name_signature(ir::UserFuncName::testcase("sample"), sig);
         let mut builder = FunctionBuilder::new(&mut func, &mut fn_ctx);
 
-        let var = Variable::from_u32(0);
-        builder.declare_var(var, cranelift_codegen::ir::types::I32);
+        let var = builder.declare_var(cranelift_codegen::ir::types::I32);
         builder.declare_var_needs_stack_map(var);
 
         let name = builder
@@ -2540,12 +2538,10 @@ block3:
         //     block_return:
         //       return
 
-        let var_struct = Variable::from_u32(0);
-        builder.declare_var(var_struct, cranelift_codegen::ir::types::I32);
+        let var_struct = builder.declare_var(cranelift_codegen::ir::types::I32);
         builder.declare_var_needs_stack_map(var_struct);
 
-        let var_array = Variable::from_u32(1);
-        builder.declare_var(var_array, cranelift_codegen::ir::types::I32);
+        let var_array = builder.declare_var(cranelift_codegen::ir::types::I32);
         builder.declare_var_needs_stack_map(var_array);
 
         let block_entry = builder.create_block();

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -81,12 +81,9 @@
 //!     let block1 = builder.create_block();
 //!     let block2 = builder.create_block();
 //!     let block3 = builder.create_block();
-//!     let x = Variable::new(0);
-//!     let y = Variable::new(1);
-//!     let z = Variable::new(2);
-//!     builder.declare_var(x, I32);
-//!     builder.declare_var(y, I32);
-//!     builder.declare_var(z, I32);
+//!     let x = builder.define_var(I32);
+//!     let y = builder.define_var(I32);
+//!     let z = builder.define_var(I32);
 //!     builder.append_block_params_for_function_params(block0);
 //!
 //!     builder.switch_to_block(block0);

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -81,9 +81,9 @@
 //!     let block1 = builder.create_block();
 //!     let block2 = builder.create_block();
 //!     let block3 = builder.create_block();
-//!     let x = builder.define_var(I32);
-//!     let y = builder.define_var(I32);
-//!     let z = builder.define_var(I32);
+//!     let x = builder.declare_var(I32);
+//!     let y = builder.declare_var(I32);
+//!     let z = builder.declare_var(I32);
 //!     builder.append_block_params_for_function_params(block0);
 //!
 //!     builder.switch_to_block(block0);

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -17,8 +17,7 @@ use cranelift::codegen::isa::CallConv;
 use cranelift::frontend::{FunctionBuilder, FunctionBuilderContext, Switch, Variable};
 use cranelift::prelude::isa::OwnedTargetIsa;
 use cranelift::prelude::{
-    EntityRef, ExtFuncData, FloatCC, InstBuilder, IntCC, JumpTableData, MemFlags, StackSlotData,
-    StackSlotKind,
+    ExtFuncData, FloatCC, InstBuilder, IntCC, JumpTableData, MemFlags, StackSlotData, StackSlotKind,
 };
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
@@ -1907,9 +1906,8 @@ where
             vars.push((ty, value));
         }
 
-        for (id, (ty, value)) in vars.into_iter().enumerate() {
-            let var = Variable::new(id);
-            builder.declare_var(var, ty);
+        for (ty, value) in vars.into_iter() {
+            let var = builder.declare_var(ty);
             builder.def_var(var, value);
 
             // Randomly declare variables as needing a stack map.

--- a/cranelift/jit/tests/basic.rs
+++ b/cranelift/jit/tests/basic.rs
@@ -95,8 +95,8 @@ fn switch_error() {
         let bb3 = bcx.create_block();
         println!("{start} {bb0} {bb1} {bb2} {bb3}");
 
-        bcx.declare_var(Variable::new(0), types::I32);
-        bcx.declare_var(Variable::new(1), types::I32);
+        bcx.declare_var(types::I32);
+        bcx.declare_var(types::I32);
         let in_val = bcx.append_block_param(start, types::I32);
         bcx.switch_to_block(start);
         bcx.def_var(Variable::new(0), in_val);

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -93,8 +93,8 @@ fn switch_error() {
         let bb3 = bcx.create_block();
         println!("{start} {bb0} {bb1} {bb2} {bb3}");
 
-        bcx.declare_var(Variable::new(0), types::I32);
-        bcx.declare_var(Variable::new(1), types::I32);
+        bcx.declare_var(types::I32);
+        bcx.declare_var(types::I32);
         let in_val = bcx.append_block_param(start, types::I32);
         bcx.switch_to_block(start);
         bcx.def_var(Variable::new(0), in_val);


### PR DESCRIPTION
Rather than requiring users to construct a `Variable` entity out of thin air and *then* declare it to the frontend, declaring a new variable now returns the new `Variable` entity. And instead of having a `SecondaryMap<Variable, Type>` inside of `FunctionBuilder` we now have a `PrimaryMap<Variable, Type>`. Using variables in `cranelift-frontend` should generally feel a little bit better and more idiomatic now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
