### PR TITLE
Cranelift(x64): Add lowering rules for conditional traps of float compares

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1900,6 +1900,9 @@
 (rule 1 (lower (trapz (icmp cc a b) code))
         (side_effect (trap_if_icmp (emit_cmp (intcc_complement cc) a b) code)))
 
+(rule 1 (lower (trapz (fcmp cc a b) code))
+        (side_effect (trap_if_fcmp (emit_fcmp (floatcc_complement cc) a b) code)))
+
 ;;;; Rules for `trapnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 0 (lower (trapnz val code))
@@ -1907,6 +1910,9 @@
 
 (rule 1 (lower (trapnz (icmp cc a b) code))
         (side_effect (trap_if_icmp (emit_cmp cc a b) code)))
+
+(rule 1 (lower (trapnz (fcmp cc a b) code))
+        (side_effect (trap_if_fcmp (emit_fcmp cc a b) code)))
 
 ;;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -222,3 +222,63 @@ block0(v0: i64, v1: i64):
 ;   retq
 ;   ud2 ; trap: user1
 
+function %trapz_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  trapz v2, user1
+  return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   ucomisd %xmm1, %xmm0
+;   trap_if_or p, z, user1
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomisd %xmm1, %xmm0
+;   jp 0x19
+;   jne 0x19
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+
+function %trapnz_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  trapnz v2, user1
+  return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   ucomisd %xmm1, %xmm0
+;   trap_if_and p, nz, user1
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomisd %xmm1, %xmm0
+;   jp 0x14
+;   je 0x19
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+

--- a/cranelift/filetests/filetests/runtests/trapnz.clif
+++ b/cranelift/filetests/filetests/runtests/trapnz.clif
@@ -22,3 +22,23 @@ block0(v0: i128):
 }
 
 ; run: %trapnz_i128(0) == 0
+
+function %trapnz_icmp(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  trapnz v2, user42
+  return v0
+}
+
+; run: %trapnz_icmp(123, 0) == 123
+; run: %trapnz_icmp(0, -1) == 0
+
+function %trapnz_fcmp(f64, f64) -> f64 {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  trapnz v2, user42
+  return v0
+}
+
+; run: %trapnz_fcmp(0x5.0, 0x0.0) == 0x5.0
+; run: %trapnz_fcmp(0x0.0, 0x1.0) == 0x0.0

--- a/cranelift/filetests/filetests/runtests/trapz.clif
+++ b/cranelift/filetests/filetests/runtests/trapz.clif
@@ -24,3 +24,23 @@ block0(v0: i128):
 
 ; run: %trapz_i128(1) == 1
 ; run: %trapz_i128(-1) == -1
+
+function %trapz_icmp(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = icmp ne v0, v1
+  trapz v2, user42
+  return v0
+}
+
+; run: %trapz_icmp(123, 0) == 123
+; run: %trapz_icmp(0, -1) == 0
+
+function %trapz_fcmp(f64, f64) -> f64 {
+block0(v0: f64, v1: f64):
+  v2 = fcmp ne v0, v1
+  trapz v2, user42
+  return v0
+}
+
+; run: %trapz_fcmp(0x5.0, 0x0.0) == 0x5.0
+; run: %trapz_fcmp(0x0.0, 0x1.0) == 0x0.0


### PR DESCRIPTION
We have similar rules for conditional traps of integer compares already; this extends that to float compares as well.

Also adds runtests for conditional traps of float and int compares.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
