### PR TITLE
Cranelift: Rewrite conditional branches to unconditional traps into conditional traps during legalization

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -168,13 +168,13 @@ impl Context {
             self.func.display()
         );
 
-        self.compute_cfg();
         if isa.flags().enable_nan_canonicalization() {
             self.canonicalize_nans(isa)?;
         }
 
         self.legalize(isa)?;
 
+        self.compute_cfg();
         self.compute_domtree();
         self.eliminate_unreachable_code(isa)?;
         self.remove_constant_phis(isa)?;
@@ -291,6 +291,7 @@ impl Context {
         // TODO: Avoid doing this when legalization doesn't actually mutate the CFG.
         self.domtree.clear();
         self.loop_analysis.clear();
+        self.cfg.clear();
 
         // Run some specific legalizations only.
         simple_legalize(&mut self.func, isa);

--- a/cranelift/codegen/src/ir/layout.rs
+++ b/cranelift/codegen/src/ir/layout.rs
@@ -516,6 +516,12 @@ impl Layout {
         }
     }
 
+    /// Does the given block contain exactly one instruction?
+    pub fn block_contains_exactly_one_inst(&self, block: Block) -> bool {
+        let block = &self.blocks[block];
+        block.first_inst.is_some() && block.first_inst == block.last_inst
+    }
+
     /// Split the block containing `before` in two.
     ///
     /// Insert `new_block` after the old block and move `before` and the following instructions to

--- a/cranelift/codegen/src/legalizer/branch_to_trap.rs
+++ b/cranelift/codegen/src/legalizer/branch_to_trap.rs
@@ -1,0 +1,86 @@
+//! Rewrite branch-to-unconditional-trap into conditional trap instructions.
+//!
+//! Given this instruction:
+//!
+//! ```clif
+//! brif v0, block1, block2
+//! ```
+//!
+//! If we know that `block1` does nothing but immediately trap then we can
+//! rewrite that `brif` into the following:
+//!
+//! ```clif
+//! trapz v0, <trapcode>
+//! jump block2
+//! ```
+//!
+//! (And we can do the equivalent with `trapz` if `block2` immediately traps).
+//!
+//! This transformation allows for the conditional trap instructions to be GVN'd
+//! and for our egraphs mid-end to generally better optimize the program. We
+//! additionally have better codegen in our backends for `trapz` than branches
+//! to unconditional traps.
+
+use super::*;
+
+#[derive(Default)]
+pub struct BranchToTrap {
+    /// The set of blocks that contain exactly one unconditional trap
+    /// instruction.
+    just_trap_blocks: EntitySet<ir::Block>,
+}
+
+impl BranchToTrap {
+    /// Analyze the given block.
+    ///
+    /// The `block` must be terminated by a `trap` instruction.
+    pub fn analyze_trapping_block(&mut self, func: &ir::Function, block: ir::Block) {
+        if func.layout.block_contains_exactly_one_inst(block) {
+            self.just_trap_blocks.insert(block);
+        }
+    }
+
+    fn just_trap_block_code(&self, func: &ir::Function, block: ir::Block) -> ir::TrapCode {
+        debug_assert!(self.just_trap_blocks.contains(block));
+        debug_assert!(func.layout.block_contains_exactly_one_inst(block));
+        let inst = func.layout.first_inst(block).unwrap();
+        match func.dfg.insts[inst] {
+            InstructionData::Trap { code, .. } => code,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Process a `brif` instruction, potentially performing our rewrite.
+    ///
+    /// The `inst` must be a `brif` containing the given `arg` and `blocks`.
+    pub fn process_brif(
+        &self,
+        func: &mut ir::Function,
+        inst: ir::Inst,
+        arg: ir::Value,
+        blocks: [ir::BlockCall; 2],
+    ) {
+        let consequent = blocks[0].block(&func.dfg.value_lists);
+        let alternative = blocks[1].block(&func.dfg.value_lists);
+
+        if self.just_trap_blocks.contains(consequent) {
+            let mut pos = FuncCursor::new(func);
+            pos.goto_inst(inst);
+
+            let code = self.just_trap_block_code(pos.func, consequent);
+            pos.ins().trapnz(arg, code);
+
+            let args: SmallVec<[_; 8]> = blocks[1].args(&pos.func.dfg.value_lists).collect();
+            pos.func.dfg.replace(inst).jump(alternative, &args);
+        } else if self.just_trap_blocks.contains(alternative) {
+            let mut pos = FuncCursor::new(func);
+            pos.goto_inst(inst);
+
+            let code = self.just_trap_block_code(pos.func, alternative);
+            pos.ins().trapz(arg, code);
+
+            let args: SmallVec<[_; 8]> = blocks[0].args(&pos.func.dfg.value_lists).collect();
+            pos.func.dfg.replace(inst).jump(consequent, &args);
+        }
+    }
+}

--- a/cranelift/filetests/filetests/egraph/misc.clif
+++ b/cranelift/filetests/filetests/egraph/misc.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ; check: function %stack_load(i64) -> i64 fast {
 ; nextln:    ss0 = explicit_slot 8
 ; check:  block0(v0: i64):
-; nextln:     v2 = stack_addr.i64 ss0
-; nextln:     store notrap v0, v2
+; nextln:     v3 = stack_addr.i64 ss0
+; nextln:     store notrap v0, v3
 ; nextln:     return v0
 ; nextln: }

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -638,15 +638,12 @@ block202:
 ;   ucomiss const(1), %xmm0
 ;   jp,nz   label2; j label1
 ; block1:
-;   jmp     label5
+;   jmp     label3
 ; block2:
 ;   ucomiss const(0), %xmm0
-;   jnp     label4; j label3
+;   jnp #trap=heap_oob
+;   jmp     label3
 ; block3:
-;   jmp     label5
-; block4:
-;   ud2 heap_oob
-; block5:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -658,16 +655,15 @@ block202:
 ; block1: ; offset 0x4
 ;   ucomiss 0x25(%rip), %xmm0
 ;   jp 0x17
-;   je 0x26
+;   je 0x24
 ; block2: ; offset 0x17
 ;   ucomiss 0x22(%rip), %xmm0
-;   jp 0x26
+;   jnp 0x29
 ; block3: ; offset 0x24
-;   ud2 ; trap: heap_oob
-; block4: ; offset 0x26
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+;   ud2 ; trap: heap_oob
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)

--- a/cranelift/filetests/filetests/legalizer/branch-to-unconditional-trap.clif
+++ b/cranelift/filetests/filetests/legalizer/branch-to-unconditional-trap.clif
@@ -1,0 +1,41 @@
+test legalizer
+target aarch64
+
+function %trapnz(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    brif v0, block1, block2(v1)
+block1:
+    trap user42
+block2(v2: i64):
+    return v2
+}
+
+; check:  block0(v0: i64, v1: i64):
+; nextln:     trapnz v0, user42
+; nextln:     jump block2(v1)
+
+function %trapz(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    brif v0, block1(v1), block2
+block1(v2: i64):
+    return v2
+block2:
+    trap user42
+}
+
+; check:  block0(v0: i64, v1: i64):
+; nextln:     trapz v0, user42
+; nextln:     jump block1(v1)
+
+function %could_be_either_doesnt_matter(i64) -> i64 {
+block0(v0: i64):
+    brif v0, block1, block2
+block1:
+    trap user36
+block2:
+    trap user42
+}
+
+; check:  block0(v0: i64):
+; nextln:     trapnz v0, user36
+; nextln:     jump block2

--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -25,10 +25,8 @@
 ;; @0021                               v3 = iconst.i32 4
 ;; @0023                               v4 = iconst.i32 4
 ;; @0025                               v5 = isub v3, v4  ; v3 = 4, v4 = 4
-;; @002a                               brif v5, block2, block4
-;;
-;;                                 block2:
-;; @002c                               trap user11
+;;                                     trapnz v5, user11
+;; @002a                               jump block4
 ;;
 ;;                                 block4:
 ;; @002e                               v6 = iconst.i32 6

--- a/tests/disas/component-model/enum.wat
+++ b/tests/disas/component-model/enum.wat
@@ -50,34 +50,31 @@
 ;; @0061                               v3 = iconst.i32 0
 ;; @0068                               v8 = icmp eq v7, v3  ; v3 = 0
 ;; @0068                               v9 = uextend.i32 v8
-;; @0069                               brif v9, block2, block3
-;;
-;;                                 block2:
-;; @006b                               trap user11
+;;                                     trapnz v9, user11
+;; @0069                               jump block3
 ;;
 ;;                                 block3:
 ;; @006d                               v10 = load.i64 notrap aligned readonly can_move v0+80
 ;; @006d                               v11 = load.i32 notrap aligned table v10
 ;; @006f                               v12 = iconst.i32 2
 ;; @0071                               v13 = band v11, v12  ; v12 = 2
-;;                                     v82 = iconst.i32 0
-;;                                     v83 = icmp eq v13, v82  ; v82 = 0
-;; @0072                               v15 = uextend.i32 v83
-;; @0073                               brif v15, block4, block5
-;;
-;;                                 block4:
-;; @0075                               trap user11
+;;                                     v80 = iconst.i32 0
+;;                                     v81 = icmp eq v13, v80  ; v80 = 0
+;; @0072                               v15 = uextend.i32 v81
+;;                                     trapnz v15, user11
+;; @0073                               jump block5
 ;;
 ;;                                 block5:
+;; @0077                               v17 = load.i32 notrap aligned table v10
 ;; @0079                               v18 = iconst.i32 -3
-;; @007b                               v19 = band.i32 v11, v18  ; v18 = -3
+;; @007b                               v19 = band v17, v18  ; v18 = -3
 ;; @007c                               store notrap aligned table v19, v10
 ;;                                     v70 = iconst.i32 -4
-;;                                     v76 = band.i32 v11, v70  ; v70 = -4
+;;                                     v76 = band v17, v70  ; v70 = -4
 ;; @0083                               store notrap aligned table v76, v10
-;;                                     v84 = iconst.i32 1
-;;                                     v85 = bor v19, v84  ; v84 = 1
-;; @008a                               store notrap aligned table v85, v10
+;;                                     v82 = iconst.i32 1
+;;                                     v83 = bor v19, v82  ; v82 = 1
+;; @008a                               store notrap aligned table v83, v10
 ;; @008c                               v32 = load.i64 notrap aligned readonly can_move v0+56
 ;; @008c                               v33 = load.i64 notrap aligned readonly can_move v0+72
 ;; @008c                               v34 = call_indirect sig0, v32(v33, v0)
@@ -88,19 +85,18 @@
 ;; @009b                               v40 = iconst.i32 3
 ;; @009d                               v41 = icmp ugt v34, v40  ; v40 = 3
 ;; @009d                               v42 = uextend.i32 v41
-;; @009e                               brif v42, block6, block7
-;;
-;;                                 block6:
-;; @00a0                               trap user11
+;;                                     trapnz v42, user11
+;; @009e                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v86 = iconst.i32 1
-;;                                     v87 = bor.i32 v36, v86  ; v86 = 1
-;; @00a9                               store notrap aligned table v87, v4
+;; @00a4                               v44 = load.i32 notrap aligned table v4
+;;                                     v84 = iconst.i32 1
+;;                                     v85 = bor v44, v84  ; v84 = 1
+;; @00a9                               store notrap aligned table v85, v4
 ;; @00ab                               v49 = load.i32 notrap aligned table v10
-;;                                     v88 = iconst.i32 2
-;;                                     v89 = bor v49, v88  ; v88 = 2
-;; @00b0                               store notrap aligned table v89, v10
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = bor v49, v86  ; v86 = 2
+;; @00b0                               store notrap aligned table v87, v10
 ;; @00b2                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -28,10 +28,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @002f                               brif v2, block2, block3
-;;
-;;                                 block2:
-;; @0031                               trap user11
+;;                                     trapnz v2, user11
+;; @002f                               jump block3
 ;;
 ;;                                 block3:
 ;; @0033                               jump block1
@@ -50,10 +48,8 @@
 ;;                                     v5 = iconst.i32 0
 ;; @0038                               v3 = icmp eq v2, v5  ; v5 = 0
 ;; @0038                               v4 = uextend.i32 v3
-;; @0039                               brif v4, block2, block3
-;;
-;;                                 block2:
-;; @003b                               trap user11
+;;                                     trapnz v4, user11
+;; @0039                               jump block3
 ;;
 ;;                                 block3:
 ;; @003d                               jump block1

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v38 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v38+24
+;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+24
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v31+24
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v31+24
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v30 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v30+24
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 16

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -25,28 +25,28 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v92 = stack_addr.i64 ss2
-;;                                     store notrap v2, v92
-;;                                     v93 = stack_addr.i64 ss1
-;;                                     store notrap v3, v93
-;;                                     v94 = stack_addr.i64 ss0
-;;                                     store notrap v4, v94
+;;                                     v135 = stack_addr.i64 ss2
+;;                                     store notrap v2, v135
+;;                                     v134 = stack_addr.i64 ss1
+;;                                     store notrap v3, v134
+;;                                     v133 = stack_addr.i64 ss0
+;;                                     store notrap v4, v133
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v15 = iconst.i32 0
 ;;                                     v148 = iconst.i32 32
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v148, v16), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v15 = 0, v148 = 32, v16 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v97 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move v97+24
+;; @0025                               v129 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v18 = load.i64 notrap aligned readonly can_move v129+24
 ;; @0025                               v19 = uextend.i64 v17
 ;; @0025                               v20 = iadd v18, v19
-;;                                     v99 = iconst.i64 16
-;; @0025                               v21 = iadd v20, v99  ; v99 = 16
+;;                                     v128 = iconst.i64 16
+;; @0025                               v21 = iadd v20, v128  ; v128 = 16
 ;; @0025                               store notrap aligned v6, v21  ; v6 = 3
-;;                                     v91 = load.i32 notrap v92
-;;                                     v101 = iconst.i32 1
-;; @0025                               v26 = band v91, v101  ; v101 = 1
+;;                                     v91 = load.i32 notrap v135
+;;                                     v126 = iconst.i32 1
+;; @0025                               v26 = band v91, v126  ; v126 = 1
 ;; @0025                               v27 = icmp eq v91, v15  ; v15 = 0
 ;; @0025                               v28 = uextend.i32 v27
 ;; @0025                               v29 = bor v26, v28
@@ -58,17 +58,17 @@
 ;; @0025                               v67 = iconst.i64 8
 ;; @0025                               v34 = iadd v32, v67  ; v67 = 8
 ;; @0025                               v35 = load.i64 notrap aligned v34
-;;                                     v131 = iconst.i64 1
-;; @0025                               v36 = iadd v35, v131  ; v131 = 1
+;;                                     v96 = iconst.i64 1
+;; @0025                               v36 = iadd v35, v96  ; v96 = 1
 ;; @0025                               store notrap aligned v36, v34
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v87 = load.i32 notrap v92
+;;                                     v87 = load.i32 notrap v135
 ;;                                     v150 = iconst.i64 20
 ;;                                     v156 = iadd.i64 v20, v150  ; v150 = 20
 ;; @0025                               store notrap aligned little v87, v156
