### PR TITLE
Remove FileInputStream from public API

### DIFF
--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -243,7 +243,7 @@ mod view;
 mod write_stream;
 
 pub use self::ctx::{WasiCtx, WasiCtxBuilder};
-pub use self::filesystem::{FileInputStream, FsError, FsResult};
+pub use self::filesystem::{FsError, FsResult};
 pub use self::network::{SocketError, SocketResult};
 pub use self::stdio::{
     AsyncStdinStream, AsyncStdoutStream, IsATTY, OutputFile, Stderr, Stdin, StdinStream, Stdout,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I suspect based on looking [at documentation for this struct](https://docs.rs/wasmtime-wasi/33.0.0/wasmtime_wasi/p2/struct.FileInputStream.html) that this struct was never intended to be part of `wasmtime-wasi`'s public API. Particularly given that external crates do not have access to the `File` struct that its [`new` method](https://docs.rs/wasmtime-wasi/33.0.0/wasmtime_wasi/p2/struct.FileInputStream.html#method.new) expects as a parameter. The `File` struct is public within the module but it's not exported by the crate so consumers outside the crate cannot create an instance of this struct to pass as a parameter to `FileInputStream`'s `new` method. IMHO it's a bit confusing as a user of `wasmtime-wasi` for the type to exist on the public API if it isn't usable outside the crate.