### PR TITLE
Cranelift: `or(x, C) + (-C)  -->  and(x, ~C)`

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -197,6 +197,11 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn i64_not(&mut self, x: i64) -> i64 {
+            !x
+        }
+
+        #[inline]
         fn u64_eq(&mut self, x: u64, y: u64) -> bool {
             x == y
         }

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -232,3 +232,11 @@
       (fcvt_from_uint ty val))
 (rule (simplify (fcvt_from_sint ty (sextend _ val)))
       (fcvt_from_sint ty val))
+
+
+(rule
+  (simplify (iadd ty
+              (bor ty x (iconst_s ty n))
+              (iconst_s ty m)))
+  (if-let m (i64_neg n))
+  (band ty x (iconst ty (imm64_masked ty (u64_not (i64_as_u64 n))))))

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -234,6 +234,7 @@
       (fcvt_from_sint ty val))
 
 
+;; or(x, C) + (-C)  -->  and(x, ~C)
 (rule
   (simplify (iadd ty
               (bor ty x (iconst_s ty n))

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -239,4 +239,4 @@
               (bor ty x (iconst_s ty n))
               (iconst_s ty m)))
   (if-let m (i64_neg n))
-  (band ty x (iconst ty (imm64_masked ty (u64_not (i64_as_u64 n))))))
+  (band ty x (iconst ty (imm64_masked ty (i64_as_u64 (i64_not n))))))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -273,6 +273,9 @@
 (decl pure u64_not (u64) u64)
 (extern constructor u64_not u64_not)
 
+(decl pure i64_not (i64) i64)
+(extern constructor i64_not i64_not)
+
 (decl pure u64_eq (u64 u64) bool)
 (extern constructor u64_eq u64_eq)
 

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -366,3 +366,17 @@ block0(v0: i16, v1: i16, v2: i16):
 ; check: v12 = iadd v0, v1
 ; check: v15 = iadd v12, v2
 ; check: return v15
+
+;; or(x, C) + (-C)  -->  and(x, ~C)
+;; Example: or(x, 123) + -123  -->  and(x, -124)
+function %or_add_to_and(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 123
+    v2 = bor v0, v1
+    v3 = iconst.i32 -123
+    v4 = iadd v2, v3
+    return v4
+    ; check: v5 = iconst.i32 -124
+    ; check: v6 = band v0, v5
+    ; check: return v6
+}

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -143,104 +143,107 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq $0xb0, %rsp
-;   movq    %rbx, 128(%rsp)
-;   movq    %r12, 136(%rsp)
-;   movq    %r13, 144(%rsp)
-;   movq    %r14, 152(%rsp)
-;   movq    %r15, 160(%rsp)
+;   subq $0xc0, %rsp
+;   movq    %rbx, 144(%rsp)
+;   movq    %r12, 152(%rsp)
+;   movq    %r13, 160(%rsp)
+;   movq    %r14, 168(%rsp)
+;   movq    %r15, 176(%rsp)
 ; block0:
 ;   movq (%rdi), %r8
-;   movq    %r8, rsp(16 + virtual offset)
+;   movq    %r8, rsp(136 + virtual offset)
 ;   movq 8(%rdi), %r8
-;   movq    %r8, rsp(8 + virtual offset)
+;   movq    %r8, rsp(16 + virtual offset)
 ;   movq 0x10(%rdi), %r8
-;   movq    %r8, rsp(120 + virtual offset)
+;   movq    %r8, rsp(128 + virtual offset)
 ;   movq 0x18(%rdi), %r8
-;   movq    %r8, rsp(112 + virtual offset)
+;   movq    %r8, rsp(120 + virtual offset)
 ;   movq 0x20(%rdi), %r8
-;   movq    %r8, rsp(104 + virtual offset)
+;   movq    %r8, rsp(112 + virtual offset)
 ;   movq 0x28(%rdi), %r8
-;   movq    %r8, rsp(96 + virtual offset)
+;   movq    %r8, rsp(104 + virtual offset)
 ;   movq 0x30(%rdi), %r8
-;   movq    %r8, rsp(88 + virtual offset)
+;   movq    %r8, rsp(96 + virtual offset)
 ;   movq 0x38(%rdi), %r8
-;   movq    %r8, rsp(80 + virtual offset)
+;   movq    %r8, rsp(88 + virtual offset)
 ;   movq 0x40(%rdi), %r8