-;;                                     v86 = load.i32 notrap v93
+;;                                     v86 = load.i32 notrap v134
 ;;                                     v180 = iconst.i32 1
 ;;                                     v181 = band v86, v180  ; v180 = 1
 ;;                                     v182 = iconst.i32 0
@@ -89,11 +89,11 @@
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v82 = load.i32 notrap v93
+;;                                     v82 = load.i32 notrap v134
 ;;                                     v158 = iconst.i64 24
 ;;                                     v164 = iadd.i64 v20, v158  ; v158 = 24
 ;; @0025                               store notrap aligned little v82, v164
-;;                                     v81 = load.i32 notrap v94
+;;                                     v81 = load.i32 notrap v133
 ;;                                     v186 = iconst.i32 1
 ;;                                     v187 = band v81, v186  ; v186 = 1
 ;;                                     v188 = iconst.i32 0
@@ -114,7 +114,7 @@
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v77 = load.i32 notrap v94
+;;                                     v77 = load.i32 notrap v133
 ;;                                     v166 = iconst.i64 28
 ;;                                     v172 = iadd.i64 v20, v166  ; v166 = 28
 ;; @0025                               store notrap aligned little v77, v172

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -27,18 +27,18 @@
 ;; @0025                               v16 = iconst.i32 8
 ;; @0025                               v17 = call fn0(v0, v14, v15, v44, v16)  ; v14 = -1476395008, v15 = 0, v44 = 48, v16 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v18 = load.i64 notrap aligned readonly can_move v31+24
+;; @0025                               v30 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v18 = load.i64 notrap aligned readonly can_move v30+24
 ;; @0025                               v19 = uextend.i64 v17
 ;; @0025                               v20 = iadd v18, v19
-;;                                     v33 = iconst.i64 16
-;; @0025                               v21 = iadd v20, v33  ; v33 = 16
+;;                                     v29 = iconst.i64 16
+;; @0025                               v21 = iadd v20, v29  ; v29 = 16
 ;; @0025                               store notrap aligned v6, v21  ; v6 = 3
 ;;                                     v35 = iconst.i64 24
 ;;                                     v51 = iadd v20, v35  ; v35 = 24
 ;; @0025                               store notrap aligned little v2, v51
-;;                                     v30 = iconst.i64 32
-;;                                     v58 = iadd v20, v30  ; v30 = 32
+;;                                     v32 = iconst.i64 32
+;;                                     v58 = iadd v20, v32  ; v32 = 32
 ;; @0025                               store notrap aligned little v3, v58
 ;;                                     v60 = iconst.i64 40
 ;;                                     v66 = iadd v20, v60  ; v60 = 40

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -24,8 +24,8 @@
 ;; @0022                               v6 = uextend.i64 v3
 ;;                                     v35 = iconst.i64 3
 ;;                                     v36 = ishl v6, v35  ; v35 = 3
-;;                                     v31 = iconst.i64 32
-;; @0022                               v8 = ushr v36, v31  ; v31 = 32
+;;                                     v33 = iconst.i64 32
+;; @0022                               v8 = ushr v36, v33  ; v33 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 24
 ;;                                     v42 = iconst.i32 3
@@ -35,18 +35,18 @@
 ;; @0022                               v13 = iconst.i32 0
 ;;                                     v40 = iconst.i32 8
 ;; @0022                               v15 = call fn0(v0, v12, v13, v10, v40)  ; v12 = -1476395008, v13 = 0, v40 = 8
-;; @0022                               v32 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v16 = load.i64 notrap aligned readonly can_move v32+24
+;; @0022                               v31 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v16 = load.i64 notrap aligned readonly can_move v31+24
 ;; @0022                               v17 = uextend.i64 v15
 ;; @0022                               v18 = iadd v16, v17
-;;                                     v34 = iconst.i64 16
-;; @0022                               v19 = iadd v18, v34  ; v34 = 16
+;;                                     v30 = iconst.i64 16
+;; @0022                               v19 = iadd v18, v30  ; v30 = 16
 ;; @0022                               store notrap aligned v3, v19
 ;;                                     v47 = iconst.i64 24
 ;;                                     v53 = iadd v18, v47  ; v47 = 24
 ;; @0022                               v25 = uextend.i64 v10
 ;; @0022                               v26 = iadd v18, v25
-;;                                     v30 = iconst.i64 8
+;;                                     v34 = iconst.i64 8
 ;; @0022                               jump block2(v53)
 ;;
 ;;                                 block2(v27: i64):

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @0024                               v6 = load.i64 notrap aligned readonly can_move v29+24
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+24
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 16

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -34,12 +34,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = stack_addr.i64 ss0
-;;                                     store notrap v2, v35
-;;                                     v37 = iconst.i32 0
-;; @002e                               v4 = icmp eq v2, v37  ; v37 = 0
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v40  ; v40 = 0
 ;; @002e                               v5 = uextend.i32 v4
-;; @002e                               brif v5, block5(v37), block3  ; v37 = 0
+;; @002e                               brif v5, block5(v40), block3  ; v40 = 0
 ;;
 ;;                                 block3:
 ;; @002e                               v7 = iconst.i32 1
@@ -48,8 +48,8 @@
 ;; @002e                               brif v8, block5(v43), block4  ; v43 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move v40+24
+;; @002e                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v36+24
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
@@ -69,7 +69,7 @@
 ;; @002e                               jump block5(v23)
 ;;
 ;;                                 block5(v24: i32):
-;;                                     v31 = load.i32 notrap v35
+;;                                     v31 = load.i32 notrap v42
 ;; @002e                               brif v24, block8, block2
 ;;
 ;;                                 block8:

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -34,12 +34,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = stack_addr.i64 ss0
-;;                                     store notrap v2, v35
-;;                                     v37 = iconst.i32 0
-;; @002f                               v4 = icmp eq v2, v37  ; v37 = 0
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v40  ; v40 = 0
 ;; @002f                               v5 = uextend.i32 v4
-;; @002f                               brif v5, block5(v37), block3  ; v37 = 0
+;; @002f                               brif v5, block5(v40), block3  ; v40 = 0
 ;;
 ;;                                 block3:
 ;; @002f                               v7 = iconst.i32 1
@@ -48,8 +48,8 @@
 ;; @002f                               brif v8, block5(v43), block4  ; v43 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move v40+24
+;; @002f                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v36+24
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
@@ -69,7 +69,7 @@
 ;; @002f                               jump block5(v23)
 ;;
 ;;                                 block5(v24: i32):
-;;                                     v31 = load.i32 notrap v35
+;;                                     v31 = load.i32 notrap v42
 ;; @002f                               brif v24, block2, block8
 ;;
 ;;                                 block8:

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -40,8 +40,8 @@
 ;; @005c                               v8 = iadd v6, v7
 ;; @005c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
 ;; @005c                               v11 = load.i64 user5 aligned table v10
-;;                                     v31 = iconst.i64 -2
-;; @005c                               v12 = band v11, v31  ; v31 = -2
+;;                                     v29 = iconst.i64 -2
+;; @005c                               v12 = band v11, v29  ; v29 = -2
 ;; @005c                               brif v11, block3(v12), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -26,15 +26,15 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v37 = iconst.i64 64
-;; @0034                               v4 = iadd v0, v37  ; v37 = 64
+;;                                     v53 = iconst.i64 64
+;; @0034                               v4 = iadd v0, v53  ; v53 = 64
 ;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v38 = stack_addr.i64 ss0
-;;                                     store notrap v5, v38
-;;                                     v40 = iconst.i32 1
-;; @0034                               v6 = band v5, v40  ; v40 = 1
-;;                                     v42 = iconst.i32 0
-;; @0034                               v7 = icmp eq v5, v42  ; v42 = 0
+;;                                     v52 = stack_addr.i64 ss0
+;;                                     store notrap v5, v52
+;;                                     v50 = iconst.i32 1
+;; @0034                               v6 = band v5, v50  ; v50 = 1
+;;                                     v48 = iconst.i32 0
+;; @0034                               v7 = icmp eq v5, v48  ; v48 = 0
 ;; @0034                               v8 = uextend.i32 v7
 ;; @0034                               v9 = bor v6, v8
 ;; @0034                               brif v9, block5, block2
@@ -47,20 +47,20 @@
 ;; @0034                               brif v14, block3, block4
 ;;
 ;;                                 block4:
-;; @0034                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @0034                               v16 = load.i64 notrap aligned readonly can_move v44+24
+;; @0034                               v45 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v16 = load.i64 notrap aligned readonly can_move v45+24
 ;; @0034                               v15 = uextend.i64 v5
 ;; @0034                               v17 = iadd v16, v15
 ;; @0034                               v18 = iconst.i64 8
 ;; @0034                               v19 = iadd v17, v18  ; v18 = 8
 ;; @0034                               v20 = load.i64 notrap aligned v19
-;;                                     v46 = iconst.i64 1
-;; @0034                               v21 = iadd v20, v46  ; v46 = 1
+;;                                     v44 = iconst.i64 1
+;; @0034                               v21 = iadd v20, v44  ; v44 = 1
 ;; @0034                               store notrap aligned v21, v19
-;;                                     v32 = load.i32 notrap v38
+;;                                     v32 = load.i32 notrap v52
 ;; @0034                               store notrap aligned v32, v12
-;;                                     v51 = iconst.i64 4
-;; @0034                               v27 = iadd.i64 v12, v51  ; v51 = 4
+;;                                     v39 = iconst.i64 4
+;; @0034                               v27 = iadd.i64 v12, v39  ; v39 = 4
 ;; @0034                               store notrap aligned v27, v11
 ;; @0034                               jump block5
 ;;
@@ -69,7 +69,7 @@
 ;; @0034                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v30 = load.i32 notrap v38
+;;                                     v30 = load.i32 notrap v52
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
@@ -89,20 +89,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v40 = iconst.i64 64
-;; @003b                               v4 = iadd v0, v40  ; v40 = 64
+;;                                     v55 = iconst.i64 64
+;; @003b                               v4 = iadd v0, v55  ; v55 = 64
 ;; @003b                               v5 = load.i32 notrap aligned v4
-;;                                     v41 = iconst.i32 1
-;; @003b                               v6 = band v2, v41  ; v41 = 1
-;;                                     v42 = iconst.i32 0
-;; @003b                               v7 = icmp eq v2, v42  ; v42 = 0
+;;                                     v54 = iconst.i32 1
+;; @003b                               v6 = band v2, v54  ; v54 = 1
+;;                                     v53 = iconst.i32 0
+;; @003b                               v7 = icmp eq v2, v53  ; v53 = 0
 ;; @003b                               v8 = uextend.i32 v7
 ;; @003b                               v9 = bor v6, v8
 ;; @003b                               brif v9, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v27 = load.i64 notrap aligned readonly can_move v50+24
+;; @003b                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v27 = load.i64 notrap aligned readonly can_move v44+24
 ;; @003b                               v10 = uextend.i64 v2
 ;; @003b                               v12 = iadd v27, v10
 ;; @003b                               v29 = iconst.i64 8
@@ -114,7 +114,7 @@
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v69 = iadd.i64 v0, v40  ; v40 = 64
+;;                                     v69 = iadd.i64 v0, v55  ; v55 = 64
 ;; @003b                               store.i32 notrap aligned v2, v69
 ;;                                     v70 = iconst.i32 1
 ;;                                     v71 = band.i32 v5, v70  ; v70 = 1
@@ -141,8 +141,8 @@
 ;; @003b                               jump block7
 ;;
 ;;                                 block6:
-;;                                     v52 = iconst.i64 -1
-;; @003b                               v32 = iadd.i64 v31, v52  ; v52 = -1
+;;                                     v43 = iconst.i64 -1
+;; @003b                               v32 = iadd.i64 v31, v43  ; v43 = -1
 ;;                                     v78 = iadd.i64 v28, v76  ; v76 = 8
 ;; @003b                               store notrap aligned v32, v78
 ;; @003b                               jump block7

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -29,18 +29,18 @@
 ;; @0020                               v4 = iconst.i32 24
 ;; @0020                               v8 = iconst.i32 8
 ;; @0020                               v9 = call fn0(v0, v6, v7, v4, v8)  ; v6 = -1342177280, v7 = 0, v4 = 24, v8 = 8
-;;                                     v19 = stack_addr.i64 ss0
-;;                                     store notrap v9, v19
+;;                                     v24 = stack_addr.i64 ss0
+;;                                     store notrap v9, v24
 ;; @0020                               v15 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
 ;; @0020                               v16 = ireduce.i32 v15
-;; @0020                               v20 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v10 = load.i64 notrap aligned readonly can_move v20+24
+;; @0020                               v22 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v10 = load.i64 notrap aligned readonly can_move v22+24
 ;; @0020                               v11 = uextend.i64 v9
 ;; @0020                               v12 = iadd v10, v11
-;;                                     v23 = iconst.i64 16
-;; @0020                               v13 = iadd v12, v23  ; v23 = 16
+;;                                     v20 = iconst.i64 16
+;; @0020                               v13 = iadd v12, v20  ; v20 = 16
 ;; @0020                               store notrap aligned little v16, v13
-;;                                     v17 = load.i32 notrap v19
+;;                                     v17 = load.i32 notrap v24
 ;; @0023                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -22,8 +22,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v57 = load.i64 notrap aligned readonly can_move v0+8
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move v57+24
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+24
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 16
@@ -34,8 +34,8 @@
 ;; @0024                               v15 = uextend.i64 v12
 ;;                                     v67 = iconst.i64 3
 ;;                                     v68 = ishl v15, v67  ; v67 = 3
-;;                                     v59 = iconst.i64 32
-;; @0024                               v17 = ushr v68, v59  ; v59 = 32
+;;                                     v64 = iconst.i64 32
+;; @0024                               v17 = ushr v68, v64  ; v64 = 32
 ;; @0024                               trapnz v17, user1
 ;;                                     v77 = iconst.i32 3
 ;;                                     v78 = ishl v12, v77  ; v77 = 3

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -23,8 +23,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v18 = load.i64 notrap aligned readonly can_move v0+8
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move v18+24
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+24
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 16

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -22,12 +22,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v29 = stack_addr.i64 ss0
-;;                                     store notrap v2, v29
-;;                                     v31 = iconst.i32 0
-;; @001e                               v4 = icmp eq v2, v31  ; v31 = 0
+;;                                     v36 = stack_addr.i64 ss0
+;;                                     store notrap v2, v36
+;;                                     v34 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v34  ; v34 = 0
 ;; @001e                               v5 = uextend.i32 v4
-;; @001e                               brif v5, block4(v31), block2  ; v31 = 0
+;; @001e                               brif v5, block4(v34), block2  ; v34 = 0
 ;;
 ;;                                 block2:
 ;; @001e                               v7 = iconst.i32 1
@@ -36,8 +36,8 @@
 ;; @001e                               brif v8, block4(v37), block3  ; v37 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v34 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move v34+24
