### PR TITLE
Add InputFile for use with WasiCtxBuilder

### DIFF
--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -246,8 +246,8 @@ pub use self::ctx::{WasiCtx, WasiCtxBuilder};
 pub use self::filesystem::{FileInputStream, FsError, FsResult};
 pub use self::network::{SocketError, SocketResult};
 pub use self::stdio::{
-    AsyncStdinStream, AsyncStdoutStream, IsATTY, OutputFile, Stderr, Stdin, StdinStream, Stdout,
-    StdoutStream, stderr, stdin, stdout,
+    AsyncStdinStream, AsyncStdoutStream, InputFile, IsATTY, OutputFile, Stderr, Stdin, StdinStream,
+    Stdout, StdoutStream, stderr, stdin, stdout,
 };
 pub use self::view::{WasiImpl, WasiView};
 // These contents of wasmtime-wasi-io are re-exported by this module for compatibility:


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
This adds a `InputFile` for use with the `stdin` method available on `WasiCtxtBuilder`. `InputFile` corresponds with `OutputFile` available for the `stdout` and the `stderr` methods.