-;   movq    %r8, rsp(72 + virtual offset)
+;   movq    %r8, rsp(80 + virtual offset)
 ;   movq 0x48(%rdi), %r8
-;   movq    %r8, rsp(64 + virtual offset)
+;   movq    %r8, rsp(72 + virtual offset)
 ;   movq 0x50(%rdi), %r8
-;   movq    %r8, rsp(56 + virtual offset)
+;   movq    %r8, rsp(64 + virtual offset)
 ;   movq 0x58(%rdi), %r8
-;   movq    %r8, rsp(48 + virtual offset)
+;   movq    %r8, rsp(56 + virtual offset)
 ;   movq 0x60(%rdi), %r8
-;   movq    %r8, rsp(40 + virtual offset)
+;   movq    %r8, rsp(48 + virtual offset)
 ;   movq 0x68(%rdi), %r8
-;   movq    %r8, rsp(32 + virtual offset)
+;   movq    %r8, rsp(40 + virtual offset)
 ;   movq 0x70(%rdi), %r8
 ;   movq    %rdi, rsp(0 + virtual offset)
-;   movq    %r8, rsp(24 + virtual offset)
+;   movq    %r8, rsp(32 + virtual offset)
 ;   uninit  %rdi
 ;   xorq %rdi, %rdi
 ;   %rdi = stack_switch_basic %rsi, %rsi, %rdi
-;   movq <offset:1>+0x10(%rsp), %r8
+;   movq <offset:1>+0x88(%rsp), %r8
+;   movq    %rdi, rsp(24 + virtual offset)
 ;   movq (%r8), %r9
-;   movq <offset:1>+8(%rsp), %r8
-;   movq    %r9, rsp(16 + virtual offset)
+;   movq <offset:1>+0x10(%rsp), %r8
+;   movq    %r9, rsp(8 + virtual offset)
+;   movq (%r8), %r10
+;   movq <offset:1>+0x80(%rsp), %r8
+;   movq    %r10, rsp(16 + virtual offset)
 ;   movq (%r8), %r10
 ;   movq <offset:1>+0x78(%rsp), %r8
-;   movq    %r10, rsp(8 + virtual offset)
 ;   movq (%r8), %r11
 ;   movq <offset:1>+0x70(%rsp), %r8
-;   movq (%r8), %r10
+;   movq (%r8), %rsi
 ;   movq <offset:1>+0x68(%rsp), %r8
 ;   movq (%r8), %rax
 ;   movq <offset:1>+0x60(%rsp), %r8
-;   movq (%r8), %rcx
-;   movq <offset:1>+0x58(%rsp), %r8
-;   movq (%r8), %rdx
-;   movq <offset:1>+0x50(%rsp), %r8
 ;   movq (%r8), %rbx
-;   movq <offset:1>+0x48(%rsp), %r8
-;   movq (%r8), %r14
-;   movq <offset:1>+0x40(%rsp), %r8
+;   movq <offset:1>+0x58(%rsp), %r8
 ;   movq (%r8), %r12
-;   movq <offset:1>+0x38(%rsp), %r8
+;   movq <offset:1>+0x50(%rsp), %r8
+;   movq (%r8), %r14
+;   movq <offset:1>+0x48(%rsp), %r8
 ;   movq (%r8), %r15
-;   movq <offset:1>+0x30(%rsp), %r8
-;   movq (%r8), %r13
-;   movq <offset:1>+0x28(%rsp), %r8
+;   movq <offset:1>+0x40(%rsp), %r8
 ;   movq (%r8), %r8
-;   movq <offset:1>+0x20(%rsp), %r9
-;   movq (%r9), %rsi
-;   movq    %rdi, %r9
-;   movq <offset:1>+0x10(%rsp), %rdi
+;   movq <offset:1>+0x38(%rsp), %r9
+;   movq (%r9), %rcx
+;   movq <offset:1>+0x30(%rsp), %rdi
+;   movq (%rdi), %r13
+;   movq <offset:1>+0x28(%rsp), %rdx
+;   movq (%rdx), %rdx
+;   movq <offset:1>+8(%rsp), %rdi
+;   movq <offset:1>+0x18(%rsp), %r9
 ;   lea     0(%r9,%rdi,1), %rdi