+;; @001e                               v30 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v30+24
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
@@ -58,7 +58,7 @@
 ;;
 ;;                                 block4(v24: i32):
 ;; @001e                               trapz v24, user19
-;;                                     v25 = load.i32 notrap v29
+;;                                     v25 = load.i32 notrap v36
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -30,8 +30,8 @@
 ;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -21,10 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v25 = iconst.i32 0
-;; @001d                               v4 = icmp eq v2, v25  ; v25 = 0
+;;                                     v27 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v27  ; v27 = 0
 ;; @001d                               v5 = uextend.i32 v4
-;; @001d                               brif v5, block4(v25), block2  ; v25 = 0
+;; @001d                               brif v5, block4(v27), block2  ; v27 = 0
 ;;
 ;;                                 block2:
 ;; @001d                               v7 = iconst.i32 1
@@ -33,8 +33,8 @@
 ;; @001d                               brif v8, block4(v28), block3  ; v28 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v26 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move v26+24
+;; @001d                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v25+24
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -29,8 +29,8 @@
 ;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -30,8 +30,8 @@
 ;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -115,19 +115,19 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v41+24
+;; @004e                               v57 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move v57+24
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 24
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 24
 ;; @004e                               v9 = load.i32 notrap aligned little v8
-;;                                     v43 = stack_addr.i64 ss0
-;;                                     store notrap v9, v43
-;;                                     v45 = iconst.i32 1
-;; @004e                               v10 = band v9, v45  ; v45 = 1
-;;                                     v47 = iconst.i32 0
-;; @004e                               v11 = icmp eq v9, v47  ; v47 = 0
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v9, v56
+;;                                     v54 = iconst.i32 1
+;; @004e                               v10 = band v9, v54  ; v54 = 1
+;;                                     v52 = iconst.i32 0
+;; @004e                               v11 = icmp eq v9, v52  ; v52 = 0
 ;; @004e                               v12 = uextend.i32 v11
 ;; @004e                               v13 = bor v10, v12
 ;; @004e                               brif v13, block5, block2
@@ -145,13 +145,13 @@
 ;; @004e                               v22 = iconst.i64 8
 ;; @004e                               v23 = iadd v21, v22  ; v22 = 8
 ;; @004e                               v24 = load.i64 notrap aligned v23
-;;                                     v51 = iconst.i64 1
-;; @004e                               v25 = iadd v24, v51  ; v51 = 1
+;;                                     v48 = iconst.i64 1
+;; @004e                               v25 = iadd v24, v48  ; v48 = 1
 ;; @004e                               store notrap aligned v25, v23
-;;                                     v36 = load.i32 notrap v43
+;;                                     v36 = load.i32 notrap v56
 ;; @004e                               store notrap aligned v36, v16
-;;                                     v56 = iconst.i64 4
-;; @004e                               v31 = iadd.i64 v16, v56  ; v56 = 4
+;;                                     v43 = iconst.i64 4
+;; @004e                               v31 = iadd.i64 v16, v43  ; v43 = 4
 ;; @004e                               store notrap aligned v31, v15
 ;; @004e                               jump block5
 ;;
@@ -160,7 +160,7 @@
 ;; @004e                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v34 = load.i32 notrap v43
+;;                                     v34 = load.i32 notrap v56
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -30,32 +30,32 @@
 ;; @0021                               v10 = iconst.i32 8
 ;; @0021                               v11 = call fn0(v0, v8, v4, v6, v10)  ; v8 = -1342177280, v4 = 0, v6 = 32, v10 = 8
 ;; @0021                               v3 = f32const 0.0
-;; @0021                               v34 = load.i64 notrap aligned readonly can_move v0+8
-;; @0021                               v12 = load.i64 notrap aligned readonly can_move v34+24
+;; @0021                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v12 = load.i64 notrap aligned readonly can_move v44+24
 ;; @0021                               v13 = uextend.i64 v11
 ;; @0021                               v14 = iadd v12, v13
-;;                                     v36 = iconst.i64 16
-;; @0021                               v15 = iadd v14, v36  ; v36 = 16
+;;                                     v43 = iconst.i64 16
+;; @0021                               v15 = iadd v14, v43  ; v43 = 16
 ;; @0021                               store notrap aligned little v3, v15  ; v3 = 0.0
-;;                                     v37 = iconst.i64 20
-;; @0021                               v16 = iadd v14, v37  ; v37 = 20
+;;                                     v42 = iconst.i64 20
+;; @0021                               v16 = iadd v14, v42  ; v42 = 20
 ;; @0021                               istore8 notrap aligned little v4, v16  ; v4 = 0
-;;                                     v39 = iconst.i32 1
-;; @0021                               brif v39, block3, block2  ; v39 = 1
+;;                                     v40 = iconst.i32 1
+;; @0021                               brif v40, block3, block2  ; v40 = 1
 ;;
 ;;                                 block2:
 ;; @0021                               v25 = iconst.i64 8
 ;; @0021                               v26 = iadd.i64 v12, v25  ; v25 = 8
 ;; @0021                               v27 = load.i64 notrap aligned v26
-;;                                     v43 = iconst.i64 1
-;; @0021                               v28 = iadd v27, v43  ; v43 = 1
+;;                                     v36 = iconst.i64 1
+;; @0021                               v28 = iadd v27, v36  ; v36 = 1
 ;; @0021                               store notrap aligned v28, v26
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v66 = iconst.i32 0
-;;                                     v38 = iconst.i64 24
-;; @0021                               v17 = iadd.i64 v14, v38  ; v38 = 24
+;;                                     v41 = iconst.i64 24
+;; @0021                               v17 = iadd.i64 v14, v41  ; v41 = 24
 ;; @0021                               store notrap aligned little v66, v17  ; v66 = 0
 ;; @0024                               jump block1
 ;;

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -25,26 +25,26 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v39 = stack_addr.i64 ss0
-;;                                     store notrap v4, v39
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v4, v56
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v12 = load.i64 notrap aligned readonly can_move v40+24
+;; @002a                               v54 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v12 = load.i64 notrap aligned readonly can_move v54+24
 ;; @002a                               v13 = uextend.i64 v11
 ;; @002a                               v14 = iadd v12, v13
-;;                                     v42 = iconst.i64 16
-;; @002a                               v15 = iadd v14, v42  ; v42 = 16
+;;                                     v53 = iconst.i64 16
+;; @002a                               v15 = iadd v14, v53  ; v53 = 16
 ;; @002a                               store notrap aligned little v2, v15
-;;                                     v43 = iconst.i64 20
-;; @002a                               v16 = iadd v14, v43  ; v43 = 20
+;;                                     v52 = iconst.i64 20
+;; @002a                               v16 = iadd v14, v52  ; v52 = 20
 ;; @002a                               istore8 notrap aligned little v3, v16
-;;                                     v38 = load.i32 notrap v39
-;;                                     v46 = iconst.i32 1
-;; @002a                               v18 = band v38, v46  ; v46 = 1
+;;                                     v38 = load.i32 notrap v56
+;;                                     v49 = iconst.i32 1
+;; @002a                               v18 = band v38, v49  ; v49 = 1
 ;; @002a                               v19 = icmp eq v38, v9  ; v9 = 0
 ;; @002a                               v20 = uextend.i32 v19
 ;; @002a                               v21 = bor v18, v20
@@ -56,15 +56,15 @@
 ;; @002a                               v25 = iconst.i64 8
 ;; @002a                               v26 = iadd v24, v25  ; v25 = 8
 ;; @002a                               v27 = load.i64 notrap aligned v26
-;;                                     v52 = iconst.i64 1
-;; @002a                               v28 = iadd v27, v52  ; v52 = 1
+;;                                     v43 = iconst.i64 1
+;; @002a                               v28 = iadd v27, v43  ; v43 = 1
 ;; @002a                               store notrap aligned v28, v26
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v34 = load.i32 notrap v39
-;;                                     v44 = iconst.i64 24
-;; @002a                               v17 = iadd.i64 v14, v44  ; v44 = 24
+;;                                     v34 = load.i32 notrap v56
+;;                                     v51 = iconst.i64 24
+;; @002a                               v17 = iadd.i64 v14, v51  ; v51 = 24
 ;; @002a                               store notrap aligned little v34, v17
 ;; @002d                               jump block1
 ;;

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -83,17 +83,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @004a                               trapz v2, user16
-;; @004a                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @004a                               v5 = load.i64 notrap aligned readonly can_move v44+24
+;; @004a                               v59 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move v59+24
 ;; @004a                               v4 = uextend.i64 v2
 ;; @004a                               v6 = iadd v5, v4
 ;; @004a                               v7 = iconst.i64 24
 ;; @004a                               v8 = iadd v6, v7  ; v7 = 24
 ;; @004a                               v9 = load.i32 notrap aligned little v8
-;;                                     v46 = iconst.i32 1
-;; @004a                               v10 = band v3, v46  ; v46 = 1
-;;                                     v47 = iconst.i32 0
-;; @004a                               v11 = icmp eq v3, v47  ; v47 = 0
+;;                                     v58 = iconst.i32 1
+;; @004a                               v10 = band v3, v58  ; v58 = 1
+;;                                     v57 = iconst.i32 0
+;; @004a                               v11 = icmp eq v3, v57  ; v57 = 0
 ;; @004a                               v12 = uextend.i32 v11
 ;; @004a                               v13 = bor v10, v12
 ;; @004a                               brif v13, block3, block2
@@ -135,8 +135,8 @@
 ;; @004a                               jump block7
 ;;
 ;;                                 block6:
-;;                                     v57 = iconst.i64 -1
-;; @004a                               v36 = iadd.i64 v35, v57  ; v57 = -1
+;;                                     v47 = iconst.i64 -1
+;; @004a                               v36 = iadd.i64 v35, v47  ; v47 = -1
 ;;                                     v81 = iadd.i64 v32, v79  ; v79 = 8
 ;; @004a                               store notrap aligned v36, v81
 ;; @004a                               jump block7

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v38 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v38+24
+;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+24
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 8

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v31+24
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v31+24
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v30 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v6 = load.i64 notrap aligned readonly can_move v30+24
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+24
 ;; @0022                               v5 = uextend.i64 v2
 ;; @0022                               v7 = iadd v6, v5
 ;; @0022                               v8 = iconst.i64 8

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -25,12 +25,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v50 = stack_addr.i64 ss2
-;;                                     store notrap v2, v50
-;;                                     v51 = stack_addr.i64 ss1
-;;                                     store notrap v3, v51
-;;                                     v52 = stack_addr.i64 ss0
-;;                                     store notrap v4, v52
+;;                                     v62 = stack_addr.i64 ss2
+;;                                     store notrap v2, v62
+;;                                     v61 = stack_addr.i64 ss1
+;;                                     store notrap v3, v61
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     store notrap v4, v60
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+40
 ;; @0025                               v18 = load.i32 notrap aligned v17
 ;;                                     v82 = iconst.i32 7
@@ -39,15 +39,15 @@
 ;; @0025                               v23 = band v21, v89  ; v89 = -8
 ;;                                     v74 = iconst.i32 24
 ;; @0025                               v24 = uadd_overflow_trap v23, v74, user18  ; v74 = 24
-;; @0025                               v55 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v55+32
+;; @0025                               v56 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v26 = load.i64 notrap aligned v56+32
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v27 = icmp ule v25, v26
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v90 = iconst.i32 -1476394984
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v55+24
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v56+24
 ;;                                     v128 = band.i32 v21, v89  ; v89 = -8
 ;;                                     v129 = uextend.i64 v128
 ;; @0025                               v33 = iadd v31, v129
@@ -57,18 +57,18 @@
 ;; @0025                               store notrap aligned v38, v33+4
 ;; @0025                               store.i32 notrap aligned v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v59 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v59  ; v59 = 8
+;;                                     v53 = iconst.i64 8
+;; @0025                               v39 = iadd v33, v53  ; v53 = 8
 ;; @0025                               store notrap aligned v6, v39  ; v6 = 3
-;;                                     v49 = load.i32 notrap v50
+;;                                     v49 = load.i32 notrap v62
 ;;                                     v64 = iconst.i64 12
 ;;                                     v103 = iadd v33, v64  ; v64 = 12
 ;; @0025                               store notrap aligned little v49, v103
-;;                                     v48 = load.i32 notrap v51
+;;                                     v48 = load.i32 notrap v61
 ;;                                     v105 = iconst.i64 16
 ;;                                     v111 = iadd v33, v105  ; v105 = 16
 ;; @0025                               store notrap aligned little v48, v111
-;;                                     v47 = load.i32 notrap v52
+;;                                     v47 = load.i32 notrap v60
 ;;                                     v113 = iconst.i64 20
 ;;                                     v119 = iadd v33, v113  ; v113 = 20
 ;; @0025                               store notrap aligned little v47, v119

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -30,15 +30,15 @@
 ;; @0025                               v23 = band v21, v80  ; v80 = -8
 ;;                                     v65 = iconst.i32 40
 ;; @0025                               v24 = uadd_overflow_trap v23, v65, user18  ; v65 = 40
-;; @0025                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v49+32
+;; @0025                               v50 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v26 = load.i64 notrap aligned v50+32
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v27 = icmp ule v25, v26
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v81 = iconst.i32 -1476394968
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v49+24
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v50+24
 ;;                                     v118 = band.i32 v21, v80  ; v80 = -8
 ;;                                     v119 = uextend.i64 v118
 ;; @0025                               v33 = iadd v31, v119
@@ -48,8 +48,8 @@
 ;; @0025                               store notrap aligned v38, v33+4
 ;; @0025                               store.i32 notrap aligned v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v47 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v47  ; v47 = 8
+;;                                     v53 = iconst.i64 8
+;; @0025                               v39 = iadd v33, v53  ; v53 = 8
 ;; @0025                               store notrap aligned v6, v39  ; v6 = 3
 ;;                                     v89 = iconst.i64 16
 ;;                                     v95 = iadd v33, v89  ; v89 = 16
@@ -57,8 +57,8 @@
 ;;                                     v55 = iconst.i64 24
 ;;                                     v102 = iadd v33, v55  ; v55 = 24
 ;; @0025                               store.i64 notrap aligned little v3, v102
-;;                                     v48 = iconst.i64 32
-;;                                     v109 = iadd v33, v48  ; v48 = 32
+;;                                     v52 = iconst.i64 32
+;;                                     v109 = iadd v33, v52  ; v52 = 32
 ;; @0025                               store.i64 notrap aligned little v4, v109
 ;; @0029                               jump block1
 ;;

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -25,8 +25,8 @@
 ;; @0022                               v6 = uextend.i64 v3
 ;;                                     v55 = iconst.i64 3
 ;;                                     v56 = ishl v6, v55  ; v55 = 3
-;;                                     v49 = iconst.i64 32
-;; @0022                               v8 = ushr v56, v49  ; v49 = 32
+;;                                     v53 = iconst.i64 32
+;; @0022                               v8 = ushr v56, v53  ; v53 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 16
 ;;                                     v62 = iconst.i32 3
