### PR TITLE
Enable clippy's `redundant_field_names` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ unnecessary_fallible_conversions = 'warn'
 unnecessary_cast = 'warn'
 allow_attributes_without_reason = 'warn'
 from_over_into = 'warn'
+redundant_field_names = 'warn'
 
 [workspace.dependencies]
 # Public crates related to Wasmtime.

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -84,7 +84,7 @@ impl SpanningTree {
 
         self.nodes.push(SpanningTreeNode {
             block: block.into(),
-            ancestor: ancestor,
+            ancestor,
             label: pre_number,
             semi: pre_number,
             idom: ancestor,

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1445,13 +1445,13 @@ impl AtomicOP {
         let mut insts = SmallInstVec::new();
         insts.push(Inst::AluRRR {
             alu_op: AluOPRRR::Srl,
-            rd: rd,
+            rd,
             rs1: rs,
             rs2: offset,
         });
         //
         insts.push(Inst::Extend {
-            rd: rd,
+            rd,
             rn: rd.to_reg(),
             signed: false,
             from_bits: ty.bits() as u8,
@@ -1471,13 +1471,13 @@ impl AtomicOP {
         let mut insts = SmallInstVec::new();
         insts.push(Inst::AluRRR {
             alu_op: AluOPRRR::Srl,
-            rd: rd,
+            rd,
             rs1: rs,
             rs2: offset,
         });
         //
         insts.push(Inst::Extend {
-            rd: rd,
+            rd,
             rn: rd.to_reg(),
             signed: true,
             from_bits: ty.bits() as u8,
@@ -1504,7 +1504,7 @@ impl AtomicOP {
         insts.push(Inst::construct_bit_not(tmp, tmp.to_reg()));
         insts.push(Inst::AluRRR {
             alu_op: AluOPRRR::And,
-            rd: rd,
+            rd,
             rs1: rd.to_reg(),
             rs2: tmp.to_reg(),
         });
@@ -1536,7 +1536,7 @@ impl AtomicOP {
         });
         insts.push(Inst::AluRRR {
             alu_op: AluOPRRR::Or,
-            rd: rd,
+            rd,
             rs1: rd.to_reg(),
             rs2: tmp.to_reg(),
         });

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -114,7 +114,7 @@ impl Inst {
             I32 | I16 => {
                 insts.push(Inst::load_imm12(rd, Imm12::from_i16(-1)));
                 insts.push(Inst::Extend {
-                    rd: rd,
+                    rd,
                     rn: rd.to_reg(),
                     signed: false,
                     from_bits: ty.bits() as u8,
@@ -1328,7 +1328,7 @@ impl Inst {
                 match rm.class() {
                     RegClass::Int => Inst::AluRRImm12 {
                         alu_op: AluOPRRI::Addi,
-                        rd: rd,
+                        rd,
                         rs: rm,
                         imm12: Imm12::ZERO,
                     },
@@ -1336,7 +1336,7 @@ impl Inst {
                         alu_op: FpuOPRRR::Fsgnj,
                         width: FpuOPWidth::try_from(ty).unwrap(),
                         frm: FRM::RNE,
-                        rd: rd,
+                        rd,
                         rs1: rm,
                         rs2: rm,
                     },
@@ -2009,7 +2009,7 @@ impl Inst {
                     // Get the current PC.
                     sink.add_reloc(Reloc::RiscvGotHi20, &**name, 0);
                     Inst::Auipc {
-                        rd: rd,
+                        rd,
                         imm: Imm20::from_i32(0),
                     }
                     .emit_uncompressed(sink, emit_info, state, start_off);
@@ -2080,7 +2080,7 @@ impl Inst {
                 // Get the current PC.
                 sink.add_reloc(Reloc::RiscvTlsGdHi20, &**name, 0);
                 Inst::Auipc {
-                    rd: rd,
+                    rd,
                     imm: Imm20::from_i32(0),
                 }
                 .emit_uncompressed(sink, emit_info, state, start_off);
@@ -2089,7 +2089,7 @@ impl Inst {
                 sink.add_reloc(Reloc::RiscvPCRelLo12I, &auipc_label, 0);
                 Inst::AluRRImm12 {
                     alu_op: AluOPRRI::Addi,
-                    rd: rd,
+                    rd,
                     rs: rd.to_reg(),
                     imm12: Imm12::from_i16(0),
                 }
@@ -2137,7 +2137,7 @@ impl Inst {
                 .emit(sink, emit_info, state);
                 // load.
                 Inst::Load {
-                    rd: rd,
+                    rd,
                     op: LoadOP::from_type(ty),
                     flags: MemFlags::new(),
                     from: AMode::RegOffset(p, 0),
@@ -2399,7 +2399,7 @@ impl Inst {
                     .emit(sink, emit_info, state);
                     Inst::AluRRR {
                         alu_op: AluOPRRR::Or,
-                        rd: rd,
+                        rd,
                         rs1: rd.to_reg(),
                         rs2: tmp2.to_reg(),
                     }

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -193,8 +193,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
             .accumulate_tail_args_size(callee_pop_size);
 
         Box::new(ReturnCallInfo {
-            dest: dest,
-            uses: uses,
+            dest,
+            uses,
             callee_pop_size,
         })
     }

--- a/cranelift/codegen/src/isa/unwind/winarm64.rs
+++ b/cranelift/codegen/src/isa/unwind/winarm64.rs
@@ -239,7 +239,7 @@ pub(crate) fn create_unwind_info_from_insts(
                         })
                     }
                     LARGE_STACK_ALLOC_MIN..=LARGE_STACK_ALLOC_MAX => {
-                        unwind_codes.push(UnwindCode::AllocL { size: size })
+                        unwind_codes.push(UnwindCode::AllocL { size })
                     }
                     _ => panic!("Stack allocation size too large"),
                 }

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -402,7 +402,7 @@ impl<'a> Parser<'a> {
         };
 
         Ok(Spec {
-            term: term,
+            term,
             args,
             provides,
             requires,

--- a/crates/test-programs/src/sockets.rs
+++ b/crates/test-programs/src/sockets.rs
@@ -313,11 +313,11 @@ impl IpSocketAddress {
     pub const fn new(ip: IpAddress, port: u16) -> IpSocketAddress {
         match ip {
             IpAddress::Ipv4(addr) => IpSocketAddress::Ipv4(Ipv4SocketAddress {
-                port: port,
+                port,
                 address: addr,
             }),
             IpAddress::Ipv6(addr) => IpSocketAddress::Ipv6(Ipv6SocketAddress {
-                port: port,
+                port,
                 address: addr,
                 flow_info: 0,
                 scope_id: 0,

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -356,7 +356,7 @@ impl Variant {
             .cases
             .iter()
             .map(|(name, ty)| Case {
-                name: name,
+                name,
                 ty: ty.as_ref().map(|ty| Type::from(ty, &self.0.instance())),
             })
     }

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -59,10 +59,7 @@ impl<'a> records::Records for WasiCtx<'a> {
         first: GuestPtr<i32>,
         second: GuestPtr<i32>,
     ) -> Result<types::PairIntPtrs, types::Errno> {
-        Ok(types::PairIntPtrs {
-            first: first,
-            second: second,
-        })
+        Ok(types::PairIntPtrs { first, second })
     }
 
     fn sum_array(

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -1073,7 +1073,7 @@ impl Assembler {
 
     fn fpu_round(&mut self, op: FpuRoundMode, rn: Reg, rd: WritableReg) {
         self.emit(Inst::FpuRound {
-            op: op,
+            op,
             rd: rd.map(Into::into),
             rn: rn.into(),
         });


### PR DESCRIPTION
Seems like a clear enough improvement and also something useful to have a lint for as refactorings enable/disable this pattern over time, so this should help us stay consistent.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