-;   movq <offset:1>+8(%rsp), %r9
-;   lea     0(%r9,%r11,1), %r9
-;   lea     0(%rdi,%r9,1), %r9
-;   lea     0(%r10,%rax,1), %r10
-;   lea     0(%rcx,%rdx,1), %r11
-;   lea     0(%rbx,%r14,1), %rdi
-;   lea     0(%r11,%rdi,1), %r11
-;   lea     0(%r12,%r15,1), %rdi
-;   lea     0(%r11,%rdi,1), %r11
-;   lea     0(%r13,%r8,1), %r8
+;   movq <offset:1>+0x10(%rsp), %r9
+;   movq    %rdi, rsp(8 + virtual offset)
+;   lea     0(%r9,%r10,1), %r9
+;   lea     0(%r11,%rsi,1), %r10
+;   lea     0(%rax,%rbx,1), %r11
+;   lea     0(%r12,%r14,1), %rsi
+;   lea     0(%r15,%r8,1), %r8
+;   lea     0(%rsi,%r8,1), %r8
 ;   lea     0(%r11,%r8,1), %r8
 ;   lea     0(%r10,%r8,1), %r8
-;   lea     0(%r9,%r8,1), %r8
-;   movq <offset:1>+0x18(%rsp), %r9
-;   addq (%r9), %rsi
+;   lea     0(%rcx,%r13,1), %r10
+;   movq <offset:1>+0x20(%rsp), %rcx
+;   addq (%rcx), %rdx
 ;   movq <offset:1>+(%rsp), %rdi