@@ -42,8 +42,8 @@
 ;;                                     v73 = iconst.i32 -8
 ;; @0022                               v21 = band v19, v73  ; v73 = -8
 ;; @0022                               v22 = uadd_overflow_trap v21, v10, user18
-;; @0022                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v24 = load.i64 notrap aligned v50+32
+;; @0022                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v24 = load.i64 notrap aligned v51+32
 ;; @0022                               v23 = uextend.i64 v22
 ;; @0022                               v25 = icmp ule v23, v24
 ;; @0022                               brif v25, block2, block3
@@ -51,7 +51,7 @@
 ;;                                 block2:
 ;; @0022                               v32 = iconst.i32 -1476395008
 ;;                                     v74 = bor.i32 v10, v32  ; v32 = -1476395008
-;; @0022                               v29 = load.i64 notrap aligned readonly can_move v50+24
+;; @0022                               v29 = load.i64 notrap aligned readonly can_move v51+24
 ;;                                     v95 = band.i32 v19, v73  ; v73 = -8
 ;;                                     v96 = uextend.i64 v95
 ;; @0022                               v31 = iadd v29, v96
@@ -60,8 +60,8 @@
 ;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
 ;; @0022                               store notrap aligned v36, v31+4
 ;; @0022                               store.i32 notrap aligned v22, v15
-;;                                     v48 = iconst.i64 8
-;; @0022                               v37 = iadd v31, v48  ; v48 = 8
+;;                                     v54 = iconst.i64 8
+;; @0022                               v37 = iadd v31, v54  ; v54 = 8
 ;; @0022                               store.i32 notrap aligned v3, v37
 ;;                                     v77 = iconst.i64 16
 ;;                                     v83 = iadd v31, v77  ; v77 = 16

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
 ;; @0024                               trapz v2, user16
-;; @0024                               v29 = load.i64 notrap aligned readonly can_move v0+8
-;; @0024                               v6 = load.i64 notrap aligned readonly can_move v29+24
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+24
 ;; @0024                               v5 = uextend.i64 v2
 ;; @0024                               v7 = iadd v6, v5
 ;; @0024                               v8 = iconst.i64 8

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -34,12 +34,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = stack_addr.i64 ss0
-;;                                     store notrap v2, v35
-;;                                     v37 = iconst.i32 0
-;; @002e                               v4 = icmp eq v2, v37  ; v37 = 0
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v40  ; v40 = 0
 ;; @002e                               v5 = uextend.i32 v4
-;; @002e                               brif v5, block5(v37), block3  ; v37 = 0
+;; @002e                               brif v5, block5(v40), block3  ; v40 = 0
 ;;
 ;;                                 block3:
 ;; @002e                               v7 = iconst.i32 1
@@ -48,8 +48,8 @@
 ;; @002e                               brif v8, block5(v43), block4  ; v43 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move v40+24
+;; @002e                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v36+24
 ;; @002e                               v13 = uextend.i64 v2
 ;; @002e                               v15 = iadd v14, v13
 ;; @002e                               v16 = iconst.i64 4
@@ -69,7 +69,7 @@
 ;; @002e                               jump block5(v23)
 ;;
 ;;                                 block5(v24: i32):
-;;                                     v31 = load.i32 notrap v35
+;;                                     v31 = load.i32 notrap v42
 ;; @002e                               brif v24, block8, block2
 ;;
 ;;                                 block8:

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -34,12 +34,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v35 = stack_addr.i64 ss0
-;;                                     store notrap v2, v35
-;;                                     v37 = iconst.i32 0
-;; @002f                               v4 = icmp eq v2, v37  ; v37 = 0
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v40  ; v40 = 0
 ;; @002f                               v5 = uextend.i32 v4
-;; @002f                               brif v5, block5(v37), block3  ; v37 = 0
+;; @002f                               brif v5, block5(v40), block3  ; v40 = 0
 ;;
 ;;                                 block3:
 ;; @002f                               v7 = iconst.i32 1
@@ -48,8 +48,8 @@
 ;; @002f                               brif v8, block5(v43), block4  ; v43 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move v40+24
+;; @002f                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v36+24
 ;; @002f                               v13 = uextend.i64 v2
 ;; @002f                               v15 = iadd v14, v13
 ;; @002f                               v16 = iconst.i64 4
@@ -69,7 +69,7 @@
 ;; @002f                               jump block5(v23)
 ;;
 ;;                                 block5(v24: i32):
-;;                                     v31 = load.i32 notrap v35
+;;                                     v31 = load.i32 notrap v42
 ;; @002f                               brif v24, block2, block8
 ;;
 ;;                                 block8:

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -40,8 +40,8 @@
 ;; @005c                               v8 = iadd v6, v7
 ;; @005c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
 ;; @005c                               v11 = load.i64 user5 aligned table v10
-;;                                     v31 = iconst.i64 -2
-;; @005c                               v12 = band v11, v31  ; v31 = -2
+;;                                     v29 = iconst.i64 -2
+;; @005c                               v12 = band v11, v29  ; v29 = -2
 ;; @005c                               brif v11, block3(v12), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -32,15 +32,15 @@
 ;; @0020                               v15 = band v13, v54  ; v54 = -8
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v16 = uadd_overflow_trap v15, v4, user18  ; v4 = 16
-;; @0020                               v35 = load.i64 notrap aligned readonly can_move v0+8
-;; @0020                               v18 = load.i64 notrap aligned v35+32
+;; @0020                               v38 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v18 = load.i64 notrap aligned v38+32
 ;; @0020                               v17 = uextend.i64 v16
 ;; @0020                               v19 = icmp ule v17, v18
 ;; @0020                               brif v19, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v55 = iconst.i32 -1342177264
-;; @0020                               v23 = load.i64 notrap aligned readonly can_move v35+24
+;; @0020                               v23 = load.i64 notrap aligned readonly can_move v38+24
 ;;                                     v62 = band.i32 v13, v54  ; v54 = -8
 ;;                                     v63 = uextend.i64 v62
 ;; @0020                               v25 = iadd v23, v63
@@ -51,8 +51,8 @@
 ;; @0020                               store.i32 notrap aligned v16, v9
 ;; @0020                               v33 = call fn1(v0, v2)
 ;; @0020                               v34 = ireduce.i32 v33
-;;                                     v39 = iconst.i64 8
-;; @0020                               v31 = iadd v25, v39  ; v39 = 8
+;;                                     v35 = iconst.i64 8
+;; @0020                               v31 = iadd v25, v35  ; v35 = 8
 ;; @0020                               store notrap aligned little v34, v31
 ;; @0023                               jump block1
 ;;

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -22,8 +22,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0024                               trapz v2, user16
-;; @0024                               v57 = load.i64 notrap aligned readonly can_move v0+8
-;; @0024                               v8 = load.i64 notrap aligned readonly can_move v57+24
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+24
 ;; @0024                               v7 = uextend.i64 v2
 ;; @0024                               v9 = iadd v8, v7
 ;; @0024                               v10 = iconst.i64 8
@@ -34,8 +34,8 @@
 ;; @0024                               v15 = uextend.i64 v12
 ;;                                     v67 = iconst.i64 3
 ;;                                     v68 = ishl v15, v67  ; v67 = 3
-;;                                     v59 = iconst.i64 32
-;; @0024                               v17 = ushr v68, v59  ; v59 = 32
+;;                                     v64 = iconst.i64 32
+;; @0024                               v17 = ushr v68, v64  ; v64 = 32
 ;; @0024                               trapnz v17, user1
 ;;                                     v77 = iconst.i32 3
 ;;                                     v78 = ishl v12, v77  ; v77 = 3

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -23,8 +23,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0023                               trapz v2, user16
-;; @0023                               v18 = load.i64 notrap aligned readonly can_move v0+8
-;; @0023                               v6 = load.i64 notrap aligned readonly can_move v18+24
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+24
 ;; @0023                               v5 = uextend.i64 v2
 ;; @0023                               v7 = iadd v6, v5
 ;; @0023                               v8 = iconst.i64 8

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -22,12 +22,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v29 = stack_addr.i64 ss0
-;;                                     store notrap v2, v29
-;;                                     v31 = iconst.i32 0
-;; @001e                               v4 = icmp eq v2, v31  ; v31 = 0
+;;                                     v36 = stack_addr.i64 ss0
+;;                                     store notrap v2, v36
+;;                                     v34 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v34  ; v34 = 0
 ;; @001e                               v5 = uextend.i32 v4
-;; @001e                               brif v5, block4(v31), block2  ; v31 = 0
+;; @001e                               brif v5, block4(v34), block2  ; v34 = 0
 ;;
 ;;                                 block2:
 ;; @001e                               v7 = iconst.i32 1
@@ -36,8 +36,8 @@
 ;; @001e                               brif v8, block4(v37), block3  ; v37 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v34 = load.i64 notrap aligned readonly can_move v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move v34+24
+;; @001e                               v30 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v30+24
 ;; @001e                               v13 = uextend.i64 v2
 ;; @001e                               v15 = iadd v14, v13
 ;; @001e                               v16 = iconst.i64 4
@@ -58,7 +58,7 @@
 ;;
 ;;                                 block4(v24: i32):
 ;; @001e                               trapz v24, user19
-;;                                     v25 = load.i32 notrap v29
+;;                                     v25 = load.i32 notrap v36
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -30,8 +30,8 @@
 ;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -21,10 +21,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v25 = iconst.i32 0
-;; @001d                               v4 = icmp eq v2, v25  ; v25 = 0
+;;                                     v27 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v27  ; v27 = 0
 ;; @001d                               v5 = uextend.i32 v4
-;; @001d                               brif v5, block4(v25), block2  ; v25 = 0
+;; @001d                               brif v5, block4(v27), block2  ; v27 = 0
 ;;
 ;;                                 block2:
 ;; @001d                               v7 = iconst.i32 1
@@ -33,8 +33,8 @@
 ;; @001d                               brif v8, block4(v28), block3  ; v28 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v26 = load.i64 notrap aligned readonly can_move v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move v26+24
+;; @001d                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v25+24
 ;; @001d                               v13 = uextend.i64 v2
 ;; @001d                               v15 = iadd v14, v13
 ;; @001d                               v16 = iconst.i64 4

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -29,8 +29,8 @@
 ;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -18,10 +18,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 = iconst.i32 0
-;; @001b                               v4 = icmp eq v2, v21  ; v21 = 0
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
 ;; @001b                               v5 = uextend.i32 v4
-;; @001b                               brif v5, block4(v21), block2  ; v21 = 0
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
 ;;
 ;;                                 block2:
 ;; @001b                               v7 = iconst.i32 1
@@ -30,8 +30,8 @@
 ;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
 ;;
 ;;                                 block3:
-;; @001b                               v22 = load.i64 notrap aligned readonly can_move v0+8
-;; @001b                               v11 = load.i64 notrap aligned readonly can_move v22+24
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+24
 ;; @001b                               v10 = uextend.i64 v2
 ;; @001b                               v12 = iadd v11, v10
 ;; @001b                               v15 = load.i32 notrap aligned readonly v12

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -32,15 +32,15 @@
 ;; @0021                               v17 = band v15, v56  ; v56 = -8
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
-;; @0021                               v36 = load.i64 notrap aligned readonly can_move v0+8
-;; @0021                               v20 = load.i64 notrap aligned v36+32
+;; @0021                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v20 = load.i64 notrap aligned v41+32
 ;; @0021                               v19 = uextend.i64 v18
 ;; @0021                               v21 = icmp ule v19, v20
 ;; @0021                               brif v21, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v57 = iconst.i32 -1342177256
-;; @0021                               v25 = load.i64 notrap aligned readonly can_move v36+24
+;; @0021                               v25 = load.i64 notrap aligned readonly can_move v41+24
 ;;                                     v64 = band.i32 v15, v56  ; v56 = -8
 ;;                                     v65 = uextend.i64 v64
 ;; @0021                               v27 = iadd v25, v65
@@ -50,15 +50,15 @@
 ;; @0021                               store notrap aligned v32, v27+4
 ;; @0021                               store.i32 notrap aligned v18, v11
 ;; @0021                               v3 = f32const 0.0
-;;                                     v40 = iconst.i64 8
-;; @0021                               v33 = iadd v27, v40  ; v40 = 8
+;;                                     v38 = iconst.i64 8
+;; @0021                               v33 = iadd v27, v38  ; v38 = 8
 ;; @0021                               store notrap aligned little v3, v33  ; v3 = 0.0
 ;; @0021                               v4 = iconst.i32 0
-;;                                     v41 = iconst.i64 12
-;; @0021                               v34 = iadd v27, v41  ; v41 = 12
+;;                                     v37 = iconst.i64 12
+;; @0021                               v34 = iadd v27, v37  ; v37 = 12
 ;; @0021                               istore8 notrap aligned little v4, v34  ; v4 = 0
-;;                                     v42 = iconst.i64 16
-;; @0021                               v35 = iadd v27, v42  ; v42 = 16
+;;                                     v36 = iconst.i64 16
+;; @0021                               v35 = iadd v27, v36  ; v36 = 16
 ;; @0021                               store notrap aligned little v4, v35  ; v4 = 0
 ;; @0024                               jump block1
 ;;

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -25,8 +25,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v37 = stack_addr.i64 ss0
-;;                                     store notrap v4, v37
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     store notrap v4, v45
 ;; @002a                               v11 = load.i64 notrap aligned readonly v0+40
 ;; @002a                               v12 = load.i32 notrap aligned v11
 ;;                                     v53 = iconst.i32 7
@@ -35,15 +35,15 @@
 ;; @002a                               v17 = band v15, v60  ; v60 = -8
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v18 = uadd_overflow_trap v17, v6, user18  ; v6 = 24
-;; @002a                               v38 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v20 = load.i64 notrap aligned v38+32
+;; @002a                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v20 = load.i64 notrap aligned v43+32
 ;; @002a                               v19 = uextend.i64 v18
 ;; @002a                               v21 = icmp ule v19, v20
 ;; @002a                               brif v21, block2, block3
 ;;
 ;;                                 block2:
 ;;                                     v61 = iconst.i32 -1342177256
-;; @002a                               v25 = load.i64 notrap aligned readonly can_move v38+24
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move v43+24
 ;;                                     v68 = band.i32 v15, v60  ; v60 = -8
 ;;                                     v69 = uextend.i64 v68
 ;; @002a                               v27 = iadd v25, v69
@@ -52,15 +52,15 @@
 ;; @002a                               v32 = load.i32 notrap aligned readonly can_move v31
 ;; @002a                               store notrap aligned v32, v27+4
 ;; @002a                               store.i32 notrap aligned v18, v11
-;;                                     v42 = iconst.i64 8
-;; @002a                               v33 = iadd v27, v42  ; v42 = 8
+;;                                     v40 = iconst.i64 8
+;; @002a                               v33 = iadd v27, v40  ; v40 = 8
 ;; @002a                               store.f32 notrap aligned little v2, v33
