### PR TITLE
 Re-enable concurrent bindings generation tests 

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -12,15 +12,14 @@ macro_rules! gentest {
                     async: true,
                 });
             }
-            // TODO: re-enable this when wasip3 is merged back into this repo
-            // mod concurrent {
-            //     wasmtime::component::bindgen!({
-            //         path: $path,
-            //         async: true,
-            //         concurrent_imports: true,
-            //         concurrent_exports: true,
-            //     });
-            // }
+            mod concurrent {
+                wasmtime::component::bindgen!({
+                    path: $path,
+                    async: true,
+                    concurrent_imports: true,
+                    concurrent_exports: true,
+                });
+            }
             mod tracing {
                 wasmtime::component::bindgen!({
                     path: $path,

--- a/crates/component-macro/tests/expanded.rs
+++ b/crates/component-macro/tests/expanded.rs
@@ -15,14 +15,13 @@ macro_rules! genexpand {
             stringify: true,
         }))?;
 
-        // TODO: re-enable this when wasip3 is merged back into this repo
-        // process_expanded($path, "_concurrent", wasmtime::component::bindgen!({
-        //     path: $path,
-        //     async: true,
-        //     concurrent_imports: true,
-        //     concurrent_exports: true,
-        //     stringify: true,
-        // }))?;
+        process_expanded($path, "_concurrent", wasmtime::component::bindgen!({
+            path: $path,
+            async: true,
+            concurrent_imports: true,
+            concurrent_exports: true,
+            stringify: true,
+        }))?;
 
         process_expanded($path, "_tracing_async", wasmtime::component::bindgen!({
             path: $path,

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheWorldPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheWorld>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -136,7 +136,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheWorld>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
@@ -150,16 +150,16 @@ const _: () = {
             let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn add_to_linker<T, U>(
+        pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            T: 'static,
-            T: Send + foo::foo::chars::Host<Data = T>,
-            U: Send + foo::foo::chars::Host<Data = T>,
+            D: foo::foo::chars::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::chars::Host + Send,
+            T: 'static + Send,
         {
-            foo::foo::chars::add_to_linker(linker, get)?;
+            foo::foo::chars::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_chars(&self) -> &exports::foo::foo::chars::Guest {
@@ -173,148 +173,60 @@ pub mod foo {
         pub mod chars {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
-            pub trait Host {
-                type Data;
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
                 /// A function that accepts a character
-                fn take_char(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn take_char<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: char,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
                 /// A function that returns a character
-                fn return_char(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> char + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn return_char<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = char> + Send
                 where
                     Self: Sized;
             }
-            pub fn add_to_linker_get_host<T, G>(
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: G,
+                host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                T: 'static,
-                G: for<'a> wasmtime::component::GetHost<
-                    &'a mut T,
-                    Host: Host<Data = T> + Send,
-                >,
-                T: Send + 'static,
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap_concurrent(
                     "take-char",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (char,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::take_char(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::take_char(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "return-char",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::return_char(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(char,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::return_char(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(char,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 Ok(())
-            }
-            pub fn add_to_linker<T, U>(
-                linker: &mut wasmtime::component::Linker<T>,
-                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-            ) -> wasmtime::Result<()>
-            where
-                T: 'static,
-                U: Host<Data = T> + Send,
-                T: Send + 'static,
-            {
-                add_to_linker_get_host(linker, get)
-            }
-            impl<_T: Host> Host for &mut _T {
-                type Data = _T::Data;
-                /// A function that accepts a character
-                fn take_char(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: char,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::take_char(store, x)
-                }
-                /// A function that returns a character
-                fn return_char(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> char + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::return_char(store)
-                }
             }
         }
     }
@@ -396,11 +308,13 @@ pub mod exports {
                 }
                 impl Guest {
                     /// A function that accepts a character
-                    pub async fn call_take_char<S: wasmtime::AsContextMut>(
+                    pub fn call_take_char<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: char,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -410,16 +324,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.take_char)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
                     /// A function that returns a character
-                    pub async fn call_return_char<S: wasmtime::AsContextMut>(
+                    pub fn call_return_char<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<char>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<char>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -429,10 +342,10 @@ pub mod exports {
                                 (char,),
                             >::new_unchecked(self.return_char)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `foo`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: FooIndices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = FooIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`Foo`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<Foo>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `foo`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`FooPre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`Foo`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {}
+pub struct FooIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `foo`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Foo::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`FooPre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`Foo::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,23 @@ pub struct TheWorldIndices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {}
+pub struct Foo {}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait FooImportsConcurrent: wasmtime::component::HasData + Send {
+    fn foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait FooImports: Send {}
+impl<_T: FooImports + ?Sized + Send> FooImports for &mut _T {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +115,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(TheWorldIndices {})
+            Ok(FooIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`Foo`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,84 +126,69 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<Foo> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(TheWorld {})
+            Ok(Foo {})
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<Foo>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            FooPre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`FooIndices::new`] and
+        /// [`FooIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker_imports<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: FooImportsConcurrent,
+            for<'a> D::Data<'a>: FooImports,
+            T: 'static + Send,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap_concurrent(
+                    "foo",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as FooImportsConcurrent>::foo(accessor).await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+            Ok(())
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostConcurrent + Send,
-            for<'a> D::Data<'a>: imports::Host + Send,
+            D: FooImportsConcurrent + Send,
+            for<'a> D::Data<'a>: FooImports + Send,
             T: 'static + Send,
         {
-            imports::add_to_linker::<T, D>(linker, host_getter)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
 };
-#[allow(clippy::all)]
-pub mod imports {
-    #[allow(unused_imports)]
-    use wasmtime::component::__internal::{anyhow, Box};
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait HostConcurrent: wasmtime::component::HasData + Send {
-        fn y<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
-        ) -> impl ::core::future::Future<Output = ()> + Send
-        where
-            Self: Sized;
-    }
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait Host: Send {}
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
-        host_getter: fn(&mut T) -> D::Data<'_>,
-    ) -> wasmtime::Result<()>
-    where
-        D: HostConcurrent,
-        for<'a> D::Data<'a>: Host,
-        T: 'static + Send,
-    {
-        let mut inst = linker.instance("imports")?;
-        inst.func_wrap_concurrent(
-            "y",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
-                wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &mut unsafe { caller.with_data(host_getter) };
-                    let r = <D as HostConcurrent>::y(accessor).await;
-                    Ok(r)
-                })
-            },
-        )?;
-        Ok(())
-    }
-}

--- a/crates/component-macro/tests/expanded/empty_concurrent.rs
+++ b/crates/component-macro/tests/expanded/empty_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `empty`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`EmptyPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`Empty`] as well.
+pub struct EmptyPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: EmptyIndices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for EmptyPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> EmptyPre<_T> {
+    /// Creates a new copy of `EmptyPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = EmptyIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`Empty`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<Empty>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `empty`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`EmptyPre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`Empty`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {}
+pub struct EmptyIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `empty`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Empty::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`EmptyPre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`EmptyPre::instantiate_async`] to
+///   create a [`Empty`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`Empty::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,12 @@ pub struct TheWorldIndices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {}
+pub struct Empty {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl EmptyIndices {
+        /// Creates a new copy of `EmptyIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +104,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(TheWorldIndices {})
+            Ok(EmptyIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`Empty`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,84 +115,34 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<Empty> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(TheWorld {})
+            Ok(Empty {})
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl Empty {
+        /// Convenience wrapper around [`EmptyPre::new`] and
+        /// [`EmptyPre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<Empty>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            EmptyPre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`EmptyIndices::new`] and
+        /// [`EmptyIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Empty> {
+            let indices = EmptyIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
-        }
-        pub fn add_to_linker<T, D>(
-            linker: &mut wasmtime::component::Linker<T>,
-            host_getter: fn(&mut T) -> D::Data<'_>,
-        ) -> wasmtime::Result<()>
-        where
-            D: imports::HostConcurrent + Send,
-            for<'a> D::Data<'a>: imports::Host + Send,
-            T: 'static + Send,
-        {
-            imports::add_to_linker::<T, D>(linker, host_getter)?;
-            Ok(())
         }
     }
 };
-#[allow(clippy::all)]
-pub mod imports {
-    #[allow(unused_imports)]
-    use wasmtime::component::__internal::{anyhow, Box};
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait HostConcurrent: wasmtime::component::HasData + Send {
-        fn y<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
-        ) -> impl ::core::future::Future<Output = ()> + Send
-        where
-            Self: Sized;
-    }
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait Host: Send {}
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
-        host_getter: fn(&mut T) -> D::Data<'_>,
-    ) -> wasmtime::Result<()>
-    where
-        D: HostConcurrent,
-        for<'a> D::Data<'a>: Host,
-        T: 'static + Send,
-    {
-        let mut inst = linker.instance("imports")?;
-        inst.func_wrap_concurrent(
-            "y",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
-                wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &mut unsafe { caller.with_data(host_getter) };
-                    let r = <D as HostConcurrent>::y(accessor).await;
-                    Ok(r)
-                })
-            },
-        )?;
-        Ok(())
-    }
-}

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheFlagsPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheFlags>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -136,7 +136,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheFlags>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheFlagsPre::new(pre)?.instantiate_async(store).await
@@ -150,16 +150,16 @@ const _: () = {
             let indices = TheFlagsIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn add_to_linker<T, U>(
+        pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            T: 'static,
-            T: Send + foo::foo::flegs::Host<Data = T>,
-            U: Send + foo::foo::flegs::Host<Data = T>,
+            D: foo::foo::flegs::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::flegs::Host + Send,
+            T: 'static + Send,
         {
-            foo::foo::flegs::add_to_linker(linker, get)?;
+            foo::foo::flegs::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_flegs(&self) -> &exports::foo::foo::flegs::Guest {
@@ -287,429 +287,184 @@ pub mod foo {
                 assert!(8 == < Flag64 as wasmtime::component::ComponentType >::SIZE32);
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
-            pub trait Host {
-                type Data;
-                fn roundtrip_flag1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn roundtrip_flag1<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag1,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag1 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag1> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag2<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag2,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag2 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag2> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag4<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag4,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag4 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag4> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag8<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag8> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag16(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag16<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag16> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag32(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag32<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag32> + Send
                 where
                     Self: Sized;
-                fn roundtrip_flag64(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn roundtrip_flag64<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: Flag64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = Flag64> + Send
                 where
                     Self: Sized;
             }
-            pub fn add_to_linker_get_host<T, G>(
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: G,
+                host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                T: 'static,
-                G: for<'a> wasmtime::component::GetHost<
-                    &'a mut T,
-                    Host: Host<Data = T> + Send,
-                >,
-                T: Send + 'static,
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag1",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag1,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag1(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag1,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag1(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag1,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag2",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag2,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag2(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag2,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag2(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag2,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag4",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag4,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag4(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag4,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag4(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag4,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag8",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag8,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag8(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag8,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag8(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag8,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag16",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag16,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag16(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag16,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag16(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag16,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag32",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag32,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag32(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag32,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag32(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag32,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag64",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (Flag64,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::roundtrip_flag64(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(Flag64,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::roundtrip_flag64(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(Flag64,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 Ok(())
-            }
-            pub fn add_to_linker<T, U>(
-                linker: &mut wasmtime::component::Linker<T>,
-                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-            ) -> wasmtime::Result<()>
-            where
-                T: 'static,
-                U: Host<Data = T> + Send,
-                T: Send + 'static,
-            {
-                add_to_linker_get_host(linker, get)
-            }
-            impl<_T: Host> Host for &mut _T {
-                type Data = _T::Data;
-                fn roundtrip_flag1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag1,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag1 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag1(store, x)
-                }
-                fn roundtrip_flag2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag2,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag2 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag2(store, x)
-                }
-                fn roundtrip_flag4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag4,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag4 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag4(store, x)
-                }
-                fn roundtrip_flag8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag8(store, x)
-                }
-                fn roundtrip_flag16(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag16(store, x)
-                }
-                fn roundtrip_flag32(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag32(store, x)
-                }
-                fn roundtrip_flag64(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: Flag64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> Flag64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::roundtrip_flag64(store, x)
-                }
             }
         }
     }
@@ -1000,11 +755,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub async fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag1,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag1>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag1>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1014,16 +771,18 @@ pub mod exports {
                                 (Flag1,),
                             >::new_unchecked(self.roundtrip_flag1)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag2,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag2>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag2>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1033,16 +792,18 @@ pub mod exports {
                                 (Flag2,),
                             >::new_unchecked(self.roundtrip_flag2)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag4,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag4>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag4>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1052,16 +813,18 @@ pub mod exports {
                                 (Flag4,),
                             >::new_unchecked(self.roundtrip_flag4)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag8,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag8>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag8>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1071,16 +834,18 @@ pub mod exports {
                                 (Flag8,),
                             >::new_unchecked(self.roundtrip_flag8)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag16<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag16,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag16>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag16>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1090,16 +855,18 @@ pub mod exports {
                                 (Flag16,),
                             >::new_unchecked(self.roundtrip_flag16)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag32<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag32,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag32>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag32>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1109,16 +876,18 @@ pub mod exports {
                                 (Flag32,),
                             >::new_unchecked(self.roundtrip_flag32)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
+                    pub fn call_roundtrip_flag64<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: Flag64,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<Flag64>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Flag64>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1128,10 +897,10 @@ pub mod exports {
                                 (Flag64,),
                             >::new_unchecked(self.roundtrip_flag64)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheWorldPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheWorld>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -138,7 +138,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheWorld>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
@@ -152,16 +152,16 @@ const _: () = {
             let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn add_to_linker<T, U>(
+        pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            T: 'static,
-            T: Send + foo::foo::floats::Host<Data = T>,
-            U: Send + foo::foo::floats::Host<Data = T>,
+            D: foo::foo::floats::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::floats::Host + Send,
+            T: 'static + Send,
         {
-            foo::foo::floats::add_to_linker(linker, get)?;
+            foo::foo::floats::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_floats(&self) -> &exports::foo::foo::floats::Guest {
@@ -175,245 +175,93 @@ pub mod foo {
         pub mod floats {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
-            pub trait Host {
-                type Data;
-                fn f32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn f32_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: f32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn f64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn f64_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: f64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn f32_result(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> f32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn f32_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = f32> + Send
                 where
                     Self: Sized;
-                fn f64_result(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> f64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn f64_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = f64> + Send
                 where
                     Self: Sized;
             }
-            pub fn add_to_linker_get_host<T, G>(
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: G,
+                host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                T: 'static,
-                G: for<'a> wasmtime::component::GetHost<
-                    &'a mut T,
-                    Host: Host<Data = T> + Send,
-                >,
-                T: Send + 'static,
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_concurrent(
                     "f32-param",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::f32_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (f32,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::f32_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "f64-param",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f64,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::f64_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (f64,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::f64_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "f32-result",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::f32_result(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(f32,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::f32_result(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(f32,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "f64-result",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::f64_result(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(f64,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::f64_result(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(f64,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 Ok(())
-            }
-            pub fn add_to_linker<T, U>(
-                linker: &mut wasmtime::component::Linker<T>,
-                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-            ) -> wasmtime::Result<()>
-            where
-                T: 'static,
-                U: Host<Data = T> + Send,
-                T: Send + 'static,
-            {
-                add_to_linker_get_host(linker, get)
-            }
-            impl<_T: Host> Host for &mut _T {
-                type Data = _T::Data;
-                fn f32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: f32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::f32_param(store, x)
-                }
-                fn f64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: f64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::f64_param(store, x)
-                }
-                fn f32_result(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> f32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::f32_result(store)
-                }
-                fn f64_result(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> f64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::f64_result(store)
-                }
             }
         }
     }
@@ -510,11 +358,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub async fn call_f32_param<S: wasmtime::AsContextMut>(
+                    pub fn call_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: f32,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -524,16 +374,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f32_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_f64_param<S: wasmtime::AsContextMut>(
+                    pub fn call_f64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: f64,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -543,15 +392,14 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f64_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_f32_result<S: wasmtime::AsContextMut>(
+                    pub fn call_f32_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<f32>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<f32>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -561,15 +409,17 @@ pub mod exports {
                                 (f32,),
                             >::new_unchecked(self.f32_result)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_f64_result<S: wasmtime::AsContextMut>(
+                    pub fn call_f64_result<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<f64>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<f64>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -579,10 +429,10 @@ pub mod exports {
                                 (f64,),
                             >::new_unchecked(self.f64_result)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `host`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`Host_Pre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`Host_`] as well.
+pub struct Host_Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: Host_Indices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for Host_Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> Host_Pre<_T> {
+    /// Creates a new copy of `Host_Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = Host_Indices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`Host_`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<Host_>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `host`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`Host_Pre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`Host_`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {}
+pub struct Host_Indices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `host`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Host_::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`Host_Pre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`Host_Pre::instantiate_async`] to
+///   create a [`Host_`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`Host_::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,23 @@ pub struct TheWorldIndices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {}
+pub struct Host_ {}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait Host_ImportsConcurrent: wasmtime::component::HasData + Send {
+    fn foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait Host_Imports: Send {}
+impl<_T: Host_Imports + ?Sized + Send> Host_Imports for &mut _T {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl Host_Indices {
+        /// Creates a new copy of `Host_Indices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +115,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(TheWorldIndices {})
+            Ok(Host_Indices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`Host_`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,84 +126,69 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<Host_> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(TheWorld {})
+            Ok(Host_ {})
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl Host_ {
+        /// Convenience wrapper around [`Host_Pre::new`] and
+        /// [`Host_Pre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<Host_>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            Host_Pre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`Host_Indices::new`] and
+        /// [`Host_Indices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Host_> {
+            let indices = Host_Indices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker_imports<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: Host_ImportsConcurrent,
+            for<'a> D::Data<'a>: Host_Imports,
+            T: 'static + Send,
+        {
+            let mut linker = linker.root();
+            linker
+                .func_wrap_concurrent(
+                    "foo",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as Host_ImportsConcurrent>::foo(accessor).await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+            Ok(())
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostConcurrent + Send,
-            for<'a> D::Data<'a>: imports::Host + Send,
+            D: Host_ImportsConcurrent + Send,
+            for<'a> D::Data<'a>: Host_Imports + Send,
             T: 'static + Send,
         {
-            imports::add_to_linker::<T, D>(linker, host_getter)?;
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
 };
-#[allow(clippy::all)]
-pub mod imports {
-    #[allow(unused_imports)]
-    use wasmtime::component::__internal::{anyhow, Box};
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait HostConcurrent: wasmtime::component::HasData + Send {
-        fn y<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
-        ) -> impl ::core::future::Future<Output = ()> + Send
-        where
-            Self: Sized;
-    }
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait Host: Send {}
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
-        host_getter: fn(&mut T) -> D::Data<'_>,
-    ) -> wasmtime::Result<()>
-    where
-        D: HostConcurrent,
-        for<'a> D::Data<'a>: Host,
-        T: 'static + Send,
-    {
-        let mut inst = linker.instance("imports")?;
-        inst.func_wrap_concurrent(
-            "y",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
-                wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &mut unsafe { caller.with_data(host_getter) };
-                    let r = <D as HostConcurrent>::y(accessor).await;
-                    Ok(r)
-                })
-            },
-        )?;
-        Ok(())
-    }
-}

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheWorldPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheWorld>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -138,7 +138,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheWorld>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
@@ -152,16 +152,16 @@ const _: () = {
             let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn add_to_linker<T, U>(
+        pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            T: 'static,
-            T: Send + foo::foo::integers::Host<Data = T>,
-            U: Send + foo::foo::integers::Host<Data = T>,
+            D: foo::foo::integers::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::integers::Host + Send,
+            T: 'static + Send,
         {
-            foo::foo::integers::add_to_linker(linker, get)?;
+            foo::foo::integers::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_integers(&self) -> &exports::foo::foo::integers::Guest {
@@ -175,90 +175,58 @@ pub mod foo {
         pub mod integers {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
-            pub trait Host {
-                type Data;
-                fn a1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn a1<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: u8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a2<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: i8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a3(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a3<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: u16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a4<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: i16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a5(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a5<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: u32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a6(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a6<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: i32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a7(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a7<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: u64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a8<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: i64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn a9(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn a9<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     p1: u8,
                     p2: i8,
                     p3: u16,
@@ -267,352 +235,170 @@ pub mod foo {
                     p6: i32,
                     p7: u64,
                     p8: i64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn r1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r1<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = u8> + Send
                 where
                     Self: Sized;
-                fn r2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r2<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = i8> + Send
                 where
                     Self: Sized;
-                fn r3(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r3<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = u16> + Send
                 where
                     Self: Sized;
-                fn r4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r4<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = i16> + Send
                 where
                     Self: Sized;
-                fn r5(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r5<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = u32> + Send
                 where
                     Self: Sized;
-                fn r6(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r6<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = i32> + Send
                 where
                     Self: Sized;
-                fn r7(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r7<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = u64> + Send
                 where
                     Self: Sized;
-                fn r8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn r8<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = i64> + Send
                 where
                     Self: Sized;
-                fn pair_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> (i64, u8) + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                fn pair_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = (i64, u8)> + Send
                 where
                     Self: Sized;
             }
-            pub fn add_to_linker_get_host<T, G>(
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: G,
+                host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                T: 'static,
-                G: for<'a> wasmtime::component::GetHost<
-                    &'a mut T,
-                    Host: Host<Data = T> + Send,
-                >,
-                T: Send + 'static,
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_concurrent(
                     "a1",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a1(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a1(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a2",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i8,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a2(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (i8,)| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a2(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a3",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u16,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a3(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (u16,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a3(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a4",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i16,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a4(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (i16,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a4(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a5",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u32,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a5(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (u32,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a5(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a6",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i32,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a6(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (i32,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a6(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a7",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u64,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a7(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (u64,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a7(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a8",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (i64,)| {
-                        let host = caller;
-                        let r = <G::Host as Host>::a8(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (i64,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a8(accessor, arg0).await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "a9",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
@@ -624,560 +410,115 @@ pub mod foo {
                             arg7,
                         ): (u8, i8, u16, i16, u32, i32, u64, i64)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::a9(
-                            host,
-                            arg0,
-                            arg1,
-                            arg2,
-                            arg3,
-                            arg4,
-                            arg5,
-                            arg6,
-                            arg7,
-                        );
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::a9(
+                                    accessor,
+                                    arg0,
+                                    arg1,
+                                    arg2,
+                                    arg3,
+                                    arg4,
+                                    arg5,
+                                    arg6,
+                                    arg7,
+                                )
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r1",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r1(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(u8,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r1(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(u8,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r2",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r2(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(i8,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r2(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(i8,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r3",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r3(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(u16,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r3(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(u16,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r4",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r4(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(i16,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r4(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(i16,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r5",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r5(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(u32,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r5(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(u32,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r6",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r6(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(i32,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r6(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(i32,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r7",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r7(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(u64,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r7(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(u64,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "r8",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::r8(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(i64,)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::r8(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(i64,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "pair-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::pair_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<((i64, u8),)> + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::pair_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<((i64, u8),)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 Ok(())
-            }
-            pub fn add_to_linker<T, U>(
-                linker: &mut wasmtime::component::Linker<T>,
-                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-            ) -> wasmtime::Result<()>
-            where
-                T: 'static,
-                U: Host<Data = T> + Send,
-                T: Send + 'static,
-            {
-                add_to_linker_get_host(linker, get)
-            }
-            impl<_T: Host> Host for &mut _T {
-                type Data = _T::Data;
-                fn a1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: u8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a1(store, x)
-                }
-                fn a2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: i8,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a2(store, x)
-                }
-                fn a3(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: u16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a3(store, x)
-                }
-                fn a4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: i16,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a4(store, x)
-                }
-                fn a5(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: u32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a5(store, x)
-                }
-                fn a6(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: i32,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a6(store, x)
-                }
-                fn a7(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: u64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a7(store, x)
-                }
-                fn a8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: i64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a8(store, x)
-                }
-                fn a9(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    p1: u8,
-                    p2: i8,
-                    p3: u16,
-                    p4: i16,
-                    p5: u32,
-                    p6: i32,
-                    p7: u64,
-                    p8: i64,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::a9(store, p1, p2, p3, p4, p5, p6, p7, p8)
-                }
-                fn r1(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r1(store)
-                }
-                fn r2(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i8 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r2(store)
-                }
-                fn r3(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r3(store)
-                }
-                fn r4(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i16 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r4(store)
-                }
-                fn r5(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r5(store)
-                }
-                fn r6(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i32 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r6(store)
-                }
-                fn r7(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> u64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r7(store)
-                }
-                fn r8(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> i64 + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::r8(store)
-                }
-                fn pair_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> (i64, u8) + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::pair_ret(store)
-                }
             }
         }
     }
@@ -1392,11 +733,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub async fn call_a1<S: wasmtime::AsContextMut>(
+                    pub fn call_a1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u8,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1406,16 +749,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a1)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a2<S: wasmtime::AsContextMut>(
+                    pub fn call_a2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i8,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1425,16 +767,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a2)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a3<S: wasmtime::AsContextMut>(
+                    pub fn call_a3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u16,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1444,16 +785,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a3)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a4<S: wasmtime::AsContextMut>(
+                    pub fn call_a4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i16,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1463,16 +803,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a4)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a5<S: wasmtime::AsContextMut>(
+                    pub fn call_a5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u32,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1482,16 +821,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a5)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a6<S: wasmtime::AsContextMut>(
+                    pub fn call_a6<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i32,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1501,16 +839,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a6)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a7<S: wasmtime::AsContextMut>(
+                    pub fn call_a7<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u64,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1520,16 +857,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a7)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a8<S: wasmtime::AsContextMut>(
+                    pub fn call_a8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: i64,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1539,12 +875,9 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a8)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_a9<S: wasmtime::AsContextMut>(
+                    pub fn call_a9<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: u8,
@@ -1555,7 +888,9 @@ pub mod exports {
                         arg5: i32,
                         arg6: u64,
                         arg7: i64,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1565,18 +900,18 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a9)
                         };
-                        let promise = callee
+                        callee
                             .call_concurrent(
                                 store.as_context_mut(),
                                 (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
                             )
-                            .await?;
-                        Ok(promise)
                     }
-                    pub async fn call_r1<S: wasmtime::AsContextMut>(
+                    pub fn call_r1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<u8>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u8>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1586,15 +921,17 @@ pub mod exports {
                                 (u8,),
                             >::new_unchecked(self.r1)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r2<S: wasmtime::AsContextMut>(
+                    pub fn call_r2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<i8>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<i8>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1604,15 +941,17 @@ pub mod exports {
                                 (i8,),
                             >::new_unchecked(self.r2)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r3<S: wasmtime::AsContextMut>(
+                    pub fn call_r3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<u16>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u16>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1622,15 +961,17 @@ pub mod exports {
                                 (u16,),
                             >::new_unchecked(self.r3)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r4<S: wasmtime::AsContextMut>(
+                    pub fn call_r4<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<i16>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<i16>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1640,15 +981,17 @@ pub mod exports {
                                 (i16,),
                             >::new_unchecked(self.r4)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r5<S: wasmtime::AsContextMut>(
+                    pub fn call_r5<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<u32>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u32>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1658,15 +1001,17 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.r5)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r6<S: wasmtime::AsContextMut>(
+                    pub fn call_r6<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<i32>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<i32>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1676,15 +1021,17 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.r6)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r7<S: wasmtime::AsContextMut>(
+                    pub fn call_r7<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<u64>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u64>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1694,15 +1041,17 @@ pub mod exports {
                                 (u64,),
                             >::new_unchecked(self.r7)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_r8<S: wasmtime::AsContextMut>(
+                    pub fn call_r8<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<i64>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<i64>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1712,15 +1061,17 @@ pub mod exports {
                                 (i64,),
                             >::new_unchecked(self.r8)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_pair_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_pair_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<(i64, u8)>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<(i64, u8)>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -1730,10 +1081,10 @@ pub mod exports {
                                 ((i64, u8),),
                             >::new_unchecked(self.pair_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheListsPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheLists>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -136,7 +136,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheLists>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheListsPre::new(pre)?.instantiate_async(store).await
@@ -150,16 +150,16 @@ const _: () = {
             let indices = TheListsIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        pub fn add_to_linker<T, U>(
+        pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
-            get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            T: 'static,
-            T: Send + foo::foo::lists::Host<Data = T>,
-            U: Send + foo::foo::lists::Host<Data = T>,
+            D: foo::foo::lists::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::lists::Host + Send,
+            T: 'static + Send,
         {
-            foo::foo::lists::add_to_linker(linker, get)?;
+            foo::foo::lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
         pub fn foo_foo_lists(&self) -> &exports::foo::foo::lists::Guest {
@@ -353,1048 +353,489 @@ pub mod foo {
                     >::ALIGN32
                 );
             };
-            pub trait Host {
-                type Data;
-                fn list_u8_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn list_u8_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u8>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_u16_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u16_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u16>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_u32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u32_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_u64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u64_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_s8_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s8_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i8>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_s16_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s16_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i16>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_s32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s32_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_s64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s64_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_f32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_f32_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_f64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_f64_param<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn list_u8_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u8_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<u8>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_u16_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u16_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u16,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<u16>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_u32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u32_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<u32>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_u64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_u64_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<u64>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_s8_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s8_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<i8>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_s16_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s16_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i16,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<i16>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_s32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s32_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<i32>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_s64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_s64_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<i64>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_f32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_f32_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            f32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<f32>,
+                > + Send
                 where
                     Self: Sized;
-                fn list_f64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn list_f64_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            f64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<f64>,
+                > + Send
                 where
                     Self: Sized;
-                fn tuple_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn tuple_list<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            (i64, u32),
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<(i64, u32)>,
+                > + Send
                 where
                     Self: Sized;
-                fn string_list_arg(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn string_list_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn string_list_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn string_list_ret<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            wasmtime::component::__internal::String,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                > + Send
                 where
                     Self: Sized;
-                fn tuple_string_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn tuple_string_list<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
                     >,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            (wasmtime::component::__internal::String, u8),
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<
+                        (wasmtime::component::__internal::String, u8),
+                    >,
+                > + Send
                 where
                     Self: Sized;
-                fn string_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn string_list<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            wasmtime::component::__internal::String,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::String,
+                    >,
+                > + Send
                 where
                     Self: Sized;
-                fn record_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn record_list<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            OtherRecord,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<OtherRecord>,
+                > + Send
                 where
                     Self: Sized;
-                fn record_list_reverse(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn record_list_reverse<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            SomeRecord,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<SomeRecord>,
+                > + Send
                 where
                     Self: Sized;
-                fn variant_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn variant_list<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
                 ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            OtherVariant,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                    Output = wasmtime::component::__internal::Vec<OtherVariant>,
+                > + Send
                 where
                     Self: Sized;
-                fn load_store_everything(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
+                fn load_store_everything<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
                     a: LoadStoreAllSizes,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> LoadStoreAllSizes + Send + Sync + 'static,
-                > + Send + Sync + 'static
+                ) -> impl ::core::future::Future<Output = LoadStoreAllSizes> + Send
                 where
                     Self: Sized;
             }
-            pub fn add_to_linker_get_host<T, G>(
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
-                host_getter: G,
+                host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                T: 'static,
-                G: for<'a> wasmtime::component::GetHost<
-                    &'a mut T,
-                    Host: Host<Data = T> + Send,
-                >,
-                T: Send + 'static,
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
             {
                 let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_concurrent(
                     "list-u8-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u8_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u8_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u16-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u16_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u16_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u32-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u32_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u32_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u64-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u64_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u64_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s8-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s8_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s8_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s16-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s16_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s16_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s32-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s32_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s32_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s64-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s64_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s64_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f32-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_f32_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_f32_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f64-param",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_f64_param(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_f64_param(accessor, arg0)
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u8-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u8_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<u8>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u8_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<u8>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u16-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u16_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<u16>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u16_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<u16>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u32-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u32_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<u32>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u32_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<u32>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-u64-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_u64_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<u64>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_u64_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<u64>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s8-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s8_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<i8>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s8_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<i8>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s16-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s16_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<i16>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s16_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<i16>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s32-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s32_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<i32>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s32_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<i32>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-s64-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_s64_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<i64>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_s64_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<i64>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f32-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_f32_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<f32>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_f32_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<f32>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "list-f64-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::list_f64_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<f64>,),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_f64_ret(accessor).await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<f64>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "tuple-list",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::tuple_list(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_list(accessor, arg0)
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<(i64, u32)>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "string-list-arg",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -1403,79 +844,32 @@ pub mod foo {
                             >,
                         )|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::string_list_arg(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok(r)
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<()> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::string_list_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<()> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "string-list-ret",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = caller;
-                        let r = <G::Host as Host>::string_list_ret(host);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (
-                                                wasmtime::component::__internal::Vec<
-                                                    wasmtime::component::__internal::String,
-                                                >,
-                                            ),
-                                        > + Send + Sync,
-                                >
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::string_list_ret(accessor)
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (
-                                                        wasmtime::component::__internal::Vec<
-                                                            wasmtime::component::__internal::String,
-                                                        >,
-                                                    ),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "tuple-string-list",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -1484,49 +878,21 @@ pub mod foo {
                             >,
                         )|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::tuple_string_list(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (
-                                                wasmtime::component::__internal::Vec<
-                                                    (wasmtime::component::__internal::String, u8),
-                                                >,
-                                            ),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_string_list(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (
-                                                        wasmtime::component::__internal::Vec<
-                                                            (wasmtime::component::__internal::String, u8),
-                                                        >,
-                                                    ),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "string-list",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (
                             arg0,
                         ): (
@@ -1535,606 +901,77 @@ pub mod foo {
                             >,
                         )|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::string_list(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (
-                                                wasmtime::component::__internal::Vec<
-                                                    wasmtime::component::__internal::String,
-                                                >,
-                                            ),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::string_list(accessor, arg0)
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (
-                                                        wasmtime::component::__internal::Vec<
-                                                            wasmtime::component::__internal::String,
-                                                        >,
-                                                    ),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "record-list",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::record_list(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<OtherRecord>,),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::record_list(accessor, arg0)
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<OtherRecord>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "record-list-reverse",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::record_list_reverse(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<SomeRecord>,),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::record_list_reverse(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<SomeRecord>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "variant-list",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::variant_list(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<
-                                            (wasmtime::component::__internal::Vec<OtherVariant>,),
-                                        > + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::variant_list(accessor, arg0)
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<
-                                                    (wasmtime::component::__internal::Vec<OtherVariant>,),
-                                                > + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 inst.func_wrap_concurrent(
                     "load-store-everything",
                     move |
-                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        caller: &mut wasmtime::component::Accessor<T>,
                         (arg0,): (LoadStoreAllSizes,)|
                     {
-                        let host = caller;
-                        let r = <G::Host as Host>::load_store_everything(host, arg0);
-                        Box::pin(async move {
-                            let fun = r.await;
-                            Box::new(move |mut caller: wasmtime::StoreContextMut<'_, T>| {
-                                let r = fun(caller);
-                                Ok((r,))
-                            })
-                                as Box<
-                                    dyn FnOnce(
-                                        wasmtime::StoreContextMut<'_, T>,
-                                    ) -> wasmtime::Result<(LoadStoreAllSizes,)> + Send + Sync,
-                                >
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::load_store_everything(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok((r,))
                         })
-                            as ::core::pin::Pin<
-                                Box<
-                                    dyn ::core::future::Future<
-                                        Output = Box<
-                                            dyn FnOnce(
-                                                wasmtime::StoreContextMut<'_, T>,
-                                            ) -> wasmtime::Result<(LoadStoreAllSizes,)> + Send + Sync,
-                                        >,
-                                    > + Send + Sync + 'static,
-                                >,
-                            >
                     },
                 )?;
                 Ok(())
-            }
-            pub fn add_to_linker<T, U>(
-                linker: &mut wasmtime::component::Linker<T>,
-                get: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-            ) -> wasmtime::Result<()>
-            where
-                T: 'static,
-                U: Host<Data = T> + Send,
-                T: Send + 'static,
-            {
-                add_to_linker_get_host(linker, get)
-            }
-            impl<_T: Host> Host for &mut _T {
-                type Data = _T::Data;
-                fn list_u8_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<u8>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u8_param(store, x)
-                }
-                fn list_u16_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<u16>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u16_param(store, x)
-                }
-                fn list_u32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<u32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u32_param(store, x)
-                }
-                fn list_u64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<u64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u64_param(store, x)
-                }
-                fn list_s8_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<i8>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s8_param(store, x)
-                }
-                fn list_s16_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<i16>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s16_param(store, x)
-                }
-                fn list_s32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<i32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s32_param(store, x)
-                }
-                fn list_s64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<i64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s64_param(store, x)
-                }
-                fn list_f32_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<f32>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_f32_param(store, x)
-                }
-                fn list_f64_param(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<f64>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_f64_param(store, x)
-                }
-                fn list_u8_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<u8> + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u8_ret(store)
-                }
-                fn list_u16_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u16,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u16_ret(store)
-                }
-                fn list_u32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u32_ret(store)
-                }
-                fn list_u64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            u64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_u64_ret(store)
-                }
-                fn list_s8_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<i8> + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s8_ret(store)
-                }
-                fn list_s16_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i16,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s16_ret(store)
-                }
-                fn list_s32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s32_ret(store)
-                }
-                fn list_s64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            i64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_s64_ret(store)
-                }
-                fn list_f32_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            f32,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_f32_ret(store)
-                }
-                fn list_f64_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            f64,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::list_f64_ret(store)
-                }
-                fn tuple_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<(u8, i8)>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            (i64, u32),
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::tuple_list(store, x)
-                }
-                fn string_list_arg(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    a: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> () + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::string_list_arg(store, a)
-                }
-                fn string_list_ret(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            wasmtime::component::__internal::String,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::string_list_ret(store)
-                }
-                fn tuple_string_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<
-                        (u8, wasmtime::component::__internal::String),
-                    >,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            (wasmtime::component::__internal::String, u8),
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::tuple_string_list(store, x)
-                }
-                fn string_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<
-                        wasmtime::component::__internal::String,
-                    >,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            wasmtime::component::__internal::String,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::string_list(store, x)
-                }
-                fn record_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<SomeRecord>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            OtherRecord,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::record_list(store, x)
-                }
-                fn record_list_reverse(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<OtherRecord>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            SomeRecord,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::record_list_reverse(store, x)
-                }
-                fn variant_list(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    x: wasmtime::component::__internal::Vec<SomeVariant>,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> wasmtime::component::__internal::Vec<
-                            OtherVariant,
-                        > + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::variant_list(store, x)
-                }
-                fn load_store_everything(
-                    store: wasmtime::StoreContextMut<'_, Self::Data>,
-                    a: LoadStoreAllSizes,
-                ) -> impl ::core::future::Future<
-                    Output = impl FnOnce(
-                        wasmtime::StoreContextMut<'_, Self::Data>,
-                    ) -> LoadStoreAllSizes + Send + Sync + 'static,
-                > + Send + Sync + 'static
-                where
-                    Self: Sized,
-                {
-                    <_T as Host>::load_store_everything(store, a)
-                }
             }
         }
     }
@@ -2730,11 +1567,13 @@ pub mod exports {
                     }
                 }
                 impl Guest {
-                    pub async fn call_list_u8_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<u8>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2744,16 +1583,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u8_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_u16_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u16_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<u16>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2763,16 +1601,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u16_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_u32_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<u32>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2782,16 +1619,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u32_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_u64_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<u64>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2801,16 +1637,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u64_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_s8_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s8_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<i8>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2820,16 +1655,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s8_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_s16_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s16_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<i16>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2839,16 +1673,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s16_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_s32_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<i32>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2858,16 +1691,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s32_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_s64_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<i64>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2877,16 +1709,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s64_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_f32_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_f32_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<f32>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2896,16 +1727,15 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f32_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_f64_param<S: wasmtime::AsContextMut>(
+                    pub fn call_list_f64_param<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<f64>,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2915,19 +1745,16 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f64_param)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_list_u8_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<u8>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2937,19 +1764,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u8>,),
                             >::new_unchecked(self.list_u8_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_u16_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<u16>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2959,19 +1786,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u16>,),
                             >::new_unchecked(self.list_u16_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_u32_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<u32>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -2981,19 +1808,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.list_u32_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_u64_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_u64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<u64>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3003,19 +1830,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u64>,),
                             >::new_unchecked(self.list_u64_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_s8_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s8_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<i8>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3025,19 +1852,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i8>,),
                             >::new_unchecked(self.list_s8_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_s16_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s16_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<i16>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3047,19 +1874,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i16>,),
                             >::new_unchecked(self.list_s16_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_s32_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<i32>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3069,19 +1896,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i32>,),
                             >::new_unchecked(self.list_s32_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_s64_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_s64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<i64>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3091,19 +1918,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i64>,),
                             >::new_unchecked(self.list_s64_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_f32_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_f32_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<f32>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3113,19 +1940,19 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f32>,),
                             >::new_unchecked(self.list_f32_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_list_f64_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_list_f64_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<f64>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3135,20 +1962,20 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f64>,),
                             >::new_unchecked(self.list_f64_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_tuple_list<S: wasmtime::AsContextMut>(
+                    pub fn call_tuple_list<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<(u8, i8)>,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<(i64, u32)>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3158,18 +1985,20 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<(i64, u32)>,),
                             >::new_unchecked(self.tuple_list)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_string_list_arg<S: wasmtime::AsContextMut>(
+                    pub fn call_string_list_arg<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3183,21 +2012,18 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.string_list_arg)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise)
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub async fn call_string_list_ret<S: wasmtime::AsContextMut>(
+                    pub fn call_string_list_ret<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<
                                 wasmtime::component::__internal::String,
                             >,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3211,24 +2037,24 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list_ret)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), ())
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_tuple_string_list<S: wasmtime::AsContextMut>(
+                    pub fn call_tuple_string_list<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<
                             (u8, wasmtime::component::__internal::String),
                         >,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<
                                 (wasmtime::component::__internal::String, u8),
                             >,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3246,24 +2072,24 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.tuple_string_list)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_string_list<S: wasmtime::AsContextMut>(
+                    pub fn call_string_list<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<
                             wasmtime::component::__internal::String,
                         >,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<
                                 wasmtime::component::__internal::String,
                             >,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3281,20 +2107,20 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_record_list<S: wasmtime::AsContextMut>(
+                    pub fn call_record_list<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<SomeRecord>,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<OtherRecord>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3304,20 +2130,20 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherRecord>,),
                             >::new_unchecked(self.record_list)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_record_list_reverse<S: wasmtime::AsContextMut>(
+                    pub fn call_record_list_reverse<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<OtherRecord>,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<SomeRecord>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3327,20 +2153,20 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<SomeRecord>,),
                             >::new_unchecked(self.record_list_reverse)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_variant_list<S: wasmtime::AsContextMut>(
+                    pub fn call_variant_list<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: wasmtime::component::__internal::Vec<SomeVariant>,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
                             wasmtime::component::__internal::Vec<OtherVariant>,
                         >,
-                    >
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3350,18 +2176,18 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherVariant>,),
                             >::new_unchecked(self.variant_list)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
-                    pub async fn call_load_store_everything<S: wasmtime::AsContextMut>(
+                    pub fn call_load_store_everything<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                         arg0: LoadStoreAllSizes,
-                    ) -> wasmtime::Result<
-                        wasmtime::component::Promise<LoadStoreAllSizes>,
-                    >
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<LoadStoreAllSizes>,
+                    > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
                     {
@@ -3371,10 +2197,10 @@ pub mod exports {
                                 (LoadStoreAllSizes,),
                             >::new_unchecked(self.load_store_everything)
                         };
-                        let promise = callee
-                            .call_concurrent(store.as_context_mut(), (arg0,))
-                            .await?;
-                        Ok(promise.map(|(v,)| v))
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `foo`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`FooPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`Foo`] as well.
+pub struct FooPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: FooIndices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for FooPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> FooPre<_T> {
+    /// Creates a new copy of `FooPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = FooIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`Foo`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<Foo>
     where
         _T: Send,
     {
@@ -56,34 +56,35 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `foo`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`FooPre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`Foo`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {
-    interface0: exports::foo::foo::strings::GuestIndices,
+pub struct FooIndices {
+    interface0: exports::my::dep0_1_0::a::GuestIndices,
+    interface1: exports::my::dep0_2_0::a::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `foo`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Foo::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`FooPre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`FooPre::instantiate_async`] to
+///   create a [`Foo`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`Foo::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -91,14 +92,15 @@ pub struct TheWorldIndices {
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {
-    interface0: exports::foo::foo::strings::Guest,
+pub struct Foo {
+    interface0: exports::my::dep0_1_0::a::Guest,
+    interface1: exports::my::dep0_2_0::a::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl FooIndices {
+        /// Creates a new copy of `FooIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -108,13 +110,15 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            let interface0 = exports::foo::foo::strings::GuestIndices::new(
-                _instance_pre,
-            )?;
-            Ok(TheWorldIndices { interface0 })
+            let interface0 = exports::my::dep0_1_0::a::GuestIndices::new(_instance_pre)?;
+            let interface1 = exports::my::dep0_2_0::a::GuestIndices::new(_instance_pre)?;
+            Ok(FooIndices {
+                interface0,
+                interface1,
+            })
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`Foo`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -122,34 +126,35 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<Foo> {
             let _ = &mut store;
             let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
-            Ok(TheWorld { interface0 })
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            Ok(Foo { interface0, interface1 })
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl Foo {
+        /// Convenience wrapper around [`FooPre::new`] and
+        /// [`FooPre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<Foo>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            FooPre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`FooIndices::new`] and
+        /// [`FooIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Foo> {
+            let indices = FooIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
         pub fn add_to_linker<T, D>(
@@ -157,46 +162,33 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostConcurrent + Send,
-            for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
+            D: my::dep0_1_0::a::HostConcurrent + my::dep0_2_0::a::HostConcurrent + Send,
+            for<'a> D::Data<'a>: my::dep0_1_0::a::Host + my::dep0_2_0::a::Host + Send,
             T: 'static + Send,
         {
-            foo::foo::strings::add_to_linker::<T, D>(linker, host_getter)?;
+            my::dep0_1_0::a::add_to_linker::<T, D>(linker, host_getter)?;
+            my::dep0_2_0::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
-        pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
+        pub fn my_dep0_1_0_a(&self) -> &exports::my::dep0_1_0::a::Guest {
             &self.interface0
+        }
+        pub fn my_dep0_2_0_a(&self) -> &exports::my::dep0_2_0::a::Guest {
+            &self.interface1
         }
     }
 };
-pub mod foo {
-    pub mod foo {
+pub mod my {
+    pub mod dep0_1_0 {
         #[allow(clippy::all)]
-        pub mod strings {
+        pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn x<T: 'static>(
                     accessor: &mut wasmtime::component::Accessor<T, Self>,
-                    x: wasmtime::component::__internal::String,
                 ) -> impl ::core::future::Future<Output = ()> + Send
-                where
-                    Self: Sized;
-                fn b<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
-                ) -> impl ::core::future::Future<
-                    Output = wasmtime::component::__internal::String,
-                > + Send
-                where
-                    Self: Sized;
-                fn c<T: 'static>(
-                    accessor: &mut wasmtime::component::Accessor<T, Self>,
-                    a: wasmtime::component::__internal::String,
-                    b: wasmtime::component::__internal::String,
-                ) -> impl ::core::future::Future<
-                    Output = wasmtime::component::__internal::String,
-                > + Send
                 where
                     Self: Sized;
             }
@@ -212,46 +204,54 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_concurrent(
-                    "a",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (wasmtime::component::__internal::String,)|
-                    {
+                    "x",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::a(accessor, arg0).await;
+                            let r = <D as HostConcurrent>::x(accessor).await;
                             Ok(r)
                         })
                     },
                 )?;
+                Ok(())
+            }
+        }
+    }
+    pub mod dep0_2_0 {
+        #[allow(clippy::all)]
+        pub mod a {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn x<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_concurrent(
-                    "b",
+                    "x",
                     move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::b(accessor).await;
-                            Ok((r,))
-                        })
-                    },
-                )?;
-                inst.func_wrap_concurrent(
-                    "c",
-                    move |
-                        caller: &mut wasmtime::component::Accessor<T>,
-                        (
-                            arg0,
-                            arg1,
-                        ): (
-                            wasmtime::component::__internal::String,
-                            wasmtime::component::__internal::String,
-                        )|
-                    {
-                        wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::c(accessor, arg0, arg1).await;
-                            Ok((r,))
+                            let r = <D as HostConcurrent>::x(accessor).await;
+                            Ok(r)
                         })
                     },
                 )?;
@@ -261,22 +261,18 @@ pub mod foo {
     }
 }
 pub mod exports {
-    pub mod foo {
-        pub mod foo {
+    pub mod my {
+        pub mod dep0_1_0 {
             #[allow(clippy::all)]
-            pub mod strings {
+            pub mod a {
                 #[allow(unused_imports)]
                 use wasmtime::component::__internal::{anyhow, Box};
                 pub struct Guest {
-                    a: wasmtime::component::Func,
-                    b: wasmtime::component::Func,
-                    c: wasmtime::component::Func,
+                    x: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
                 pub struct GuestIndices {
-                    a: wasmtime::component::ComponentExportIndex,
-                    b: wasmtime::component::ComponentExportIndex,
-                    c: wasmtime::component::ComponentExportIndex,
+                    x: wasmtime::component::ComponentExportIndex,
                 }
                 impl GuestIndices {
                     /// Constructor for [`GuestIndices`] which takes a
@@ -290,10 +286,10 @@ pub mod exports {
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance = _instance_pre
                             .component()
-                            .get_export_index(None, "foo:foo/strings")
+                            .get_export_index(None, "my:dep/a@0.1.0")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
-                                    "no exported instance named `foo:foo/strings`"
+                                    "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
                         let mut lookup = move |name| {
@@ -302,16 +298,14 @@ pub mod exports {
                                 .get_export_index(Some(&instance), name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
-                                        "instance export `foo:foo/strings` does \
+                                        "instance export `my:dep/a@0.1.0` does \
                 not have export `{name}`"
                                     )
                                 })
                         };
                         let _ = &mut lookup;
-                        let a = lookup("a")?;
-                        let b = lookup("b")?;
-                        let c = lookup("c")?;
-                        Ok(GuestIndices { a, b, c })
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
                     }
                     pub fn load(
                         &self,
@@ -323,29 +317,16 @@ pub mod exports {
                         let _instance_type = _instance_pre.instance_type();
                         let mut store = store.as_context_mut();
                         let _ = &mut store;
-                        let a = *_instance
-                            .get_typed_func::<(&str,), ()>(&mut store, &self.a)?
+                        let x = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.x)?
                             .func();
-                        let b = *_instance
-                            .get_typed_func::<
-                                (),
-                                (wasmtime::component::__internal::String,),
-                            >(&mut store, &self.b)?
-                            .func();
-                        let c = *_instance
-                            .get_typed_func::<
-                                (&str, &str),
-                                (wasmtime::component::__internal::String,),
-                            >(&mut store, &self.c)?
-                            .func();
-                        Ok(Guest { a, b, c })
+                        Ok(Guest { x })
                     }
                 }
                 impl Guest {
-                    pub fn call_a<S: wasmtime::AsContextMut>(
+                    pub fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                        arg0: wasmtime::component::__internal::String,
                     ) -> impl wasmtime::component::__internal::Future<
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
@@ -354,19 +335,82 @@ pub mod exports {
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::String,),
                                 (),
-                            >::new_unchecked(self.a)
+                                (),
+                            >::new_unchecked(self.x)
                         };
-                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                        callee.call_concurrent(store.as_context_mut(), ())
                     }
-                    pub fn call_b<S: wasmtime::AsContextMut>(
+                }
+            }
+        }
+        pub mod dep0_2_0 {
+            #[allow(clippy::all)]
+            pub mod a {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub struct Guest {
+                    x: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    x: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "my:dep/a@0.2.0")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `my:dep/a@0.2.0`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `my:dep/a@0.2.0` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let x = lookup("x")?;
+                        Ok(GuestIndices { x })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let x = *_instance
+                            .get_typed_func::<(), ()>(&mut store, &self.x)?
+                            .func();
+                        Ok(Guest { x })
+                    }
+                }
+                impl Guest {
+                    pub fn call_x<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::String,
-                        >,
+                        Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
                     where
                         <S as wasmtime::AsContext>::Data: Send + 'static,
@@ -374,40 +418,10 @@ pub mod exports {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
+                                (),
+                            >::new_unchecked(self.x)
                         };
-                        wasmtime::component::__internal::FutureExt::map(
-                            callee.call_concurrent(store.as_context_mut(), ()),
-                            |v| v.map(|(v,)| v),
-                        )
-                    }
-                    pub fn call_c<S: wasmtime::AsContextMut>(
-                        &self,
-                        mut store: S,
-                        arg0: wasmtime::component::__internal::String,
-                        arg1: wasmtime::component::__internal::String,
-                    ) -> impl wasmtime::component::__internal::Future<
-                        Output = wasmtime::Result<
-                            wasmtime::component::__internal::String,
-                        >,
-                    > + Send + 'static + use<S>
-                    where
-                        <S as wasmtime::AsContext>::Data: Send + 'static,
-                    {
-                        let callee = unsafe {
-                            wasmtime::component::TypedFunc::<
-                                (
-                                    wasmtime::component::__internal::String,
-                                    wasmtime::component::__internal::String,
-                                ),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
-                        };
-                        wasmtime::component::__internal::FutureExt::map(
-                            callee.call_concurrent(store.as_context_mut(), (arg0, arg1)),
-                            |v| v.map(|(v,)| v),
-                        )
+                        callee.call_concurrent(store.as_context_mut(), ())
                     }
                 }
             }

--- a/crates/component-macro/tests/expanded/path1_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path1_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `path1`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`Path1Pre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`Path1`] as well.
+pub struct Path1Pre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: Path1Indices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for Path1Pre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> Path1Pre<_T> {
+    /// Creates a new copy of `Path1Pre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = Path1Indices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`Path1`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<Path1>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `path1`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`Path1Pre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`Path1`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {}
+pub struct Path1Indices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `path1`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Path1::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`Path1Pre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`Path1Pre::instantiate_async`] to
+///   create a [`Path1`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`Path1::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,12 @@ pub struct TheWorldIndices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {}
+pub struct Path1 {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl Path1Indices {
+        /// Creates a new copy of `Path1Indices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +104,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(TheWorldIndices {})
+            Ok(Path1Indices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`Path1`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,33 +115,33 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<Path1> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(TheWorld {})
+            Ok(Path1 {})
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl Path1 {
+        /// Convenience wrapper around [`Path1Pre::new`] and
+        /// [`Path1Pre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<Path1>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            Path1Pre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`Path1Indices::new`] and
+        /// [`Path1Indices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Path1> {
+            let indices = Path1Indices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
         pub fn add_to_linker<T, D>(
@@ -149,50 +149,36 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: imports::HostConcurrent + Send,
-            for<'a> D::Data<'a>: imports::Host + Send,
+            D: wasmtime::component::HasData,
+            for<'a> D::Data<'a>: paths::path1::test::Host + Send,
             T: 'static + Send,
         {
-            imports::add_to_linker::<T, D>(linker, host_getter)?;
+            paths::path1::test::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
 };
-#[allow(clippy::all)]
-pub mod imports {
-    #[allow(unused_imports)]
-    use wasmtime::component::__internal::{anyhow, Box};
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait HostConcurrent: wasmtime::component::HasData + Send {
-        fn y<T: 'static>(
-            accessor: &mut wasmtime::component::Accessor<T, Self>,
-        ) -> impl ::core::future::Future<Output = ()> + Send
-        where
-            Self: Sized;
-    }
-    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
-    pub trait Host: Send {}
-    impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
-        host_getter: fn(&mut T) -> D::Data<'_>,
-    ) -> wasmtime::Result<()>
-    where
-        D: HostConcurrent,
-        for<'a> D::Data<'a>: Host,
-        T: 'static + Send,
-    {
-        let mut inst = linker.instance("imports")?;
-        inst.func_wrap_concurrent(
-            "y",
-            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
-                wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &mut unsafe { caller.with_data(host_getter) };
-                    let r = <D as HostConcurrent>::y(accessor).await;
-                    Ok(r)
-                })
-            },
-        )?;
-        Ok(())
+pub mod paths {
+    pub mod path1 {
+        #[allow(clippy::all)]
+        pub mod test {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("paths:path1/test")?;
+                Ok(())
+            }
+        }
     }
 }

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -1,0 +1,1127 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T: 'static> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface0: exports::foo::foo::records::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface0: exports::foo::foo::records::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            let interface0 = exports::foo::foo::records::GuestIndices::new(
+                _instance_pre,
+            )?;
+            Ok(TheWorldIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _ = &mut store;
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(TheWorld { interface0 })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: foo::foo::records::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::records::Host + Send,
+            T: 'static + Send,
+        {
+            foo::foo::records::add_to_linker::<T, D>(linker, host_getter)?;
+            Ok(())
+        }
+        pub fn foo_foo_records(&self) -> &exports::foo::foo::records::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod records {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Empty {}
+            impl core::fmt::Debug for Empty {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Empty").finish()
+                }
+            }
+            const _: () = {
+                assert!(0 == < Empty as wasmtime::component::ComponentType >::SIZE32);
+                assert!(1 == < Empty as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record containing two scalar fields
+            /// that both have the same type
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct Scalars {
+                /// The first field, named a
+                #[component(name = "a")]
+                pub a: u32,
+                /// The second field, named b
+                #[component(name = "b")]
+                pub b: u32,
+            }
+            impl core::fmt::Debug for Scalars {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Scalars")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Scalars as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            /// A record that is really just flags
+            /// All of the fields are bool
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone, Copy)]
+            pub struct ReallyFlags {
+                #[component(name = "a")]
+                pub a: bool,
+                #[component(name = "b")]
+                pub b: bool,
+                #[component(name = "c")]
+                pub c: bool,
+                #[component(name = "d")]
+                pub d: bool,
+                #[component(name = "e")]
+                pub e: bool,
+                #[component(name = "f")]
+                pub f: bool,
+                #[component(name = "g")]
+                pub g: bool,
+                #[component(name = "h")]
+                pub h: bool,
+                #[component(name = "i")]
+                pub i: bool,
+            }
+            impl core::fmt::Debug for ReallyFlags {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("ReallyFlags")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .field("f", &self.f)
+                        .field("g", &self.g)
+                        .field("h", &self.h)
+                        .field("i", &self.i)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    9 == < ReallyFlags as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    1 == < ReallyFlags as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Aggregates {
+                #[component(name = "a")]
+                pub a: Scalars,
+                #[component(name = "b")]
+                pub b: u32,
+                #[component(name = "c")]
+                pub c: Empty,
+                #[component(name = "d")]
+                pub d: wasmtime::component::__internal::String,
+                #[component(name = "e")]
+                pub e: ReallyFlags,
+            }
+            impl core::fmt::Debug for Aggregates {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Aggregates")
+                        .field("a", &self.a)
+                        .field("b", &self.b)
+                        .field("c", &self.c)
+                        .field("d", &self.d)
+                        .field("e", &self.e)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    32 == < Aggregates as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < Aggregates as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type TupleTypedef = (i32,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type IntTypedef = i32;
+            const _: () = {
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < IntTypedef as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type TupleTypedef2 = (IntTypedef,);
+            const _: () = {
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < TupleTypedef2 as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn tuple_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: (char, u32),
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn tuple_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = (char, u32)> + Send
+                where
+                    Self: Sized;
+                fn empty_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Empty,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn empty_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = Empty> + Send
+                where
+                    Self: Sized;
+                fn scalar_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Scalars,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn scalar_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = Scalars> + Send
+                where
+                    Self: Sized;
+                fn flags_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: ReallyFlags,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn flags_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = ReallyFlags> + Send
+                where
+                    Self: Sized;
+                fn aggregate_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Aggregates,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn aggregate_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = Aggregates> + Send
+                where
+                    Self: Sized;
+                fn typedef_inout<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    e: TupleTypedef2,
+                ) -> impl ::core::future::Future<Output = i32> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                inst.func_wrap_concurrent(
+                    "tuple-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): ((char, u32),)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "empty-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Empty,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::empty_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "empty-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::empty_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "scalar-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Scalars,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::scalar_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "scalar-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::scalar_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "flags-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (ReallyFlags,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::flags_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "flags-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::flags_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "aggregate-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Aggregates,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::aggregate_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "aggregate-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::aggregate_result(accessor)
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "typedef-inout",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (TupleTypedef2,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::typedef_inout(accessor, arg0)
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod records {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Empty {}
+                impl core::fmt::Debug for Empty {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Empty").finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        0 == < Empty as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        1 == < Empty as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record containing two scalar fields
+                /// that both have the same type
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct Scalars {
+                    /// The first field, named a
+                    #[component(name = "a")]
+                    pub a: u32,
+                    /// The second field, named b
+                    #[component(name = "b")]
+                    pub b: u32,
+                }
+                impl core::fmt::Debug for Scalars {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Scalars")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        8 == < Scalars as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < Scalars as wasmtime::component::ComponentType >::ALIGN32
+                    );
+                };
+                /// A record that is really just flags
+                /// All of the fields are bool
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone, Copy)]
+                pub struct ReallyFlags {
+                    #[component(name = "a")]
+                    pub a: bool,
+                    #[component(name = "b")]
+                    pub b: bool,
+                    #[component(name = "c")]
+                    pub c: bool,
+                    #[component(name = "d")]
+                    pub d: bool,
+                    #[component(name = "e")]
+                    pub e: bool,
+                    #[component(name = "f")]
+                    pub f: bool,
+                    #[component(name = "g")]
+                    pub g: bool,
+                    #[component(name = "h")]
+                    pub h: bool,
+                    #[component(name = "i")]
+                    pub i: bool,
+                }
+                impl core::fmt::Debug for ReallyFlags {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("ReallyFlags")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .field("f", &self.f)
+                            .field("g", &self.g)
+                            .field("h", &self.h)
+                            .field("i", &self.i)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        9 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        1 == < ReallyFlags as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                #[derive(wasmtime::component::ComponentType)]
+                #[derive(wasmtime::component::Lift)]
+                #[derive(wasmtime::component::Lower)]
+                #[component(record)]
+                #[derive(Clone)]
+                pub struct Aggregates {
+                    #[component(name = "a")]
+                    pub a: Scalars,
+                    #[component(name = "b")]
+                    pub b: u32,
+                    #[component(name = "c")]
+                    pub c: Empty,
+                    #[component(name = "d")]
+                    pub d: wasmtime::component::__internal::String,
+                    #[component(name = "e")]
+                    pub e: ReallyFlags,
+                }
+                impl core::fmt::Debug for Aggregates {
+                    fn fmt(
+                        &self,
+                        f: &mut core::fmt::Formatter<'_>,
+                    ) -> core::fmt::Result {
+                        f.debug_struct("Aggregates")
+                            .field("a", &self.a)
+                            .field("b", &self.b)
+                            .field("c", &self.c)
+                            .field("d", &self.d)
+                            .field("e", &self.e)
+                            .finish()
+                    }
+                }
+                const _: () = {
+                    assert!(
+                        32 == < Aggregates as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < Aggregates as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef = (i32,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type IntTypedef = i32;
+                const _: () = {
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType >::SIZE32
+                    );
+                    assert!(
+                        4 == < IntTypedef as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub type TupleTypedef2 = (IntTypedef,);
+                const _: () = {
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::SIZE32
+                    );
+                    assert!(
+                        4 == < TupleTypedef2 as wasmtime::component::ComponentType
+                        >::ALIGN32
+                    );
+                };
+                pub struct Guest {
+                    tuple_arg: wasmtime::component::Func,
+                    tuple_result: wasmtime::component::Func,
+                    empty_arg: wasmtime::component::Func,
+                    empty_result: wasmtime::component::Func,
+                    scalar_arg: wasmtime::component::Func,
+                    scalar_result: wasmtime::component::Func,
+                    flags_arg: wasmtime::component::Func,
+                    flags_result: wasmtime::component::Func,
+                    aggregate_arg: wasmtime::component::Func,
+                    aggregate_result: wasmtime::component::Func,
+                    typedef_inout: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    tuple_arg: wasmtime::component::ComponentExportIndex,
+                    tuple_result: wasmtime::component::ComponentExportIndex,
+                    empty_arg: wasmtime::component::ComponentExportIndex,
+                    empty_result: wasmtime::component::ComponentExportIndex,
+                    scalar_arg: wasmtime::component::ComponentExportIndex,
+                    scalar_result: wasmtime::component::ComponentExportIndex,
+                    flags_arg: wasmtime::component::ComponentExportIndex,
+                    flags_result: wasmtime::component::ComponentExportIndex,
+                    aggregate_arg: wasmtime::component::ComponentExportIndex,
+                    aggregate_result: wasmtime::component::ComponentExportIndex,
+                    typedef_inout: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/records")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/records`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/records` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let tuple_arg = lookup("tuple-arg")?;
+                        let tuple_result = lookup("tuple-result")?;
+                        let empty_arg = lookup("empty-arg")?;
+                        let empty_result = lookup("empty-result")?;
+                        let scalar_arg = lookup("scalar-arg")?;
+                        let scalar_result = lookup("scalar-result")?;
+                        let flags_arg = lookup("flags-arg")?;
+                        let flags_result = lookup("flags-result")?;
+                        let aggregate_arg = lookup("aggregate-arg")?;
+                        let aggregate_result = lookup("aggregate-result")?;
+                        let typedef_inout = lookup("typedef-inout")?;
+                        Ok(GuestIndices {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let tuple_arg = *_instance
+                            .get_typed_func::<
+                                ((char, u32),),
+                                (),
+                            >(&mut store, &self.tuple_arg)?
+                            .func();
+                        let tuple_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                ((char, u32),),
+                            >(&mut store, &self.tuple_result)?
+                            .func();
+                        let empty_arg = *_instance
+                            .get_typed_func::<(Empty,), ()>(&mut store, &self.empty_arg)?
+                            .func();
+                        let empty_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Empty,),
+                            >(&mut store, &self.empty_result)?
+                            .func();
+                        let scalar_arg = *_instance
+                            .get_typed_func::<
+                                (Scalars,),
+                                (),
+                            >(&mut store, &self.scalar_arg)?
+                            .func();
+                        let scalar_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Scalars,),
+                            >(&mut store, &self.scalar_result)?
+                            .func();
+                        let flags_arg = *_instance
+                            .get_typed_func::<
+                                (ReallyFlags,),
+                                (),
+                            >(&mut store, &self.flags_arg)?
+                            .func();
+                        let flags_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (ReallyFlags,),
+                            >(&mut store, &self.flags_result)?
+                            .func();
+                        let aggregate_arg = *_instance
+                            .get_typed_func::<
+                                (&Aggregates,),
+                                (),
+                            >(&mut store, &self.aggregate_arg)?
+                            .func();
+                        let aggregate_result = *_instance
+                            .get_typed_func::<
+                                (),
+                                (Aggregates,),
+                            >(&mut store, &self.aggregate_result)?
+                            .func();
+                        let typedef_inout = *_instance
+                            .get_typed_func::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >(&mut store, &self.typedef_inout)?
+                            .func();
+                        Ok(Guest {
+                            tuple_arg,
+                            tuple_result,
+                            empty_arg,
+                            empty_result,
+                            scalar_arg,
+                            scalar_result,
+                            flags_arg,
+                            flags_result,
+                            aggregate_arg,
+                            aggregate_result,
+                            typedef_inout,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub fn call_tuple_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: (char, u32),
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                ((char, u32),),
+                                (),
+                            >::new_unchecked(self.tuple_arg)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                    pub fn call_tuple_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<(char, u32)>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                ((char, u32),),
+                            >::new_unchecked(self.tuple_result)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_empty_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Empty,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Empty,),
+                                (),
+                            >::new_unchecked(self.empty_arg)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                    pub fn call_empty_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Empty>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Empty,),
+                            >::new_unchecked(self.empty_result)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_scalar_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Scalars,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Scalars,),
+                                (),
+                            >::new_unchecked(self.scalar_arg)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                    pub fn call_scalar_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Scalars>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Scalars,),
+                            >::new_unchecked(self.scalar_result)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_flags_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: ReallyFlags,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (ReallyFlags,),
+                                (),
+                            >::new_unchecked(self.flags_arg)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                    pub fn call_flags_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<ReallyFlags>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (ReallyFlags,),
+                            >::new_unchecked(self.flags_result)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_aggregate_arg<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: Aggregates,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (Aggregates,),
+                                (),
+                            >::new_unchecked(self.aggregate_arg)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                    pub fn call_aggregate_result<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<Aggregates>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (Aggregates,),
+                            >::new_unchecked(self.aggregate_result)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_typedef_inout<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: TupleTypedef2,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<i32>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (TupleTypedef2,),
+                                (i32,),
+                            >::new_unchecked(self.typedef_inout)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `path2`.
+/// component which implements the world `neptune`.
 ///
-/// This structure is created through [`Path2Pre::new`] which
+/// This structure is created through [`NeptunePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Path2`] as well.
-pub struct Path2Pre<T: 'static> {
+/// For more information see [`Neptune`] as well.
+pub struct NeptunePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: Path2Indices,
+    indices: NeptuneIndices,
 }
-impl<T: 'static> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for NeptunePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T: 'static> Path2Pre<_T> {
-    /// Creates a new copy of `Path2Pre` bindings which can then
+impl<_T: 'static> NeptunePre<_T> {
+    /// Creates a new copy of `NeptunePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = Path2Indices::new(&instance_pre)?;
+        let indices = NeptuneIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Path2`] within the
+    /// Instantiates a new instance of [`Neptune`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Path2>
+    ) -> wasmtime::Result<Neptune>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> Path2Pre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `path2`.
+/// `neptune`.
 ///
-/// This is an implementation detail of [`Path2Pre`] and can
+/// This is an implementation detail of [`NeptunePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Path2`] as well.
+/// For more information see [`Neptune`] as well.
 #[derive(Clone)]
-pub struct Path2Indices {}
+pub struct NeptuneIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `path2`.
+/// implements the world `neptune`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Path2::instantiate_async`] which only needs a
+///   [`Neptune::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`Path2Pre`] ahead of
+/// * Alternatively you can create a [`NeptunePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`Path2Pre::instantiate_async`] to
-///   create a [`Path2`].
+///   method then uses [`NeptunePre::instantiate_async`] to
+///   create a [`Neptune`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Path2::new`].
+///   then you can use [`Neptune::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,12 @@ pub struct Path2Indices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Path2 {}
+pub struct Neptune {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl Path2Indices {
-        /// Creates a new copy of `Path2Indices` bindings which can then
+    impl NeptuneIndices {
+        /// Creates a new copy of `NeptuneIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +104,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(Path2Indices {})
+            Ok(NeptuneIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Path2`] from the instance provided.
+        /// of [`Neptune`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,33 +115,33 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Path2> {
+        ) -> wasmtime::Result<Neptune> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(Path2 {})
+            Ok(Neptune {})
         }
     }
-    impl Path2 {
-        /// Convenience wrapper around [`Path2Pre::new`] and
-        /// [`Path2Pre::instantiate_async`].
+    impl Neptune {
+        /// Convenience wrapper around [`NeptunePre::new`] and
+        /// [`NeptunePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Path2>
+        ) -> wasmtime::Result<Neptune>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            Path2Pre::new(pre)?.instantiate_async(store).await
+            NeptunePre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`Path2Indices::new`] and
-        /// [`Path2Indices::load`].
+        /// Convenience wrapper around [`NeptuneIndices::new`] and
+        /// [`NeptuneIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Path2> {
-            let indices = Path2Indices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Neptune> {
+            let indices = NeptuneIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
         pub fn add_to_linker<T, D>(
@@ -149,21 +149,27 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: wasmtime::component::HasData,
-            for<'a> D::Data<'a>: paths::path2::test::Host + Send,
+            D: foo::foo::red::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::green::Host + foo::foo::red::Host + Send,
             T: 'static + Send,
         {
-            paths::path2::test::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::green::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::red::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
 };
-pub mod paths {
-    pub mod path2 {
+pub mod foo {
+    pub mod foo {
         #[allow(clippy::all)]
-        pub mod test {
+        pub mod green {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            pub type Thing = i32;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -176,7 +182,50 @@ pub mod paths {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("paths:path2/test")?;
+                let mut inst = linker.instance("foo:foo/green")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod red {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type Thing = super::super::super::foo::foo::green::Thing;
+            const _: () = {
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn foo<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = Thing> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                inst.func_wrap_concurrent(
+                    "foo",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::foo(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
                 Ok(())
             }
         }

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -1,0 +1,802 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `w`.
+///
+/// This structure is created through [`WPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`W`] as well.
+pub struct WPre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: WIndices,
+}
+impl<T: 'static> Clone for WPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> WPre<_T> {
+    /// Creates a new copy of `WPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = WIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`W`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<W>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `w`.
+///
+/// This is an implementation detail of [`WPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`W`] as well.
+#[derive(Clone)]
+pub struct WIndices {
+    interface0: exports::foo::foo::simple_export::GuestIndices,
+    interface1: exports::foo::foo::export_using_import::GuestIndices,
+    interface2: exports::foo::foo::export_using_export1::GuestIndices,
+    interface3: exports::foo::foo::export_using_export2::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `w`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`W::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`WPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`WPre::instantiate_async`] to
+///   create a [`W`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`W::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct W {
+    interface0: exports::foo::foo::simple_export::Guest,
+    interface1: exports::foo::foo::export_using_import::Guest,
+    interface2: exports::foo::foo::export_using_export1::Guest,
+    interface3: exports::foo::foo::export_using_export2::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl WIndices {
+        /// Creates a new copy of `WIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            let interface0 = exports::foo::foo::simple_export::GuestIndices::new(
+                _instance_pre,
+            )?;
+            let interface1 = exports::foo::foo::export_using_import::GuestIndices::new(
+                _instance_pre,
+            )?;
+            let interface2 = exports::foo::foo::export_using_export1::GuestIndices::new(
+                _instance_pre,
+            )?;
+            let interface3 = exports::foo::foo::export_using_export2::GuestIndices::new(
+                _instance_pre,
+            )?;
+            Ok(WIndices {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`W`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let _ = &mut store;
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            let interface2 = self.interface2.load(&mut store, &_instance)?;
+            let interface3 = self.interface3.load(&mut store, &_instance)?;
+            Ok(W {
+                interface0,
+                interface1,
+                interface2,
+                interface3,
+            })
+        }
+    }
+    impl W {
+        /// Convenience wrapper around [`WPre::new`] and
+        /// [`WPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<W>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            WPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`WIndices::new`] and
+        /// [`WIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<W> {
+            let indices = WIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: wasmtime::component::HasData,
+            for<'a> D::Data<'a>: foo::foo::transitive_import::Host + Send,
+            T: 'static + Send,
+        {
+            foo::foo::transitive_import::add_to_linker::<T, D>(linker, host_getter)?;
+            Ok(())
+        }
+        pub fn foo_foo_simple_export(&self) -> &exports::foo::foo::simple_export::Guest {
+            &self.interface0
+        }
+        pub fn foo_foo_export_using_import(
+            &self,
+        ) -> &exports::foo::foo::export_using_import::Guest {
+            &self.interface1
+        }
+        pub fn foo_foo_export_using_export1(
+            &self,
+        ) -> &exports::foo::foo::export_using_export1::Guest {
+            &self.interface2
+        }
+        pub fn foo_foo_export_using_export2(
+            &self,
+        ) -> &exports::foo::foo::export_using_export2::Guest {
+            &self.interface3
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod transitive_import {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Y {}
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostY: Send {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostY + ?Sized + Send> HostY for &mut _T {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Y>,
+                ) -> wasmtime::Result<()> {
+                    HostY::drop(*self, rep).await
+                }
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send + HostY {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                inst.resource_async(
+                    "y",
+                    wasmtime::component::ResourceType::host::<Y>(),
+                    move |mut store, rep| {
+                        wasmtime::component::__internal::Box::new(async move {
+                            HostY::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                                .await
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod simple_export {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                    static_a_static_a: wasmtime::component::ComponentExportIndex,
+                    method_a_method_a: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/simple-export")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/simple-export`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/simple-export` does \
+                  not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        let static_a_static_a = *_instance
+                            .get_typed_func::<
+                                (),
+                                (u32,),
+                            >(&mut store, &self.static_a_static_a)?
+                            .func();
+                        let method_a_method_a = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >(&mut store, &self.method_a_method_a)?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u32>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (u32,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<u32>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (u32,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_import {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type Y = super::super::super::super::foo::foo::transitive_import::Y;
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                    static_a_static_a: wasmtime::component::Func,
+                    method_a_method_a: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                    static_a_static_a: wasmtime::component::ComponentExportIndex,
+                    method_a_method_a: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/export-using-import")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-import`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-import` does \
+                        not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        let static_a_static_a = lookup("[static]a.static-a")?;
+                        let method_a_method_a = lookup("[method]a.method-a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        let static_a_static_a = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >(&mut store, &self.static_a_static_a)?
+                            .func();
+                        let method_a_method_a = *_instance
+                            .get_typed_func::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >(&mut store, &self.method_a_method_a)?
+                            .func();
+                        Ok(Guest {
+                            constructor_a_constructor,
+                            static_a_static_a,
+                            method_a_method_a,
+                        })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Y>,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Y>,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_static_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.static_a_static_a)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_method_a<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                        arg1: wasmtime::component::Resource<Y>,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::Resource<Y>>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::ResourceAny,
+                                    wasmtime::component::Resource<Y>,
+                                ),
+                                (wasmtime::component::Resource<Y>,),
+                            >::new_unchecked(self.funcs.method_a_method_a)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0, arg1)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export1 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = wasmtime::component::ResourceAny;
+                pub struct GuestA<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_a_constructor: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_a_constructor: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/export-using-export1")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export1`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-export1` does \
+                              not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_a_constructor = lookup("[constructor]a")?;
+                        Ok(GuestIndices {
+                            constructor_a_constructor,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let constructor_a_constructor = *_instance
+                            .get_typed_func::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_a_constructor)?
+                            .func();
+                        Ok(Guest { constructor_a_constructor })
+                    }
+                }
+                impl Guest {
+                    pub fn a(&self) -> GuestA<'_> {
+                        GuestA { funcs: self }
+                    }
+                }
+                impl GuestA<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_a_constructor)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), ()),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                }
+            }
+            #[allow(clippy::all)]
+            pub mod export_using_export2 {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type A = super::super::super::super::exports::foo::foo::export_using_export1::A;
+                pub type B = wasmtime::component::ResourceAny;
+                pub struct GuestB<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {
+                    constructor_b_constructor: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    constructor_b_constructor: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/export-using-export2")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/export-using-export2`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/export-using-export2` does \
+                                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let constructor_b_constructor = lookup("[constructor]b")?;
+                        Ok(GuestIndices {
+                            constructor_b_constructor,
+                        })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let constructor_b_constructor = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >(&mut store, &self.constructor_b_constructor)?
+                            .func();
+                        Ok(Guest { constructor_b_constructor })
+                    }
+                }
+                impl Guest {
+                    pub fn b(&self) -> GuestB<'_> {
+                        GuestB { funcs: self }
+                    }
+                }
+                impl GuestB<'_> {
+                    pub fn call_constructor<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::ResourceAny,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<wasmtime::component::ResourceAny>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::ResourceAny,),
+                                (wasmtime::component::ResourceAny,),
+                            >::new_unchecked(self.funcs.constructor_b_constructor)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -1,0 +1,1220 @@
+pub enum WorldResource {}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait HostWorldResourceConcurrent: wasmtime::component::HasData + Send {
+    fn new<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<
+        Output = wasmtime::component::Resource<WorldResource>,
+    > + Send
+    where
+        Self: Sized;
+    fn foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        self_: wasmtime::component::Resource<WorldResource>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+    fn static_foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait HostWorldResource: Send {
+    async fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()>;
+}
+impl<_T: HostWorldResource + ?Sized + Send> HostWorldResource for &mut _T {
+    async fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<WorldResource>,
+    ) -> wasmtime::Result<()> {
+        HostWorldResource::drop(*self, rep).await
+    }
+}
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T: 'static> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {
+    interface1: exports::foo::foo::uses_resource_transitively::GuestIndices,
+    some_world_func2: wasmtime::component::ComponentExportIndex,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {
+    interface1: exports::foo::foo::uses_resource_transitively::Guest,
+    some_world_func2: wasmtime::component::Func,
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait TheWorldImportsConcurrent: wasmtime::component::HasData + Send + HostWorldResourceConcurrent {
+    fn some_world_func<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<
+        Output = wasmtime::component::Resource<WorldResource>,
+    > + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait TheWorldImports: Send + HostWorldResource {}
+impl<_T: TheWorldImports + ?Sized + Send> TheWorldImports for &mut _T {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            let interface1 = exports::foo::foo::uses_resource_transitively::GuestIndices::new(
+                _instance_pre,
+            )?;
+            let some_world_func2 = {
+                let (item, index) = _component
+                    .get_export(None, "some-world-func2")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no export `some-world-func2` found")
+                    })?;
+                match item {
+                    wasmtime::component::types::ComponentItem::ComponentFunc(func) => {
+                        anyhow::Context::context(
+                            func
+                                .typecheck::<
+                                    (),
+                                    (wasmtime::component::Resource<WorldResource>,),
+                                >(&_instance_type),
+                            "type-checking export func `some-world-func2`",
+                        )?;
+                        index
+                    }
+                    _ => {
+                        Err(
+                            anyhow::anyhow!(
+                                "export `some-world-func2` is not a function"
+                            ),
+                        )?
+                    }
+                }
+            };
+            Ok(TheWorldIndices {
+                interface1,
+                some_world_func2,
+            })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _ = &mut store;
+            let _instance = instance;
+            let interface1 = self.interface1.load(&mut store, &_instance)?;
+            let some_world_func2 = *_instance
+                .get_typed_func::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >(&mut store, &self.some_world_func2)?
+                .func();
+            Ok(TheWorld {
+                interface1,
+                some_world_func2,
+            })
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker_imports<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: TheWorldImportsConcurrent,
+            for<'a> D::Data<'a>: TheWorldImports,
+            T: 'static + Send,
+        {
+            let mut linker = linker.root();
+            linker
+                .resource_async(
+                    "world-resource",
+                    wasmtime::component::ResourceType::host::<WorldResource>(),
+                    move |mut store, rep| {
+                        wasmtime::component::__internal::Box::new(async move {
+                            HostWorldResource::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                                .await
+                        })
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "some-world-func",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as TheWorldImportsConcurrent>::some_world_func(
+                                    accessor,
+                                )
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[constructor]world-resource",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostWorldResourceConcurrent>::new(accessor)
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[method]world-resource.foo",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (wasmtime::component::Resource<WorldResource>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostWorldResourceConcurrent>::foo(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+            linker
+                .func_wrap_concurrent(
+                    "[static]world-resource.static-foo",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostWorldResourceConcurrent>::static_foo(
+                                    accessor,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+            Ok(())
+        }
+        pub fn add_to_linker<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: foo::foo::resources::HostConcurrent
+                + foo::foo::long_use_chain4::HostConcurrent + TheWorldImportsConcurrent
+                + Send,
+            for<'a> D::Data<
+                'a,
+            >: foo::foo::resources::Host + foo::foo::long_use_chain1::Host
+                + foo::foo::long_use_chain2::Host + foo::foo::long_use_chain3::Host
+                + foo::foo::long_use_chain4::Host
+                + foo::foo::transitive_interface_with_resource::Host + TheWorldImports
+                + Send,
+            T: 'static + Send,
+        {
+            Self::add_to_linker_imports::<T, D>(linker, host_getter)?;
+            foo::foo::resources::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain1::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain2::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain3::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::long_use_chain4::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::transitive_interface_with_resource::add_to_linker::<
+                T,
+                D,
+            >(linker, host_getter)?;
+            Ok(())
+        }
+        pub fn call_some_world_func2<S: wasmtime::AsContextMut>(
+            &self,
+            mut store: S,
+        ) -> impl wasmtime::component::__internal::Future<
+            Output = wasmtime::Result<wasmtime::component::Resource<WorldResource>>,
+        > + Send + 'static + use<S>
+        where
+            <S as wasmtime::AsContext>::Data: Send + 'static,
+        {
+            let callee = unsafe {
+                wasmtime::component::TypedFunc::<
+                    (),
+                    (wasmtime::component::Resource<WorldResource>,),
+                >::new_unchecked(self.some_world_func2)
+            };
+            wasmtime::component::__internal::FutureExt::map(
+                callee.call_concurrent(store.as_context_mut(), ()),
+                |v| v.map(|(v,)| v),
+            )
+        }
+        pub fn foo_foo_uses_resource_transitively(
+            &self,
+        ) -> &exports::foo::foo::uses_resource_transitively::Guest {
+            &self.interface1
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod resources {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Bar {}
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostBarConcurrent: wasmtime::component::HasData + Send {
+                fn new<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = wasmtime::component::Resource<Bar>,
+                > + Send
+                where
+                    Self: Sized;
+                fn static_a<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = u32> + Send
+                where
+                    Self: Sized;
+                fn method_a<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::core::future::Future<Output = u32> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostBar: Send {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostBar + ?Sized + Send> HostBar for &mut _T {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()> {
+                    HostBar::drop(*self, rep).await
+                }
+            }
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedOwn {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedOwn {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedOwn")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedOwn as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            pub struct NestedBorrow {
+                #[component(name = "nested-bar")]
+                pub nested_bar: wasmtime::component::Resource<Bar>,
+            }
+            impl core::fmt::Debug for NestedBorrow {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("NestedBorrow")
+                        .field("nested-bar", &self.nested_bar)
+                        .finish()
+                }
+            }
+            const _: () = {
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < NestedBorrow as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            pub type SomeHandle = wasmtime::component::Resource<Bar>;
+            const _: () = {
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::SIZE32
+                );
+                assert!(
+                    4 == < SomeHandle as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send + HostBarConcurrent {
+                fn bar_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn bar_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: wasmtime::component::Resource<Bar>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn bar_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = wasmtime::component::Resource<Bar>,
+                > + Send
+                where
+                    Self: Sized;
+                fn tuple_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn tuple_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: (wasmtime::component::Resource<Bar>, u32),
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn tuple_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = (wasmtime::component::Resource<Bar>, u32),
+                > + Send
+                where
+                    Self: Sized;
+                fn option_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn option_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Option<wasmtime::component::Resource<Bar>>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn option_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::Resource<Bar>>,
+                > + Send
+                where
+                    Self: Sized;
+                fn result_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn result_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: Result<wasmtime::component::Resource<Bar>, ()>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn result_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = Result<wasmtime::component::Resource<Bar>, ()>,
+                > + Send
+                where
+                    Self: Sized;
+                fn list_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn list_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn list_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = wasmtime::component::__internal::Vec<
+                        wasmtime::component::Resource<Bar>,
+                    >,
+                > + Send
+                where
+                    Self: Sized;
+                fn record_own_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: NestedOwn,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn record_borrow_arg<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: NestedBorrow,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+                fn record_result<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = NestedOwn> + Send
+                where
+                    Self: Sized;
+                fn func_with_handle_typedef<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    x: SomeHandle,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send + HostBar {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                inst.resource_async(
+                    "bar",
+                    wasmtime::component::ResourceType::host::<Bar>(),
+                    move |mut store, rep| {
+                        wasmtime::component::__internal::Box::new(async move {
+                            HostBar::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                                .await
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[constructor]bar",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostBarConcurrent>::new(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[static]bar.static-a",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostBarConcurrent>::static_a(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "[method]bar.method-a",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostBarConcurrent>::method_a(accessor, arg0)
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::bar_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (wasmtime::component::Resource<Bar>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::bar_borrow_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "bar-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::bar_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_borrow_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "tuple-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::tuple_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::option_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::option_borrow_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "option-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::option_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::result_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::result_borrow_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "result-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::result_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::Resource<Bar>,
+                            >,
+                        )|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_borrow_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "list-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::list_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-own-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (NestedOwn,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::record_own_arg(accessor, arg0)
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-borrow-arg",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (NestedBorrow,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::record_borrow_arg(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "record-result",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::record_result(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "func-with-handle-typedef",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (arg0,): (SomeHandle,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::func_with_handle_typedef(
+                                    accessor,
+                                    arg0,
+                                )
+                                .await;
+                            Ok(r)
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain1 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum A {}
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostA: Send {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostA + ?Sized + Send> HostA for &mut _T {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<A>,
+                ) -> wasmtime::Result<()> {
+                    HostA::drop(*self, rep).await
+                }
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send + HostA {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                inst.resource_async(
+                    "a",
+                    wasmtime::component::ResourceType::host::<A>(),
+                    move |mut store, rep| {
+                        wasmtime::component::__internal::Box::new(async move {
+                            HostA::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                                .await
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain2 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain1::A;
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain2")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain3 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain2::A;
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain3")?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod long_use_chain4 {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub type A = super::super::super::foo::foo::long_use_chain3::A;
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn foo<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<
+                    Output = wasmtime::component::Resource<A>,
+                > + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                inst.func_wrap_concurrent(
+                    "foo",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::foo(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+        #[allow(clippy::all)]
+        pub mod transitive_interface_with_resource {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            pub enum Foo {}
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostFoo: Send {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostFoo + ?Sized + Send> HostFoo for &mut _T {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Foo>,
+                ) -> wasmtime::Result<()> {
+                    HostFoo::drop(*self, rep).await
+                }
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send + HostFoo {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                inst.resource_async(
+                    "foo",
+                    wasmtime::component::ResourceType::host::<Foo>(),
+                    move |mut store, rep| {
+                        wasmtime::component::__internal::Box::new(async move {
+                            HostFoo::drop(
+                                    &mut host_getter(store.data_mut()),
+                                    wasmtime::component::Resource::new_own(rep),
+                                )
+                                .await
+                        })
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    }
+}
+pub mod exports {
+    pub mod foo {
+        pub mod foo {
+            #[allow(clippy::all)]
+            pub mod uses_resource_transitively {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type Foo = super::super::super::super::foo::foo::transitive_interface_with_resource::Foo;
+                pub struct Guest {
+                    handle: wasmtime::component::Func,
+                }
+                #[derive(Clone)]
+                pub struct GuestIndices {
+                    handle: wasmtime::component::ComponentExportIndex,
+                }
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "foo:foo/uses-resource-transitively")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `foo:foo/uses-resource-transitively`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `foo:foo/uses-resource-transitively` does \
+                        not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        let handle = lookup("handle")?;
+                        Ok(GuestIndices { handle })
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        let handle = *_instance
+                            .get_typed_func::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >(&mut store, &self.handle)?
+                            .func();
+                        Ok(Guest { handle })
+                    }
+                }
+                impl Guest {
+                    pub fn call_handle<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::Resource<Foo>,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<()>,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (wasmtime::component::Resource<Foo>,),
+                                (),
+                            >::new_unchecked(self.handle)
+                        };
+                        callee.call_concurrent(store.as_context_mut(), (arg0,))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -1,0 +1,378 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `http-interface`.
+///
+/// This structure is created through [`HttpInterfacePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`HttpInterface`] as well.
+pub struct HttpInterfacePre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: HttpInterfaceIndices,
+}
+impl<T: 'static> Clone for HttpInterfacePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> HttpInterfacePre<_T> {
+    /// Creates a new copy of `HttpInterfacePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = HttpInterfaceIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`HttpInterface`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<HttpInterface>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `http-interface`.
+///
+/// This is an implementation detail of [`HttpInterfacePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`HttpInterface`] as well.
+#[derive(Clone)]
+pub struct HttpInterfaceIndices {
+    interface0: exports::http_handler::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `http-interface`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`HttpInterface::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`HttpInterfacePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`HttpInterfacePre::instantiate_async`] to
+///   create a [`HttpInterface`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`HttpInterface::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct HttpInterface {
+    interface0: exports::http_handler::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl HttpInterfaceIndices {
+        /// Creates a new copy of `HttpInterfaceIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            let interface0 = exports::http_handler::GuestIndices::new(_instance_pre)?;
+            Ok(HttpInterfaceIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`HttpInterface`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let _ = &mut store;
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(HttpInterface { interface0 })
+        }
+    }
+    impl HttpInterface {
+        /// Convenience wrapper around [`HttpInterfacePre::new`] and
+        /// [`HttpInterfacePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<HttpInterface>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            HttpInterfacePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`HttpInterfaceIndices::new`] and
+        /// [`HttpInterfaceIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<HttpInterface> {
+            let indices = HttpInterfaceIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: http_fetch::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::http_types::Host + http_fetch::Host + Send,
+            T: 'static + Send,
+        {
+            foo::foo::http_types::add_to_linker::<T, D>(linker, host_getter)?;
+            http_fetch::add_to_linker::<T, D>(linker, host_getter)?;
+            Ok(())
+        }
+        pub fn http_handler(&self) -> &exports::http_handler::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod http_types {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Request {
+                #[component(name = "method")]
+                pub method: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Request {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Request").field("method", &self.method).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(record)]
+            #[derive(Clone)]
+            pub struct Response {
+                #[component(name = "body")]
+                pub body: wasmtime::component::__internal::String,
+            }
+            impl core::fmt::Debug for Response {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    f.debug_struct("Response").field("body", &self.body).finish()
+                }
+            }
+            const _: () = {
+                assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+                assert!(
+                    4 == < Response as wasmtime::component::ComponentType >::ALIGN32
+                );
+            };
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: wasmtime::component::HasData,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/http-types")?;
+                Ok(())
+            }
+        }
+    }
+}
+#[allow(clippy::all)]
+pub mod http_fetch {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::{anyhow, Box};
+    pub type Request = super::foo::foo::http_types::Request;
+    const _: () = {
+        assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    pub type Response = super::foo::foo::http_types::Response;
+    const _: () = {
+        assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+        assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+    };
+    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+    pub trait HostConcurrent: wasmtime::component::HasData + Send {
+        fn fetch_request<T: 'static>(
+            accessor: &mut wasmtime::component::Accessor<T, Self>,
+            request: Request,
+        ) -> impl ::core::future::Future<Output = Response> + Send
+        where
+            Self: Sized;
+    }
+    #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+    pub trait Host: Send {}
+    impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostConcurrent,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        inst.func_wrap_concurrent(
+            "fetch-request",
+            move |caller: &mut wasmtime::component::Accessor<T>, (arg0,): (Request,)| {
+                wasmtime::component::__internal::Box::pin(async move {
+                    let accessor = &mut unsafe { caller.with_data(host_getter) };
+                    let r = <D as HostConcurrent>::fetch_request(accessor, arg0).await;
+                    Ok((r,))
+                })
+            },
+        )?;
+        Ok(())
+    }
+}
+pub mod exports {
+    #[allow(clippy::all)]
+    pub mod http_handler {
+        #[allow(unused_imports)]
+        use wasmtime::component::__internal::{anyhow, Box};
+        pub type Request = super::super::foo::foo::http_types::Request;
+        const _: () = {
+            assert!(8 == < Request as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Request as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub type Response = super::super::foo::foo::http_types::Response;
+        const _: () = {
+            assert!(8 == < Response as wasmtime::component::ComponentType >::SIZE32);
+            assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
+        };
+        pub struct Guest {
+            handle_request: wasmtime::component::Func,
+        }
+        #[derive(Clone)]
+        pub struct GuestIndices {
+            handle_request: wasmtime::component::ComponentExportIndex,
+        }
+        impl GuestIndices {
+            /// Constructor for [`GuestIndices`] which takes a
+            /// [`Component`](wasmtime::component::Component) as input and can be executed
+            /// before instantiation.
+            ///
+            /// This constructor can be used to front-load string lookups to find exports
+            /// within a component.
+            pub fn new<_T>(
+                _instance_pre: &wasmtime::component::InstancePre<_T>,
+            ) -> wasmtime::Result<GuestIndices> {
+                let instance = _instance_pre
+                    .component()
+                    .get_export_index(None, "http-handler")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("no exported instance named `http-handler`")
+                    })?;
+                let mut lookup = move |name| {
+                    _instance_pre
+                        .component()
+                        .get_export_index(Some(&instance), name)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "instance export `http-handler` does \
+            not have export `{name}`"
+                            )
+                        })
+                };
+                let _ = &mut lookup;
+                let handle_request = lookup("handle-request")?;
+                Ok(GuestIndices { handle_request })
+            }
+            pub fn load(
+                &self,
+                mut store: impl wasmtime::AsContextMut,
+                instance: &wasmtime::component::Instance,
+            ) -> wasmtime::Result<Guest> {
+                let _instance = instance;
+                let _instance_pre = _instance.instance_pre(&store);
+                let _instance_type = _instance_pre.instance_type();
+                let mut store = store.as_context_mut();
+                let _ = &mut store;
+                let handle_request = *_instance
+                    .get_typed_func::<
+                        (&Request,),
+                        (Response,),
+                    >(&mut store, &self.handle_request)?
+                    .func();
+                Ok(Guest { handle_request })
+            }
+        }
+        impl Guest {
+            pub fn call_handle_request<S: wasmtime::AsContextMut>(
+                &self,
+                mut store: S,
+                arg0: Request,
+            ) -> impl wasmtime::component::__internal::Future<
+                Output = wasmtime::Result<Response>,
+            > + Send + 'static + use<S>
+            where
+                <S as wasmtime::AsContext>::Data: Send + 'static,
+            {
+                let callee = unsafe {
+                    wasmtime::component::TypedFunc::<
+                        (Request,),
+                        (Response,),
+                    >::new_unchecked(self.handle_request)
+                };
+                wasmtime::component::__internal::FutureExt::map(
+                    callee.call_concurrent(store.as_context_mut(), (arg0,)),
+                    |v| v.map(|(v,)| v),
+                )
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `the-world`.
+/// component which implements the world `my-world`.
 ///
-/// This structure is created through [`TheWorldPre::new`] which
+/// This structure is created through [`MyWorldPre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`TheWorld`] as well.
-pub struct TheWorldPre<T: 'static> {
+/// For more information see [`MyWorld`] as well.
+pub struct MyWorldPre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: TheWorldIndices,
+    indices: MyWorldIndices,
 }
-impl<T: 'static> Clone for TheWorldPre<T> {
+impl<T: 'static> Clone for MyWorldPre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for TheWorldPre<T> {
         }
     }
 }
-impl<_T: 'static> TheWorldPre<_T> {
-    /// Creates a new copy of `TheWorldPre` bindings which can then
+impl<_T: 'static> MyWorldPre<_T> {
+    /// Creates a new copy of `MyWorldPre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = TheWorldIndices::new(&instance_pre)?;
+        let indices = MyWorldIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`TheWorld`] within the
+    /// Instantiates a new instance of [`MyWorld`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> TheWorldPre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<TheWorld>
+    ) -> wasmtime::Result<MyWorld>
     where
         _T: Send,
     {
@@ -56,34 +56,34 @@ impl<_T: 'static> TheWorldPre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `the-world`.
+/// `my-world`.
 ///
-/// This is an implementation detail of [`TheWorldPre`] and can
+/// This is an implementation detail of [`MyWorldPre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`TheWorld`] as well.
+/// For more information see [`MyWorld`] as well.
 #[derive(Clone)]
-pub struct TheWorldIndices {
-    interface0: exports::foo::foo::strings::GuestIndices,
+pub struct MyWorldIndices {
+    interface0: exports::foo::foo::simple_lists::GuestIndices,
 }
 /// Auto-generated bindings for an instance a component which
-/// implements the world `the-world`.
+/// implements the world `my-world`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`TheWorld::instantiate_async`] which only needs a
+///   [`MyWorld::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`TheWorldPre`] ahead of
+/// * Alternatively you can create a [`MyWorldPre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`TheWorldPre::instantiate_async`] to
-///   create a [`TheWorld`].
+///   method then uses [`MyWorldPre::instantiate_async`] to
+///   create a [`MyWorld`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`TheWorld::new`].
+///   then you can use [`MyWorld::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -91,14 +91,14 @@ pub struct TheWorldIndices {
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct TheWorld {
-    interface0: exports::foo::foo::strings::Guest,
+pub struct MyWorld {
+    interface0: exports::foo::foo::simple_lists::Guest,
 }
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl TheWorldIndices {
-        /// Creates a new copy of `TheWorldIndices` bindings which can then
+    impl MyWorldIndices {
+        /// Creates a new copy of `MyWorldIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -108,13 +108,13 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            let interface0 = exports::foo::foo::strings::GuestIndices::new(
+            let interface0 = exports::foo::foo::simple_lists::GuestIndices::new(
                 _instance_pre,
             )?;
-            Ok(TheWorldIndices { interface0 })
+            Ok(MyWorldIndices { interface0 })
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`TheWorld`] from the instance provided.
+        /// of [`MyWorld`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -122,34 +122,34 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
+        ) -> wasmtime::Result<MyWorld> {
             let _ = &mut store;
             let _instance = instance;
             let interface0 = self.interface0.load(&mut store, &_instance)?;
-            Ok(TheWorld { interface0 })
+            Ok(MyWorld { interface0 })
         }
     }
-    impl TheWorld {
-        /// Convenience wrapper around [`TheWorldPre::new`] and
-        /// [`TheWorldPre::instantiate_async`].
+    impl MyWorld {
+        /// Convenience wrapper around [`MyWorldPre::new`] and
+        /// [`MyWorldPre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<TheWorld>
+        ) -> wasmtime::Result<MyWorld>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            TheWorldPre::new(pre)?.instantiate_async(store).await
+            MyWorldPre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`TheWorldIndices::new`] and
-        /// [`TheWorldIndices::load`].
+        /// Convenience wrapper around [`MyWorldIndices::new`] and
+        /// [`MyWorldIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<TheWorld> {
-            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<MyWorld> {
+            let indices = MyWorldIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
         pub fn add_to_linker<T, D>(
@@ -157,14 +157,14 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::strings::HostConcurrent + Send,
-            for<'a> D::Data<'a>: foo::foo::strings::Host + Send,
+            D: foo::foo::simple_lists::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::simple_lists::Host + Send,
             T: 'static + Send,
         {
-            foo::foo::strings::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::simple_lists::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
-        pub fn foo_foo_strings(&self) -> &exports::foo::foo::strings::Guest {
+        pub fn foo_foo_simple_lists(&self) -> &exports::foo::foo::simple_lists::Guest {
             &self.interface0
         }
     }
@@ -172,30 +172,45 @@ const _: () = {
 pub mod foo {
     pub mod foo {
         #[allow(clippy::all)]
-        pub mod strings {
+        pub mod simple_lists {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait HostConcurrent: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn simple_list1<T: 'static>(
                     accessor: &mut wasmtime::component::Accessor<T, Self>,
-                    x: wasmtime::component::__internal::String,
+                    l: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send
                 where
                     Self: Sized;
-                fn b<T: 'static>(
+                fn simple_list2<T: 'static>(
                     accessor: &mut wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
-                    Output = wasmtime::component::__internal::String,
+                    Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send
                 where
                     Self: Sized;
-                fn c<T: 'static>(
+                fn simple_list3<T: 'static>(
                     accessor: &mut wasmtime::component::Accessor<T, Self>,
-                    a: wasmtime::component::__internal::String,
-                    b: wasmtime::component::__internal::String,
+                    a: wasmtime::component::__internal::Vec<u32>,
+                    b: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<
-                    Output = wasmtime::component::__internal::String,
+                    Output = (
+                        wasmtime::component::__internal::Vec<u32>,
+                        wasmtime::component::__internal::Vec<u32>,
+                    ),
+                > + Send
+                where
+                    Self: Sized;
+                fn simple_list4<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    l: wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
+                ) -> impl ::core::future::Future<
+                    Output = wasmtime::component::__internal::Vec<
+                        wasmtime::component::__internal::Vec<u32>,
+                    >,
                 > + Send
                 where
                     Self: Sized;
@@ -212,45 +227,71 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_concurrent(
-                    "a",
+                    "simple-list1",
                     move |
                         caller: &mut wasmtime::component::Accessor<T>,
-                        (arg0,): (wasmtime::component::__internal::String,)|
+                        (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::a(accessor, arg0).await;
+                            let r = <D as HostConcurrent>::simple_list1(accessor, arg0)
+                                .await;
                             Ok(r)
                         })
                     },
                 )?;
                 inst.func_wrap_concurrent(
-                    "b",
+                    "simple-list2",
                     move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::b(accessor).await;
+                            let r = <D as HostConcurrent>::simple_list2(accessor).await;
                             Ok((r,))
                         })
                     },
                 )?;
                 inst.func_wrap_concurrent(
-                    "c",
+                    "simple-list3",
                     move |
                         caller: &mut wasmtime::component::Accessor<T>,
                         (
                             arg0,
                             arg1,
                         ): (
-                            wasmtime::component::__internal::String,
-                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::Vec<u32>,
+                            wasmtime::component::__internal::Vec<u32>,
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
                             let accessor = &mut unsafe { caller.with_data(host_getter) };
-                            let r = <D as HostConcurrent>::c(accessor, arg0, arg1).await;
+                            let r = <D as HostConcurrent>::simple_list3(
+                                    accessor,
+                                    arg0,
+                                    arg1,
+                                )
+                                .await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "simple-list4",
+                    move |
+                        caller: &mut wasmtime::component::Accessor<T>,
+                        (
+                            arg0,
+                        ): (
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        )|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::simple_list4(accessor, arg0)
+                                .await;
                             Ok((r,))
                         })
                     },
@@ -264,19 +305,21 @@ pub mod exports {
     pub mod foo {
         pub mod foo {
             #[allow(clippy::all)]
-            pub mod strings {
+            pub mod simple_lists {
                 #[allow(unused_imports)]
                 use wasmtime::component::__internal::{anyhow, Box};
                 pub struct Guest {
-                    a: wasmtime::component::Func,
-                    b: wasmtime::component::Func,
-                    c: wasmtime::component::Func,
+                    simple_list1: wasmtime::component::Func,
+                    simple_list2: wasmtime::component::Func,
+                    simple_list3: wasmtime::component::Func,
+                    simple_list4: wasmtime::component::Func,
                 }
                 #[derive(Clone)]
                 pub struct GuestIndices {
-                    a: wasmtime::component::ComponentExportIndex,
-                    b: wasmtime::component::ComponentExportIndex,
-                    c: wasmtime::component::ComponentExportIndex,
+                    simple_list1: wasmtime::component::ComponentExportIndex,
+                    simple_list2: wasmtime::component::ComponentExportIndex,
+                    simple_list3: wasmtime::component::ComponentExportIndex,
+                    simple_list4: wasmtime::component::ComponentExportIndex,
                 }
                 impl GuestIndices {
                     /// Constructor for [`GuestIndices`] which takes a
@@ -290,10 +333,10 @@ pub mod exports {
                     ) -> wasmtime::Result<GuestIndices> {
                         let instance = _instance_pre
                             .component()
-                            .get_export_index(None, "foo:foo/strings")
+                            .get_export_index(None, "foo:foo/simple-lists")
                             .ok_or_else(|| {
                                 anyhow::anyhow!(
-                                    "no exported instance named `foo:foo/strings`"
+                                    "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
                         let mut lookup = move |name| {
@@ -302,16 +345,22 @@ pub mod exports {
                                 .get_export_index(Some(&instance), name)
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
-                                        "instance export `foo:foo/strings` does \
+                                        "instance export `foo:foo/simple-lists` does \
                 not have export `{name}`"
                                     )
                                 })
                         };
                         let _ = &mut lookup;
-                        let a = lookup("a")?;
-                        let b = lookup("b")?;
-                        let c = lookup("c")?;
-                        Ok(GuestIndices { a, b, c })
+                        let simple_list1 = lookup("simple-list1")?;
+                        let simple_list2 = lookup("simple-list2")?;
+                        let simple_list3 = lookup("simple-list3")?;
+                        let simple_list4 = lookup("simple-list4")?;
+                        Ok(GuestIndices {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
                     }
                     pub fn load(
                         &self,
@@ -323,29 +372,52 @@ pub mod exports {
                         let _instance_type = _instance_pre.instance_type();
                         let mut store = store.as_context_mut();
                         let _ = &mut store;
-                        let a = *_instance
-                            .get_typed_func::<(&str,), ()>(&mut store, &self.a)?
+                        let simple_list1 = *_instance
+                            .get_typed_func::<
+                                (&[u32],),
+                                (),
+                            >(&mut store, &self.simple_list1)?
                             .func();
-                        let b = *_instance
+                        let simple_list2 = *_instance
                             .get_typed_func::<
                                 (),
-                                (wasmtime::component::__internal::String,),
-                            >(&mut store, &self.b)?
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >(&mut store, &self.simple_list2)?
                             .func();
-                        let c = *_instance
+                        let simple_list3 = *_instance
                             .get_typed_func::<
-                                (&str, &str),
-                                (wasmtime::component::__internal::String,),
-                            >(&mut store, &self.c)?
+                                (&[u32], &[u32]),
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >(&mut store, &self.simple_list3)?
                             .func();
-                        Ok(Guest { a, b, c })
+                        let simple_list4 = *_instance
+                            .get_typed_func::<
+                                (&[wasmtime::component::__internal::Vec<u32>],),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >(&mut store, &self.simple_list4)?
+                            .func();
+                        Ok(Guest {
+                            simple_list1,
+                            simple_list2,
+                            simple_list3,
+                            simple_list4,
+                        })
                     }
                 }
                 impl Guest {
-                    pub fn call_a<S: wasmtime::AsContextMut>(
+                    pub fn call_simple_list1<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                        arg0: wasmtime::component::__internal::String,
+                        arg0: wasmtime::component::__internal::Vec<u32>,
                     ) -> impl wasmtime::component::__internal::Future<
                         Output = wasmtime::Result<()>,
                     > + Send + 'static + use<S>
@@ -354,18 +426,18 @@ pub mod exports {
                     {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
-                                (wasmtime::component::__internal::String,),
+                                (wasmtime::component::__internal::Vec<u32>,),
                                 (),
-                            >::new_unchecked(self.a)
+                            >::new_unchecked(self.simple_list1)
                         };
                         callee.call_concurrent(store.as_context_mut(), (arg0,))
                     }
-                    pub fn call_b<S: wasmtime::AsContextMut>(
+                    pub fn call_simple_list2<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
                     ) -> impl wasmtime::component::__internal::Future<
                         Output = wasmtime::Result<
-                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::Vec<u32>,
                         >,
                     > + Send + 'static + use<S>
                     where
@@ -374,22 +446,25 @@ pub mod exports {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.b)
+                                (wasmtime::component::__internal::Vec<u32>,),
+                            >::new_unchecked(self.simple_list2)
                         };
                         wasmtime::component::__internal::FutureExt::map(
                             callee.call_concurrent(store.as_context_mut(), ()),
                             |v| v.map(|(v,)| v),
                         )
                     }
-                    pub fn call_c<S: wasmtime::AsContextMut>(
+                    pub fn call_simple_list3<S: wasmtime::AsContextMut>(
                         &self,
                         mut store: S,
-                        arg0: wasmtime::component::__internal::String,
-                        arg1: wasmtime::component::__internal::String,
+                        arg0: wasmtime::component::__internal::Vec<u32>,
+                        arg1: wasmtime::component::__internal::Vec<u32>,
                     ) -> impl wasmtime::component::__internal::Future<
                         Output = wasmtime::Result<
-                            wasmtime::component::__internal::String,
+                            (
+                                wasmtime::component::__internal::Vec<u32>,
+                                wasmtime::component::__internal::Vec<u32>,
+                            ),
                         >,
                     > + Send + 'static + use<S>
                     where
@@ -398,14 +473,54 @@ pub mod exports {
                         let callee = unsafe {
                             wasmtime::component::TypedFunc::<
                                 (
-                                    wasmtime::component::__internal::String,
-                                    wasmtime::component::__internal::String,
+                                    wasmtime::component::__internal::Vec<u32>,
+                                    wasmtime::component::__internal::Vec<u32>,
                                 ),
-                                (wasmtime::component::__internal::String,),
-                            >::new_unchecked(self.c)
+                                (
+                                    (
+                                        wasmtime::component::__internal::Vec<u32>,
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    ),
+                                ),
+                            >::new_unchecked(self.simple_list3)
                         };
                         wasmtime::component::__internal::FutureExt::map(
                             callee.call_concurrent(store.as_context_mut(), (arg0, arg1)),
+                            |v| v.map(|(v,)| v),
+                        )
+                    }
+                    pub fn call_simple_list4<S: wasmtime::AsContextMut>(
+                        &self,
+                        mut store: S,
+                        arg0: wasmtime::component::__internal::Vec<
+                            wasmtime::component::__internal::Vec<u32>,
+                        >,
+                    ) -> impl wasmtime::component::__internal::Future<
+                        Output = wasmtime::Result<
+                            wasmtime::component::__internal::Vec<
+                                wasmtime::component::__internal::Vec<u32>,
+                            >,
+                        >,
+                    > + Send + 'static + use<S>
+                    where
+                        <S as wasmtime::AsContext>::Data: Send + 'static,
+                    {
+                        let callee = unsafe {
+                            wasmtime::component::TypedFunc::<
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                                (
+                                    wasmtime::component::__internal::Vec<
+                                        wasmtime::component::__internal::Vec<u32>,
+                                    >,
+                                ),
+                            >::new_unchecked(self.simple_list4)
+                        };
+                        wasmtime::component::__internal::FutureExt::map(
+                            callee.call_concurrent(store.as_context_mut(), (arg0,)),
                             |v| v.map(|(v,)| v),
                         )
                     }

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -48,7 +48,7 @@ impl<_T: 'static> TheWorldPre<_T> {
         mut store: impl wasmtime::AsContextMut<Data = _T>,
     ) -> wasmtime::Result<TheWorld>
     where
-        _T: Send + 'static,
+        _T: Send,
     {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
@@ -136,7 +136,7 @@ const _: () = {
             linker: &wasmtime::component::Linker<_T>,
         ) -> wasmtime::Result<TheWorld>
         where
-            _T: Send + 'static,
+            _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
             TheWorldPre::new(pre)?.instantiate_async(store).await
@@ -213,18 +213,19 @@ pub mod exports {
             }
         }
         impl Guest {
-            pub async fn call_y<S: wasmtime::AsContextMut>(
+            pub fn call_y<S: wasmtime::AsContextMut>(
                 &self,
                 mut store: S,
-            ) -> wasmtime::Result<wasmtime::component::Promise<()>>
+            ) -> impl wasmtime::component::__internal::Future<
+                Output = wasmtime::Result<()>,
+            > + Send + 'static + use<S>
             where
                 <S as wasmtime::AsContext>::Data: Send + 'static,
             {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
                 };
-                let promise = callee.call_concurrent(store.as_context_mut(), ()).await?;
-                Ok(promise)
+                callee.call_concurrent(store.as_context_mut(), ())
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -1,0 +1,496 @@
+/// Link-time configurations.
+#[derive(Clone, Debug, Default)]
+pub struct LinkOptions {
+    experimental_interface: bool,
+    experimental_interface_function: bool,
+    experimental_interface_resource: bool,
+    experimental_interface_resource_method: bool,
+    experimental_world: bool,
+    experimental_world_function_import: bool,
+    experimental_world_interface_import: bool,
+    experimental_world_resource: bool,
+    experimental_world_resource_method: bool,
+}
+impl LinkOptions {
+    /// Enable members marked as `@unstable(feature = experimental-interface)`
+    pub fn experimental_interface(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-function)`
+    pub fn experimental_interface_function(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface_function = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-resource)`
+    pub fn experimental_interface_resource(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_interface_resource = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-interface-resource-method)`
+    pub fn experimental_interface_resource_method(
+        &mut self,
+        enabled: bool,
+    ) -> &mut Self {
+        self.experimental_interface_resource_method = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world)`
+    pub fn experimental_world(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-function-import)`
+    pub fn experimental_world_function_import(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_function_import = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-interface-import)`
+    pub fn experimental_world_interface_import(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_interface_import = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-resource)`
+    pub fn experimental_world_resource(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_resource = enabled;
+        self
+    }
+    /// Enable members marked as `@unstable(feature = experimental-world-resource-method)`
+    pub fn experimental_world_resource_method(&mut self, enabled: bool) -> &mut Self {
+        self.experimental_world_resource_method = enabled;
+        self
+    }
+}
+impl core::convert::From<LinkOptions> for foo::foo::the_interface::LinkOptions {
+    fn from(src: LinkOptions) -> Self {
+        (&src).into()
+    }
+}
+impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions {
+    fn from(src: &LinkOptions) -> Self {
+        let mut dest = Self::default();
+        dest.experimental_interface(src.experimental_interface);
+        dest.experimental_interface_function(src.experimental_interface_function);
+        dest.experimental_interface_resource(src.experimental_interface_resource);
+        dest.experimental_interface_resource_method(
+            src.experimental_interface_resource_method,
+        );
+        dest
+    }
+}
+pub enum Baz {}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait HostBazConcurrent: wasmtime::component::HasData + Send {
+    fn foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+        self_: wasmtime::component::Resource<Baz>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait HostBaz: Send {
+    async fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<Baz>,
+    ) -> wasmtime::Result<()>;
+}
+impl<_T: HostBaz + ?Sized + Send> HostBaz for &mut _T {
+    async fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<Baz>,
+    ) -> wasmtime::Result<()> {
+        HostBaz::drop(*self, rep).await
+    }
+}
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `the-world`.
+///
+/// This structure is created through [`TheWorldPre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`TheWorld`] as well.
+pub struct TheWorldPre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: TheWorldIndices,
+}
+impl<T: 'static> Clone for TheWorldPre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> TheWorldPre<_T> {
+    /// Creates a new copy of `TheWorldPre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = TheWorldIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`TheWorld`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<TheWorld>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `the-world`.
+///
+/// This is an implementation detail of [`TheWorldPre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`TheWorld`] as well.
+#[derive(Clone)]
+pub struct TheWorldIndices {}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `the-world`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`TheWorld::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`TheWorldPre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`TheWorldPre::instantiate_async`] to
+///   create a [`TheWorld`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`TheWorld::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct TheWorld {}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait TheWorldImportsConcurrent: wasmtime::component::HasData + Send + HostBazConcurrent {
+    fn foo<T: 'static>(
+        accessor: &mut wasmtime::component::Accessor<T, Self>,
+    ) -> impl ::core::future::Future<Output = ()> + Send
+    where
+        Self: Sized;
+}
+#[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+pub trait TheWorldImports: Send + HostBaz {}
+impl<_T: TheWorldImports + ?Sized + Send> TheWorldImports for &mut _T {}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl TheWorldIndices {
+        /// Creates a new copy of `TheWorldIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            Ok(TheWorldIndices {})
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`TheWorld`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let _ = &mut store;
+            let _instance = instance;
+            Ok(TheWorld {})
+        }
+    }
+    impl TheWorld {
+        /// Convenience wrapper around [`TheWorldPre::new`] and
+        /// [`TheWorldPre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<TheWorld>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            TheWorldPre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`TheWorldIndices::new`] and
+        /// [`TheWorldIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<TheWorld> {
+            let indices = TheWorldIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn add_to_linker_imports<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            options: &LinkOptions,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: TheWorldImportsConcurrent,
+            for<'a> D::Data<'a>: TheWorldImports,
+            T: 'static + Send,
+        {
+            let mut linker = linker.root();
+            if options.experimental_world {
+                if options.experimental_world_resource {
+                    linker
+                        .resource_async(
+                            "baz",
+                            wasmtime::component::ResourceType::host::<Baz>(),
+                            move |mut store, rep| {
+                                wasmtime::component::__internal::Box::new(async move {
+                                    HostBaz::drop(
+                                            &mut host_getter(store.data_mut()),
+                                            wasmtime::component::Resource::new_own(rep),
+                                        )
+                                        .await
+                                })
+                            },
+                        )?;
+                }
+                if options.experimental_world_function_import {
+                    linker
+                        .func_wrap_concurrent(
+                            "foo",
+                            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                                wasmtime::component::__internal::Box::pin(async move {
+                                    let accessor = &mut unsafe {
+                                        caller.with_data(host_getter)
+                                    };
+                                    let r = <D as TheWorldImportsConcurrent>::foo(accessor)
+                                        .await;
+                                    Ok(r)
+                                })
+                            },
+                        )?;
+                }
+                if options.experimental_world_resource_method {
+                    linker
+                        .func_wrap_concurrent(
+                            "[method]baz.foo",
+                            move |
+                                caller: &mut wasmtime::component::Accessor<T>,
+                                (arg0,): (wasmtime::component::Resource<Baz>,)|
+                            {
+                                wasmtime::component::__internal::Box::pin(async move {
+                                    let accessor = &mut unsafe {
+                                        caller.with_data(host_getter)
+                                    };
+                                    let r = <D as HostBazConcurrent>::foo(accessor, arg0).await;
+                                    Ok(r)
+                                })
+                            },
+                        )?;
+                }
+            }
+            Ok(())
+        }
+        pub fn add_to_linker<T, D>(
+            linker: &mut wasmtime::component::Linker<T>,
+            options: &LinkOptions,
+            host_getter: fn(&mut T) -> D::Data<'_>,
+        ) -> wasmtime::Result<()>
+        where
+            D: foo::foo::the_interface::HostConcurrent + TheWorldImportsConcurrent
+                + Send,
+            for<'a> D::Data<'a>: foo::foo::the_interface::Host + TheWorldImports + Send,
+            T: 'static + Send,
+        {
+            if options.experimental_world {
+                Self::add_to_linker_imports::<T, D>(linker, options, host_getter)?;
+                if options.experimental_world_interface_import {
+                    foo::foo::the_interface::add_to_linker::<
+                        T,
+                        D,
+                    >(linker, &options.into(), host_getter)?;
+                }
+            }
+            Ok(())
+        }
+    }
+};
+pub mod foo {
+    pub mod foo {
+        #[allow(clippy::all)]
+        pub mod the_interface {
+            #[allow(unused_imports)]
+            use wasmtime::component::__internal::{anyhow, Box};
+            /// Link-time configurations.
+            #[derive(Clone, Debug, Default)]
+            pub struct LinkOptions {
+                experimental_interface: bool,
+                experimental_interface_function: bool,
+                experimental_interface_resource: bool,
+                experimental_interface_resource_method: bool,
+            }
+            impl LinkOptions {
+                /// Enable members marked as `@unstable(feature = experimental-interface)`
+                pub fn experimental_interface(&mut self, enabled: bool) -> &mut Self {
+                    self.experimental_interface = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-function)`
+                pub fn experimental_interface_function(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_function = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-resource)`
+                pub fn experimental_interface_resource(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_resource = enabled;
+                    self
+                }
+                /// Enable members marked as `@unstable(feature = experimental-interface-resource-method)`
+                pub fn experimental_interface_resource_method(
+                    &mut self,
+                    enabled: bool,
+                ) -> &mut Self {
+                    self.experimental_interface_resource_method = enabled;
+                    self
+                }
+            }
+            pub enum Bar {}
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostBarConcurrent: wasmtime::component::HasData + Send {
+                fn foo<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                    self_: wasmtime::component::Resource<Bar>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostBar: Send {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()>;
+            }
+            impl<_T: HostBar + ?Sized + Send> HostBar for &mut _T {
+                async fn drop(
+                    &mut self,
+                    rep: wasmtime::component::Resource<Bar>,
+                ) -> wasmtime::Result<()> {
+                    HostBar::drop(*self, rep).await
+                }
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send + HostBarConcurrent {
+                fn foo<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = ()> + Send
+                where
+                    Self: Sized;
+            }
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait Host: Send + HostBar {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostConcurrent,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                if options.experimental_interface {
+                    let mut inst = linker.instance("foo:foo/the-interface")?;
+                    if options.experimental_interface_resource {
+                        inst.resource_async(
+                            "bar",
+                            wasmtime::component::ResourceType::host::<Bar>(),
+                            move |mut store, rep| {
+                                wasmtime::component::__internal::Box::new(async move {
+                                    HostBar::drop(
+                                            &mut host_getter(store.data_mut()),
+                                            wasmtime::component::Resource::new_own(rep),
+                                        )
+                                        .await
+                                })
+                            },
+                        )?;
+                    }
+                    if options.experimental_interface_function {
+                        inst.func_wrap_concurrent(
+                            "foo",
+                            move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                                wasmtime::component::__internal::Box::pin(async move {
+                                    let accessor = &mut unsafe {
+                                        caller.with_data(host_getter)
+                                    };
+                                    let r = <D as HostConcurrent>::foo(accessor).await;
+                                    Ok(r)
+                                })
+                            },
+                        )?;
+                    }
+                    if options.experimental_interface_resource_method {
+                        inst.func_wrap_concurrent(
+                            "[method]bar.foo",
+                            move |
+                                caller: &mut wasmtime::component::Accessor<T>,
+                                (arg0,): (wasmtime::component::Resource<Bar>,)|
+                            {
+                                wasmtime::component::__internal::Box::pin(async move {
+                                    let accessor = &mut unsafe {
+                                        caller.with_data(host_getter)
+                                    };
+                                    let r = <D as HostBarConcurrent>::foo(accessor, arg0).await;
+                                    Ok(r)
+                                })
+                            },
+                        )?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `path2`.
+/// component which implements the world `nope`.
 ///
-/// This structure is created through [`Path2Pre::new`] which
+/// This structure is created through [`NopePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Path2`] as well.
-pub struct Path2Pre<T: 'static> {
+/// For more information see [`Nope`] as well.
+pub struct NopePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: Path2Indices,
+    indices: NopeIndices,
 }
-impl<T: 'static> Clone for Path2Pre<T> {
+impl<T: 'static> Clone for NopePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for Path2Pre<T> {
         }
     }
 }
-impl<_T: 'static> Path2Pre<_T> {
-    /// Creates a new copy of `Path2Pre` bindings which can then
+impl<_T: 'static> NopePre<_T> {
+    /// Creates a new copy of `NopePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = Path2Indices::new(&instance_pre)?;
+        let indices = NopeIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Path2`] within the
+    /// Instantiates a new instance of [`Nope`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,7 +46,7 @@ impl<_T: 'static> Path2Pre<_T> {
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Path2>
+    ) -> wasmtime::Result<Nope>
     where
         _T: Send,
     {
@@ -56,32 +56,32 @@ impl<_T: 'static> Path2Pre<_T> {
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `path2`.
+/// `nope`.
 ///
-/// This is an implementation detail of [`Path2Pre`] and can
+/// This is an implementation detail of [`NopePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Path2`] as well.
+/// For more information see [`Nope`] as well.
 #[derive(Clone)]
-pub struct Path2Indices {}
+pub struct NopeIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `path2`.
+/// implements the world `nope`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Path2::instantiate_async`] which only needs a
+///   [`Nope::instantiate_async`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`Path2Pre`] ahead of
+/// * Alternatively you can create a [`NopePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`Path2Pre::instantiate_async`] to
-///   create a [`Path2`].
+///   method then uses [`NopePre::instantiate_async`] to
+///   create a [`Nope`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Path2::new`].
+///   then you can use [`Nope::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -89,12 +89,12 @@ pub struct Path2Indices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Path2 {}
+pub struct Nope {}
 const _: () = {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::anyhow;
-    impl Path2Indices {
-        /// Creates a new copy of `Path2Indices` bindings which can then
+    impl NopeIndices {
+        /// Creates a new copy of `NopeIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -104,10 +104,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(Path2Indices {})
+            Ok(NopeIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Path2`] from the instance provided.
+        /// of [`Nope`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -115,33 +115,33 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Path2> {
+        ) -> wasmtime::Result<Nope> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(Path2 {})
+            Ok(Nope {})
         }
     }
-    impl Path2 {
-        /// Convenience wrapper around [`Path2Pre::new`] and
-        /// [`Path2Pre::instantiate_async`].
+    impl Nope {
+        /// Convenience wrapper around [`NopePre::new`] and
+        /// [`NopePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Path2>
+        ) -> wasmtime::Result<Nope>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            Path2Pre::new(pre)?.instantiate_async(store).await
+            NopePre::new(pre)?.instantiate_async(store).await
         }
-        /// Convenience wrapper around [`Path2Indices::new`] and
-        /// [`Path2Indices::load`].
+        /// Convenience wrapper around [`NopeIndices::new`] and
+        /// [`NopeIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Path2> {
-            let indices = Path2Indices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Nope> {
+            let indices = NopeIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
         pub fn add_to_linker<T, D>(
@@ -149,21 +149,57 @@ const _: () = {
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: wasmtime::component::HasData,
-            for<'a> D::Data<'a>: paths::path2::test::Host + Send,
+            D: foo::foo::a::HostConcurrent + Send,
+            for<'a> D::Data<'a>: foo::foo::a::Host + Send,
             T: 'static + Send,
         {
-            paths::path2::test::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
             Ok(())
         }
     }
 };
-pub mod paths {
-    pub mod path2 {
+pub mod foo {
+    pub mod foo {
         #[allow(clippy::all)]
-        pub mod test {
+        pub mod a {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
+            #[derive(wasmtime::component::ComponentType)]
+            #[derive(wasmtime::component::Lift)]
+            #[derive(wasmtime::component::Lower)]
+            #[component(variant)]
+            #[derive(Clone)]
+            pub enum Error {
+                #[component(name = "other")]
+                Other(wasmtime::component::__internal::String),
+            }
+            impl core::fmt::Debug for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        Error::Other(e) => {
+                            f.debug_tuple("Error::Other").field(e).finish()
+                        }
+                    }
+                }
+            }
+            impl core::fmt::Display for Error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+            impl core::error::Error for Error {}
+            const _: () = {
+                assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
+                assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
+            };
+            #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
+            pub trait HostConcurrent: wasmtime::component::HasData + Send {
+                fn g<T: 'static>(
+                    accessor: &mut wasmtime::component::Accessor<T, Self>,
+                ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send
+                where
+                    Self: Sized;
+            }
             #[wasmtime::component::__internal::trait_variant_make(::core::marker::Send)]
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
@@ -172,11 +208,21 @@ pub mod paths {
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
-                D: wasmtime::component::HasData,
+                D: HostConcurrent,
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("paths:path2/test")?;
+                let mut inst = linker.instance("foo:foo/a")?;
+                inst.func_wrap_concurrent(
+                    "g",
+                    move |caller: &mut wasmtime::component::Accessor<T>, (): ()| {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let accessor = &mut unsafe { caller.with_data(host_getter) };
+                            let r = <D as HostConcurrent>::g(accessor).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
                 Ok(())
             }
         }

--- a/crates/component-macro/tests/expanded/wat_concurrent.rs
+++ b/crates/component-macro/tests/expanded/wat_concurrent.rs
@@ -1,0 +1,225 @@
+/// Auto-generated bindings for a pre-instantiated version of a
+/// component which implements the world `example`.
+///
+/// This structure is created through [`ExamplePre::new`] which
+/// takes a [`InstancePre`](wasmtime::component::InstancePre) that
+/// has been created through a [`Linker`](wasmtime::component::Linker).
+///
+/// For more information see [`Example`] as well.
+pub struct ExamplePre<T: 'static> {
+    instance_pre: wasmtime::component::InstancePre<T>,
+    indices: ExampleIndices,
+}
+impl<T: 'static> Clone for ExamplePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            instance_pre: self.instance_pre.clone(),
+            indices: self.indices.clone(),
+        }
+    }
+}
+impl<_T: 'static> ExamplePre<_T> {
+    /// Creates a new copy of `ExamplePre` bindings which can then
+    /// be used to instantiate into a particular store.
+    ///
+    /// This method may fail if the component behind `instance_pre`
+    /// does not have the required exports.
+    pub fn new(
+        instance_pre: wasmtime::component::InstancePre<_T>,
+    ) -> wasmtime::Result<Self> {
+        let indices = ExampleIndices::new(&instance_pre)?;
+        Ok(Self { instance_pre, indices })
+    }
+    pub fn engine(&self) -> &wasmtime::Engine {
+        self.instance_pre.engine()
+    }
+    pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
+        &self.instance_pre
+    }
+    /// Instantiates a new instance of [`Example`] within the
+    /// `store` provided.
+    ///
+    /// This function will use `self` as the pre-instantiated
+    /// instance to perform instantiation. Afterwards the preloaded
+    /// indices in `self` are used to lookup all exports on the
+    /// resulting instance.
+    pub async fn instantiate_async(
+        &self,
+        mut store: impl wasmtime::AsContextMut<Data = _T>,
+    ) -> wasmtime::Result<Example>
+    where
+        _T: Send,
+    {
+        let mut store = store.as_context_mut();
+        let instance = self.instance_pre.instantiate_async(&mut store).await?;
+        self.indices.load(&mut store, &instance)
+    }
+}
+/// Auto-generated bindings for index of the exports of
+/// `example`.
+///
+/// This is an implementation detail of [`ExamplePre`] and can
+/// be constructed if needed as well.
+///
+/// For more information see [`Example`] as well.
+#[derive(Clone)]
+pub struct ExampleIndices {
+    interface0: exports::same::name::this_name_is_duplicated::GuestIndices,
+}
+/// Auto-generated bindings for an instance a component which
+/// implements the world `example`.
+///
+/// This structure can be created through a number of means
+/// depending on your requirements and what you have on hand:
+///
+/// * The most convenient way is to use
+///   [`Example::instantiate_async`] which only needs a
+///   [`Store`], [`Component`], and [`Linker`].
+///
+/// * Alternatively you can create a [`ExamplePre`] ahead of
+///   time with a [`Component`] to front-load string lookups
+///   of exports once instead of per-instantiation. This
+///   method then uses [`ExamplePre::instantiate_async`] to
+///   create a [`Example`].
+///
+/// * If you've instantiated the instance yourself already
+///   then you can use [`Example::new`].
+///
+/// These methods are all equivalent to one another and move
+/// around the tradeoff of what work is performed when.
+///
+/// [`Store`]: wasmtime::Store
+/// [`Component`]: wasmtime::component::Component
+/// [`Linker`]: wasmtime::component::Linker
+pub struct Example {
+    interface0: exports::same::name::this_name_is_duplicated::Guest,
+}
+const _: () = {
+    #[allow(unused_imports)]
+    use wasmtime::component::__internal::anyhow;
+    impl ExampleIndices {
+        /// Creates a new copy of `ExampleIndices` bindings which can then
+        /// be used to instantiate into a particular store.
+        ///
+        /// This method may fail if the component does not have the
+        /// required exports.
+        pub fn new<_T>(
+            _instance_pre: &wasmtime::component::InstancePre<_T>,
+        ) -> wasmtime::Result<Self> {
+            let _component = _instance_pre.component();
+            let _instance_type = _instance_pre.instance_type();
+            let interface0 = exports::same::name::this_name_is_duplicated::GuestIndices::new(
+                _instance_pre,
+            )?;
+            Ok(ExampleIndices { interface0 })
+        }
+        /// Uses the indices stored in `self` to load an instance
+        /// of [`Example`] from the instance provided.
+        ///
+        /// Note that at this time this method will additionally
+        /// perform type-checks of all exports.
+        pub fn load(
+            &self,
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let _ = &mut store;
+            let _instance = instance;
+            let interface0 = self.interface0.load(&mut store, &_instance)?;
+            Ok(Example { interface0 })
+        }
+    }
+    impl Example {
+        /// Convenience wrapper around [`ExamplePre::new`] and
+        /// [`ExamplePre::instantiate_async`].
+        pub async fn instantiate_async<_T>(
+            store: impl wasmtime::AsContextMut<Data = _T>,
+            component: &wasmtime::component::Component,
+            linker: &wasmtime::component::Linker<_T>,
+        ) -> wasmtime::Result<Example>
+        where
+            _T: Send,
+        {
+            let pre = linker.instantiate_pre(component)?;
+            ExamplePre::new(pre)?.instantiate_async(store).await
+        }
+        /// Convenience wrapper around [`ExampleIndices::new`] and
+        /// [`ExampleIndices::load`].
+        pub fn new(
+            mut store: impl wasmtime::AsContextMut,
+            instance: &wasmtime::component::Instance,
+        ) -> wasmtime::Result<Example> {
+            let indices = ExampleIndices::new(&instance.instance_pre(&store))?;
+            indices.load(&mut store, instance)
+        }
+        pub fn same_name_this_name_is_duplicated(
+            &self,
+        ) -> &exports::same::name::this_name_is_duplicated::Guest {
+            &self.interface0
+        }
+    }
+};
+pub mod exports {
+    pub mod same {
+        pub mod name {
+            #[allow(clippy::all)]
+            pub mod this_name_is_duplicated {
+                #[allow(unused_imports)]
+                use wasmtime::component::__internal::{anyhow, Box};
+                pub type ThisNameIsDuplicated = wasmtime::component::ResourceAny;
+                pub struct GuestThisNameIsDuplicated<'a> {
+                    funcs: &'a Guest,
+                }
+                pub struct Guest {}
+                #[derive(Clone)]
+                pub struct GuestIndices {}
+                impl GuestIndices {
+                    /// Constructor for [`GuestIndices`] which takes a
+                    /// [`Component`](wasmtime::component::Component) as input and can be executed
+                    /// before instantiation.
+                    ///
+                    /// This constructor can be used to front-load string lookups to find exports
+                    /// within a component.
+                    pub fn new<_T>(
+                        _instance_pre: &wasmtime::component::InstancePre<_T>,
+                    ) -> wasmtime::Result<GuestIndices> {
+                        let instance = _instance_pre
+                            .component()
+                            .get_export_index(None, "same:name/this-name-is-duplicated")
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "no exported instance named `same:name/this-name-is-duplicated`"
+                                )
+                            })?;
+                        let mut lookup = move |name| {
+                            _instance_pre
+                                .component()
+                                .get_export_index(Some(&instance), name)
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "instance export `same:name/this-name-is-duplicated` does \
+                not have export `{name}`"
+                                    )
+                                })
+                        };
+                        let _ = &mut lookup;
+                        Ok(GuestIndices {})
+                    }
+                    pub fn load(
+                        &self,
+                        mut store: impl wasmtime::AsContextMut,
+                        instance: &wasmtime::component::Instance,
+                    ) -> wasmtime::Result<Guest> {
+                        let _instance = instance;
+                        let _instance_pre = _instance.instance_pre(&store);
+                        let _instance_type = _instance_pre.instance_type();
+                        let mut store = store.as_context_mut();
+                        let _ = &mut store;
+                        Ok(Guest {})
+                    }
+                }
+                impl Guest {}
+            }
+        }
+    }
+}

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1,8 +1,9 @@
 use {
     crate::{
         AsContextMut, ValRaw,
+        component::{HasData, HasSelf, Instance},
         store::StoreInner,
-        vm::{VMFuncRef, VMMemoryDefinition, component::ComponentInstance},
+        vm::{VMFuncRef, VMMemoryDefinition, VMStore, component::ComponentInstance},
     },
     anyhow::Result,
     futures::{FutureExt, stream::FuturesUnordered},
@@ -78,6 +79,37 @@ impl<T: 'static> PromisesUnordered<T> {
     /// Get the next result from this collection, if any.
     pub async fn next<U: Send>(&mut self, store: impl AsContextMut<Data = U>) -> Result<Option<T>> {
         _ = store;
+        todo!()
+    }
+}
+
+/// Provides scoped mutable access to store data in the context of a concurrent
+/// host task future.
+///
+/// This allows multiple host task futures to execute concurrently and access
+/// the store between (but not across) `await` points.
+pub struct Accessor<T: 'static, D = HasSelf<T>>
+where
+    D: HasData,
+{
+    #[expect(dead_code, reason = "to be used in the future")]
+    get: fn() -> *mut dyn VMStore,
+    #[expect(dead_code, reason = "to be used in the future")]
+    get_data: fn(&mut T) -> D::Data<'_>,
+    #[expect(dead_code, reason = "to be used in the future")]
+    instance: Instance,
+}
+
+impl<T, D> Accessor<T, D>
+where
+    D: HasData,
+{
+    #[doc(hidden)]
+    pub fn with_data<D2: HasData>(
+        &mut self,
+        get_data: fn(&mut T) -> D2::Data<'_>,
+    ) -> Accessor<T, D2> {
+        let _ = get_data;
         todo!()
     }
 }

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "component-model-async")]
+use crate::component::concurrent::Accessor;
 use crate::component::func::HostFunc;
 use crate::component::instance::RuntimeImport;
 use crate::component::matching::{InstanceType, TypeChecker};
@@ -455,30 +457,21 @@ impl<T: 'static> LinkerInstance<'_, T> {
     /// method because it takes a function which returns a future that owns a
     /// unique reference to the Store, meaning the Store can't be used for
     /// anything else until the future resolves.
-    ///
-    /// Ideally, we'd have a way to thread a `StoreContextMut<T>` through an
-    /// arbitrary `Future` such that it has access to the `Store` only while
-    /// being polled (i.e. between, but not across, await points). However,
-    /// there's currently no way to express that in async Rust, so we make do
-    /// with a more awkward scheme: each function registered using
-    /// `func_wrap_concurrent` gets access to the `Store` twice: once before
-    /// doing any concurrent operations (i.e. before awaiting) and once
-    /// afterward. This allows multiple calls to proceed concurrently without
-    /// any one of them monopolizing the store.
     #[cfg(feature = "component-model-async")]
-    pub fn func_wrap_concurrent<Params, Return, F, N, FN>(&mut self, name: &str, f: F) -> Result<()>
+    pub fn func_wrap_concurrent<Params, Return, F>(&mut self, name: &str, f: F) -> Result<()>
     where
-        N: FnOnce(StoreContextMut<T>) -> Result<Return> + Send + Sync + 'static,
-        FN: Future<Output = N> + Send + Sync + 'static,
-        F: Fn(StoreContextMut<T>, Params) -> FN + Send + Sync + 'static,
-        Params: ComponentNamedList + Lift + 'static,
+        T: 'static,
+        F: for<'a> Fn(
+                &'a mut Accessor<T>,
+                Params,
+            ) -> Pin<Box<dyn Future<Output = Result<Return>> + Send + 'a>>
+            + Send
+            + Sync
+            + 'static,
+        Params: ComponentNamedList + Lift + Send + Sync + 'static,
         Return: ComponentNamedList + Lower + Send + Sync + 'static,
     {
-        assert!(
-            self.engine.config().async_support,
-            "cannot use `func_wrap_concurrent` without enabling async support in the config"
-        );
-        _ = (name, f);
+        let _ = (name, f);
         todo!()
     }
 

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -117,7 +117,8 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    ErrorContext, FutureReader, Promise, PromisesUnordered, StreamReader, VMComponentAsyncStore,
+    Accessor, ErrorContext, FutureReader, Promise, PromisesUnordered, StreamReader,
+    VMComponentAsyncStore,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
@@ -156,7 +157,10 @@ pub mod __internal {
     pub use alloc::vec::Vec;
     pub use anyhow;
     pub use core::cell::RefCell;
+    pub use core::future::Future;
     pub use core::mem::transmute;
+    #[cfg(feature = "component-model-async")]
+    pub use futures::future::FutureExt;
     #[cfg(feature = "async")]
     pub use trait_variant::make as trait_variant_make;
     pub use wasmtime_environ;

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -176,12 +176,12 @@ pub trait RustGenerator<'a> {
             TypeDefKind::Future(ty) => {
                 let wt = self.wasmtime_path();
                 let t = self.optional_ty(ty.as_ref(), TypeMode::Owned);
-                format!("{wt}::component::FutureReader<{t}>")
+                format!("{wt}::component::HostFuture<{t}>")
             }
             TypeDefKind::Stream(ty) => {
                 let wt = self.wasmtime_path();
                 let t = self.optional_ty(ty.as_ref(), TypeMode::Owned);
-                format!("{wt}::component::StreamReader<{t}>")
+                format!("{wt}::component::HostStream<{t}>")
             }
             TypeDefKind::Handle(handle) => self.handle(handle),
             TypeDefKind::Resource => unreachable!(),
@@ -234,7 +234,7 @@ pub trait RustGenerator<'a> {
     }
     fn stream(&self, ty: Option<&Type>) -> String {
         let wt = self.wasmtime_path();
-        let mut out = format!("{wt}::component::StreamReader<");
+        let mut out = format!("{wt}::component::HostStream<");
         out.push_str(&self.optional_ty(ty, TypeMode::Owned));
         out.push_str(">");
         out
@@ -245,7 +245,7 @@ pub trait RustGenerator<'a> {
     }
     fn future(&self, ty: Option<&Type>) -> String {
         let wt = self.wasmtime_path();
-        let mut out = format!("{wt}::component::FutureReader<");
+        let mut out = format!("{wt}::component::HostFuture<");
         out.push_str(&self.optional_ty(ty, TypeMode::Owned));
         out.push_str(">");
         out


### PR DESCRIPTION
This commit re-enables tests for bindings generation for concurrent
calls in the main repo after all syncs have now finished with wasip3.
This additionally adds some skeleton APIs that the bindings generator
uses which are necessary to get tests passing.