### PR TITLE
Disable disas tests in QEMU-emulated architectures

### DIFF
--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     // why. Finally QEMU-emulating these tests is relatively slow and without
     // much benefit from emulation it's hard to justify this. In the end disable
     // this test suite when QEMU is enabled.
-    if env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
+    if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());
     }
 


### PR DESCRIPTION
I'm not sure why it's getting stuck in CI but it's occasionally getting stuck in CI and causing runners to time out. #10980 is the most recent version of this but it was seen a number of times last week as well. In an attempt to make things less flaky and also scope down the breadth of testing to only what's necessary this just goes ahead and disables testing in QEMU for the `disas` test suite.

Closes #10980

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