-;;                                     v43 = iconst.i64 12
-;; @002a                               v34 = iadd v27, v43  ; v43 = 12
+;;                                     v39 = iconst.i64 12
+;; @002a                               v34 = iadd v27, v39  ; v39 = 12
 ;; @002a                               istore8.i32 notrap aligned little v3, v34
-;;                                     v36 = load.i32 notrap v37
-;;                                     v44 = iconst.i64 16
-;; @002a                               v35 = iadd v27, v44  ; v44 = 16
+;;                                     v36 = load.i32 notrap v45
+;;                                     v38 = iconst.i64 16
+;; @002a                               v35 = iadd v27, v38  ; v38 = 16
 ;; @002a                               store notrap aligned little v36, v35
 ;; @002d                               jump block1
 ;;

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -23,8 +23,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0022                               trapz v2, user16
-;; @0022                               v17 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v5 = load.i64 notrap aligned readonly can_move v17+24
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+24
 ;; @0022                               v4 = uextend.i64 v2
 ;; @0022                               v6 = iadd v5, v4
 ;; @0022                               v7 = iconst.i64 16

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -32,36 +32,36 @@
 ;; @0023                               v11 = iconst.i32 16
 ;; @0023                               v12 = call fn0(v0, v9, v4, v7, v11)  ; v9 = -1342177280, v4 = 0, v7 = 48, v11 = 16
 ;; @0023                               v3 = f32const 0.0
-;; @0023                               v36 = load.i64 notrap aligned readonly can_move v0+8
-;; @0023                               v13 = load.i64 notrap aligned readonly can_move v36+24
+;; @0023                               v47 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v13 = load.i64 notrap aligned readonly can_move v47+24
 ;; @0023                               v14 = uextend.i64 v12
 ;; @0023                               v15 = iadd v13, v14
-;;                                     v38 = iconst.i64 16
-;; @0023                               v16 = iadd v15, v38  ; v38 = 16
+;;                                     v46 = iconst.i64 16
+;; @0023                               v16 = iadd v15, v46  ; v46 = 16
 ;; @0023                               store notrap aligned little v3, v16  ; v3 = 0.0
-;;                                     v39 = iconst.i64 20
-;; @0023                               v17 = iadd v15, v39  ; v39 = 20
+;;                                     v45 = iconst.i64 20
+;; @0023                               v17 = iadd v15, v45  ; v45 = 20
 ;; @0023                               istore8 notrap aligned little v4, v17  ; v4 = 0
-;;                                     v41 = iconst.i32 1
-;; @0023                               brif v41, block3, block2  ; v41 = 1
+;;                                     v43 = iconst.i32 1
+;; @0023                               brif v43, block3, block2  ; v43 = 1
 ;;
 ;;                                 block2:
 ;; @0023                               v26 = iconst.i64 8
 ;; @0023                               v27 = iadd.i64 v13, v26  ; v26 = 8
 ;; @0023                               v28 = load.i64 notrap aligned v27
-;;                                     v45 = iconst.i64 1
-;; @0023                               v29 = iadd v28, v45  ; v45 = 1
+;;                                     v39 = iconst.i64 1
+;; @0023                               v29 = iadd v28, v39  ; v39 = 1
 ;; @0023                               store notrap aligned v29, v27
 ;; @0023                               jump block3
 ;;
 ;;                                 block3:
 ;;                                     v69 = iconst.i32 0
-;;                                     v40 = iconst.i64 24
-;; @0023                               v18 = iadd.i64 v15, v40  ; v40 = 24
+;;                                     v44 = iconst.i64 24
+;; @0023                               v18 = iadd.i64 v15, v44  ; v44 = 24
 ;; @0023                               store notrap aligned little v69, v18  ; v69 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
-;;                                     v48 = iconst.i64 32
-;; @0023                               v35 = iadd.i64 v15, v48  ; v48 = 32
+;;                                     v36 = iconst.i64 32
+;; @0023                               v35 = iadd.i64 v15, v36  ; v36 = 32
 ;; @0023                               store notrap aligned little v6, v35  ; v6 = const0
 ;; @0026                               jump block1
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -25,26 +25,26 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
-;;                                     v39 = stack_addr.i64 ss0
-;;                                     store notrap v4, v39
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     store notrap v4, v56
 ;; @002a                               v8 = iconst.i32 -1342177280
 ;; @002a                               v9 = iconst.i32 0
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v10 = iconst.i32 8
 ;; @002a                               v11 = call fn0(v0, v8, v9, v6, v10), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v9 = 0, v6 = 32, v10 = 8
-;; @002a                               v40 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v12 = load.i64 notrap aligned readonly can_move v40+24
+;; @002a                               v54 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v12 = load.i64 notrap aligned readonly can_move v54+24
 ;; @002a                               v13 = uextend.i64 v11
 ;; @002a                               v14 = iadd v12, v13
-;;                                     v42 = iconst.i64 16
-;; @002a                               v15 = iadd v14, v42  ; v42 = 16
+;;                                     v53 = iconst.i64 16
+;; @002a                               v15 = iadd v14, v53  ; v53 = 16
 ;; @002a                               store notrap aligned little v2, v15
-;;                                     v43 = iconst.i64 20
-;; @002a                               v16 = iadd v14, v43  ; v43 = 20
+;;                                     v52 = iconst.i64 20
+;; @002a                               v16 = iadd v14, v52  ; v52 = 20
 ;; @002a                               istore8 notrap aligned little v3, v16
-;;                                     v38 = load.i32 notrap v39
-;;                                     v46 = iconst.i32 1
-;; @002a                               v18 = band v38, v46  ; v46 = 1
+;;                                     v38 = load.i32 notrap v56
+;;                                     v49 = iconst.i32 1
+;; @002a                               v18 = band v38, v49  ; v49 = 1
 ;; @002a                               v19 = icmp eq v38, v9  ; v9 = 0
 ;; @002a                               v20 = uextend.i32 v19
 ;; @002a                               v21 = bor v18, v20
@@ -56,15 +56,15 @@
 ;; @002a                               v25 = iconst.i64 8
 ;; @002a                               v26 = iadd v24, v25  ; v25 = 8
 ;; @002a                               v27 = load.i64 notrap aligned v26
-;;                                     v52 = iconst.i64 1
-;; @002a                               v28 = iadd v27, v52  ; v52 = 1
+;;                                     v43 = iconst.i64 1
+;; @002a                               v28 = iadd v27, v43  ; v43 = 1
 ;; @002a                               store notrap aligned v28, v26
 ;; @002a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v34 = load.i32 notrap v39
-;;                                     v44 = iconst.i64 24
-;; @002a                               v17 = iadd.i64 v14, v44  ; v44 = 24
+;;                                     v34 = load.i32 notrap v56
+;;                                     v51 = iconst.i64 24
+;; @002a                               v17 = iadd.i64 v14, v51  ; v51 = 24
 ;; @002a                               store notrap aligned little v34, v17
 ;; @002d                               jump block1
 ;;

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -43,7 +43,7 @@
 ;; @002b                               v8 = ishl v6, v29  ; v29 = 3
 ;; @002b                               v9 = iadd v7, v8
 ;; @002b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;;                                     v30 = iconst.i64 -2
+;;                                     v28 = iconst.i64 -2
 ;; @002b                               v15 = iconst.i32 0
 ;; @002b                               v20 = load.i64 notrap aligned readonly can_move v0+48
 ;; @002b                               v21 = load.i32 notrap aligned readonly can_move v20
@@ -85,7 +85,7 @@
 ;; @0038                               v6 = load.i64 notrap aligned readonly can_move v0+56
 ;;                                     v37 = iconst.i64 8
 ;; @0038                               v8 = iadd v6, v37  ; v37 = 8
-;;                                     v28 = iconst.i64 -2
+;;                                     v26 = iconst.i64 -2
 ;; @0038                               v14 = iconst.i32 0
 ;;                                     v36 = iconst.i64 1
 ;; @0038                               v19 = load.i64 notrap aligned readonly can_move v0+48

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -30,8 +30,8 @@
 ;; @0033                               v11 = iconst.i64 0
 ;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0033                               v13 = load.i64 user5 aligned table v12
-;;                                     v30 = iconst.i64 -2
-;; @0033                               v14 = band v13, v30  ; v30 = -2
+;;                                     v28 = iconst.i64 -2
+;; @0033                               v14 = band v13, v28  ; v28 = -2
 ;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -30,8 +30,8 @@
 ;; @0033                               v11 = iconst.i64 0
 ;; @0033                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0033                               v13 = load.i64 user5 aligned table v12
-;;                                     v30 = iconst.i64 -2
-;; @0033                               v14 = band v13, v30  ; v30 = -2
+;;                                     v28 = iconst.i64 -2
+;; @0033                               v14 = band v13, v28  ; v28 = -2
 ;; @0033                               brif v13, block3(v14), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -20,10 +20,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               brif v2, block2, block4
-;;
-;;                                 block2:
-;; @001d                               trap user11
+;;                                     trapnz v2, user11
+;; @001b                               jump block4
 ;;
 ;;                                 block4:
 ;; @0020                               jump block3

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -20,13 +20,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               brif v2, block2, block4
+;;                                     trapz v2, user11
+;; @001b                               jump block2
 ;;
 ;;                                 block2:
 ;; @001e                               jump block3
-;;
-;;                                 block4:
-;; @001f                               trap user11
 ;;
 ;;                                 block3:
 ;; @0021                               v4 = iconst.i32 0

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -20,10 +20,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001b                               brif v2, block2, block4
-;;
-;;                                 block2:
-;; @001d                               trap user11
+;;                                     trapnz v2, user11
+;; @001b                               jump block4
 ;;
 ;;                                 block4:
 ;; @001f                               trap user11

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -22,16 +22,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @001c                               brif v2, block2, block5
+;;                                     trapz v2, user11
+;; @001c                               jump block2
 ;;
 ;;                                 block2:
-;; @0020                               brif.i32 v3, block3, block4
-;;
-;;                                 block4:
-;; @0022                               trap user11
-;;
-;;                                 block5:
-;; @0024                               trap user11
+;;                                     trapz.i32 v3, user11
+;; @0020                               jump block3
 ;;
 ;;                                 block3:
 ;; @0026                               v5 = iconst.i32 0

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -22,16 +22,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @001c                               brif v2, block2, block4
-;;
-;;                                 block2:
-;; @001e                               trap user11
+;;                                     trapnz v2, user11
+;; @001c                               jump block4
 ;;
 ;;                                 block4:
-;; @0022                               brif.i32 v3, block3, block5
-;;
-;;                                 block5:
-;; @0024                               trap user11
+;;                                     trapz.i32 v3, user11
+;; @0022                               jump block3
 ;;
 ;;                                 block3:
 ;; @0026                               v5 = iconst.i32 0

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -30,7 +30,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0049                               v5 = f64const 0x1.0000000000000p0
-;; @0056                               brif v3, block2, block4
+;;                                     trapz v3, user11
+;; @0056                               jump block2
 ;;
 ;;                                 block2:
 ;; @0058                               v7 = uextend.i64 v2
@@ -38,9 +39,6 @@
 ;; @0058                               v9 = iadd v8, v7
 ;; @0058                               v10 = sload16.i64 little heap v9
 ;; @005c                               jump block3
-;;
-;;                                 block4:
-;; @005d                               trap user11
 ;;
 ;;                                 block3:
 ;; @005f                               jump block1

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -84,8 +84,8 @@
 ;; @0050                               v10 = iconst.i64 0
 ;; @0050                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0050                               v12 = load.i64 user5 aligned table v11
-;;                                     v29 = iconst.i64 -2
-;; @0050                               v13 = band v12, v29  ; v29 = -2
+;;                                     v27 = iconst.i64 -2
+;; @0050                               v13 = band v12, v27  ; v27 = -2
 ;; @0050                               brif v12, block3(v13), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -53,8 +53,8 @@
 ;; @0031                               v8 = iadd v6, v7
 ;; @0031                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
 ;; @0031                               v11 = load.i64 user5 aligned table v10
-;;                                     v27 = iconst.i64 -2
-;; @0031                               v12 = band v11, v27  ; v27 = -2
+;;                                     v25 = iconst.i64 -2
+;; @0031                               v12 = band v11, v25  ; v25 = -2
 ;; @0031                               brif v11, block3(v12), block2
 ;;
 ;;                                 block2 cold:

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -28,19 +28,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v78 = iconst.i64 80
-;; @008f                               v7 = iadd v0, v78  ; v78 = 80
+;;                                     v111 = iconst.i64 80
+;; @008f                               v7 = iadd v0, v111  ; v111 = 80
 ;; @008f                               v8 = load.i32 notrap aligned readonly can_move v7
-;;                                     v79 = stack_addr.i64 ss0
-;;                                     store notrap v8, v79
-;;                                     v80 = stack_addr.i64 ss0
-;;                                     v77 = load.i32 notrap v80
-;;                                     v81 = iconst.i32 1
-;; @008f                               v9 = band v77, v81  ; v81 = 1
-;;                                     v82 = stack_addr.i64 ss0
-;;                                     v76 = load.i32 notrap v82
-;;                                     v83 = iconst.i32 0
-;; @008f                               v10 = icmp eq v76, v83  ; v83 = 0
+;;                                     v110 = stack_addr.i64 ss0
+;;                                     store notrap v8, v110
+;;                                     v109 = stack_addr.i64 ss0
+;;                                     v77 = load.i32 notrap v109
+;;                                     v108 = iconst.i32 1
+;; @008f                               v9 = band v77, v108  ; v108 = 1
+;;                                     v107 = stack_addr.i64 ss0
+;;                                     v76 = load.i32 notrap v107
+;;                                     v106 = iconst.i32 0
+;; @008f                               v10 = icmp eq v76, v106  ; v106 = 0
 ;; @008f                               v11 = uextend.i32 v10
 ;; @008f                               v12 = bor v9, v11
 ;; @008f                               brif v12, block5, block2
@@ -53,54 +53,54 @@
 ;; @008f                               brif v17, block3, block4
 ;;
 ;;                                 block4:
-;;                                     v84 = stack_addr.i64 ss0
-;;                                     v75 = load.i32 notrap v84
+;;                                     v105 = stack_addr.i64 ss0
+;;                                     v75 = load.i32 notrap v105
 ;; @008f                               v18 = uextend.i64 v75
-;; @008f                               v85 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v19 = load.i64 notrap aligned readonly can_move v85+24
+;; @008f                               v103 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v19 = load.i64 notrap aligned readonly can_move v103+24
 ;; @008f                               v20 = iadd v19, v18
 ;; @008f                               v21 = iconst.i64 8
 ;; @008f                               v22 = iadd v20, v21  ; v21 = 8
 ;; @008f                               v23 = load.i64 notrap aligned v22