-;   lea     0(%rsi,%rdi,1), %r9
-;   lea     0(%r8,%r9,1), %rax
-;   movq 0x80(%rsp), %rbx
-;   movq 0x88(%rsp), %r12
-;   movq 0x90(%rsp), %r13
-;   movq 0x98(%rsp), %r14
-;   movq 0xa0(%rsp), %r15
-;   addq $0xb0, %rsp
+;   lea     0(%rdx,%rdi,1), %r11
+;   lea     0(%r10,%r11,1), %r10
+;   lea     0(%r8,%r10,1), %r8
+;   lea     0(%r9,%r8,1), %r8
+;   movq <offset:1>+8(%rsp), %r9
+;   lea     0(%r9,%r8,1), %rax
+;   movq 0x90(%rsp), %rbx
+;   movq 0x98(%rsp), %r12
+;   movq 0xa0(%rsp), %r13
+;   movq 0xa8(%rsp), %r14
+;   movq 0xb0(%rsp), %r15
+;   addq $0xc0, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -249,44 +252,44 @@ block0(v0: i64, v1: i64):
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0xb0, %rsp
-;   movq %rbx, 0x80(%rsp)
-;   movq %r12, 0x88(%rsp)
-;   movq %r13, 0x90(%rsp)
-;   movq %r14, 0x98(%rsp)
-;   movq %r15, 0xa0(%rsp)
+;   subq $0xc0, %rsp
+;   movq %rbx, 0x90(%rsp)
+;   movq %r12, 0x98(%rsp)
+;   movq %r13, 0xa0(%rsp)
+;   movq %r14, 0xa8(%rsp)
+;   movq %r15, 0xb0(%rsp)
 ; block1: ; offset 0x33
 ;   movq (%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x10(%rsp)
+;   movq %r8, 0x88(%rsp)
 ;   movq 8(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 8(%rsp)
+;   movq %r8, 0x10(%rsp)
 ;   movq 0x10(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x78(%rsp)
+;   movq %r8, 0x80(%rsp)
 ;   movq 0x18(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x70(%rsp)
+;   movq %r8, 0x78(%rsp)
 ;   movq 0x20(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x68(%rsp)
+;   movq %r8, 0x70(%rsp)
 ;   movq 0x28(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x60(%rsp)
+;   movq %r8, 0x68(%rsp)
 ;   movq 0x30(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x58(%rsp)
+;   movq %r8, 0x60(%rsp)
 ;   movq 0x38(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x50(%rsp)
+;   movq %r8, 0x58(%rsp)
 ;   movq 0x40(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x48(%rsp)
+;   movq %r8, 0x50(%rsp)
 ;   movq 0x48(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x40(%rsp)
+;   movq %r8, 0x48(%rsp)
 ;   movq 0x50(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x38(%rsp)
+;   movq %r8, 0x40(%rsp)
 ;   movq 0x58(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x30(%rsp)
+;   movq %r8, 0x38(%rsp)
 ;   movq 0x60(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x28(%rsp)
+;   movq %r8, 0x30(%rsp)
 ;   movq 0x68(%rdi), %r8 ; trap: heap_oob
-;   movq %r8, 0x20(%rsp)
+;   movq %r8, 0x28(%rsp)
 ;   movq 0x70(%rdi), %r8 ; trap: heap_oob
 ;   movq %rdi, (%rsp)
-;   movq %r8, 0x18(%rsp)
+;   movq %r8, 0x20(%rsp)
 ;   xorq %rdi, %rdi
 ;   movq (%rsi), %rax
 ;   movq %rsp, (%rsi)
@@ -298,63 +301,66 @@ block0(v0: i64, v1: i64):
 ;   leaq 6(%rip), %rcx
 ;   movq %rcx, 0x10(%rsi)
 ;   jmpq *%rax
-;   movq 0x10(%rsp), %r8
+;   movq 0x88(%rsp), %r8
+;   movq %rdi, 0x18(%rsp)
 ;   movq (%r8), %r9 ; trap: heap_oob
-;   movq 8(%rsp), %r8
-;   movq %r9, 0x10(%rsp)
+;   movq 0x10(%rsp), %r8
+;   movq %r9, 8(%rsp)
+;   movq (%r8), %r10 ; trap: heap_oob
+;   movq 0x80(%rsp), %r8
+;   movq %r10, 0x10(%rsp)
 ;   movq (%r8), %r10 ; trap: heap_oob
 ;   movq 0x78(%rsp), %r8
-;   movq %r10, 8(%rsp)
 ;   movq (%r8), %r11 ; trap: heap_oob
 ;   movq 0x70(%rsp), %r8
-;   movq (%r8), %r10 ; trap: heap_oob
+;   movq (%r8), %rsi ; trap: heap_oob
 ;   movq 0x68(%rsp), %r8
 ;   movq (%r8), %rax ; trap: heap_oob
 ;   movq 0x60(%rsp), %r8
-;   movq (%r8), %rcx ; trap: heap_oob
-;   movq 0x58(%rsp), %r8
-;   movq (%r8), %rdx ; trap: heap_oob
-;   movq 0x50(%rsp), %r8
 ;   movq (%r8), %rbx ; trap: heap_oob
-;   movq 0x48(%rsp), %r8
-;   movq (%r8), %r14 ; trap: heap_oob
-;   movq 0x40(%rsp), %r8
+;   movq 0x58(%rsp), %r8
 ;   movq (%r8), %r12 ; trap: heap_oob
-;   movq 0x38(%rsp), %r8
+;   movq 0x50(%rsp), %r8
+;   movq (%r8), %r14 ; trap: heap_oob
+;   movq 0x48(%rsp), %r8
 ;   movq (%r8), %r15 ; trap: heap_oob
-;   movq 0x30(%rsp), %r8
-;   movq (%r8), %r13 ; trap: heap_oob
-;   movq 0x28(%rsp), %r8
+;   movq 0x40(%rsp), %r8
 ;   movq (%r8), %r8 ; trap: heap_oob
-;   movq 0x20(%rsp), %r9
-;   movq (%r9), %rsi ; trap: heap_oob
-;   movq %rdi, %r9
-;   movq 0x10(%rsp), %rdi
+;   movq 0x38(%rsp), %r9
+;   movq (%r9), %rcx ; trap: heap_oob
+;   movq 0x30(%rsp), %rdi
+;   movq (%rdi), %r13 ; trap: heap_oob
+;   movq 0x28(%rsp), %rdx
+;   movq (%rdx), %rdx ; trap: heap_oob
+;   movq 8(%rsp), %rdi
+;   movq 0x18(%rsp), %r9
 ;   addq %r9, %rdi
-;   movq 8(%rsp), %r9
-;   addq %r11, %r9
-;   addq %rdi, %r9
-;   addq %rax, %r10
-;   leaq (%rcx, %rdx), %r11
-;   leaq (%rbx, %r14), %rdi
-;   addq %rdi, %r11
-;   leaq (%r12, %r15), %rdi
-;   addq %rdi, %r11
-;   addq %r13, %r8
+;   movq 0x10(%rsp), %r9
+;   movq %rdi, 8(%rsp)
+;   addq %r10, %r9
+;   leaq (%r11, %rsi), %r10
+;   leaq (%rax, %rbx), %r11
+;   leaq (%r12, %r14), %rsi
+;   addq %r15, %r8
+;   addq %rsi, %r8
 ;   addq %r11, %r8
 ;   addq %r10, %r8
-;   addq %r9, %r8
-;   movq 0x18(%rsp), %r9
-;   addq (%r9), %rsi ; trap: heap_oob
+;   leaq (%rcx, %r13), %r10
+;   movq 0x20(%rsp), %rcx
+;   addq (%rcx), %rdx ; trap: heap_oob
 ;   movq (%rsp), %rdi
-;   leaq (%rsi, %rdi), %r9
-;   leaq (%r8, %r9), %rax
-;   movq 0x80(%rsp), %rbx
-;   movq 0x88(%rsp), %r12
-;   movq 0x90(%rsp), %r13
-;   movq 0x98(%rsp), %r14
-;   movq 0xa0(%rsp), %r15
-;   addq $0xb0, %rsp
+;   leaq (%rdx, %rdi), %r11
+;   addq %r11, %r10
+;   addq %r10, %r8
+;   addq %r9, %r8
+;   movq 8(%rsp), %r9
+;   leaq (%r9, %r8), %rax
+;   movq 0x90(%rsp), %rbx
+;   movq 0x98(%rsp), %r12
+;   movq 0xa0(%rsp), %r13
+;   movq 0xa8(%rsp), %r14
+;   movq 0xb0(%rsp), %r15
+;   addq $0xc0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This add `or(x, C) + (-C)  -->  and(x, ~C)`


<details>
<summary>proof.isle</summary>

```
(rule
  (simplify (iadd ty
              (bor ty x (iconst_s ty n))
              (iconst_s ty m)))
  (if-let m (i64_neg n))
  (band ty x (iconst ty (imm64_masked ty (i64_as_u64 (i64_not n))))))

(form
  bv_unary_8_to_64
  ((args (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args (bv 64)) (ret (bv 64)) (canon (bv 64)))
)

(form
  bv_binary_8_to_64
  ((args (bv  8) (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args (bv 16) (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args (bv 32) (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args (bv 64) (bv 64)) (ret (bv 64)) (canon (bv 64)))
)

(form
  bv_ternary_8_to_64
  ((args (bv  8) (bv  8) (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args (bv 16) (bv 16) (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args (bv 32) (bv 32) (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args (bv 64) (bv 64) (bv 64)) (ret (bv 64)) (canon (bv 64)))
)


(form
  bv_ty_unary_8_to_64
  ((args Int (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args Int (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args Int (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args Int (bv 64)) (ret (bv 64)) (canon (bv 64)))
)

(form
  bv_ty_binary_8_to_64
  ((args Int (bv  8) (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args Int (bv 16) (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args Int (bv 32) (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args Int (bv 64) (bv 64)) (ret (bv 64)) (canon (bv 64)))
)

(form
  bv_ty_ternary_8_to_64
  ((args Int (bv  8) (bv  8) (bv  8)) (ret (bv  8)) (canon (bv  8)))
  ((args Int (bv 16) (bv 16) (bv 16)) (ret (bv 16)) (canon (bv 16)))
  ((args Int (bv 32) (bv 32) (bv 32)) (ret (bv 32)) (canon (bv 32)))
  ((args Int (bv 64) (bv 64) (bv 64)) (ret (bv 64)) (canon (bv 64)))
)

(type Type (primitive Type))
(type Value (primitive Value))
(type Imm64 (primitive Imm64))
(type Inst (primitive Inst))
(type SkeletonInstSimplification (primitive SkeletonInstSimplification))
(type IntCC extern
    (enum
        Equal
        NotEqual
        SignedGreaterThan
        SignedGreaterThanOrEqual
        SignedLessThan
        SignedLessThanOrEqual
        UnsignedGreaterThan
        UnsignedGreaterThanOrEqual
        UnsignedLessThan
        UnsignedLessThanOrEqual))
                    
(model IntCC (enum
    (Equal #x00)
    (NotEqual #x01)
    (SignedGreaterThan #x02)
    (SignedGreaterThanOrEqual #x03)
    (SignedLessThan #x04)
    (SignedLessThanOrEqual #x05)
    (UnsignedGreaterThan #x06)
    (UnsignedGreaterThanOrEqual #x07)
    (UnsignedLessThan #x08)
    (UnsignedLessThanOrEqual #x09)))


(spec (bor ty x y)
    (provide (= (bvor x y) result))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl bor (Type Value Value) Value)
(extern extractor bor bor)
(extern constructor bor bor)
(instantiate bor bv_ty_binary_8_to_64)

(spec (band ty x y)
    (provide (= (bvand x y) result))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl band (Type Value Value) Value)
(extern extractor band band)
(extern constructor band band)
(instantiate band bv_ty_binary_8_to_64)

(spec (bxor ty x y)
    (provide (= (bvxor x y) result))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl bxor (Type Value Value) Value)
(extern extractor bxor bxor)
(extern constructor bxor bxor)
(instantiate bxor bv_ty_binary_8_to_64)

(spec (sshr ty x y)
    (provide
        (= result
           (bvashr x
                  (bvand (conv_to (widthof y) (bvsub (int2bv 64 (widthof y))
                                                     #x0000000000000001))
                         y))))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl sshr (Type Value Value) Value)
(extern extractor sshr sshr)
(extern constructor sshr sshr)
(instantiate sshr bv_ty_binary_8_to_64)

(spec (ushr ty x y)
    (provide
        (= result
           (bvlshr x
                  (bvand (conv_to (widthof y) (bvsub (int2bv 64 (widthof y))
                                                     #x0000000000000001))
                         y))))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl ushr (Type Value Value) Value)
(extern extractor ushr ushr)
(extern constructor ushr ushr)
(instantiate ushr bv_ty_binary_8_to_64)

(spec (iadd ty x y)
    (provide (= result (bvadd x y)))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl iadd (Type Value Value) Value)
(extern extractor iadd iadd)
(extern constructor iadd iadd)
(instantiate iadd bv_ty_binary_8_to_64)

(spec (isub ty x y)
    (provide (= result (bvsub x y)))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl isub (Type Value Value) Value)
(extern extractor isub isub)
(extern constructor isub isub)
(instantiate isub bv_ty_binary_8_to_64)

(spec (imul ty x y)
    (provide (= result (bvmul x y)))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl imul (Type Value Value) Value)
(extern extractor imul imul)
(extern constructor imul imul)
(instantiate imul bv_ty_binary_8_to_64)

(spec (iabs ty x)
    (provide (= result
                (if (bvsge x (conv_to (widthof x) #x0000000000000000))
                    x
                    (bvneg x))))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x))))
(decl iabs (Type Value) Value)
(extern extractor iabs iabs)
(extern constructor iabs iabs)
(instantiate iabs bv_ty_unary_8_to_64)


; s &:= y \pmod B,
; a &:= x \cdot 2^s \pmod{2^B}.
(spec (ishl ty x y)
    (provide
        (= result
           (bvshl x
                  (bvand (conv_to (widthof y) (bvsub (int2bv 64 (widthof y))
                                                     #x0000000000000001))
                         y))))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl ishl (Type Value Value) Value)
(extern extractor ishl ishl)
(extern constructor ishl ishl)
(instantiate ishl bv_ty_binary_8_to_64)

(spec (select ty c x y)
    (provide (= result (if (= c #x00) y x)))
    (require
        (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))
        (= ty (widthof x)) (= ty (widthof y))))
(decl select (Type Value Value Value) Value)
(extern extractor select select)
(extern constructor select select)
(instantiate select bv_ty_ternary_8_to_64)

(spec (icmp ty cc x y)
    (provide
        (= result
            (switch cc
                ((IntCC.Equal)                        (if (= x y)       #x01 #x00))
                ((IntCC.NotEqual)                     (if (not (= x y)) #x01 #x00))
                ((IntCC.SignedGreaterThan)            (if (bvsgt x y)   #x01 #x00))
                ((IntCC.SignedGreaterThanOrEqual)     (if (bvsge x y)   #x01 #x00))
                ((IntCC.SignedLessThan)               (if (bvslt x y)   #x01 #x00))
                ((IntCC.SignedLessThanOrEqual)        (if (bvsle x y)   #x01 #x00))
                ((IntCC.UnsignedGreaterThan)          (if (bvugt x y)   #x01 #x00))
                ((IntCC.UnsignedGreaterThanOrEqual)   (if (bvuge x y)   #x01 #x00))
                ((IntCC.UnsignedLessThan)             (if (bvult x y)   #x01 #x00))
                ((IntCC.UnsignedLessThanOrEqual)      (if (bvule x y)   #x01 #x00)))))
    (require
        (= ty 8)
        (or (= 8 (widthof x)) (= 16 (widthof x)) (= 32 (widthof x)) (= 64 (widthof x)))
        (or
            (= cc (IntCC.Equal))
            (= cc (IntCC.NotEqual))
            (= cc (IntCC.UnsignedGreaterThanOrEqual))
            (= cc (IntCC.UnsignedGreaterThan))
            (= cc (IntCC.UnsignedLessThanOrEqual))
            (= cc (IntCC.UnsignedLessThan))
            (= cc (IntCC.SignedGreaterThanOrEqual))
            (= cc (IntCC.SignedGreaterThan))
            (= cc (IntCC.SignedLessThanOrEqual))
            (= cc (IntCC.SignedLessThan)))))

(decl icmp (Type IntCC Value Value) Value)
(extern extractor icmp icmp)
(extern constructor icmp icmp)
(instantiate icmp
  ((args Int (bv 8) (bv 8) (bv 8)) (ret (bv 8)) (canon (bv 8)))
  ((args Int (bv 8) (bv 16) (bv 16)) (ret (bv 8)) (canon (bv 16)))
  ((args Int (bv 8) (bv 32) (bv 32)) (ret (bv 8)) (canon (bv 32)))
  ((args Int (bv 8) (bv 64) (bv 64)) (ret (bv 8)) (canon (bv 64)))
)

(spec (iconst ty arg)
    (provide (= arg (zero_ext ty result)))
    (require (or (= ty 8) (= ty 16) (= ty 32) (= ty 64))))
(decl iconst (Type Imm64) Value)
(extern constructor iconst iconst)
(extern extractor iconst iconst)
(instantiate iconst bv_ty_unary_8_to_64)

(spec (u64_zero) (provide (= #x0000000000000000 result)))
(decl u64_zero () u64)
(extern extractor u64_zero u64_zero)

(spec (u64_nonzero arg) (provide (= result arg)) (require (bvsgt arg #x0000000000000000)))
(decl u64_nonzero (u64) u64)
(extern extractor u64_nonzero u64_nonzero)

(spec (u64_from_imm64 arg) (provide (= arg result)))
(decl u64_from_imm64 (u64) Imm64)
(extern extractor u64_from_imm64 u64_from_imm64)

(spec (nonzero_u64_from_imm64 arg) (provide (= arg result)) (require (bvsgt arg #x0000000000000000)))
(decl nonzero_u64_from_imm64 (u64) Imm64)
(extern extractor nonzero_u64_from_imm64 nonzero_u64_from_imm64)

(spec (i64_as_u64 arg) (provide (= arg result)))
(decl pure i64_as_u64 (i64) u64)
(extern constructor i64_as_u64 i64_as_u64)

(spec (i64_neg x) (provide (= result (bvneg x))))
(decl pure i64_neg (i64) i64)
(extern constructor i64_neg i64_neg)

(spec (i64_not arg) (provide (= (bvnot arg) result)))
(decl pure i64_not (i64) i64)
(extern constructor i64_not i64_not)

(spec (u64_not arg) (provide (= (bvnot arg) result)))
(decl pure u64_not (u64) u64)
(extern constructor u64_not u64_not)

(spec (u64_add x y) (provide (= (bvadd x y) result)))
(decl pure u64_add (u64 u64) u64)
(extern constructor u64_add u64_add)

(spec (u64_and x y) (provide (= (bvand x y) result)))
(decl pure u64_and (u64 u64) u64)
(extern constructor u64_and u64_and)

(spec (u64_or x y) (provide (= (bvor x y) result)))
(decl pure u64_or (u64 u64) u64)
(extern constructor u64_or u64_or)
                    
(spec (u64_sub x y) (provide (= (bvsub x y) result)))
(decl pure u64_sub (u64 u64) u64)
(extern constructor u64_sub u64_sub)

(spec (u64_xor x y) (provide (= (bvxor x y) result)))
(decl pure u64_xor (u64 u64) u64)
(extern constructor u64_xor u64_xor)

(spec (u64_udiv x y)
    (provide (= result (bvudiv x y))))
(decl pure partial u64_udiv (u64 u64) u64)
(extern constructor u64_udiv u64_udiv)

(spec (u64_eq x y)
      (provide (= result (if (= x y) true false))))
(decl pure u64_eq (u64 u64) bool)
(extern constructor u64_eq u64_eq)

(spec (u64_le x y)
      (provide (= result (if (bvule x y) true false))))
(decl pure u64_le (u64 u64) bool)
(extern constructor u64_le u64_le)

(spec (u64_lt x y)
      (provide (= result (if (bvult x y) true false))))
(decl pure u64_lt (u64 u64) bool)
(extern constructor u64_lt u64_lt)

(spec (u64_shl x y)
      (provide (= result (bvshl x y))))
(decl pure u64_shl (u64 u64) u64)
(extern constructor u64_shl u64_shl)

(spec (u64_rem x y)
      (provide (= result (bvurem x y)))
      (require
        (not (= y (zero_ext (widthof y) #b0)))))
(decl pure partial u64_rem (u64 u64) u64)
(extern constructor u64_rem u64_rem)

(spec (u64_is_odd x)
      (provide (= result (if (= (bvand x #x0000000000000001) #x0000000000000001) true false))))
(decl pure u64_is_odd (u64) bool)
(extern constructor u64_is_odd u64_is_odd)

(spec (imm64 x) (provide (= x result)))
(decl imm64 (u64) Imm64)
(extern constructor imm64 imm64)
                    
(spec (imm64_masked ty x) (provide (= (conv_to ty x) result)))
(decl imm64_masked (Type u64) Imm64)
(extern constructor imm64_masked imm64_masked)

(spec (imm64_power_of_two x)
  (provide (= result (bvshl #x0000000000000001 x)))
  (require
    (bvsgt x #x0000000000000000)
    (bvule x #x000000000000003e)
    (= (bvand x (bvsub x #x0000000000000001)) #x0000000000000000)))
(decl imm64_power_of_two (u64) Imm64)
(extern extractor imm64_power_of_two imm64_power_of_two)

(spec (fits_in_64 ty)
    (provide (= result ty))
    (require (<= ty 64)))
(decl fits_in_64 (Type) Type)
(extern extractor fits_in_64 fits_in_64)

(spec (ty_bits_u64 ty)
    (provide (= result (int2bv 64 ty))))
(decl pure ty_bits_u64 (Type) u64)
(extern constructor ty_bits_u64 ty_bits_u64)


(spec (udiv x y)
    (provide (= result (bvudiv x y)))
    (require (not (= y (zero_ext (widthof y) #b0)))))
(decl udiv (Value Value) Inst)
(extern extractor udiv udiv)
(instantiate udiv bv_binary_8_to_64)

(spec (sdiv x y)
    (provide (= result (bvsdiv x y)))
    (require (not (= y (zero_ext (widthof y) #b0)))))
(decl sdiv (Value Value) Inst)
(extern extractor sdiv sdiv)
(extern constructor sdiv sdiv)
(instantiate sdiv bv_binary_8_to_64)

(spec (urem x y)
    (provide (= result (bvurem x y)))
    (require (not (= y (zero_ext (widthof y) #b0)))))
(decl urem (Value Value) Inst)
(extern extractor urem urem)
(extern constructor urem urem)
(instantiate urem bv_binary_8_to_64)

(spec (srem x y)
    (provide (= result (bvsrem x y)))
    (require (not (= y (zero_ext (widthof y) #b0)))))
(decl srem (Value Value) Inst)
(extern extractor srem srem)
(extern constructor srem srem)
(instantiate srem bv_binary_8_to_64)

(spec (subsume x) (provide (= result x)))
(decl subsume (Value) Value)
(extern constructor subsume subsume)


(spec (iconst_u ty arg)
    (provide (= arg (zero_ext 64 result))))
(decl iconst_u (Type u64) Value)
(extern extractor iconst_u iconst_u)
(instantiate iconst_u
    ((args (bv 64)) (ret (bv 8)) (canon (bv 8)))
    ((args (bv 64)) (ret (bv 16)) (canon (bv 16)))
    ((args (bv 64)) (ret (bv 32)) (canon (bv 32)))
    ((args (bv 64)) (ret (bv 64)) (canon (bv 64))))

(spec (iconst_s ty arg)
    (provide (= arg (sign_ext 64 result))))
(decl iconst_s (Type i64) Value)
(extern extractor iconst_s iconst_s)
(instantiate iconst_s
    ((args (bv 64)) (ret (bv 8)) (canon (bv 8)))
    ((args (bv 64)) (ret (bv 16)) (canon (bv 16)))
    ((args (bv 64)) (ret (bv 32)) (canon (bv 32)))
    ((args (bv 64)) (ret (bv 64)) (canon (bv 64))))(decl simplify (Value) Value)
(spec (simplify x) (provide (= x result)))
(instantiate simplify
    ((args (bv  8)) (ret (bv  8)) (canon (bv 8)))
    ((args (bv 16)) (ret (bv 16)) (canon (bv 16)))
    ((args (bv 32)) (ret (bv 32)) (canon (bv 32)))
    ((args (bv 64)) (ret (bv 64)) (canon (bv 64))))
```
</details>