### PR TITLE
Add a knob to `wasmtime::Config` and a CLI flag for GC support in the component model

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -375,6 +375,9 @@ wasmtime_option_group! {
         /// Component model support for `error-context`: this corresponds
         /// to the 📝 emoji in the component model specification.
         pub component_model_error_context: Option<bool>,
+        /// GC support in the component model: this corresponds to the 🛸 emoji
+        /// in the component model specification.
+        pub component_model_gc: Option<bool>,
         /// Configure support for the function-references proposal.
         pub function_references: Option<bool>,
         /// Configure support for the stack-switching proposal.
@@ -1042,6 +1045,16 @@ impl CommonOptions {
             ("gc", function_references, wasm_function_references)
             ("stack-switching", stack_switching, wasm_stack_switching)
         }
+
+        if let Some(enable) = self.wasm.component_model_gc {
+            #[cfg(all(feature = "component-model", feature = "gc"))]
+            config.wasm_component_model_gc(enable);
+            #[cfg(not(all(feature = "component-model", feature = "gc")))]
+            if enable && all.is_none() {
+                anyhow::bail!("support for `component-model-gc` was disabled at compile time")
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1171,6 +1171,21 @@ impl Config {
         self
     }
 
+    /// Configures whether the [GC extension to the component-model
+    /// proposal][proposal] is enabled or not.
+    ///
+    /// This corresponds to the 🛸 emoji in the component model specification.
+    ///
+    /// Please note that Wasmtime's support for this feature is _very_
+    /// incomplete.
+    ///
+    /// [proposal]: https://github.com/WebAssembly/component-model/issues/525
+    #[cfg(feature = "component-model")]
+    pub fn wasm_component_model_gc(&mut self, enable: bool) -> &mut Self {
+        self.wasm_feature(WasmFeatures::CM_GC, enable);
+        self
+    }
+
     #[doc(hidden)] // FIXME(#3427) - if/when implemented then un-hide this
     pub fn wasm_exceptions(&mut self, enable: bool) -> &mut Self {
         self.wasm_feature(WasmFeatures::EXCEPTIONS, enable);


### PR DESCRIPTION


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