-;;                                     v87 = iconst.i64 1
-;; @008f                               v24 = iadd v23, v87  ; v87 = 1
-;;                                     v88 = stack_addr.i64 ss0
-;;                                     v74 = load.i32 notrap v88
+;;                                     v102 = iconst.i64 1
+;; @008f                               v24 = iadd v23, v102  ; v102 = 1
+;;                                     v101 = stack_addr.i64 ss0
+;;                                     v74 = load.i32 notrap v101
 ;; @008f                               v25 = uextend.i64 v74
-;; @008f                               v89 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v26 = load.i64 notrap aligned readonly can_move v89+24
+;; @008f                               v99 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v26 = load.i64 notrap aligned readonly can_move v99+24
 ;; @008f                               v27 = iadd v26, v25
 ;; @008f                               v28 = iconst.i64 8
 ;; @008f                               v29 = iadd v27, v28  ; v28 = 8
 ;; @008f                               store notrap aligned v24, v29
-;;                                     v91 = stack_addr.i64 ss0
-;;                                     v73 = load.i32 notrap v91
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     v73 = load.i32 notrap v98
 ;; @008f                               store notrap aligned v73, v15
-;;                                     v92 = iconst.i64 4
-;; @008f                               v30 = iadd.i64 v15, v92  ; v92 = 4
+;;                                     v97 = iconst.i64 4
+;; @008f                               v30 = iadd.i64 v15, v97  ; v97 = 4
 ;; @008f                               store notrap aligned v30, v14
 ;; @008f                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v93 = stack_addr.i64 ss0
-;;                                     v72 = load.i32 notrap v93
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     v72 = load.i32 notrap v96
 ;; @008f                               v32 = call fn0(v0, v72), stack_map=[i32 @ ss0+0]
 ;; @008f                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v94 = iconst.i64 96
-;; @0091                               v34 = iadd.i64 v0, v94  ; v94 = 96
+;;                                     v95 = iconst.i64 96
+;; @0091                               v34 = iadd.i64 v0, v95  ; v95 = 96
 ;; @0091                               v35 = load.i32 notrap aligned readonly can_move v34
-;;                                     v95 = stack_addr.i64 ss1
-;;                                     store notrap v35, v95
-;;                                     v96 = stack_addr.i64 ss1
-;;                                     v71 = load.i32 notrap v96
-;;                                     v97 = iconst.i32 1
-;; @0091                               v36 = band v71, v97  ; v97 = 1
-;;                                     v98 = stack_addr.i64 ss1
-;;                                     v70 = load.i32 notrap v98
-;;                                     v99 = iconst.i32 0
-;; @0091                               v37 = icmp eq v70, v99  ; v99 = 0
+;;                                     v94 = stack_addr.i64 ss1
+;;                                     store notrap v35, v94
+;;                                     v93 = stack_addr.i64 ss1
+;;                                     v71 = load.i32 notrap v93
+;;                                     v92 = iconst.i32 1
+;; @0091                               v36 = band v71, v92  ; v92 = 1
+;;                                     v91 = stack_addr.i64 ss1
+;;                                     v70 = load.i32 notrap v91
+;;                                     v90 = iconst.i32 0
+;; @0091                               v37 = icmp eq v70, v90  ; v90 = 0
 ;; @0091                               v38 = uextend.i32 v37
 ;; @0091                               v39 = bor v36, v38
 ;; @0091                               brif v39, block9, block6
@@ -113,47 +113,47 @@
 ;; @0091                               brif v44, block7, block8
 ;;
 ;;                                 block8:
-;;                                     v100 = stack_addr.i64 ss1
-;;                                     v69 = load.i32 notrap v100
+;;                                     v89 = stack_addr.i64 ss1
+;;                                     v69 = load.i32 notrap v89
 ;; @0091                               v45 = uextend.i64 v69
-;; @0091                               v101 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v46 = load.i64 notrap aligned readonly can_move v101+24
+;; @0091                               v87 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v46 = load.i64 notrap aligned readonly can_move v87+24
 ;; @0091                               v47 = iadd v46, v45
 ;; @0091                               v48 = iconst.i64 8
 ;; @0091                               v49 = iadd v47, v48  ; v48 = 8
 ;; @0091                               v50 = load.i64 notrap aligned v49
-;;                                     v103 = iconst.i64 1
-;; @0091                               v51 = iadd v50, v103  ; v103 = 1
-;;                                     v104 = stack_addr.i64 ss1
-;;                                     v68 = load.i32 notrap v104
+;;                                     v86 = iconst.i64 1
+;; @0091                               v51 = iadd v50, v86  ; v86 = 1
+;;                                     v85 = stack_addr.i64 ss1
+;;                                     v68 = load.i32 notrap v85
 ;; @0091                               v52 = uextend.i64 v68
-;; @0091                               v105 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v53 = load.i64 notrap aligned readonly can_move v105+24
+;; @0091                               v83 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v53 = load.i64 notrap aligned readonly can_move v83+24
 ;; @0091                               v54 = iadd v53, v52
 ;; @0091                               v55 = iconst.i64 8
 ;; @0091                               v56 = iadd v54, v55  ; v55 = 8
 ;; @0091                               store notrap aligned v51, v56
-;;                                     v107 = stack_addr.i64 ss1
-;;                                     v67 = load.i32 notrap v107
+;;                                     v82 = stack_addr.i64 ss1
+;;                                     v67 = load.i32 notrap v82
 ;; @0091                               store notrap aligned v67, v42
-;;                                     v108 = iconst.i64 4
-;; @0091                               v57 = iadd.i64 v42, v108  ; v108 = 4
+;;                                     v81 = iconst.i64 4
+;; @0091                               v57 = iadd.i64 v42, v81  ; v81 = 4
 ;; @0091                               store notrap aligned v57, v41
 ;; @0091                               jump block9
 ;;
 ;;                                 block7 cold:
-;;                                     v109 = stack_addr.i64 ss1
-;;                                     v66 = load.i32 notrap v109
+;;                                     v80 = stack_addr.i64 ss1
+;;                                     v66 = load.i32 notrap v80
 ;; @0091                               v59 = call fn0(v0, v66), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0091                               jump block9
 ;;
 ;;                                 block9:
 ;; @0093                               v61 = load.i64 notrap aligned table v0+112
 ;; @0095                               v63 = load.i64 notrap aligned table v0+128
-;;                                     v110 = stack_addr.i64 ss0
-;;                                     v64 = load.i32 notrap v110
-;;                                     v111 = stack_addr.i64 ss1
-;;                                     v65 = load.i32 notrap v111
+;;                                     v79 = stack_addr.i64 ss0
+;;                                     v64 = load.i32 notrap v79
+;;                                     v78 = stack_addr.i64 ss1
+;;                                     v65 = load.i32 notrap v78
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -35,22 +35,22 @@
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0054                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;;                                     v45 = iconst.i64 2
-;; @0054                               v8 = ishl v6, v45  ; v45 = 2
+;;                                     v60 = iconst.i64 2
+;; @0054                               v8 = ishl v6, v60  ; v60 = 2
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.i32 user5 aligned table v11
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v12, v46
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     v43 = load.i32 notrap v47
-;;                                     v48 = iconst.i32 1
-;; @0054                               v13 = band v43, v48  ; v48 = 1
-;;                                     v49 = stack_addr.i64 ss0
-;;                                     v42 = load.i32 notrap v49
-;;                                     v50 = iconst.i32 0
-;; @0054                               v14 = icmp eq v42, v50  ; v50 = 0
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     store notrap v12, v59
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v43 = load.i32 notrap v58
+;;                                     v57 = iconst.i32 1
+;; @0054                               v13 = band v43, v57  ; v57 = 1
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     v42 = load.i32 notrap v56
+;;                                     v55 = iconst.i32 0
+;; @0054                               v14 = icmp eq v42, v55  ; v55 = 0
 ;; @0054                               v15 = uextend.i32 v14
 ;; @0054                               v16 = bor v13, v15
 ;; @0054                               brif v16, block5, block2
@@ -63,8 +63,8 @@
 ;; @0054                               brif v21, block3, block4
 ;;
 ;;                                 block4:
-;;                                     v51 = stack_addr.i64 ss0
-;;                                     v41 = load.i32 notrap v51
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     v41 = load.i32 notrap v54
 ;; @0054                               v22 = uextend.i64 v41
 ;; @0054                               v52 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0054                               v23 = load.i64 notrap aligned readonly can_move v52+24
@@ -72,34 +72,34 @@
 ;; @0054                               v25 = iconst.i64 8
 ;; @0054                               v26 = iadd v24, v25  ; v25 = 8
 ;; @0054                               v27 = load.i64 notrap aligned v26
-;;                                     v54 = iconst.i64 1
-;; @0054                               v28 = iadd v27, v54  ; v54 = 1
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v40 = load.i32 notrap v55
+;;                                     v51 = iconst.i64 1
+;; @0054                               v28 = iadd v27, v51  ; v51 = 1
+;;                                     v50 = stack_addr.i64 ss0
+;;                                     v40 = load.i32 notrap v50
 ;; @0054                               v29 = uextend.i64 v40
-;; @0054                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v30 = load.i64 notrap aligned readonly can_move v56+24
+;; @0054                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v30 = load.i64 notrap aligned readonly can_move v48+24
 ;; @0054                               v31 = iadd v30, v29
 ;; @0054                               v32 = iconst.i64 8
 ;; @0054                               v33 = iadd v31, v32  ; v32 = 8
 ;; @0054                               store notrap aligned v28, v33
-;;                                     v58 = stack_addr.i64 ss0
-;;                                     v39 = load.i32 notrap v58
+;;                                     v47 = stack_addr.i64 ss0
+;;                                     v39 = load.i32 notrap v47
 ;; @0054                               store notrap aligned v39, v19
-;;                                     v59 = iconst.i64 4
-;; @0054                               v34 = iadd.i64 v19, v59  ; v59 = 4
+;;                                     v46 = iconst.i64 4
+;; @0054                               v34 = iadd.i64 v19, v46  ; v46 = 4
 ;; @0054                               store notrap aligned v34, v18
 ;; @0054                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v38 = load.i32 notrap v60
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     v38 = load.i32 notrap v45
 ;; @0054                               v36 = call fn0(v0, v38), stack_map=[i32 @ ss0+0]
 ;; @0054                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v37 = load.i32 notrap v61
+;;                                     v44 = stack_addr.i64 ss0
+;;                                     v37 = load.i32 notrap v44
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -125,22 +125,22 @@
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;;                                     v45 = iconst.i64 2
-;; @005b                               v8 = ishl v6, v45  ; v45 = 2
+;;                                     v60 = iconst.i64 2
+;; @005b                               v8 = ishl v6, v60  ; v60 = 2
 ;; @005b                               v9 = iadd v7, v8
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.i32 user5 aligned table v11
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v12, v46
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     v43 = load.i32 notrap v47
-;;                                     v48 = iconst.i32 1
-;; @005b                               v13 = band v43, v48  ; v48 = 1
-;;                                     v49 = stack_addr.i64 ss0
-;;                                     v42 = load.i32 notrap v49
-;;                                     v50 = iconst.i32 0
-;; @005b                               v14 = icmp eq v42, v50  ; v50 = 0
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     store notrap v12, v59
+;;                                     v58 = stack_addr.i64 ss0
+;;                                     v43 = load.i32 notrap v58
+;;                                     v57 = iconst.i32 1
+;; @005b                               v13 = band v43, v57  ; v57 = 1
+;;                                     v56 = stack_addr.i64 ss0
+;;                                     v42 = load.i32 notrap v56
+;;                                     v55 = iconst.i32 0
+;; @005b                               v14 = icmp eq v42, v55  ; v55 = 0
 ;; @005b                               v15 = uextend.i32 v14
 ;; @005b                               v16 = bor v13, v15
 ;; @005b                               brif v16, block5, block2
@@ -153,8 +153,8 @@
 ;; @005b                               brif v21, block3, block4
 ;;
 ;;                                 block4:
-;;                                     v51 = stack_addr.i64 ss0
-;;                                     v41 = load.i32 notrap v51
+;;                                     v54 = stack_addr.i64 ss0
+;;                                     v41 = load.i32 notrap v54
 ;; @005b                               v22 = uextend.i64 v41
 ;; @005b                               v52 = load.i64 notrap aligned readonly can_move v0+8
 ;; @005b                               v23 = load.i64 notrap aligned readonly can_move v52+24
@@ -162,34 +162,34 @@
 ;; @005b                               v25 = iconst.i64 8
 ;; @005b                               v26 = iadd v24, v25  ; v25 = 8
 ;; @005b                               v27 = load.i64 notrap aligned v26
-;;                                     v54 = iconst.i64 1
-;; @005b                               v28 = iadd v27, v54  ; v54 = 1
-;;                                     v55 = stack_addr.i64 ss0
-;;                                     v40 = load.i32 notrap v55
+;;                                     v51 = iconst.i64 1
+;; @005b                               v28 = iadd v27, v51  ; v51 = 1
+;;                                     v50 = stack_addr.i64 ss0
+;;                                     v40 = load.i32 notrap v50
 ;; @005b                               v29 = uextend.i64 v40
-;; @005b                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v30 = load.i64 notrap aligned readonly can_move v56+24
+;; @005b                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v30 = load.i64 notrap aligned readonly can_move v48+24
 ;; @005b                               v31 = iadd v30, v29
 ;; @005b                               v32 = iconst.i64 8
 ;; @005b                               v33 = iadd v31, v32  ; v32 = 8
 ;; @005b                               store notrap aligned v28, v33
-;;                                     v58 = stack_addr.i64 ss0
-;;                                     v39 = load.i32 notrap v58
+;;                                     v47 = stack_addr.i64 ss0
+;;                                     v39 = load.i32 notrap v47
 ;; @005b                               store notrap aligned v39, v19
-;;                                     v59 = iconst.i64 4
-;; @005b                               v34 = iadd.i64 v19, v59  ; v59 = 4
+;;                                     v46 = iconst.i64 4
+;; @005b                               v34 = iadd.i64 v19, v46  ; v46 = 4
 ;; @005b                               store notrap aligned v34, v18
 ;; @005b                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v38 = load.i32 notrap v60
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     v38 = load.i32 notrap v45
 ;; @005b                               v36 = call fn0(v0, v38), stack_map=[i32 @ ss0+0]
 ;; @005b                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v61 = stack_addr.i64 ss0
-;;                                     v37 = load.i32 notrap v61
+;;                                     v44 = stack_addr.i64 ss0
+;;                                     v37 = load.i32 notrap v44
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -36,22 +36,22 @@
 ;; @0053                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0053                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0053                               v8 = load.i64 notrap aligned v0+56
-;;                                     v47 = iconst.i64 2
-;; @0053                               v9 = ishl v7, v47  ; v47 = 2
+;;                                     v61 = iconst.i64 2
+;; @0053                               v9 = ishl v7, v61  ; v61 = 2
 ;; @0053                               v10 = iadd v8, v9
 ;; @0053                               v11 = iconst.i64 0
 ;; @0053                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0053                               v13 = load.i32 user5 aligned table v12
