### PR TITLE
Fix ASAN in combination with throw intrinsic

### DIFF
--- a/crates/unwinder/build.rs
+++ b/crates/unwinder/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    // NB: duplicating a workaround in the wasmtime-fiber build script.
+    custom_cfg("asan", cfg_is("sanitize", "address"));
+}
+
+fn cfg_is(key: &str, val: &str) -> bool {
+    std::env::var(&format!("CARGO_CFG_{}", key.to_uppercase()))
+        .ok()
+        .as_deref()
+        == Some(val)
+}
+
+fn custom_cfg(key: &str, enabled: bool) {
+    println!("cargo:rustc-check-cfg=cfg({key})");
+    if enabled {
+        println!("cargo:rustc-cfg={key}");
+    }
+}

--- a/crates/unwinder/src/arch/mod.rs
+++ b/crates/unwinder/src/arch/mod.rs
@@ -88,7 +88,9 @@ cfg_if::cfg_if! {
                     __asan_handle_no_return();
                 }
             }
-            imp::resume_to_exception_handler(pc, sp, fp, payload1, payload2)
+            unsafe {
+                imp::resume_to_exception_handler(pc, sp, fp, payload1, payload2)
+            }
         }
 
         /// Get the return address in the function at the next-older

--- a/crates/unwinder/src/arch/mod.rs
+++ b/crates/unwinder/src/arch/mod.rs
@@ -61,7 +61,35 @@ cfg_if::cfg_if! {
         /// - The Rust frames between the unwind destination and this
         ///   frame to be unwind-safe: that is, they cannot have `Drop`
         ///   handlers for which safety requires that they run.
-        pub use imp::resume_to_exception_handler;
+        pub unsafe fn resume_to_exception_handler(
+            pc: usize,
+            sp: usize,
+            fp: usize,
+            payload1: usize,
+            payload2: usize,
+        ) -> ! {
+            // Without this ASAN seems to nondeterministically trigger an
+            // internal assertion when running tests with threads. Not entirely
+            // clear what's going on here but it seems related to the fact that
+            // there's Rust code on the stack which is never cleaned up due to
+            // the jump out of `imp::resume_to_exception_handler`.
+            //
+            // This function is documented as something that should be called to
+            // clean up the entire thread's shadow memory and stack which isn't
+            // exactly what we want but this at least seems to resolve ASAN
+            // issues for now. Probably a heavy hammer but better than false
+            // positives I suppose...
+            #[cfg(asan)]
+            {
+                unsafe extern "C" {
+                    fn __asan_handle_no_return();
+                }
+                unsafe {
+                    __asan_handle_no_return();
+                }
+            }
+            imp::resume_to_exception_handler(pc, sp, fp, payload1, payload2)
+        }
 
         /// Get the return address in the function at the next-older
         /// frame from the given FP.


### PR DESCRIPTION
Prior to this commit locally I would see a nondeterministic crash when executing:

    RUSTFLAGS=-Zsanitizer=address \
      cargo +nightly run --release test filetests

The crash has a scary-looking internal assertion within the ASAN runtime itself and local debugging seems to show that threads are required to reproduce this and it's nondeterministic. I don't know why CI is currently passing on all PRs when this is failing so frequently for myself locally.

In any case it seems like there's a magical ASAN intrinsic to call before `noreturn` things which I think is intended for thread-stopping events which isn't a great fit for exceptions here but it seems to resolve the crash.

Basically I have no idea why things crash locally, what this new function does, nor why it fixes things. I am but a slave to the CI gods in an attempt to make it so our CI is more reliable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
