### PR TITLE
Simplify some assembly in the unwinder crate

### DIFF
--- a/crates/unwinder/src/arch/aarch64.rs
+++ b/crates/unwinder/src/arch/aarch64.rs
@@ -57,22 +57,16 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mov x0, {}",
-            "mov x1, {}",
             "mov sp, {}",
             "mov fp, {}",
             "br {}",
-            in(reg) payload1,
-            in(reg) payload2,
             in(reg) sp,
             in(reg) fp,
             in(reg) pc,
-            out("x0") _,
-            out("x1") _,
-            options(nostack, nomem),
+            in("x0") payload1,
+            in("x1") payload2,
+            options(nostack, nomem, noreturn),
         );
-
-        core::hint::unreachable_unchecked()
     }
 }
 

--- a/crates/unwinder/src/arch/riscv64.rs
+++ b/crates/unwinder/src/arch/riscv64.rs
@@ -26,22 +26,16 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mv a0, {}",
-            "mv a1, {}",
             "mv sp, {}",
             "mv fp, {}",
             "jr {}",
-            in(reg) payload1,
-            in(reg) payload2,
             in(reg) sp,
             in(reg) fp,
             in(reg) pc,
-            out("a0") _,
-            out("a1") _,
-            options(nostack, nomem),
+            in("a0") payload1,
+            in("a1") payload2,
+            options(nostack, nomem, noreturn),
         );
-
-        core::hint::unreachable_unchecked()
     }
 }
 

--- a/crates/unwinder/src/arch/x86.rs
+++ b/crates/unwinder/src/arch/x86.rs
@@ -29,22 +29,16 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mov rax, {}",
-            "mov rdx, {}",
             "mov rsp, {}",
             "mov rbp, {}",
             "jmp {}",
-            in(reg) payload1,
-            in(reg) payload2,
             in(reg) sp,
             in(reg) fp,
             in(reg) pc,
-            out("rax") _,
-            out("rdx") _,
-            options(nostack, nomem),
+            in("rax") payload1,
+            in("rdx") payload2,
+            options(nostack, nomem, noreturn),
         );
-
-        core::hint::unreachable_unchecked()
     }
 }
 


### PR DESCRIPTION
This was split out of #10960 after some CI issues. The simplification of s390x is split to #10973 to show its failure but otherwise these changes aren't expected to cause any issues (yet). Part of enabling this was in #10974 where ASAN showed some issues as well.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