-;;                                     v48 = stack_addr.i64 ss0
-;;                                     store notrap v13, v48
-;;                                     v49 = stack_addr.i64 ss0
-;;                                     v44 = load.i32 notrap v49
-;;                                     v50 = iconst.i32 1
-;; @0053                               v14 = band v44, v50  ; v50 = 1
-;;                                     v51 = stack_addr.i64 ss0
-;;                                     v43 = load.i32 notrap v51
-;;                                     v52 = iconst.i32 0
-;; @0053                               v15 = icmp eq v43, v52  ; v52 = 0
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     store notrap v13, v60
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v59
+;;                                     v58 = iconst.i32 1
+;; @0053                               v14 = band v44, v58  ; v58 = 1
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v43 = load.i32 notrap v57
+;;                                     v56 = iconst.i32 0
+;; @0053                               v15 = icmp eq v43, v56  ; v56 = 0
 ;; @0053                               v16 = uextend.i32 v15
 ;; @0053                               v17 = bor v14, v16
 ;; @0053                               brif v17, block5, block2
@@ -64,43 +64,43 @@
 ;; @0053                               brif v22, block3, block4
 ;;
 ;;                                 block4:
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     v42 = load.i32 notrap v53
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v42 = load.i32 notrap v55
 ;; @0053                               v23 = uextend.i64 v42
-;; @0053                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v24 = load.i64 notrap aligned readonly can_move v54+24
+;; @0053                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v24 = load.i64 notrap aligned readonly can_move v53+24
 ;; @0053                               v25 = iadd v24, v23
 ;; @0053                               v26 = iconst.i64 8
 ;; @0053                               v27 = iadd v25, v26  ; v26 = 8
 ;; @0053                               v28 = load.i64 notrap aligned v27
-;;                                     v56 = iconst.i64 1
-;; @0053                               v29 = iadd v28, v56  ; v56 = 1
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v41 = load.i32 notrap v57
+;;                                     v52 = iconst.i64 1
+;; @0053                               v29 = iadd v28, v52  ; v52 = 1
+;;                                     v51 = stack_addr.i64 ss0
+;;                                     v41 = load.i32 notrap v51
 ;; @0053                               v30 = uextend.i64 v41
-;; @0053                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v31 = load.i64 notrap aligned readonly can_move v58+24
+;; @0053                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v31 = load.i64 notrap aligned readonly can_move v49+24
 ;; @0053                               v32 = iadd v31, v30
 ;; @0053                               v33 = iconst.i64 8
 ;; @0053                               v34 = iadd v32, v33  ; v33 = 8
 ;; @0053                               store notrap aligned v29, v34
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v40 = load.i32 notrap v60
+;;                                     v48 = stack_addr.i64 ss0
+;;                                     v40 = load.i32 notrap v48
 ;; @0053                               store notrap aligned v40, v20
-;;                                     v61 = iconst.i64 4
-;; @0053                               v35 = iadd.i64 v20, v61  ; v61 = 4
+;;                                     v47 = iconst.i64 4
+;; @0053                               v35 = iadd.i64 v20, v47  ; v47 = 4
 ;; @0053                               store notrap aligned v35, v19
 ;; @0053                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v39 = load.i32 notrap v62
+;;                                     v46 = stack_addr.i64 ss0
+;;                                     v39 = load.i32 notrap v46
 ;; @0053                               v37 = call fn0(v0, v39), stack_map=[i32 @ ss0+0]
 ;; @0053                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v38 = load.i32 notrap v63
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     v38 = load.i32 notrap v45
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
@@ -128,22 +128,22 @@
 ;; @005a                               v6 = icmp uge v2, v5
 ;; @005a                               v7 = uextend.i64 v2
 ;; @005a                               v8 = load.i64 notrap aligned v0+56
-;;                                     v47 = iconst.i64 2
-;; @005a                               v9 = ishl v7, v47  ; v47 = 2
+;;                                     v61 = iconst.i64 2
+;; @005a                               v9 = ishl v7, v61  ; v61 = 2
 ;; @005a                               v10 = iadd v8, v9
 ;; @005a                               v11 = iconst.i64 0
 ;; @005a                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005a                               v13 = load.i32 user5 aligned table v12
-;;                                     v48 = stack_addr.i64 ss0
-;;                                     store notrap v13, v48
-;;                                     v49 = stack_addr.i64 ss0
-;;                                     v44 = load.i32 notrap v49
-;;                                     v50 = iconst.i32 1
-;; @005a                               v14 = band v44, v50  ; v50 = 1
-;;                                     v51 = stack_addr.i64 ss0
-;;                                     v43 = load.i32 notrap v51
-;;                                     v52 = iconst.i32 0
-;; @005a                               v15 = icmp eq v43, v52  ; v52 = 0
+;;                                     v60 = stack_addr.i64 ss0
+;;                                     store notrap v13, v60
+;;                                     v59 = stack_addr.i64 ss0
+;;                                     v44 = load.i32 notrap v59
+;;                                     v58 = iconst.i32 1
+;; @005a                               v14 = band v44, v58  ; v58 = 1
+;;                                     v57 = stack_addr.i64 ss0
+;;                                     v43 = load.i32 notrap v57
+;;                                     v56 = iconst.i32 0
+;; @005a                               v15 = icmp eq v43, v56  ; v56 = 0
 ;; @005a                               v16 = uextend.i32 v15
 ;; @005a                               v17 = bor v14, v16
 ;; @005a                               brif v17, block5, block2
@@ -156,43 +156,43 @@
 ;; @005a                               brif v22, block3, block4
 ;;
 ;;                                 block4:
-;;                                     v53 = stack_addr.i64 ss0
-;;                                     v42 = load.i32 notrap v53
+;;                                     v55 = stack_addr.i64 ss0
+;;                                     v42 = load.i32 notrap v55
 ;; @005a                               v23 = uextend.i64 v42
-;; @005a                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v24 = load.i64 notrap aligned readonly can_move v54+24
+;; @005a                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v24 = load.i64 notrap aligned readonly can_move v53+24
 ;; @005a                               v25 = iadd v24, v23
 ;; @005a                               v26 = iconst.i64 8
 ;; @005a                               v27 = iadd v25, v26  ; v26 = 8
 ;; @005a                               v28 = load.i64 notrap aligned v27
-;;                                     v56 = iconst.i64 1
-;; @005a                               v29 = iadd v28, v56  ; v56 = 1
-;;                                     v57 = stack_addr.i64 ss0
-;;                                     v41 = load.i32 notrap v57
+;;                                     v52 = iconst.i64 1
+;; @005a                               v29 = iadd v28, v52  ; v52 = 1
+;;                                     v51 = stack_addr.i64 ss0
+;;                                     v41 = load.i32 notrap v51
 ;; @005a                               v30 = uextend.i64 v41
-;; @005a                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v31 = load.i64 notrap aligned readonly can_move v58+24
+;; @005a                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v31 = load.i64 notrap aligned readonly can_move v49+24
 ;; @005a                               v32 = iadd v31, v30
 ;; @005a                               v33 = iconst.i64 8
 ;; @005a                               v34 = iadd v32, v33  ; v33 = 8
 ;; @005a                               store notrap aligned v29, v34
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     v40 = load.i32 notrap v60
+;;                                     v48 = stack_addr.i64 ss0
+;;                                     v40 = load.i32 notrap v48
 ;; @005a                               store notrap aligned v40, v20
-;;                                     v61 = iconst.i64 4
-;; @005a                               v35 = iadd.i64 v20, v61  ; v61 = 4
+;;                                     v47 = iconst.i64 4
+;; @005a                               v35 = iadd.i64 v20, v47  ; v47 = 4
 ;; @005a                               store notrap aligned v35, v19
 ;; @005a                               jump block5
 ;;
 ;;                                 block3 cold:
-;;                                     v62 = stack_addr.i64 ss0
-;;                                     v39 = load.i32 notrap v62
+;;                                     v46 = stack_addr.i64 ss0
+;;                                     v39 = load.i32 notrap v46
 ;; @005a                               v37 = call fn0(v0, v39), stack_map=[i32 @ ss0+0]
 ;; @005a                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v63 = stack_addr.i64 ss0
-;;                                     v38 = load.i32 notrap v63
+;;                                     v45 = stack_addr.i64 ss0
+;;                                     v38 = load.i32 notrap v45
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -35,33 +35,33 @@
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0056                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;;                                     v48 = iconst.i64 2
-;; @0056                               v8 = ishl v6, v48  ; v48 = 2
+;;                                     v62 = iconst.i64 2
+;; @0056                               v8 = ishl v6, v62  ; v62 = 2
 ;; @0056                               v9 = iadd v7, v8
 ;; @0056                               v10 = iconst.i64 0
 ;; @0056                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0056                               v12 = load.i32 user5 aligned table v11
-;;                                     v49 = iconst.i32 1
-;; @0056                               v13 = band v2, v49  ; v49 = 1
-;;                                     v50 = iconst.i32 0
-;; @0056                               v14 = icmp eq v2, v50  ; v50 = 0
+;;                                     v61 = iconst.i32 1
+;; @0056                               v13 = band v2, v61  ; v61 = 1
+;;                                     v60 = iconst.i32 0
+;; @0056                               v14 = icmp eq v2, v60  ; v60 = 0
 ;; @0056                               v15 = uextend.i32 v14
 ;; @0056                               v16 = bor v13, v15
 ;; @0056                               brif v16, block3, block2
 ;;
 ;;                                 block2:
 ;; @0056                               v17 = uextend.i64 v2
-;; @0056                               v51 = load.i64 notrap aligned readonly can_move v0+8
-;; @0056                               v18 = load.i64 notrap aligned readonly can_move v51+24
+;; @0056                               v58 = load.i64 notrap aligned readonly can_move v0+8
+;; @0056                               v18 = load.i64 notrap aligned readonly can_move v58+24
 ;; @0056                               v19 = iadd v18, v17
 ;; @0056                               v20 = iconst.i64 8
 ;; @0056                               v21 = iadd v19, v20  ; v20 = 8
 ;; @0056                               v22 = load.i64 notrap aligned v21
-;;                                     v53 = iconst.i64 1
-;; @0056                               v23 = iadd v22, v53  ; v53 = 1
+;;                                     v57 = iconst.i64 1
+;; @0056                               v23 = iadd v22, v57  ; v57 = 1
 ;; @0056                               v24 = uextend.i64 v2
-;; @0056                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @0056                               v25 = load.i64 notrap aligned readonly can_move v54+24
+;; @0056                               v55 = load.i64 notrap aligned readonly can_move v0+8
+;; @0056                               v25 = load.i64 notrap aligned readonly can_move v55+24
 ;; @0056                               v26 = iadd v25, v24
 ;; @0056                               v27 = iconst.i64 8
 ;; @0056                               v28 = iadd v26, v27  ; v27 = 8
@@ -70,26 +70,26 @@
 ;;
 ;;                                 block3:
 ;; @0056                               store.i32 user5 aligned table v2, v11
-;;                                     v56 = iconst.i32 1
-;; @0056                               v29 = band.i32 v12, v56  ; v56 = 1
-;;                                     v57 = iconst.i32 0
-;; @0056                               v30 = icmp.i32 eq v12, v57  ; v57 = 0
+;;                                     v54 = iconst.i32 1
+;; @0056                               v29 = band.i32 v12, v54  ; v54 = 1
+;;                                     v53 = iconst.i32 0
+;; @0056                               v30 = icmp.i32 eq v12, v53  ; v53 = 0
 ;; @0056                               v31 = uextend.i32 v30
 ;; @0056                               v32 = bor v29, v31
 ;; @0056                               brif v32, block7, block4
 ;;
 ;;                                 block4:
 ;; @0056                               v33 = uextend.i64 v12
-;; @0056                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @0056                               v34 = load.i64 notrap aligned readonly can_move v58+24
+;; @0056                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @0056                               v34 = load.i64 notrap aligned readonly can_move v51+24
 ;; @0056                               v35 = iadd v34, v33
 ;; @0056                               v36 = iconst.i64 8
 ;; @0056                               v37 = iadd v35, v36  ; v36 = 8
 ;; @0056                               v38 = load.i64 notrap aligned v37
-;;                                     v60 = iconst.i64 -1
-;; @0056                               v39 = iadd v38, v60  ; v60 = -1
-;;                                     v61 = iconst.i64 0
-;; @0056                               v40 = icmp eq v39, v61  ; v61 = 0
+;;                                     v50 = iconst.i64 -1
+;; @0056                               v39 = iadd v38, v50  ; v50 = -1
+;;                                     v49 = iconst.i64 0
+;; @0056                               v40 = icmp eq v39, v49  ; v49 = 0
 ;; @0056                               brif v40, block5, block6
 ;;
 ;;                                 block5 cold:
@@ -98,8 +98,8 @@
 ;;
 ;;                                 block6:
 ;; @0056                               v42 = uextend.i64 v12
-;; @0056                               v62 = load.i64 notrap aligned readonly can_move v0+8
-;; @0056                               v43 = load.i64 notrap aligned readonly can_move v62+24
+;; @0056                               v47 = load.i64 notrap aligned readonly can_move v0+8
+;; @0056                               v43 = load.i64 notrap aligned readonly can_move v47+24
 ;; @0056                               v44 = iadd v43, v42
 ;; @0056                               v45 = iconst.i64 8
 ;; @0056                               v46 = iadd v44, v45  ; v45 = 8
@@ -131,33 +131,33 @@
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
 ;; @005f                               v7 = load.i64 notrap aligned readonly can_move v0+56
-;;                                     v48 = iconst.i64 2
-;; @005f                               v8 = ishl v6, v48  ; v48 = 2
+;;                                     v62 = iconst.i64 2
+;; @005f                               v8 = ishl v6, v62  ; v62 = 2
 ;; @005f                               v9 = iadd v7, v8
 ;; @005f                               v10 = iconst.i64 0
 ;; @005f                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005f                               v12 = load.i32 user5 aligned table v11
-;;                                     v49 = iconst.i32 1
-;; @005f                               v13 = band v3, v49  ; v49 = 1
-;;                                     v50 = iconst.i32 0
-;; @005f                               v14 = icmp eq v3, v50  ; v50 = 0
+;;                                     v61 = iconst.i32 1
+;; @005f                               v13 = band v3, v61  ; v61 = 1
+;;                                     v60 = iconst.i32 0
+;; @005f                               v14 = icmp eq v3, v60  ; v60 = 0
 ;; @005f                               v15 = uextend.i32 v14
 ;; @005f                               v16 = bor v13, v15
 ;; @005f                               brif v16, block3, block2
 ;;
 ;;                                 block2:
 ;; @005f                               v17 = uextend.i64 v3
-;; @005f                               v51 = load.i64 notrap aligned readonly can_move v0+8
-;; @005f                               v18 = load.i64 notrap aligned readonly can_move v51+24
+;; @005f                               v58 = load.i64 notrap aligned readonly can_move v0+8
+;; @005f                               v18 = load.i64 notrap aligned readonly can_move v58+24
 ;; @005f                               v19 = iadd v18, v17
 ;; @005f                               v20 = iconst.i64 8
 ;; @005f                               v21 = iadd v19, v20  ; v20 = 8
 ;; @005f                               v22 = load.i64 notrap aligned v21
-;;                                     v53 = iconst.i64 1
-;; @005f                               v23 = iadd v22, v53  ; v53 = 1
+;;                                     v57 = iconst.i64 1
+;; @005f                               v23 = iadd v22, v57  ; v57 = 1
 ;; @005f                               v24 = uextend.i64 v3
-;; @005f                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @005f                               v25 = load.i64 notrap aligned readonly can_move v54+24
+;; @005f                               v55 = load.i64 notrap aligned readonly can_move v0+8
+;; @005f                               v25 = load.i64 notrap aligned readonly can_move v55+24
 ;; @005f                               v26 = iadd v25, v24
 ;; @005f                               v27 = iconst.i64 8
 ;; @005f                               v28 = iadd v26, v27  ; v27 = 8
@@ -166,26 +166,26 @@
 ;;
 ;;                                 block3:
 ;; @005f                               store.i32 user5 aligned table v3, v11
-;;                                     v56 = iconst.i32 1
-;; @005f                               v29 = band.i32 v12, v56  ; v56 = 1
-;;                                     v57 = iconst.i32 0
-;; @005f                               v30 = icmp.i32 eq v12, v57  ; v57 = 0
+;;                                     v54 = iconst.i32 1
+;; @005f                               v29 = band.i32 v12, v54  ; v54 = 1
+;;                                     v53 = iconst.i32 0
+;; @005f                               v30 = icmp.i32 eq v12, v53  ; v53 = 0
 ;; @005f                               v31 = uextend.i32 v30
 ;; @005f                               v32 = bor v29, v31
 ;; @005f                               brif v32, block7, block4
 ;;
 ;;                                 block4:
 ;; @005f                               v33 = uextend.i64 v12
-;; @005f                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @005f                               v34 = load.i64 notrap aligned readonly can_move v58+24
+;; @005f                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @005f                               v34 = load.i64 notrap aligned readonly can_move v51+24
 ;; @005f                               v35 = iadd v34, v33
 ;; @005f                               v36 = iconst.i64 8
 ;; @005f                               v37 = iadd v35, v36  ; v36 = 8
 ;; @005f                               v38 = load.i64 notrap aligned v37
-;;                                     v60 = iconst.i64 -1
-;; @005f                               v39 = iadd v38, v60  ; v60 = -1
-;;                                     v61 = iconst.i64 0
-;; @005f                               v40 = icmp eq v39, v61  ; v61 = 0
+;;                                     v50 = iconst.i64 -1
+;; @005f                               v39 = iadd v38, v50  ; v50 = -1
+;;                                     v49 = iconst.i64 0
+;; @005f                               v40 = icmp eq v39, v49  ; v49 = 0
 ;; @005f                               brif v40, block5, block6
 ;;
 ;;                                 block5 cold:
@@ -194,8 +194,8 @@
 ;;
 ;;                                 block6:
 ;; @005f                               v42 = uextend.i64 v12
-;; @005f                               v62 = load.i64 notrap aligned readonly can_move v0+8
-;; @005f                               v43 = load.i64 notrap aligned readonly can_move v62+24
+;; @005f                               v47 = load.i64 notrap aligned readonly can_move v0+8
+;; @005f                               v43 = load.i64 notrap aligned readonly can_move v47+24
 ;; @005f                               v44 = iadd v43, v42
 ;; @005f                               v45 = iconst.i64 8
 ;; @005f                               v46 = iadd v44, v45  ; v45 = 8

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -37,30 +37,30 @@
 ;; @0055                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0055                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0055                               v8 = load.i64 notrap aligned v0+56
-;;                                     v50 = iconst.i64 2
-;; @0055                               v9 = ishl v7, v50  ; v50 = 2
+;;                                     v63 = iconst.i64 2
+;; @0055                               v9 = ishl v7, v63  ; v63 = 2
 ;; @0055                               v10 = iadd v8, v9
 ;; @0055                               v11 = iconst.i64 0
 ;; @0055                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0055                               v13 = load.i32 user5 aligned table v12
-;;                                     v51 = iconst.i32 1
-;; @0055                               v14 = band v2, v51  ; v51 = 1
-;;                                     v52 = iconst.i32 0
-;; @0055                               v15 = icmp eq v2, v52  ; v52 = 0
+;;                                     v62 = iconst.i32 1
+;; @0055                               v14 = band v2, v62  ; v62 = 1
+;;                                     v61 = iconst.i32 0
+;; @0055                               v15 = icmp eq v2, v61  ; v61 = 0
 ;; @0055                               v16 = uextend.i32 v15
 ;; @0055                               v17 = bor v14, v16
 ;; @0055                               brif v17, block3, block2
 ;;
 ;;                                 block2:
 ;; @0055                               v18 = uextend.i64 v2
-;; @0055                               v53 = load.i64 notrap aligned readonly can_move v0+8
-;; @0055                               v19 = load.i64 notrap aligned readonly can_move v53+24
+;; @0055                               v59 = load.i64 notrap aligned readonly can_move v0+8
+;; @0055                               v19 = load.i64 notrap aligned readonly can_move v59+24
 ;; @0055                               v20 = iadd v19, v18
 ;; @0055                               v21 = iconst.i64 8
 ;; @0055                               v22 = iadd v20, v21  ; v21 = 8
 ;; @0055                               v23 = load.i64 notrap aligned v22
-;;                                     v55 = iconst.i64 1
-;; @0055                               v24 = iadd v23, v55  ; v55 = 1
+;;                                     v58 = iconst.i64 1
+;; @0055                               v24 = iadd v23, v58  ; v58 = 1
 ;; @0055                               v25 = uextend.i64 v2
 ;; @0055                               v56 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0055                               v26 = load.i64 notrap aligned readonly can_move v56+24
@@ -72,26 +72,26 @@
 ;;
 ;;                                 block3:
 ;; @0055                               store.i32 user5 aligned table v2, v12
-;;                                     v58 = iconst.i32 1
-;; @0055                               v30 = band.i32 v13, v58  ; v58 = 1
-;;                                     v59 = iconst.i32 0
-;; @0055                               v31 = icmp.i32 eq v13, v59  ; v59 = 0
+;;                                     v55 = iconst.i32 1
+;; @0055                               v30 = band.i32 v13, v55  ; v55 = 1
+;;                                     v54 = iconst.i32 0
+;; @0055                               v31 = icmp.i32 eq v13, v54  ; v54 = 0
 ;; @0055                               v32 = uextend.i32 v31
 ;; @0055                               v33 = bor v30, v32
 ;; @0055                               brif v33, block7, block4
 ;;
 ;;                                 block4:
 ;; @0055                               v34 = uextend.i64 v13
-;; @0055                               v60 = load.i64 notrap aligned readonly can_move v0+8
-;; @0055                               v35 = load.i64 notrap aligned readonly can_move v60+24
+;; @0055                               v52 = load.i64 notrap aligned readonly can_move v0+8
+;; @0055                               v35 = load.i64 notrap aligned readonly can_move v52+24
 ;; @0055                               v36 = iadd v35, v34
 ;; @0055                               v37 = iconst.i64 8
 ;; @0055                               v38 = iadd v36, v37  ; v37 = 8
 ;; @0055                               v39 = load.i64 notrap aligned v38
-;;                                     v62 = iconst.i64 -1
-;; @0055                               v40 = iadd v39, v62  ; v62 = -1
-;;                                     v63 = iconst.i64 0
-;; @0055                               v41 = icmp eq v40, v63  ; v63 = 0
+;;                                     v51 = iconst.i64 -1
+;; @0055                               v40 = iadd v39, v51  ; v51 = -1
+;;                                     v50 = iconst.i64 0
+;; @0055                               v41 = icmp eq v40, v50  ; v50 = 0
 ;; @0055                               brif v41, block5, block6
 ;;
 ;;                                 block5 cold:
@@ -100,8 +100,8 @@
 ;;
 ;;                                 block6:
 ;; @0055                               v43 = uextend.i64 v13
-;; @0055                               v64 = load.i64 notrap aligned readonly can_move v0+8
-;; @0055                               v44 = load.i64 notrap aligned readonly can_move v64+24
+;; @0055                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @0055                               v44 = load.i64 notrap aligned readonly can_move v48+24
 ;; @0055                               v45 = iadd v44, v43
 ;; @0055                               v46 = iconst.i64 8
 ;; @0055                               v47 = iadd v45, v46  ; v46 = 8
@@ -135,30 +135,30 @@
 ;; @005e                               v6 = icmp uge v2, v5
 ;; @005e                               v7 = uextend.i64 v2
 ;; @005e                               v8 = load.i64 notrap aligned v0+56
-;;                                     v50 = iconst.i64 2
-;; @005e                               v9 = ishl v7, v50  ; v50 = 2
+;;                                     v63 = iconst.i64 2
+;; @005e                               v9 = ishl v7, v63  ; v63 = 2
 ;; @005e                               v10 = iadd v8, v9
 ;; @005e                               v11 = iconst.i64 0
 ;; @005e                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005e                               v13 = load.i32 user5 aligned table v12
-;;                                     v51 = iconst.i32 1
-;; @005e                               v14 = band v3, v51  ; v51 = 1
-;;                                     v52 = iconst.i32 0
-;; @005e                               v15 = icmp eq v3, v52  ; v52 = 0
+;;                                     v62 = iconst.i32 1
+;; @005e                               v14 = band v3, v62  ; v62 = 1
+;;                                     v61 = iconst.i32 0
+;; @005e                               v15 = icmp eq v3, v61  ; v61 = 0
 ;; @005e                               v16 = uextend.i32 v15
 ;; @005e                               v17 = bor v14, v16
 ;; @005e                               brif v17, block3, block2
 ;;
 ;;                                 block2:
 ;; @005e                               v18 = uextend.i64 v3
-;; @005e                               v53 = load.i64 notrap aligned readonly can_move v0+8
-;; @005e                               v19 = load.i64 notrap aligned readonly can_move v53+24
+;; @005e                               v59 = load.i64 notrap aligned readonly can_move v0+8
+;; @005e                               v19 = load.i64 notrap aligned readonly can_move v59+24
 ;; @005e                               v20 = iadd v19, v18
 ;; @005e                               v21 = iconst.i64 8
 ;; @005e                               v22 = iadd v20, v21  ; v21 = 8
 ;; @005e                               v23 = load.i64 notrap aligned v22
-;;                                     v55 = iconst.i64 1
-;; @005e                               v24 = iadd v23, v55  ; v55 = 1
+;;                                     v58 = iconst.i64 1
+;; @005e                               v24 = iadd v23, v58  ; v58 = 1
 ;; @005e                               v25 = uextend.i64 v3
 ;; @005e                               v56 = load.i64 notrap aligned readonly can_move v0+8
 ;; @005e                               v26 = load.i64 notrap aligned readonly can_move v56+24
@@ -170,26 +170,26 @@
 ;;
 ;;                                 block3:
 ;; @005e                               store.i32 user5 aligned table v3, v12
-;;                                     v58 = iconst.i32 1
-;; @005e                               v30 = band.i32 v13, v58  ; v58 = 1
-;;                                     v59 = iconst.i32 0
-;; @005e                               v31 = icmp.i32 eq v13, v59  ; v59 = 0
+;;                                     v55 = iconst.i32 1
+;; @005e                               v30 = band.i32 v13, v55  ; v55 = 1
+;;                                     v54 = iconst.i32 0
+;; @005e                               v31 = icmp.i32 eq v13, v54  ; v54 = 0
 ;; @005e                               v32 = uextend.i32 v31
 ;; @005e                               v33 = bor v30, v32
 ;; @005e                               brif v33, block7, block4
 ;;
 ;;                                 block4:
 ;; @005e                               v34 = uextend.i64 v13
-;; @005e                               v60 = load.i64 notrap aligned readonly can_move v0+8
-;; @005e                               v35 = load.i64 notrap aligned readonly can_move v60+24
+;; @005e                               v52 = load.i64 notrap aligned readonly can_move v0+8
+;; @005e                               v35 = load.i64 notrap aligned readonly can_move v52+24
 ;; @005e                               v36 = iadd v35, v34
 ;; @005e                               v37 = iconst.i64 8
 ;; @005e                               v38 = iadd v36, v37  ; v37 = 8
 ;; @005e                               v39 = load.i64 notrap aligned v38
-;;                                     v62 = iconst.i64 -1
-;; @005e                               v40 = iadd v39, v62  ; v62 = -1
-;;                                     v63 = iconst.i64 0
-;; @005e                               v41 = icmp eq v40, v63  ; v63 = 0
+;;                                     v51 = iconst.i64 -1
+;; @005e                               v40 = iadd v39, v51  ; v51 = -1
+;;                                     v50 = iconst.i64 0
+;; @005e                               v41 = icmp eq v40, v50  ; v50 = 0
 ;; @005e                               brif v41, block5, block6
 ;;
 ;;                                 block5 cold:
@@ -198,8 +198,8 @@
 ;;
 ;;                                 block6:
 ;; @005e                               v43 = uextend.i64 v13
-;; @005e                               v64 = load.i64 notrap aligned readonly can_move v0+8
-;; @005e                               v44 = load.i64 notrap aligned readonly can_move v64+24
+;; @005e                               v48 = load.i64 notrap aligned readonly can_move v0+8
+;; @005e                               v44 = load.i64 notrap aligned readonly can_move v48+24
 ;; @005e                               v45 = iadd v44, v43
 ;; @005e                               v46 = iconst.i64 8
 ;; @005e                               v47 = iadd v45, v46  ; v46 = 8

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -142,8 +142,8 @@
 ;;                                     v68 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
-;;                                     v56 = iconst.i64 -2
-;; @0048                               v18 = band v17, v56  ; v56 = -2
+;;                                     v57 = iconst.i64 -2
+;; @0048                               v18 = band v17, v57  ; v57 = -2
 ;; @0048                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
@@ -196,8 +196,8 @@
 ;;                                     v68 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v68  ; v68 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14
-;;                                     v56 = iconst.i64 -2
-;; @0075                               v18 = band v17, v56  ; v56 = -2
+;;                                     v57 = iconst.i64 -2
+;; @0075                               v18 = band v17, v57  ; v57 = -2
 ;; @0075                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:


### PR DESCRIPTION
Given this instruction:

```clif
brif v0, block1, block2
```

If we know that `block1` does nothing but immediately trap then we can rewrite
that `brif` into the following:

```clif
trapz v0, <trapcode>
jump block2
```

(And we can do the equivalent with `trapz` if `block2` immediately traps).

This transformation allows for the conditional trap instructions to be GVN'd and
for our egraphs mid-end to generally better optimize the program. We
additionally have better codegen in our backends for `trapz` than branches to
unconditional traps.

Fixes https://github.com/bytecodealliance/wasmtime/issues/10941
