### PR TITLE
winch: Simplify constant handling, part 2/N

### DIFF
--- a/tests/disas/winch/aarch64/br_table/large.wat
+++ b/tests/disas/winch/aarch64/br_table/large.wat
@@ -757,8 +757,8 @@
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
-;;       mov     x16, #0x6027
-;;       cmp     x0, x16, uxtx
+;;       mov     x1, #0x6027
+;;       cmp     w0, w1, uxtx
 ;;       b.hs    #0x18110
 ;;   54: csel    x1, xzr, x0, hs
 ;;       csdb

--- a/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
+++ b/tests/disas/winch/aarch64/br_table/nested_br_table_loop_block.wat
@@ -29,7 +29,7 @@
 ;;       movk    x17, #0x18
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0xc4
+;;       b.lo    #0xcc
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -37,30 +37,32 @@
 ;;       stur    x1, [x28, #8]
 ;;       stur    w2, [x28, #4]
 ;;       ldur    w0, [x28, #4]
-;;       cmp     x0, #2
-;;       b.hs    #0x74
-;;   50: csel    x1, xzr, x0, hs
+;;       mov     x1, #2
+;;       cmp     w0, w1, uxtx
+;;       b.hs    #0x78
+;;   54: csel    x1, xzr, x0, hs
 ;;       csdb
-;;       adr     x16, #0x68
+;;       adr     x16, #0x6c
 ;;       ldrsw   x1, [x16, w1, uxtw #2]
 ;;       add     x16, x16, x1
 ;;       br      x16
-;;   68: .byte   0xdc, 0xff, 0xff, 0xff
+;;   6c: .byte   0xd8, 0xff, 0xff, 0xff
 ;;       .byte   0x0c, 0x00, 0x00, 0x00
 ;;       b       #0x44
-;;   74: mov     x0, #0
+;;   78: mov     x0, #0
 ;;       stur    w0, [x28, #4]
 ;;       ldur    w0, [x28, #4]
-;;       cmp     x0, #2
-;;       b.hs    #0x7c
-;;   88: csel    x1, xzr, x0, hs
+;;       mov     x1, #2
+;;       cmp     w0, w1, uxtx
+;;       b.hs    #0x80
+;;   90: csel    x1, xzr, x0, hs
 ;;       csdb
-;;       adr     x16, #0xa0
+;;       adr     x16, #0xa8
 ;;       ldrsw   x1, [x16, w1, uxtw #2]
 ;;       add     x16, x16, x1
 ;;       br      x16
-;;   a0: .byte   0x08, 0x00, 0x00, 0x00
-;;       .byte   0xdc, 0xff, 0xff, 0xff
+;;   a8: .byte   0x08, 0x00, 0x00, 0x00
+;;       .byte   0xd8, 0xff, 0xff, 0xff
 ;;       mov     x0, #3
 ;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -68,4 +70,4 @@
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   c4: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   cc: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/winch/aarch64/i32_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i32_rotl/16_const.wat
@@ -26,8 +26,8 @@
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x0, #1
-;;       neg     w0, w0
 ;;       mov     x16, #0x200
+;;       neg     w16, w16
 ;;       ror     w0, w0, w16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/tests/disas/winch/aarch64/i64_rotl/16_const.wat
+++ b/tests/disas/winch/aarch64/i64_rotl/16_const.wat
@@ -26,8 +26,8 @@
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x0, #1
-;;       neg     x0, x0
 ;;       mov     x16, #0x200
+;;       neg     x16, x16
 ;;       ror     x0, x0, x16
 ;;       add     x28, x28, #0x10
 ;;       mov     sp, x28

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -9,8 +9,8 @@ use crate::{
     frame::Frame,
     isa::reg::RegClass,
     masm::{
-        ExtractLaneKind, MacroAssembler, MemMoveDirection, OperandSize, RegImm, ReplaceLaneKind,
-        SPOffset, ShiftKind, StackSlot, Imm,
+        ExtractLaneKind, Imm, MacroAssembler, MemMoveDirection, OperandSize, RegImm,
+        ReplaceLaneKind, SPOffset, ShiftKind, StackSlot,
     },
     reg::{Reg, WritableReg, writable},
     regalloc::RegAlloc,

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -10,7 +10,7 @@ use crate::{
     isa::reg::RegClass,
     masm::{
         ExtractLaneKind, MacroAssembler, MemMoveDirection, OperandSize, RegImm, ReplaceLaneKind,
-        SPOffset, ShiftKind, StackSlot,
+        SPOffset, ShiftKind, StackSlot, Imm,
     },
     reg::{Reg, WritableReg, writable},
     regalloc::RegAlloc,
@@ -64,7 +64,7 @@ impl<'a> CodeGenContext<'a, Emission> {
             let typed_reg = self.pop_to_reg(masm, None)?;
             masm.shift_ir(
                 writable!(typed_reg.reg),
-                val as u64,
+                Imm::i32(val),
                 typed_reg.reg,
                 kind,
                 OperandSize::S32,
@@ -93,7 +93,7 @@ impl<'a> CodeGenContext<'a, Emission> {
             let typed_reg = self.pop_to_reg(masm, None)?;
             masm.shift_ir(
                 writable!(typed_reg.reg),
-                val as u64,
+                Imm::i64(val),
                 typed_reg.reg,
                 kind,
                 OperandSize::S64,

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1102,7 +1102,7 @@ where
         let pow = heap_data.memory.page_size_log2;
         self.masm.shift_ir(
             writable!(dst.reg),
-            pow as u64,
+            Imm::i32(pow as i32),
             dst.into(),
             ShiftKind::ShrU,
             heap_data.index_type().try_into()?,

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -122,12 +122,14 @@ impl ABI for Aarch64ABI {
 
     fn scratch_for(ty: &WasmValType) -> Reg {
         match ty {
+            #[expect(deprecated, reason = "Pending migration to Masm::with_scratch")]
             WasmValType::I32
             | WasmValType::I64
             | WasmValType::Ref(WasmRefType {
                 heap_type: WasmHeapType::Func,
                 ..
             }) => regs::scratch(),
+            #[expect(deprecated, reason = "Pending migration to Masm::with_scratch")]
             WasmValType::F32 | WasmValType::F64 | WasmValType::V128 => regs::float_scratch(),
             _ => unimplemented!(),
         }

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -298,29 +298,31 @@ impl Assembler {
     /// into the destination register.
     /// The emitted instructions will depend on the destination register class.
     pub fn mov_ir(&mut self, rd: WritableReg, imm: Imm, size: OperandSize) {
-	match rd.to_reg().class() {
-	    RegClass::Int => {
-		Inst::load_constant(rd.map(Into::into), imm.unwrap_as_u64(), &mut |_| rd.map(Into::into))
-		    .into_iter()
-		    .for_each(|i| self.emit(i));
-	    },
-	    RegClass::Float => {
-		match ASIMDFPModImm::maybe_from_u64(imm.unwrap_as_u64(), size.into()) {
-		    Some(imm) => {
-			self.emit(Inst::FpuMoveFPImm {
-			    rd: rd.map(Into::into),
-			    imm,
-			    size: size.into(),
-			});
-		    }
-		    _ => {
-			let addr = self.add_constant(&imm.to_bytes());
-			self.uload(addr, rd, size, TRUSTED_FLAGS);
-		    }
-		}
-	    },
-	    _ => unreachable!()
-	}
+        match rd.to_reg().class() {
+            RegClass::Int => {
+                Inst::load_constant(rd.map(Into::into), imm.unwrap_as_u64(), &mut |_| {
+                    rd.map(Into::into)
+                })
+                .into_iter()
+                .for_each(|i| self.emit(i));
+            }
+            RegClass::Float => {
+                match ASIMDFPModImm::maybe_from_u64(imm.unwrap_as_u64(), size.into()) {
+                    Some(imm) => {
+                        self.emit(Inst::FpuMoveFPImm {
+                            rd: rd.map(Into::into),
+                            imm,
+                            size: size.into(),
+                        });
+                    }
+                    _ => {
+                        let addr = self.add_constant(&imm.to_bytes());
+                        self.uload(addr, rd, size, TRUSTED_FLAGS);
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
     }
 
     /// Register to register move.
@@ -401,12 +403,12 @@ impl Assembler {
 
     /// Subtract immediate and register.
     pub fn sub_ir(&mut self, imm: Imm12, rn: Reg, rd: WritableReg, size: OperandSize) {
-	self.alu_rri(ALUOp::Sub, imm, rn, rd, size);
+        self.alu_rri(ALUOp::Sub, imm, rn, rd, size);
     }
 
     /// Subtract immediate and register, setting flags.
     pub fn subs_ir(&mut self, imm: Imm12, rn: Reg, size: OperandSize) {
-	self.alu_rri(ALUOp::SubS, imm, rn, writable!(regs::zero()), size);
+        self.alu_rri(ALUOp::SubS, imm, rn, writable!(regs::zero()), size);
     }
 
     /// Subtract with three registers.
@@ -543,7 +545,7 @@ impl Assembler {
 
     /// And immediate and register.
     pub fn and_ir(&mut self, imm: ImmLogic, rn: Reg, rd: WritableReg, size: OperandSize) {
-	self.alu_rri_logic(ALUOp::And, imm, rn, rd, size);
+        self.alu_rri_logic(ALUOp::And, imm, rn, rd, size);
     }
 
     /// Or with three registers.
@@ -553,7 +555,7 @@ impl Assembler {
 
     /// Or immediate and register.
     pub fn or_ir(&mut self, imm: ImmLogic, rn: Reg, rd: WritableReg, size: OperandSize) {
-	self.alu_rri_logic(ALUOp::Orr, imm, rn, rd, size);
+        self.alu_rri_logic(ALUOp::Orr, imm, rn, rd, size);
     }
 
     /// Xor with three registers.
@@ -563,7 +565,7 @@ impl Assembler {
 
     /// Xor immediate and register.
     pub fn xor_ir(&mut self, imm: ImmLogic, rn: Reg, rd: WritableReg, size: OperandSize) {
-	self.alu_rri_logic(ALUOp::Eor, imm, rn, rd, size);
+        self.alu_rri_logic(ALUOp::Eor, imm, rn, rd, size);
     }
 
     /// Shift with three registers.
@@ -589,7 +591,7 @@ impl Assembler {
         size: OperandSize,
     ) {
         let shift_op = self.shift_kind_to_alu_op(kind, rn, size);
-	self.alu_rri_shift(shift_op, imm, rn, rd, size);
+        self.alu_rri_shift(shift_op, imm, rn, rd, size);
     }
 
     /// Count Leading Zeros.

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -1,5 +1,4 @@
-use self::regs::{ALL_GPR, MAX_FPR, MAX_GPR, NON_ALLOCATABLE_GPR};
-use crate::isa::aarch64::regs::{ALL_FPR, NON_ALLOCATABLE_FPR};
+use self::regs::{gpr_bit_set, fpr_bit_set};
 use crate::{
     BuiltinFunctions,
     abi::{ABI, wasm_sig},
@@ -8,7 +7,6 @@ use crate::{
     isa::{Builder, TargetIsa},
     masm::MacroAssembler,
     regalloc::RegAlloc,
-    regset::RegBitSet,
     stack::Stack,
 };
 use anyhow::Result;
@@ -111,17 +109,7 @@ impl TargetIsa for Aarch64 {
         let defined_locals =
             DefinedLocals::new::<abi::Aarch64ABI>(&type_converter, &mut body, validator)?;
         let frame = Frame::new::<abi::Aarch64ABI>(&abi_sig, &defined_locals)?;
-        let gpr = RegBitSet::int(
-            ALL_GPR.into(),
-            NON_ALLOCATABLE_GPR.into(),
-            usize::try_from(MAX_GPR).unwrap(),
-        );
-        let fpr = RegBitSet::float(
-            ALL_FPR.into(),
-            NON_ALLOCATABLE_FPR.into(),
-            usize::try_from(MAX_FPR).unwrap(),
-        );
-        let regalloc = RegAlloc::from(gpr, fpr);
+        let regalloc = RegAlloc::from(gpr_bit_set(), fpr_bit_set());
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
         let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
 

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -1,4 +1,4 @@
-use self::regs::{gpr_bit_set, fpr_bit_set};
+use self::regs::{fpr_bit_set, gpr_bit_set};
 use crate::{
     BuiltinFunctions,
     abi::{ABI, wasm_sig},

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -169,7 +169,6 @@ const ALLOCATABLE_SCRATCH_FPR: u32 = 1 << float_scratch().hw_enc();
 /// Non-allocatable scratch general purpose registers.
 const NON_ALLOCATABLE_SCRATCH_FPR: u32 = u32::MAX & !ALLOCATABLE_SCRATCH_FPR;
 
-
 /// Bitset for allocatable general purpose registers.
 pub fn gpr_bit_set() -> RegBitSet {
     RegBitSet::int(

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -27,13 +27,14 @@ pub(crate) const fn ip0() -> Reg {
     xreg(16)
 }
 
-// TODO: delete this.
 /// Alias to the IP0 register.
+#[deprecated]
 pub(crate) const fn scratch() -> Reg {
     ip0()
 }
 
 // Alias to register v31.
+#[deprecated]
 pub(crate) const fn float_scratch() -> Reg {
     vreg(31)
 }
@@ -156,6 +157,8 @@ const ALLOCATABLE_GPR: u32 = u32::MAX & !NON_ALLOCATABLE_GPR;
 
 /// Bitmask for non-allocatable FPR.
 /// All FPRs are allocatable, v0..=v7 are generally used for params and results.
+
+#[expect(deprecated, reason = "Not used for instruction emission")]
 const NON_ALLOCATABLE_FPR: u32 = 1 << float_scratch().hw_enc();
 /// Bitmask to represent the available floating point registers.
 const ALLOCATABLE_FPR: u32 = u32::MAX & !NON_ALLOCATABLE_FPR;
@@ -165,6 +168,7 @@ const ALLOCATABLE_SCRATCH_GPR: u32 = (1 << ip0().hw_enc()) | (1 << ip1().hw_enc(
 /// Non-allocatable scratch general purpose registers.
 const NON_ALLOCATABLE_SCRATCH_GPR: u32 = u32::MAX & !ALLOCATABLE_SCRATCH_GPR;
 
+#[expect(deprecated, reason = "Not used for instruction emission")]
 const ALLOCATABLE_SCRATCH_FPR: u32 = 1 << float_scratch().hw_enc();
 /// Non-allocatable scratch general purpose registers.
 const NON_ALLOCATABLE_SCRATCH_FPR: u32 = u32::MAX & !ALLOCATABLE_SCRATCH_FPR;

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -1,12 +1,13 @@
 //! AArch64 register definition.
 
 use crate::isa::reg::Reg;
+use crate::regset::RegBitSet;
 use regalloc2::{PReg, RegClass};
 
 /// FPR index bound.
-pub(crate) const MAX_FPR: u32 = 32;
+const MAX_FPR: u32 = 32;
 /// FPR index bound.
-pub(crate) const MAX_GPR: u32 = 32;
+const MAX_GPR: u32 = 32;
 
 /// Construct a X-register from an index.
 pub(crate) const fn xreg(num: u8) -> Reg {
@@ -26,6 +27,7 @@ pub(crate) const fn ip0() -> Reg {
     xreg(16)
 }
 
+// TODO: delete this.
 /// Alias to the IP0 register.
 pub(crate) const fn scratch() -> Reg {
     ip0()
@@ -141,7 +143,7 @@ pub(crate) const fn shadow_sp() -> Reg {
 }
 
 /// Bitmask for non-allocatable GPR.
-pub(crate) const NON_ALLOCATABLE_GPR: u32 = (1 << ip0().hw_enc())
+const NON_ALLOCATABLE_GPR: u32 = (1 << ip0().hw_enc())
     | (1 << ip1().hw_enc())
     | (1 << platform().hw_enc())
     | (1 << fp().hw_enc())
@@ -149,13 +151,57 @@ pub(crate) const NON_ALLOCATABLE_GPR: u32 = (1 << ip0().hw_enc())
     | (1 << zero().hw_enc())
     | (1 << shadow_sp().hw_enc())
     | (1 << vmctx().hw_enc());
-
 /// Bitmask to represent the available general purpose registers.
-pub(crate) const ALL_GPR: u32 = u32::MAX & !NON_ALLOCATABLE_GPR;
+const ALLOCATABLE_GPR: u32 = u32::MAX & !NON_ALLOCATABLE_GPR;
 
 /// Bitmask for non-allocatable FPR.
 /// All FPRs are allocatable, v0..=v7 are generally used for params and results.
-pub(crate) const NON_ALLOCATABLE_FPR: u32 = 1 << float_scratch().hw_enc();
-
+const NON_ALLOCATABLE_FPR: u32 = 1 << float_scratch().hw_enc();
 /// Bitmask to represent the available floating point registers.
-pub(crate) const ALL_FPR: u32 = u32::MAX & !NON_ALLOCATABLE_FPR;
+const ALLOCATABLE_FPR: u32 = u32::MAX & !NON_ALLOCATABLE_FPR;
+
+/// Allocatable scratch general purpose registers.
+const ALLOCATABLE_SCRATCH_GPR: u32 = (1 << ip0().hw_enc()) | (1 << ip1().hw_enc());
+/// Non-allocatable scratch general purpose registers.
+const NON_ALLOCATABLE_SCRATCH_GPR: u32 = u32::MAX & !ALLOCATABLE_SCRATCH_GPR;
+
+const ALLOCATABLE_SCRATCH_FPR: u32 = 1 << float_scratch().hw_enc();
+/// Non-allocatable scratch general purpose registers.
+const NON_ALLOCATABLE_SCRATCH_FPR: u32 = u32::MAX & !ALLOCATABLE_SCRATCH_FPR;
+
+
+/// Bitset for allocatable general purpose registers.
+pub fn gpr_bit_set() -> RegBitSet {
+    RegBitSet::int(
+        ALLOCATABLE_GPR.into(),
+        NON_ALLOCATABLE_GPR.into(),
+        usize::try_from(MAX_GPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable floating point registers.
+pub fn fpr_bit_set() -> RegBitSet {
+    RegBitSet::float(
+        ALLOCATABLE_FPR.into(),
+        NON_ALLOCATABLE_FPR.into(),
+        usize::try_from(MAX_FPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable scratch general purpose registers.
+pub fn scratch_gpr_bitset() -> RegBitSet {
+    RegBitSet::int(
+        ALLOCATABLE_SCRATCH_GPR.into(),
+        NON_ALLOCATABLE_SCRATCH_GPR.into(),
+        usize::try_from(MAX_GPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable scratch floating point registers.
+pub fn scratch_fpr_bitset() -> RegBitSet {
+    RegBitSet::float(
+        ALLOCATABLE_SCRATCH_FPR.into(),
+        NON_ALLOCATABLE_SCRATCH_FPR.into(),
+        usize::try_from(MAX_FPR).unwrap(),
+    )
+}

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -100,12 +100,14 @@ impl ABI for X64ABI {
 
     fn scratch_for(ty: &WasmValType) -> Reg {
         match ty {
+            #[expect(deprecated, reason = "Pending migration to Masm::with_scratch")]
             WasmValType::I32
             | WasmValType::I64
             | WasmValType::Ref(WasmRefType {
                 heap_type: WasmHeapType::Func,
                 ..
             }) => regs::scratch(),
+            #[expect(deprecated, reason = "Pending migration to Masm::with_scratch")]
             WasmValType::F32 | WasmValType::F64 | WasmValType::V128 => regs::scratch_xmm(),
             _ => unimplemented!(),
         }

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -8,7 +8,6 @@ use crate::{
         RoundingMode, ShiftKind, Signed, V128ExtendKind, V128LoadExtendKind, Zero,
     },
     reg::writable,
-    x64::regs::scratch,
 };
 use cranelift_codegen::{
     CallInfo, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit, MachInstEmitState,
@@ -1226,6 +1225,7 @@ impl Assembler {
         addr: Address,
         operand: Reg,
         dst: WritableReg,
+        temp: WritableReg,
         size: OperandSize,
         flags: MemFlags,
         op: AtomicRmwSeqOp,
@@ -1236,7 +1236,7 @@ impl Assembler {
             ty: Type::int_with_byte_size(size.bytes() as _).unwrap(),
             mem,
             operand: operand.into(),
-            temp: writable!(scratch().into()),
+            temp: temp.map(Into::into),
             dst_old: dst.map(Into::into),
             op,
         });

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1,18 +1,14 @@
 use super::{
-    abi::X64ABI,
+    RegAlloc,
     address::Address,
     asm::{Assembler, PatchableAddToReg, VcmpKind, VcvtKind, VroundMode},
-    regs::{self, rbp, rsp},
+    abi::X64ABI,
+    regs::{self, rbp, rsp, scratch_fpr_bitset, scratch_gpr_bitset},
 };
 use anyhow::{Result, anyhow, bail};
 
 use crate::masm::{
-    DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, Imm as I, IntCmpKind, LaneSelector,
-    LoadKind, MacroAssembler as Masm, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind,
-    RmwOp, RoundingMode, ShiftKind, SplatKind, StoreKind, TRUSTED_FLAGS, TrapCode, TruncKind,
-    UNTRUSTED_FLAGS, V128AbsKind, V128AddKind, V128ConvertKind, V128ExtAddKind, V128ExtMulKind,
-    V128ExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind,
-    V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero,
+    DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, FloatScratch, Imm as I, IntCmpKind, IntScratch, LaneSelector, LoadKind, MacroAssembler as Masm, MulWideKind, OperandSize, RegImm, RemKind, ReplaceLaneKind, RmwOp, RoundingMode, Scratch, ScratchType, ShiftKind, SplatKind, StoreKind, TrapCode, TruncKind, V128AbsKind, V128AddKind, V128ConvertKind, V128ExtAddKind, V128ExtMulKind, V128ExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind, V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero, TRUSTED_FLAGS, UNTRUSTED_FLAGS
 };
 use crate::{
     abi::{self, LocalSlot, align_to, calculate_frame_adjustment},
@@ -98,6 +94,8 @@ pub(crate) struct MacroAssembler {
     shared_flags: settings::Flags,
     /// The target pointer size.
     ptr_size: OperandSize,
+    /// Scratch register scope.
+    scratch_scope: RegAlloc,
 }
 
 impl Masm for MacroAssembler {
@@ -125,22 +123,24 @@ impl Masm for MacroAssembler {
 
     fn check_stack(&mut self, vmctx: Reg) -> Result<()> {
         let ptr_size: u8 = self.ptr_size.bytes().try_into().unwrap();
-        let scratch = regs::scratch();
 
-        self.load_ptr(
-            self.address_at_reg(vmctx, ptr_size.vmcontext_store_context().into())?,
-            writable!(scratch),
-        )?;
+	self.with_scratch::<IntScratch, _>(|masm, scratch| {
+	    masm.load_ptr(
+		masm.address_at_reg(vmctx, ptr_size.vmcontext_store_context().into())?,
+		scratch.writable(),
+	    )?;
 
-        self.load_ptr(
-            Address::offset(scratch, ptr_size.vmstore_context_stack_limit().into()),
-            writable!(scratch),
-        )?;
+            masm.load_ptr(
+		Address::offset(scratch.inner(), ptr_size.vmstore_context_stack_limit().into()),
+		scratch.writable(),
+            )?;
 
-        self.add_stack_max(scratch);
+            masm.add_stack_max(scratch.inner());
 
-        self.asm.cmp_rr(scratch, regs::rsp(), self.ptr_size);
-        self.asm.trapif(IntCmpKind::GtU, TrapCode::STACK_OVERFLOW);
+            masm.asm.cmp_rr(scratch.inner(), regs::rsp(), masm.ptr_size);
+            masm.asm.trapif(IntCmpKind::GtU, TrapCode::STACK_OVERFLOW);
+	    Ok(())
+	})?;
 
         // Emit unwind info.
         if self.shared_flags.unwind_info() {
@@ -306,6 +306,17 @@ impl Masm for MacroAssembler {
         Ok(())
     }
 
+    fn with_scratch<T: ScratchType, F>(&mut self, mut f:  F) -> Result<()>
+	where F: FnMut(&mut Self, Scratch) -> Result<()> {
+
+	let r = self.scratch_scope.reg_for_class(T::reg_class(), &mut |_| Ok(()))
+	    .expect("Scratch register to be available");
+
+	f(self, Scratch::new(r))?;
+	self.scratch_scope.free(r);
+	Ok(())
+    }
+
     fn call(
         &mut self,
         stack_args_size: u32,
@@ -386,16 +397,20 @@ impl Masm for MacroAssembler {
             }
             LoadKind::VectorLane(LaneSelector { lane, size }) => {
                 self.ensure_has_avx()?;
-                let byte_tmp = regs::scratch();
-                self.load_impl(src, writable!(byte_tmp), size, UNTRUSTED_FLAGS)?;
-                self.asm
-                    .xmm_vpinsr_rrr(dst, dst.to_reg(), byte_tmp, lane, size);
+		self.with_scratch::<IntScratch, _>(|masm, byte_tmp| {
+		    masm.load_impl(src, byte_tmp.writable(), size, UNTRUSTED_FLAGS)?;
+		    masm.asm
+			.xmm_vpinsr_rrr(dst, dst.to_reg(), byte_tmp.inner(), lane, size);
+		    Ok(())
+		})?;
             }
             LoadKind::VectorZero(size) => {
                 self.ensure_has_avx()?;
-                let scratch = regs::scratch();
-                self.load_impl(src, writable!(scratch), size, UNTRUSTED_FLAGS)?;
-                self.asm.avx_gpr_to_xmm(scratch, dst, size);
+		self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		    masm.load_impl(src, scratch.writable(), size, UNTRUSTED_FLAGS)?;
+		    masm.asm.avx_gpr_to_xmm(scratch.inner(), dst, size);
+		    Ok(())
+		})?;
             }
         }
 
@@ -447,9 +462,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.add_ir(v, dst, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.add_rr(scratch, dst, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.add_rr(scratch.inner(), dst, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -481,9 +498,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.sub_ir(v, reg, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.sub_rr(scratch, reg, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.sub_rr(scratch.inner(), reg, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -502,9 +521,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.mul_ir(v, dst, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.mul_rr(scratch, dst, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.mul_rr(scratch.inner(), dst, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -560,8 +581,6 @@ impl Masm for MacroAssembler {
         size: OperandSize,
     ) -> Result<()> {
         Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
-        let scratch_gpr = regs::scratch();
-        let scratch_xmm = regs::scratch_xmm();
         let sign_mask = match size {
             OperandSize::S32 => I::I32(0x80000000),
             OperandSize::S64 => I::I64(0x8000000000000000),
@@ -569,22 +588,27 @@ impl Masm for MacroAssembler {
                 bail!(CodeGenError::unexpected_operand_size())
             }
         };
-        self.load_constant(&sign_mask, writable!(scratch_gpr), size)?;
-        self.asm
-            .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
 
-        // Clear everything except sign bit in src.
-        self.asm.xmm_and_rr(scratch_xmm, writable!(rhs), size);
+	self.with_scratch::<IntScratch, _>(|masm, scratch_gpr| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, scratch_xmm| {
+		masm.load_constant(&sign_mask, scratch_gpr.writable(), size)?;
+		masm.asm
+		    .gpr_to_xmm(scratch_gpr.inner(), scratch_xmm.writable(), size);
 
-        // Clear sign bit in dst using scratch to store result. Then copy the
-        // result back to dst.
-        self.asm
-            .xmm_andn_rr(dst.to_reg(), writable!(scratch_xmm), size);
-        self.asm.xmm_mov_rr(scratch_xmm, dst, size);
+		// Clear everything except sign bit in src.
+		masm.asm.xmm_and_rr(scratch_xmm.inner(), writable!(rhs), size);
 
-        // Copy sign bit from src to dst.
-        self.asm.xmm_or_rr(rhs, dst, size);
-        Ok(())
+		// Clear sign bit in dst using scratch to store result. Then copy the
+		// result back to dst.
+		masm.asm
+		    .xmm_andn_rr(dst.to_reg(), scratch_xmm.writable(), size);
+		masm.asm.xmm_mov_rr(scratch_xmm.inner(), dst, size);
+
+		// Copy sign bit from src to dst.
+		masm.asm.xmm_or_rr(rhs, dst, size);
+		Ok(())
+	    })
+	})
     }
 
     fn float_neg(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {
@@ -596,13 +620,15 @@ impl Masm for MacroAssembler {
                 bail!(CodeGenError::unexpected_operand_size())
             }
         };
-        let scratch_gpr = regs::scratch();
-        self.load_constant(&mask, writable!(scratch_gpr), size)?;
-        let scratch_xmm = regs::scratch_xmm();
-        self.asm
-            .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
-        self.asm.xmm_xor_rr(scratch_xmm, dst, size);
-        Ok(())
+	self.with_scratch::<IntScratch, _>(|masm, scratch_gpr| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, scratch_xmm| {
+		masm.load_constant(&mask, scratch_gpr.writable(), size)?;
+		masm.asm
+		    .gpr_to_xmm(scratch_gpr.inner(), scratch_xmm.writable(), size);
+		masm.asm.xmm_xor_rr(scratch_xmm.inner(), dst, size);
+		Ok(())
+	    })
+	})
     }
 
     fn float_abs(&mut self, dst: WritableReg, size: OperandSize) -> Result<()> {
@@ -614,13 +640,17 @@ impl Masm for MacroAssembler {
                 bail!(CodeGenError::unexpected_operand_size())
             }
         };
-        let scratch_gpr = regs::scratch();
-        self.load_constant(&mask, writable!(scratch_gpr), size)?;
-        let scratch_xmm = regs::scratch_xmm();
-        self.asm
-            .gpr_to_xmm(scratch_gpr, writable!(scratch_xmm), size);
-        self.asm.xmm_and_rr(scratch_xmm, dst, size);
-        Ok(())
+
+	self.with_scratch::<IntScratch, _>(|masm, scratch_gpr| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, scratch_xmm| {
+		masm.load_constant(&mask, scratch_gpr.writable(), size)?;
+
+		masm.asm
+		    .gpr_to_xmm(scratch_gpr.inner(), scratch_xmm.writable(), size);
+		masm.asm.xmm_and_rr(scratch_xmm.inner(), dst, size);
+		Ok(())
+	    })
+	})
     }
 
     fn float_round<
@@ -656,9 +686,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.and_ir(v, dst, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.and_rr(scratch, dst, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.and_rr(scratch.inner(), dst, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -677,9 +709,12 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.or_ir(v, dst, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.or_rr(scratch, dst, size);
+
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.or_rr(scratch.inner(), dst, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -698,9 +733,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.xor_ir(v, dst, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.xor_rr(scratch, dst, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.xor_rr(scratch.inner(), dst, size);
+			Ok(())
+		    })?;
                 }
             }
 
@@ -715,13 +752,13 @@ impl Masm for MacroAssembler {
     fn shift_ir(
         &mut self,
         dst: WritableReg,
-        imm: u64,
+        imm: I,
         lhs: Reg,
         kind: ShiftKind,
         size: OperandSize,
     ) -> Result<()> {
         Self::ensure_two_argument_form(&dst.to_reg(), &lhs)?;
-        self.asm.shift_ir(imm as u8, dst, kind, size);
+        self.asm.shift_ir(imm.unwrap_as_u64() as u8, dst, kind, size);
         Ok(())
     }
 
@@ -826,9 +863,11 @@ impl Masm for MacroAssembler {
                 if let Some(v) = imm.to_i32() {
                     self.asm.cmp_ir(src1, v, size);
                 } else {
-                    let scratch = regs::scratch();
-                    self.load_constant(&imm, writable!(scratch), size)?;
-                    self.asm.cmp_rr(src1, scratch, size);
+		    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			masm.load_constant(&imm, scratch.writable(), size)?;
+			masm.asm.cmp_rr(src1, scratch.inner(), size);
+			Ok(())
+		    })?;
                 }
             }
             RegImm::Reg(src2) => {
@@ -885,16 +924,20 @@ impl Masm for MacroAssembler {
             FloatCmpKind::Eq | FloatCmpKind::Gt | FloatCmpKind::Ge => {
                 // Return false if either operand is NaN by ensuring PF is
                 // unset.
-                let scratch = regs::scratch();
-                self.asm.setnp(writable!(scratch));
-                self.asm.and_rr(scratch, dst, size);
+		self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		    masm.asm.setnp(scratch.writable());
+		    masm.asm.and_rr(scratch.inner(), dst, size);
+		    Ok(())
+		})?;
             }
             FloatCmpKind::Ne => {
                 // Return true if either operand is NaN by checking if PF is
                 // set.
-                let scratch = regs::scratch();
-                self.asm.setp(writable!(scratch));
-                self.asm.or_rr(scratch, dst, size);
+		self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		    masm.asm.setp(scratch.writable());
+		    masm.asm.or_rr(scratch.inner(), dst, size);
+		    Ok(())
+		})?;
             }
             FloatCmpKind::Lt | FloatCmpKind::Le => (),
         };
@@ -905,16 +948,18 @@ impl Masm for MacroAssembler {
         if self.flags.has_lzcnt() {
             self.asm.lzcnt(src, dst, size);
         } else {
-            let scratch = regs::scratch();
 
-            // Use the following approach:
-            // dst = size.num_bits() - bsr(src) - is_not_zero
-            //     = size.num.bits() + -bsr(src) - is_not_zero.
-            self.asm.bsr(src, dst, size);
-            self.asm.setcc(IntCmpKind::Ne, writable!(scratch));
-            self.asm.neg(dst.to_reg(), dst, size);
-            self.asm.add_ir(size.num_bits() as i32, dst, size);
-            self.asm.sub_rr(scratch, dst, size);
+	    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		// Use the following approach:
+		// dst = size.num_bits() - bsr(src) - is_not_zero
+		//     = size.num.bits() + -bsr(src) - is_not_zero.
+		masm.asm.bsr(src, dst, size);
+		masm.asm.setcc(IntCmpKind::Ne, scratch.writable());
+		masm.asm.neg(dst.to_reg(), dst, size);
+		masm.asm.add_ir(size.num_bits() as i32, dst, size);
+		masm.asm.sub_rr(scratch.inner(), dst, size);
+		Ok(())
+	    })?;
         }
 
         Ok(())
@@ -924,19 +969,20 @@ impl Masm for MacroAssembler {
         if self.flags.has_bmi1() {
             self.asm.tzcnt(src, dst, size);
         } else {
-            let scratch = regs::scratch();
-
-            // Use the following approach:
-            // dst = bsf(src) + (is_zero * size.num_bits())
-            //     = bsf(src) + (is_zero << size.log2()).
-            // BSF outputs the correct value for every value except 0.
-            // When the value is 0, BSF outputs 0, correct output for ctz is
-            // the number of bits.
-            self.asm.bsf(src, dst, size);
-            self.asm.setcc(IntCmpKind::Eq, writable!(scratch));
-            self.asm
-                .shift_ir(size.log2(), writable!(scratch), ShiftKind::Shl, size);
-            self.asm.add_rr(scratch, dst, size);
+	    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		// Use the following approach:
+		// dst = bsf(src) + (is_zero * size.num_bits())
+		//     = bsf(src) + (is_zero << size.log2()).
+		// BSF outputs the correct value for every value except 0.
+		// When the value is 0, BSF outputs 0, correct output for ctz is
+		// the number of bits.
+		masm.asm.bsf(src, dst, size);
+		masm.asm.setcc(IntCmpKind::Eq, scratch.writable());
+		masm.asm
+		    .shift_ir(size.log2(), scratch.writable(), ShiftKind::Shl, size);
+		masm.asm.add_rr(scratch.inner(), dst, size);
+		Ok(())
+	    })?;
         }
 
         Ok(())
@@ -1027,11 +1073,14 @@ impl Masm for MacroAssembler {
             self.asm.mov_rr(tmp.to_reg(), dst, size);
             // Load `0x3333...` into the scratch reg once, allowing us to use
             // `and_rr` and avoid inadvertently loading it twice as with `and`
-            let scratch = regs::scratch();
-            self.load_constant(&I::i64(masks[1]), writable!(scratch), size)?;
-            self.asm.and_rr(scratch, dst, size);
-            self.asm.shift_ir(2u8, tmp, ShiftKind::ShrU, size);
-            self.asm.and_rr(scratch, tmp, size);
+	    
+	    self.with_scratch::<IntScratch, _>(|masm, scratch| {
+		masm.load_constant(&I::i64(masks[1]), scratch.writable(), size)?;
+		masm.asm.and_rr(scratch.inner(), dst, size);
+		masm.asm.shift_ir(2u8, tmp, ShiftKind::ShrU, size);
+		masm.asm.and_rr(scratch.inner(), tmp, size);
+		Ok(())
+	    })?;
             self.asm.add_rr(dst.to_reg(), tmp, size);
 
             // x = (x + (x >> 4)) & m4;
@@ -1079,16 +1128,20 @@ impl Masm for MacroAssembler {
         dst_size: OperandSize,
         kind: TruncKind,
     ) -> Result<()> {
-        self.asm.cvt_float_to_sint_seq(
-            src,
-            dst,
-            regs::scratch(),
-            regs::scratch_xmm(),
-            src_size,
-            dst_size,
-            kind.is_checked(),
-        );
-        Ok(())
+	self.with_scratch::<IntScratch, _>(|masm, gpr_scratch| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, xmm_scratch| {
+		masm.asm.cvt_float_to_sint_seq(
+		    src,
+		    dst,
+		    gpr_scratch.inner(),
+		    xmm_scratch.inner(),
+		    src_size,
+		    dst_size,
+		    kind.is_checked(),
+		);
+		Ok(())
+	    })
+	})
     }
 
     fn unsigned_truncate(
@@ -1104,25 +1157,29 @@ impl Masm for MacroAssembler {
             _ => bail!(CodeGenError::unexpected_operand_size()),
         };
 
-        ctx.convert_op_with_tmp_reg(
-            self,
-            dst_ty,
-            RegClass::Float,
-            |masm, dst, src, tmp_fpr, dst_size| {
-                masm.asm.cvt_float_to_uint_seq(
-                    src,
-                    writable!(dst),
-                    regs::scratch(),
-                    regs::scratch_xmm(),
-                    tmp_fpr,
-                    src_size,
-                    dst_size,
-                    kind.is_checked(),
-                );
+	self.with_scratch::<IntScratch, _>(|masm, gpr_scratch| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, xmm_scratch| {
+		ctx.convert_op_with_tmp_reg(
+		    masm,
+		    dst_ty,
+		    RegClass::Float,
+		    |masm, dst, src, tmp_fpr, dst_size| {
+			masm.asm.cvt_float_to_uint_seq(
+			    src,
+			    writable!(dst),
+			    gpr_scratch.inner(),
+			    xmm_scratch.inner(),
+			    tmp_fpr,
+			    src_size,
+			    dst_size,
+			    kind.is_checked(),
+			);
 
-                Ok(())
-            },
-        )
+			Ok(())
+		    },
+		)
+	    })
+	})
     }
 
     fn signed_convert(
@@ -1153,9 +1210,11 @@ impl Masm for MacroAssembler {
             )?;
         }
 
-        self.asm
-            .cvt_uint64_to_float_seq(src, dst, regs::scratch(), tmp_gpr, dst_size);
-        Ok(())
+	self.with_scratch::<IntScratch, _>(|masm, scratch| {
+	    masm.asm
+		.cvt_uint64_to_float_seq(src, dst, scratch.inner(), tmp_gpr, dst_size);
+	    Ok(())
+	})
     }
 
     fn reinterpret_float_as_int(
@@ -1226,9 +1285,11 @@ impl Masm for MacroAssembler {
 
         let default = targets[default_index];
         let rest = &targets[0..default_index];
-        let tmp1 = regs::scratch();
-        self.asm.jmp_table(rest.into(), default, index, tmp1, tmp);
-        Ok(())
+
+	self.with_scratch::<IntScratch, _>(|masm, tmp1| {
+	    masm.asm.jmp_table(rest.into(), default, index, tmp1.inner(), tmp);
+	    Ok(())
+	})
     }
 
     fn start_source_loc(&mut self, loc: RelSourceLoc) -> Result<(CodeOffset, RelSourceLoc)> {
@@ -1407,10 +1468,11 @@ impl Masm for MacroAssembler {
         let mask_rhs = self.asm.add_constant(&mask_rhs);
 
         self.asm.xmm_vpshufb_rrm(dst, lhs, &mask_lhs);
-        let scratch = writable!(regs::scratch_xmm());
-        self.asm.xmm_vpshufb_rrm(scratch, rhs, &mask_rhs);
-        self.asm.vpor(dst, dst.to_reg(), scratch.to_reg());
-        Ok(())
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    masm.asm.xmm_vpshufb_rrm(scratch.writable(), rhs, &mask_rhs);
+	    masm.asm.vpor(dst, dst.to_reg(), scratch.inner());
+	    Ok(())
+	})
     }
 
     fn swizzle(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg) -> Result<()> {
@@ -1594,9 +1656,12 @@ impl Masm for MacroAssembler {
                             // 64 bits of the register so need to load the
                             // immediate to a register to use the register
                             // variant of `vmovsd` to perform the merge.
-                            let scratch = writable!(regs::scratch_xmm());
-                            self.asm.xmm_vmovsd_rm(scratch, &address);
-                            self.asm.xmm_vmovsd_rrr(dst, dst.to_reg(), scratch.to_reg());
+
+			    self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+				masm.asm.xmm_vmovsd_rm(scratch.writable(), &address);
+				masm.asm.xmm_vmovsd_rrr(dst, dst.to_reg(), scratch.inner());
+				Ok(())
+			    })?;
                         }
                         1 => self.asm.xmm_vmovlhps_rrm(dst, dst.to_reg(), &address),
                         _ => unreachable!(),
@@ -1868,14 +1933,15 @@ impl Masm for MacroAssembler {
     fn v128_not(&mut self, dst: WritableReg) -> Result<()> {
         self.ensure_has_avx()?;
 
-        let tmp = regs::scratch_xmm();
-        // First, we initialize `tmp` with all ones, by comparing it with itself.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpcmpeqd, tmp, tmp, writable!(tmp));
-        // then we `xor` tmp and `dst` together, yielding `!dst`.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, tmp, dst.to_reg(), dst);
-        Ok(())
+	self.with_scratch::<FloatScratch, _>(|masm, tmp| {
+	    // First, we initialize `tmp` with all ones, by comparing it with itself.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpcmpeqd, tmp.inner(), tmp.inner(), tmp.writable());
+	    // then we `xor` tmp and `dst` together, yielding `!dst`.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, tmp.inner(), dst.to_reg(), dst);
+	    Ok(())
+	})
     }
 
     fn v128_and(&mut self, src1: Reg, src2: Reg, dst: WritableReg) -> Result<()> {
@@ -1904,12 +1970,13 @@ impl Masm for MacroAssembler {
 
     fn v128_bitselect(&mut self, src1: Reg, src2: Reg, mask: Reg, dst: WritableReg) -> Result<()> {
         self.ensure_has_avx()?;
-        let tmp = regs::scratch_xmm();
-        self.v128_and(src1, mask, writable!(tmp))?;
-        self.v128_and_not(mask, src2, dst)?;
-        self.v128_or(dst.to_reg(), tmp, dst)?;
 
-        Ok(())
+	self.with_scratch::<FloatScratch, _>(|masm, tmp| {
+	    masm.v128_and(src1, mask, tmp.writable())?;
+	    masm.v128_and_not(mask, src2, dst)?;
+	    masm.v128_or(dst.to_reg(), tmp.inner(), dst)?;
+	    Ok(())
+	})
     }
 
     fn v128_any_true(&mut self, src: Reg, dst: WritableReg) -> Result<()> {
@@ -1925,33 +1992,35 @@ impl Masm for MacroAssembler {
             V128ConvertKind::I32x4S => self.asm.xmm_vcvt_rr(src, dst, VcvtKind::I32ToF32),
             V128ConvertKind::I32x4LowS => self.asm.xmm_vcvt_rr(src, dst, VcvtKind::I32ToF64),
             V128ConvertKind::I32x4U => {
-                let scratch = writable!(regs::scratch_xmm());
 
-                // Split each 32-bit integer into 16-bit parts.
-                // `scratch` will contain the low bits and `dst` will contain
-                // the high bits.
-                self.asm
-                    .xmm_vpsll_rr(src, scratch, 0x10, kind.src_lane_size());
-                self.asm
-                    .xmm_vpsrl_rr(scratch.to_reg(), scratch, 0x10, kind.src_lane_size());
-                self.asm
-                    .xmm_vpsub_rrr(src, scratch.to_reg(), dst, kind.src_lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Split each 32-bit integer into 16-bit parts.
+		    // `scratch` will contain the low bits and `dst` will contain
+		    // the high bits.
+		    masm.asm
+			.xmm_vpsll_rr(src, scratch.writable(), 0x10, kind.src_lane_size());
+		    masm.asm
+			.xmm_vpsrl_rr(scratch.inner(), scratch.writable(), 0x10, kind.src_lane_size());
+		    masm.asm
+			.xmm_vpsub_rrr(src, scratch.inner(), dst, kind.src_lane_size());
 
-                // Convert the low bits in `scratch` to floating point numbers.
-                self.asm
-                    .xmm_vcvt_rr(scratch.to_reg(), scratch, VcvtKind::I32ToF32);
+		    // Convert the low bits in `scratch` to floating point numbers.
+		    masm.asm
+			.xmm_vcvt_rr(scratch.inner(), scratch.writable(), VcvtKind::I32ToF32);
 
-                // Prevent overflow by right shifting high bits.
-                self.asm
-                    .xmm_vpsrl_rr(dst.to_reg(), dst, 1, kind.src_lane_size());
-                // Convert high bits in `dst` to floating point numbers.
-                self.asm.xmm_vcvt_rr(dst.to_reg(), dst, VcvtKind::I32ToF32);
-                // Double high bits in `dst` to reverse right shift.
-                self.asm
-                    .xmm_vaddp_rrr(dst.to_reg(), dst.to_reg(), dst, kind.src_lane_size());
-                // Add high bits in `dst` to low bits in `scratch`.
-                self.asm
-                    .xmm_vaddp_rrr(dst.to_reg(), scratch.to_reg(), dst, kind.src_lane_size());
+		    // Prevent overflow by right shifting high bits.
+		    masm.asm
+			.xmm_vpsrl_rr(dst.to_reg(), dst, 1, kind.src_lane_size());
+		    // Convert high bits in `dst` to floating point numbers.
+		    masm.asm.xmm_vcvt_rr(dst.to_reg(), dst, VcvtKind::I32ToF32);
+		    // Double high bits in `dst` to reverse right shift.
+		    masm.asm
+			.xmm_vaddp_rrr(dst.to_reg(), dst.to_reg(), dst, kind.src_lane_size());
+		    // Add high bits in `dst` to low bits in `scratch`.
+		    masm.asm
+			.xmm_vaddp_rrr(dst.to_reg(), scratch.inner(), dst, kind.src_lane_size());
+		    Ok(())
+		})?;
             }
             V128ConvertKind::I32x4LowU => {
                 // See
@@ -2029,11 +2098,13 @@ impl Masm for MacroAssembler {
                 self.asm.xmm_vpmov_rr(dst.to_reg(), dst, kind.into());
             }
             V128ExtendKind::HighI8x16U | V128ExtendKind::HighI16x8U => {
-                let scratch = regs::scratch_xmm();
-                self.asm
-                    .xmm_vex_rr(AvxOpcode::Vpxor, scratch, scratch, writable!(scratch));
-                self.asm
-                    .xmm_vpunpckh_rrr(src, scratch, dst, kind.src_lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    masm.asm
+			.xmm_vex_rr(AvxOpcode::Vpxor, scratch.inner(), scratch.inner(), scratch.writable());
+		    masm.asm
+			.xmm_vpunpckh_rrr(src, scratch.inner(), dst, kind.src_lane_size());
+		    Ok(())
+		})?;
             }
             V128ExtendKind::HighI32x4S => {
                 // Move the 3rd element (i.e., 0b10) to the 1st (rightmost)
@@ -2044,13 +2115,15 @@ impl Masm for MacroAssembler {
                 self.asm.xmm_vpmov_rr(dst.to_reg(), dst, kind.into());
             }
             V128ExtendKind::HighI32x4U => {
-                // Set `scratch` to a vector 0s.
-                let scratch = regs::scratch_xmm();
-                self.asm
-                    .xmm_vxorp_rrr(scratch, scratch, writable!(scratch), kind.src_lane_size());
-                // Interleave the 0 bits into the two 32-bit integers to zero extend them.
-                self.asm
-                    .xmm_vunpckhp_rrr(src, scratch, dst, kind.src_lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Set `scratch` to a vector 0s.
+		    masm.asm
+			.xmm_vxorp_rrr(scratch.inner(), scratch.inner(), scratch.writable(), kind.src_lane_size());
+		    // Interleave the 0 bits into the two 32-bit integers to zero extend them.
+		    masm.asm
+			.xmm_vunpckhp_rrr(src, scratch.inner(), dst, kind.src_lane_size());
+		    Ok(())
+		})?;
             }
         }
         Ok(())
@@ -2141,40 +2214,41 @@ impl Masm for MacroAssembler {
                 // > the lower 32-bits, however, we will need to use shifts to isolate the high
                 // > 32-bits when doing calculations, i.e., `Ah == A >> 32`.
 
-                let tmp1 = regs::scratch_xmm();
                 let tmp2 = context.any_fpr(this)?;
+		this.with_scratch::<FloatScratch, _>(|this, tmp1| {
+		    // tmp1 = lhs_hi = (lhs >> 32)
+		    this.asm
+			.xmm_vex_ri(AvxOpcode::Vpsrlq, lhs.reg, 32, tmp1.writable());
+		    // tmp2 = lhs_hi * rhs_low = tmp1 * rhs
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpmuldq, tmp1.inner(), rhs.reg, writable!(tmp2));
 
-                // tmp1 = lhs_hi = (lhs >> 32)
-                this.asm
-                    .xmm_vex_ri(AvxOpcode::Vpsrlq, lhs.reg, 32, writable!(tmp1));
-                // tmp2 = lhs_hi * rhs_low = tmp1 * rhs
-                this.asm
-                    .xmm_vex_rr(AvxOpcode::Vpmuldq, tmp1, rhs.reg, writable!(tmp2));
+                    // tmp1 = rhs_hi = rhs >> 32
+                    this.asm
+			.xmm_vex_ri(AvxOpcode::Vpsrlq, rhs.reg, 32, tmp1.writable());
 
-                // tmp1 = rhs_hi = rhs >> 32
-                this.asm
-                    .xmm_vex_ri(AvxOpcode::Vpsrlq, rhs.reg, 32, writable!(tmp1));
+                    // tmp1 = lhs_low * rhs_high = tmp1 * lhs
+                    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpmuludq, tmp1.inner(), lhs.reg, tmp1.writable());
 
-                // tmp1 = lhs_low * rhs_high = tmp1 * lhs
-                this.asm
-                    .xmm_vex_rr(AvxOpcode::Vpmuludq, tmp1, lhs.reg, writable!(tmp1));
+                    // tmp1 = ((lhs_hi * rhs_low) + (lhs_lo * rhs_hi)) = tmp1 + tmp2
+                    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpaddq, tmp1.inner(), tmp2, tmp1.writable());
 
-                // tmp1 = ((lhs_hi * rhs_low) + (lhs_lo * rhs_hi)) = tmp1 + tmp2
-                this.asm
-                    .xmm_vex_rr(AvxOpcode::Vpaddq, tmp1, tmp2, writable!(tmp1));
+                    //tmp1 = tmp1 << 32
+                    this.asm
+			.xmm_vex_ri(AvxOpcode::Vpsllq, tmp1.inner(), 32, tmp1.writable());
 
-                //tmp1 = tmp1 << 32
-                this.asm
-                    .xmm_vex_ri(AvxOpcode::Vpsllq, tmp1, 32, writable!(tmp1));
+                    // tmp2 = lhs_lo + rhs_lo
+                    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpmuludq, lhs.reg, rhs.reg, writable!(tmp2));
 
-                // tmp2 = lhs_lo + rhs_lo
-                this.asm
-                    .xmm_vex_rr(AvxOpcode::Vpmuludq, lhs.reg, rhs.reg, writable!(tmp2));
-
-                // finally, with `lhs` as destination:
-                // lhs = (lhs_low * rhs_low) + ((lhs_hi * rhs_low) + (lhs_lo * rhs_hi)) = tmp1 + tmp2
-                this.asm
-                    .xmm_vex_rr(AvxOpcode::Vpaddq, tmp1, tmp2, writable!(lhs.reg));
+                    // finally, with `lhs` as destination:
+                    // lhs = (lhs_low * rhs_low) + ((lhs_hi * rhs_low) + (lhs_lo * rhs_hi)) = tmp1 + tmp2
+                    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpaddq, tmp1.inner(), tmp2, writable!(lhs.reg));
+		    Ok(())
+		})?;
 
                 context.free_reg(tmp2);
 
@@ -2210,43 +2284,47 @@ impl Masm for MacroAssembler {
                 self.asm.xmm_vpabs_rr(src, dst, kind.lane_size())
             }
             V128AbsKind::I64x2 => {
-                let scratch = writable!(regs::scratch_xmm());
-                // Perform an arithmetic right shift of 31 bits. If the number
-                // is positive, this will result in all zeroes in the upper
-                // 32-bits. If the number is negative, this will result in all
-                // ones in the upper 32-bits.
-                self.asm.xmm_vpsra_rri(src, scratch, 0x1f, OperandSize::S32);
-                // Copy the ones and zeroes in the high bits of each 64-bit
-                // lane to the low bits of each 64-bit lane.
-                self.asm
-                    .xmm_vpshuf_rr(scratch.to_reg(), scratch, 0b11_11_01_01, OperandSize::S32);
-                // Flip the bits in lanes that were negative in `src` and leave
-                // the positive lanes as they are. Positive lanes will have a
-                // zero mask in `scratch` so xor doesn't affect them.
-                self.asm
-                    .xmm_vex_rr(AvxOpcode::Vpxor, src, scratch.to_reg(), dst);
-                // Subtract the mask from the results of xor which will
-                // complete the two's complement for lanes which were negative.
-                self.asm
-                    .xmm_vpsub_rrr(dst.to_reg(), scratch.to_reg(), dst, kind.lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Perform an arithmetic right shift of 31 bits. If the number
+		    // is positive, this will result in all zeroes in the upper
+		    // 32-bits. If the number is negative, this will result in all
+		    // ones in the upper 32-bits.
+		    masm.asm.xmm_vpsra_rri(src, scratch.writable(), 0x1f, OperandSize::S32);
+		    // Copy the ones and zeroes in the high bits of each 64-bit
+		    // lane to the low bits of each 64-bit lane.
+		    masm.asm
+			.xmm_vpshuf_rr(scratch.inner(), scratch.writable(), 0b11_11_01_01, OperandSize::S32);
+		    // Flip the bits in lanes that were negative in `src` and leave
+		    // the positive lanes as they are. Positive lanes will have a
+		    // zero mask in `scratch` so xor doesn't affect them.
+		    masm.asm
+			.xmm_vex_rr(AvxOpcode::Vpxor, src, scratch.inner(), dst);
+		    // Subtract the mask from the results of xor which will
+		    // complete the two's complement for lanes which were negative.
+		    masm.asm
+			.xmm_vpsub_rrr(dst.to_reg(), scratch.inner(), dst, kind.lane_size());
+		    Ok(())
+		})?;
             }
             V128AbsKind::F32x4 | V128AbsKind::F64x2 => {
-                let scratch = writable!(regs::scratch_xmm());
-                // Create a mask of all ones.
-                self.asm.xmm_vpcmpeq_rrr(
-                    scratch,
-                    scratch.to_reg(),
-                    scratch.to_reg(),
-                    kind.lane_size(),
-                );
-                // Right shift the mask so each lane is a single zero followed
-                // by all ones.
-                self.asm
-                    .xmm_vpsrl_rr(scratch.to_reg(), scratch, 0x1, kind.lane_size());
-                // Use the mask to zero the sign bit in each lane which will
-                // make the float value positive.
-                self.asm
-                    .xmm_vandp_rrr(src, scratch.to_reg(), dst, kind.lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Create a mask of all ones.
+		    masm.asm.xmm_vpcmpeq_rrr(
+			scratch.writable(),
+			scratch.inner(),
+			scratch.inner(),
+			kind.lane_size(),
+		    );
+		    // Right shift the mask so each lane is a single zero followed
+		    // by all ones.
+		    masm.asm
+			.xmm_vpsrl_rr(scratch.inner(), scratch.writable(), 0x1, kind.lane_size());
+		    // Use the mask to zero the sign bit in each lane which will
+		    // make the float value positive.
+		    masm.asm
+			.xmm_vandp_rrr(src, scratch.inner(), dst, kind.lane_size());
+		    Ok(())
+		})?;
             }
         }
         Ok(())
@@ -2255,27 +2333,32 @@ impl Masm for MacroAssembler {
     fn v128_neg(&mut self, op: WritableReg, kind: V128NegKind) -> Result<()> {
         self.ensure_has_avx()?;
 
-        let tmp = regs::scratch_xmm();
         match kind {
             V128NegKind::I8x16 | V128NegKind::I16x8 | V128NegKind::I32x4 | V128NegKind::I64x2 => {
-                self.v128_xor(tmp, tmp, writable!(tmp))?;
-                self.v128_sub(tmp, op.to_reg(), op, kind.into())?;
+		self.with_scratch::<FloatScratch, _>(|masm, tmp| {
+		    masm.v128_xor(tmp.inner(), tmp.inner(),tmp.writable())?;
+		    masm.v128_sub(tmp.inner(), op.to_reg(), op, kind.into())?;
+		    Ok(())
+		})?;
             }
             V128NegKind::F32x4 | V128NegKind::F64x2 => {
-                // Create a mask of all 1s.
-                self.asm
-                    .xmm_vpcmpeq_rrr(writable!(tmp), tmp, tmp, kind.lane_size());
-                // Left shift the lanes in the mask so only the sign bit in the
-                // mask is set to 1.
-                self.asm.xmm_vpsll_rr(
-                    tmp,
-                    writable!(tmp),
-                    (kind.lane_size().num_bits() - 1) as u32,
-                    kind.lane_size(),
-                );
-                // Use the mask to flip the sign bit.
-                self.asm
-                    .xmm_vxorp_rrr(op.to_reg(), tmp, op, kind.lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, tmp| {
+		    // Create a mask of all 1s.
+		    masm.asm
+			.xmm_vpcmpeq_rrr(tmp.writable(), tmp.inner(), tmp.inner(), kind.lane_size());
+		    // Left shift the lanes in the mask so only the sign bit in the
+		    // mask is set to 1.
+		    masm.asm.xmm_vpsll_rr(
+			tmp.inner(),
+			tmp.writable(),
+			(kind.lane_size().num_bits() - 1) as u32,
+			kind.lane_size(),
+		    );
+		    // Use the mask to flip the sign bit.
+		    masm.asm
+			.xmm_vxorp_rrr(op.to_reg(), tmp.inner(), op, kind.lane_size());
+		    Ok(())
+		})?;
             }
         }
         Ok(())
@@ -2290,10 +2373,8 @@ impl Masm for MacroAssembler {
         self.ensure_has_avx()?;
         let shift_amount = context.pop_to_reg(self, None)?.reg;
         let operand = context.pop_to_reg(self, None)?.reg;
-
-        let tmp_xmm = regs::scratch_xmm();
-        let tmp = regs::scratch();
         let amount_mask = lane_width.num_bits() - 1;
+
         self.and(
             writable!(shift_amount),
             shift_amount,
@@ -2301,167 +2382,180 @@ impl Masm for MacroAssembler {
             OperandSize::S32,
         )?;
 
-        let shl_normal = |this: &mut Self, op: AvxOpcode| {
-            this.asm
-                .avx_gpr_to_xmm(shift_amount, writable!(tmp_xmm), OperandSize::S32);
-            this.asm
-                .xmm_vex_rr(op, operand, tmp_xmm, writable!(operand));
-        };
+	self.with_scratch::<IntScratch, _>(|masm, tmp| {
+	    masm.with_scratch::<FloatScratch, _>(|masm, tmp_xmm| {
+		let shl_normal = |this: &mut Self, op: AvxOpcode| {
+		    this.asm
+			.avx_gpr_to_xmm(shift_amount, tmp_xmm.writable(), OperandSize::S32);
+		    this.asm
+			.xmm_vex_rr(op, operand, tmp_xmm.inner(), writable!(operand));
+		};
 
-        let shift_i8x16 = |this: &mut Self, masks: &'static [u8], op: AvxOpcode| {
-            // The case for i8x16 is a little bit trickier because x64 doesn't provide a 8bit
-            // shift instruction. Instead, we shift as 16bits, and then mask the bits in the
-            // 8bits lane, for example (with 2 8bits lanes):
-            // - Before shifting:
-            // 01001101 11101110
-            // - shifting by 2 left:
-            // 00110111 10111000
-            //       ^^_ these bits come from the previous byte, and need to be masked.
-            // - The mask:
-            // 11111100 11111111
-            // - After masking:
-            // 00110100 10111000
-            //
-            // The mask is loaded from a well known memory, depending on the shift amount.
 
-            this.asm
-                .avx_gpr_to_xmm(shift_amount, writable!(tmp_xmm), OperandSize::S32);
+		let shift_i8x16 = |this: &mut Self, masks: &'static [u8], op: AvxOpcode| {
+		    // The case for i8x16 is a little bit trickier because x64 doesn't provide a 8bit
+		    // shift instruction. Instead, we shift as 16bits, and then mask the bits in the
+		    // 8bits lane, for example (with 2 8bits lanes):
+		    // - Before shifting:
+		    // 01001101 11101110
+		    // - shifting by 2 left:
+		    // 00110111 10111000
+		    //       ^^_ these bits come from the previous byte, and need to be masked.
+		    // - The mask:
+		    // 11111100 11111111
+		    // - After masking:
+		    // 00110100 10111000
+		    //
+		    // The mask is loaded from a well known memory, depending on the shift amount.
 
-            // perform 16 bit shift
-            this.asm
-                .xmm_vex_rr(op, operand, tmp_xmm, writable!(operand));
+		    this.asm
+			.avx_gpr_to_xmm(shift_amount, tmp_xmm.writable(), OperandSize::S32);
 
-            // get a handle to the masks array constant.
-            let masks_addr = this.asm.add_constant(masks);
+		    // perform 16 bit shift
+		    this.asm
+			.xmm_vex_rr(op, operand, tmp_xmm.inner(), writable!(operand));
 
-            // Load the masks array effective address into the tmp register.
-            this.asm.lea(&masks_addr, writable!(tmp), OperandSize::S64);
+		    // get a handle to the masks array constant.
+		    let masks_addr = this.asm.add_constant(masks);
 
-            // Compute the offset of the mask that we need to use. This is shift_amount * 16 ==
-            // shift_amount << 4.
-            this.asm
-                .shift_ir(4, writable!(shift_amount), ShiftKind::Shl, OperandSize::S32);
+		    // Load the masks array effective address into the tmp register.
+		    this.asm.lea(&masks_addr, tmp.writable(), OperandSize::S64);
 
-            // Load the mask to tmp_xmm.
-            this.asm.xmm_vmovdqu_mr(
-                &Address::ImmRegRegShift {
-                    simm32: 0,
-                    base: tmp,
-                    index: shift_amount,
-                    shift: 0,
-                },
-                writable!(tmp_xmm),
-                MemFlags::trusted(),
-            );
+		    // Compute the offset of the mask that we need to use. This is shift_amount * 16 ==
+		    // shift_amount << 4.
+		    this.asm
+			.shift_ir(4, writable!(shift_amount), ShiftKind::Shl, OperandSize::S32);
 
-            // Mask unwanted bits from operand.
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpand, tmp_xmm, operand, writable!(operand));
-        };
+		    // Load the mask to tmp_xmm.
+		    this.asm.xmm_vmovdqu_mr(
+			&Address::ImmRegRegShift {
+			    simm32: 0,
+			    base: tmp.inner(),
+			    index: shift_amount,
+			    shift: 0,
+			},
+			tmp_xmm.writable(),
+			MemFlags::trusted(),
+		    );
 
-        let i64x2_shr_s = |this: &mut Self, context: &mut CodeGenContext<Emission>| -> Result<()> {
-            const SIGN_MASK: u128 = 0x8000000000000000_8000000000000000;
+		    // Mask unwanted bits from operand.
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpand, tmp_xmm.inner(), operand, writable!(operand));
+		};
 
-            // AVX doesn't have an instruction for i64x2 signed right shift. Instead we use the
-            // following formula (from hacker's delight 2-7), where x is the value and n the shift
-            // amount, for each lane:
-            // t = (1 << 63) >> n; ((x >> n) ^ t) - t
+		let i64x2_shr_s = |this: &mut Self, context: &mut CodeGenContext<Emission>| -> Result<()> {
+		    const SIGN_MASK: u128 = 0x8000000000000000_8000000000000000;
 
-            // we need an extra scratch register
-            let tmp_xmm2 = context.any_fpr(this)?;
+		    // AVX doesn't have an instruction for i64x2 signed right shift. Instead we use the
+		    // following formula (from hacker's delight 2-7), where x is the value and n the shift
+		    // amount, for each lane:
+		    // t = (1 << 63) >> n; ((x >> n) ^ t) - t
 
-            this.asm
-                .avx_gpr_to_xmm(shift_amount, writable!(tmp_xmm), OperandSize::S32);
+		    // we need an extra scratch register
+		    let tmp_xmm2 = context.any_fpr(this)?;
 
-            let cst = this.asm.add_constant(&SIGN_MASK.to_le_bytes());
+		    this.asm
+			.avx_gpr_to_xmm(shift_amount, tmp_xmm.writable(), OperandSize::S32);
 
-            this.asm
-                .xmm_vmovdqu_mr(&cst, writable!(tmp_xmm2), MemFlags::trusted());
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpsrlq, tmp_xmm2, tmp_xmm, writable!(tmp_xmm2));
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpsrlq, operand, tmp_xmm, writable!(operand));
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpxor, operand, tmp_xmm2, writable!(operand));
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpsubq, operand, tmp_xmm2, writable!(operand));
+		    let cst = this.asm.add_constant(&SIGN_MASK.to_le_bytes());
 
-            context.free_reg(tmp_xmm2);
+		    this.asm
+			.xmm_vmovdqu_mr(&cst, writable!(tmp_xmm2), MemFlags::trusted());
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpsrlq, tmp_xmm2, tmp_xmm.inner(), writable!(tmp_xmm2));
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpsrlq, operand, tmp_xmm.inner(), writable!(operand));
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpxor, operand, tmp_xmm2, writable!(operand));
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpsubq, operand, tmp_xmm2, writable!(operand));
 
-            Ok(())
-        };
+		    context.free_reg(tmp_xmm2);
 
-        let i8x16_shr_s = |this: &mut Self, context: &mut CodeGenContext<Emission>| -> Result<()> {
-            // Since the x86 instruction set does not have an 8x16 shift instruction and the
-            // approach used for `ishl` and `ushr` cannot be easily used (the masks do not
-            // preserve the sign), we use a different approach here: separate the low and
-            // high lanes, shift them separately, and merge them into the final result.
-            //
-            // Visually, this looks like the following, where `src.i8x16 = [s0, s1, ...,
-            // s15]:
-            //
-            //   lo.i16x8 = [(s0, s0), (s1, s1), ..., (s7, s7)]
-            //   shifted_lo.i16x8 = shift each lane of `low`
-            //   hi.i16x8 = [(s8, s8), (s9, s9), ..., (s15, s15)]
-            //   shifted_hi.i16x8 = shift each lane of `high`
-            //   result = [s0'', s1'', ..., s15'']
+		    Ok(())
+		};
 
-            // In order for `packsswb` later to only use the high byte of each
-            // 16x8 lane, we shift right an extra 8 bits, relying on `psraw` to
-            // fill in the upper bits appropriately.
-            this.asm
-                .add_ir(8, writable!(shift_amount), OperandSize::S32);
-            this.asm
-                .avx_gpr_to_xmm(shift_amount, writable!(tmp_xmm), OperandSize::S32);
+		let i8x16_shr_s = |this: &mut Self, context: &mut CodeGenContext<Emission>| -> Result<()> {
+		    // Since the x86 instruction set does not have an 8x16 shift instruction and the
+		    // approach used for `ishl` and `ushr` cannot be easily used (the masks do not
+		    // preserve the sign), we use a different approach here: separate the low and
+		    // high lanes, shift them separately, and merge them into the final result.
+		    //
+		    // Visually, this looks like the following, where `src.i8x16 = [s0, s1, ...,
+		    // s15]:
+		    //
+		    //   lo.i16x8 = [(s0, s0), (s1, s1), ..., (s7, s7)]
+		    //   shifted_lo.i16x8 = shift each lane of `low`
+		    //   hi.i16x8 = [(s8, s8), (s9, s9), ..., (s15, s15)]
+		    //   shifted_hi.i16x8 = shift each lane of `high`
+		    //   result = [s0'', s1'', ..., s15'']
 
-            let tmp_lo = context.any_fpr(this)?;
-            let tmp_hi = context.any_fpr(this)?;
+		    // In order for `packsswb` later to only use the high byte of each
+		    // 16x8 lane, we shift right an extra 8 bits, relying on `psraw` to
+		    // fill in the upper bits appropriately.
+		    this.asm
+			.add_ir(8, writable!(shift_amount), OperandSize::S32);
+		    this.asm
+			.avx_gpr_to_xmm(shift_amount, tmp_xmm.writable(), OperandSize::S32);
 
-            // Extract lower and upper bytes.
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpunpcklbw, operand, operand, writable!(tmp_lo));
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpunpckhbw, operand, operand, writable!(tmp_hi));
+		    let tmp_lo = context.any_fpr(this)?;
+		    let tmp_hi = context.any_fpr(this)?;
 
-            // Perform 16bit right shift of upper and lower bytes.
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpsraw, tmp_lo, tmp_xmm, writable!(tmp_lo));
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpsraw, tmp_hi, tmp_xmm, writable!(tmp_hi));
+		    // Extract lower and upper bytes.
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpunpcklbw, operand, operand, writable!(tmp_lo));
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpunpckhbw, operand, operand, writable!(tmp_hi));
 
-            // Merge lower and upper bytes back.
-            this.asm
-                .xmm_vex_rr(AvxOpcode::Vpacksswb, tmp_lo, tmp_hi, writable!(operand));
+		    // Perform 16bit right shift of upper and lower bytes.
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpsraw, tmp_lo, tmp_xmm.inner(), writable!(tmp_lo));
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpsraw, tmp_hi, tmp_xmm.inner(), writable!(tmp_hi));
 
-            context.free_reg(tmp_lo);
-            context.free_reg(tmp_hi);
+		    // Merge lower and upper bytes back.
+		    this.asm
+			.xmm_vex_rr(AvxOpcode::Vpacksswb, tmp_lo, tmp_hi, writable!(operand));
 
-            Ok(())
-        };
+		    context.free_reg(tmp_lo);
+		    context.free_reg(tmp_hi);
 
-        match (lane_width, kind) {
-            // shl
-            (OperandSize::S8, ShiftKind::Shl) => {
-                shift_i8x16(self, &I8X16_ISHL_MASKS, AvxOpcode::Vpsllw)
-            }
-            (OperandSize::S16, ShiftKind::Shl) => shl_normal(self, AvxOpcode::Vpsllw),
-            (OperandSize::S32, ShiftKind::Shl) => shl_normal(self, AvxOpcode::Vpslld),
-            (OperandSize::S64, ShiftKind::Shl) => shl_normal(self, AvxOpcode::Vpsllq),
-            // shr_u
-            (OperandSize::S8, ShiftKind::ShrU) => {
-                shift_i8x16(self, &I8X16_USHR_MASKS, AvxOpcode::Vpsrlw)
-            }
-            (OperandSize::S16, ShiftKind::ShrU) => shl_normal(self, AvxOpcode::Vpsrlw),
-            (OperandSize::S32, ShiftKind::ShrU) => shl_normal(self, AvxOpcode::Vpsrld),
-            (OperandSize::S64, ShiftKind::ShrU) => shl_normal(self, AvxOpcode::Vpsrlq),
-            // shr_s
-            (OperandSize::S8, ShiftKind::ShrS) => i8x16_shr_s(self, context)?,
-            (OperandSize::S16, ShiftKind::ShrS) => shl_normal(self, AvxOpcode::Vpsraw),
-            (OperandSize::S32, ShiftKind::ShrS) => shl_normal(self, AvxOpcode::Vpsrad),
-            (OperandSize::S64, ShiftKind::ShrS) => i64x2_shr_s(self, context)?,
+		    Ok(())
+		};
 
-            _ => bail!(CodeGenError::invalid_operand_combination()),
-        }
+		
+		match (lane_width, kind) {
+		    // shl
+		    (OperandSize::S8, ShiftKind::Shl) => {
+			shift_i8x16(masm, &I8X16_ISHL_MASKS, AvxOpcode::Vpsllw)
+		    }
+		    (OperandSize::S16, ShiftKind::Shl) => shl_normal(masm, AvxOpcode::Vpsllw),
+		    (OperandSize::S32, ShiftKind::Shl) => shl_normal(masm, AvxOpcode::Vpslld),
+		    (OperandSize::S64, ShiftKind::Shl) => shl_normal(masm, AvxOpcode::Vpsllq),
+		    // shr_u
+		    (OperandSize::S8, ShiftKind::ShrU) => {
+			shift_i8x16(masm, &I8X16_USHR_MASKS, AvxOpcode::Vpsrlw)
+		    }
+		    (OperandSize::S16, ShiftKind::ShrU) => shl_normal(masm, AvxOpcode::Vpsrlw),
+		    (OperandSize::S32, ShiftKind::ShrU) => shl_normal(masm, AvxOpcode::Vpsrld),
+		    (OperandSize::S64, ShiftKind::ShrU) => shl_normal(masm , AvxOpcode::Vpsrlq),
+		    // shr_s
+		    (OperandSize::S8, ShiftKind::ShrS) => i8x16_shr_s(masm, context)?,
+		    (OperandSize::S16, ShiftKind::ShrS) => shl_normal(masm, AvxOpcode::Vpsraw),
+		    (OperandSize::S32, ShiftKind::ShrS) => shl_normal(masm, AvxOpcode::Vpsrad),
+		    (OperandSize::S64, ShiftKind::ShrS) => i64x2_shr_s(masm, context)?,
+
+		    _ => bail!(CodeGenError::invalid_operand_combination()),
+		}
+
+		Ok(())
+	    })
+	})?;
+
+
+
+
+
 
         context.free_reg(shift_amount);
         context
@@ -2500,17 +2594,19 @@ impl Masm for MacroAssembler {
     fn v128_all_true(&mut self, src: Reg, dst: WritableReg, size: OperandSize) -> Result<()> {
         self.ensure_has_avx()?;
 
-        let scratch = regs::scratch_xmm();
-        // Create a mask of all 0s.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, scratch, scratch, writable!(scratch));
-        // Sets lane in `dst` to not zero if `src` lane was zero, and lane in
-        // `dst` to zero if `src` lane was not zero.
-        self.asm.xmm_vpcmpeq_rrr(writable!(src), src, scratch, size);
-        // Sets ZF if all values are zero (i.e., if all original values were not zero).
-        self.asm.xmm_vptest(src, src);
-        // Set byte if ZF=1.
-        self.asm.setcc(IntCmpKind::Eq, dst);
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Create a mask of all 0s.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, scratch.inner(), scratch.inner(), scratch.writable());
+	    // Sets lane in `dst` to not zero if `src` lane was zero, and lane in
+	    // `dst` to zero if `src` lane was not zero.
+	    masm.asm.xmm_vpcmpeq_rrr(writable!(src), src, scratch.inner(), size);
+	    // Sets ZF if all values are zero (i.e., if all original values were not zero).
+	    masm.asm.xmm_vptest(src, src);
+	    // Set byte if ZF=1.
+	    Ok(())
+	})?;
+	self.asm.setcc(IntCmpKind::Eq, dst);
         Ok(())
     }
 
@@ -2553,7 +2649,7 @@ impl Masm for MacroAssembler {
                 kind.dst_lane_size(),
             ),
             V128TruncKind::I32x4FromF32x4S => {
-                self.v128_trunc_sat_f32x4_s(reg, kind.src_lane_size(), kind.dst_lane_size());
+                self.v128_trunc_sat_f32x4_s(reg, kind.src_lane_size(), kind.dst_lane_size())?;
             }
             V128TruncKind::I32x4FromF32x4U => {
                 let temp_reg = writable!(context.any_fpr(self)?);
@@ -2562,14 +2658,14 @@ impl Masm for MacroAssembler {
                     temp_reg,
                     kind.src_lane_size(),
                     kind.dst_lane_size(),
-                );
+                )?;
                 context.free_reg(temp_reg.to_reg());
             }
             V128TruncKind::I32x4FromF64x2SZero => {
-                self.v128_trunc_sat_f64x2_s_zero(reg, kind.src_lane_size());
+                self.v128_trunc_sat_f64x2_s_zero(reg, kind.src_lane_size())?;
             }
             V128TruncKind::I32x4FromF64x2UZero => {
-                self.v128_trunc_sat_f64x2_u_zero(reg, kind.src_lane_size(), kind.dst_lane_size());
+                self.v128_trunc_sat_f64x2_u_zero(reg, kind.src_lane_size(), kind.dst_lane_size())?;
             }
         }
 
@@ -2605,19 +2701,21 @@ impl Masm for MacroAssembler {
                 self.asm.xmm_vex_rr(op, src1, src2, dst);
             }
             V128MinKind::F32x4 | V128MinKind::F64x2 => {
-                // Handling +0 and -0 as well as NaN values are not commutative
-                // when using `vminp` so we have to compensate.
-                let scratch = writable!(regs::scratch_xmm());
-                // Perform two comparison operations with the operands swapped
-                // and OR the result to propagate 0 (positive and negative) and
-                // NaN.
-                self.asm
-                    .xmm_vminp_rrr(src1, src2, scratch, kind.lane_size());
-                self.asm.xmm_vminp_rrr(src2, src1, dst, kind.lane_size());
-                // Use a single OR instruction to set the sign bit if either
-                // result has the sign bit set to correctly propagate -0.
-                self.asm
-                    .xmm_vorp_rrr(dst.to_reg(), scratch.to_reg(), dst, kind.lane_size());
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Handling +0 and -0 as well as NaN values are not commutative
+		    // when using `vminp` so we have to compensate.
+		    // Perform two comparison operations with the operands swapped
+		    // and OR the result to propagate 0 (positive and negative) and
+		    // NaN.
+		    masm.asm
+			.xmm_vminp_rrr(src1, src2, scratch.writable(), kind.lane_size());
+		    masm.asm.xmm_vminp_rrr(src2, src1, dst, kind.lane_size());
+		    // Use a single OR instruction to set the sign bit if either
+		    // result has the sign bit set to correctly propagate -0.
+		    masm.asm
+			.xmm_vorp_rrr(dst.to_reg(), scratch.inner(), dst, kind.lane_size());
+		    Ok(())
+		})?;
                 // Set lanes with NaN to all 1s.
                 self.asm.xmm_vcmpp_rrr(
                     writable!(src2),
@@ -2664,28 +2762,31 @@ impl Masm for MacroAssembler {
                 self.asm.xmm_vex_rr(op, src1, src2, dst);
             }
             V128MaxKind::F32x4 | V128MaxKind::F64x2 => {
-                // Handling +0 and -0 as well as NaN values are not commutative
-                // when using `vmaxp` so we have to compensate.
-                let scratch = writable!(regs::scratch_xmm());
-                // Perform two comparison operations with the operands swapped
-                // so we can propagate 0 (positive and negative) and NaNs
-                // correctly.
-                self.asm
-                    .xmm_vmaxp_rrr(src1, src2, scratch, kind.lane_size());
-                self.asm.xmm_vmaxp_rrr(src2, src1, dst, kind.lane_size());
-                // This combination of XOR, OR, and SUB will set the sign bit
-                // on a 0 result to the correct value for a max operation.
-                self.asm
-                    .xmm_vxorp_rrr(dst.to_reg(), scratch.to_reg(), dst, kind.lane_size());
-                self.asm.xmm_vorp_rrr(
-                    dst.to_reg(),
-                    scratch.to_reg(),
-                    writable!(src2),
-                    kind.lane_size(),
-                );
-                self.asm
-                    .xmm_vsub_rrr(src2, dst.to_reg(), dst, kind.lane_size());
-                // Set lanes of NaN values to 1.
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Handling +0 and -0 as well as NaN values are not commutative
+		    // when using `vmaxp` so we have to compensate.
+		    // Perform two comparison operations with the operands swapped
+		    // so we can propagate 0 (positive and negative) and NaNs
+		    // correctly.
+
+		    masm.asm
+			.xmm_vmaxp_rrr(src1, src2, scratch.writable(), kind.lane_size());
+		    masm.asm.xmm_vmaxp_rrr(src2, src1, dst, kind.lane_size());
+		    // This combination of XOR, OR, and SUB will set the sign bit
+		    // on a 0 result to the correct value for a max operation.
+		    masm.asm
+			.xmm_vxorp_rrr(dst.to_reg(), scratch.inner(), dst, kind.lane_size());
+		    masm.asm.xmm_vorp_rrr(
+			dst.to_reg(),
+			scratch.inner(),
+			writable!(src2),
+			kind.lane_size(),
+		    );
+		    Ok(())
+		})?;
+		self.asm
+		    .xmm_vsub_rrr(src2, dst.to_reg(), dst, kind.lane_size());
+		// Set lanes of NaN values to 1.
                 self.asm.xmm_vcmpp_rrr(
                     writable!(src2),
                     src2,
@@ -2732,20 +2833,22 @@ impl Masm for MacroAssembler {
 
         match kind {
             V128ExtAddKind::I8x16S => {
-                let scratch = regs::scratch_xmm();
-                // Use `vpmaddubsw` with a vector of 16 8-bit 1's which will
-                // sign extend `src` to 16 bits and add adjacent words.
-                // Need to supply constant as first operand since first operand
-                // is treated as unsigned and the second operand is signed.
-                let mask = self.asm.add_constant(&[1; 16]);
-                self.asm.xmm_mov_mr(
-                    &mask,
-                    writable!(scratch),
-                    OperandSize::S128,
-                    MemFlags::trusted(),
-                );
-                self.asm
-                    .xmm_vex_rr(AvxOpcode::Vpmaddubsw, scratch, src, dst);
+		self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+		    // Use `vpmaddubsw` with a vector of 16 8-bit 1's which will
+		    // sign extend `src` to 16 bits and add adjacent words.
+		    // Need to supply constant as first operand since first operand
+		    // is treated as unsigned and the second operand is signed.
+		    let mask = masm.asm.add_constant(&[1; 16]);
+		    masm.asm.xmm_mov_mr(
+			&mask,
+			scratch.writable(),
+			OperandSize::S128,
+			MemFlags::trusted(),
+		    );
+		    masm.asm
+			.xmm_vex_rr(AvxOpcode::Vpmaddubsw, scratch.inner(), src, dst);
+		    Ok(())
+		})?;
             }
             V128ExtAddKind::I8x16U => {
                 // Same approach as the signed variant but treat `src` as
@@ -2805,7 +2908,6 @@ impl Masm for MacroAssembler {
         self.ensure_has_avx()?;
 
         let reg = writable!(context.pop_to_reg(self, None)?.reg);
-        let scratch = writable!(regs::scratch_xmm());
 
         // This works by using a lookup table to determine the count of bits
         // set in the upper 4 bits and lower 4 bits separately and then adding
@@ -2816,51 +2918,56 @@ impl Masm for MacroAssembler {
             0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F,
             0x0F, 0x0F,
         ]);
-        // Zero out the upper 4 bits of each lane.
-        self.asm.xmm_vpand_rrm(reg.to_reg(), &address, scratch);
-        // Right shift bytes in input by 4 bits to put the upper 4 bits in the
-        // lower 4 bits.
-        self.asm
-            .xmm_vpsrl_rr(reg.to_reg(), reg, 0x4, OperandSize::S16);
-        // Zero out the upper 4 bits of each shifted lane.
-        self.asm.xmm_vpand_rrm(reg.to_reg(), &address, reg);
 
-        // Write a lookup table of 4 bit values to number of bits set to a
-        // register so we only perform the memory read once.
-        // Index (hex) | Value (binary) | Population Count
-        // 0x0         | 0000          | 0
-        // 0x1         | 0001          | 1
-        // 0x2         | 0010          | 1
-        // 0x3         | 0011          | 2
-        // 0x4         | 0100          | 1
-        // 0x5         | 0101          | 2
-        // 0x6         | 0110          | 2
-        // 0x7         | 0111          | 3
-        // 0x8         | 1000          | 1
-        // 0x9         | 1001          | 2
-        // 0xA         | 1010          | 2
-        // 0xB         | 1011          | 3
-        // 0xC         | 1100          | 2
-        // 0xD         | 1101          | 3
-        // 0xE         | 1110          | 3
-        // 0xF         | 1111          | 4
-        let address = self.asm.add_constant(&[
-            0x0, 0x1, 0x1, 0x2, 0x1, 0x2, 0x2, 0x3, 0x1, 0x2, 0x2, 0x3, 0x2, 0x3, 0x3, 0x4,
-        ]);
-        let reg2 = writable!(context.any_fpr(self)?);
-        self.asm
-            .xmm_mov_mr(&address, reg2, OperandSize::S128, MemFlags::trusted());
-        // Use the upper 4 bits as an index into the lookup table.
-        self.asm.xmm_vpshufb_rrr(reg, reg2.to_reg(), reg.to_reg());
-        // Use the lower 4 bits as an index into the lookup table.
-        self.asm
-            .xmm_vpshufb_rrr(scratch, reg2.to_reg(), scratch.to_reg());
-        context.free_reg(reg2.to_reg());
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Zero out the upper 4 bits of each lane.
+	    masm.asm.xmm_vpand_rrm(reg.to_reg(), &address, scratch.writable());
+	    // Right shift bytes in input by 4 bits to put the upper 4 bits in the
+	    // lower 4 bits.
+	    masm.asm
+		.xmm_vpsrl_rr(reg.to_reg(), reg, 0x4, OperandSize::S16);
+	    // Zero out the upper 4 bits of each shifted lane.
+	    masm.asm.xmm_vpand_rrm(reg.to_reg(), &address, reg);
 
-        // Add the counts of the upper 4 bits and the lower 4 bits to get the
-        // total number of bits set.
-        self.asm
-            .xmm_vpadd_rrr(reg.to_reg(), scratch.to_reg(), reg, OperandSize::S8);
+            // Write a lookup table of 4 bit values to number of bits set to a
+            // register so we only perform the memory read once.
+            // Index (hex) | Value (binary) | Population Count
+            // 0x0         | 0000          | 0
+            // 0x1         | 0001          | 1
+            // 0x2         | 0010          | 1
+            // 0x3         | 0011          | 2
+            // 0x4         | 0100          | 1
+            // 0x5         | 0101          | 2
+            // 0x6         | 0110          | 2
+            // 0x7         | 0111          | 3
+            // 0x8         | 1000          | 1
+            // 0x9         | 1001          | 2
+            // 0xA         | 1010          | 2
+            // 0xB         | 1011          | 3
+            // 0xC         | 1100          | 2
+            // 0xD         | 1101          | 3
+            // 0xE         | 1110          | 3
+            // 0xF         | 1111          | 4
+            let address = masm.asm.add_constant(&[
+		0x0, 0x1, 0x1, 0x2, 0x1, 0x2, 0x2, 0x3, 0x1, 0x2, 0x2, 0x3, 0x2, 0x3, 0x3, 0x4,
+            ]);
+            let reg2 = writable!(context.any_fpr(masm)?);
+            masm.asm
+		.xmm_mov_mr(&address, reg2, OperandSize::S128, MemFlags::trusted());
+            // Use the upper 4 bits as an index into the lookup table.
+            masm.asm.xmm_vpshufb_rrr(reg, reg2.to_reg(), reg.to_reg());
+            // Use the lower 4 bits as an index into the lookup table.
+            masm.asm
+		.xmm_vpshufb_rrr(scratch.writable(), reg2.to_reg(), scratch.inner());
+            context.free_reg(reg2.to_reg());
+
+            // Add the counts of the upper 4 bits and the lower 4 bits to get the
+            // total number of bits set.
+            masm.asm
+		.xmm_vpadd_rrr(reg.to_reg(), scratch.inner(), reg, OperandSize::S8);
+	    Ok(())
+	})?;
+
 
         context.stack.push(TypedReg::v128(reg.to_reg()).into());
         Ok(())
@@ -2939,6 +3046,7 @@ impl MacroAssembler {
             flags: isa_flags,
             shared_flags,
             ptr_size: ptr_type.try_into()?,
+            scratch_scope: RegAlloc::from(scratch_gpr_bitset(), scratch_fpr_bitset()),
         })
     }
 
@@ -3040,41 +3148,50 @@ impl MacroAssembler {
                     Err(_) => {
                         // If the immediate doesn't sign extend, use a scratch
                         // register.
-                        let scratch = regs::scratch();
-                        self.asm.mov_ir(v, writable!(scratch), size);
-                        self.asm.mov_rm(scratch, &dst, size, flags);
+			self.with_scratch::<IntScratch, _>(|masm, scratch| {
+			    masm.asm.mov_ir(v, scratch.writable(), size);
+			    masm.asm.mov_rm(scratch.inner(), &dst, size, flags);
+			    Ok(())
+			})?;
                     }
                 },
                 I::F32(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
-                    let float_scratch = regs::scratch_xmm();
-                    // Always trusted, since we are loading the constant from
-                    // the constant pool.
-                    self.asm
-                        .xmm_mov_mr(&addr, writable!(float_scratch), size, MemFlags::trusted());
-                    self.asm.xmm_mov_rm(float_scratch, &dst, size, flags);
+		    self.with_scratch::<FloatScratch, _>(|masm, float_scratch| {
+			// Always trusted, since we are loading the constant from
+			// the constant pool.
+			masm.asm
+			    .xmm_mov_mr(&addr, float_scratch.writable(), size, MemFlags::trusted());
+			masm.asm.xmm_mov_rm(float_scratch.inner(), &dst, size, flags);
+			Ok(())
+		    })?;
                 }
                 I::F64(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
-                    let float_scratch = regs::scratch_xmm();
-                    // Similar to above, always trusted since we are loading the
-                    // constant from the constant pool.
-                    self.asm
-                        .xmm_mov_mr(&addr, writable!(float_scratch), size, MemFlags::trusted());
-                    self.asm.xmm_mov_rm(float_scratch, &dst, size, flags);
+                    
+		    self.with_scratch::<FloatScratch, _>(|masm, float_scratch| {
+			// Similar to above, always trusted since we are loading the
+			// constant from the constant pool.
+			masm.asm
+			    .xmm_mov_mr(&addr, float_scratch.writable(), size, MemFlags::trusted());
+			masm.asm.xmm_mov_rm(float_scratch.inner(), &dst, size, flags);
+			Ok(())
+		    })?;
                 }
                 I::V128(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
-                    let vector_scratch = regs::scratch_xmm();
-                    // Always trusted, since we are loading the constant from
-                    // the constant pool.
-                    self.asm.xmm_mov_mr(
-                        &addr,
-                        writable!(vector_scratch),
-                        size,
-                        MemFlags::trusted(),
-                    );
-                    self.asm.xmm_mov_rm(vector_scratch, &dst, size, flags);
+		    self.with_scratch::<FloatScratch, _>(|masm, vector_scratch| {
+			// Always trusted, since we are loading the constant from
+			// the constant pool.
+			masm.asm.xmm_mov_mr(
+			    &addr,
+			    vector_scratch.writable(),
+			    size,
+			    MemFlags::trusted(),
+			);
+			masm.asm.xmm_mov_rm(vector_scratch.inner(), &dst, size, flags);
+			Ok(())
+		    })?;
                 }
             },
             RegImm::Reg(reg) => {
@@ -3110,36 +3227,38 @@ impl MacroAssembler {
         reg: WritableReg,
         src_lane_size: OperandSize,
         dst_lane_size: OperandSize,
-    ) {
-        let scratch = writable!(regs::scratch_xmm());
-        // Create a mask to handle NaN values (1 for not NaN, 0 for
-        // NaN).
-        self.asm.xmm_vcmpp_rrr(
-            scratch,
-            reg.to_reg(),
-            reg.to_reg(),
-            src_lane_size,
-            VcmpKind::Eq,
-        );
-        // Zero out any NaN values.
-        self.asm
-            .xmm_vandp_rrr(reg.to_reg(), scratch.to_reg(), reg, src_lane_size);
-        // Create a mask for the sign bits.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, scratch.to_reg(), reg.to_reg(), scratch);
-        // Convert floats to integers.
-        self.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F32ToI32);
-        // Apply sign mask to the converted integers.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpand, reg.to_reg(), scratch.to_reg(), scratch);
-        // Create a saturation mask of all 1s for negative numbers,
-        // all 0s for positive numbers. The arithmetic shift will cop
-        // the sign bit.
-        self.asm
-            .xmm_vpsra_rri(scratch.to_reg(), scratch, 0x1F, dst_lane_size);
-        // Combine converted integers with saturation mask.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), scratch.to_reg(), reg);
+    ) -> Result<()> {
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Create a mask to handle NaN values (1 for not NaN, 0 for
+	    // NaN).
+	    masm.asm.xmm_vcmpp_rrr(
+		scratch.writable(),
+		reg.to_reg(),
+		reg.to_reg(),
+		src_lane_size,
+		VcmpKind::Eq,
+	    );
+	    // Zero out any NaN values.
+	    masm.asm
+		.xmm_vandp_rrr(reg.to_reg(), scratch.inner(), reg, src_lane_size);
+	    // Create a mask for the sign bits.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, scratch.inner(), reg.to_reg(), scratch.writable());
+	    // Convert floats to integers.
+	    masm.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F32ToI32);
+	    // Apply sign mask to the converted integers.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpand, reg.to_reg(), scratch.inner(), scratch.writable());
+	    // Create a saturation mask of all 1s for negative numbers,
+	    // all 0s for positive numbers. The arithmetic shift will cop
+	    // the sign bit.
+	    masm.asm
+		.xmm_vpsra_rri(scratch.inner(), scratch.writable(), 0x1F, dst_lane_size);
+	    // Combine converted integers with saturation mask.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), scratch.inner(), reg);
+	    Ok(())
+	})
     }
 
     fn v128_trunc_sat_f32x4_u(
@@ -3148,88 +3267,95 @@ impl MacroAssembler {
         temp_reg: WritableReg,
         src_lane_size: OperandSize,
         dst_lane_size: OperandSize,
-    ) {
-        let scratch = writable!(regs::scratch_xmm());
-        // Set scratch to all zeros.
-        self.asm
-            .xmm_vxorp_rrr(reg.to_reg(), reg.to_reg(), scratch, src_lane_size);
-        // Clamp negative numbers to 0.
-        self.asm
-            .xmm_vmaxp_rrr(reg.to_reg(), scratch.to_reg(), reg, src_lane_size);
-        // Create a vector of all 1s.
-        self.asm
-            .xmm_vpcmpeq_rrr(scratch, scratch.to_reg(), scratch.to_reg(), src_lane_size);
-        // Set scratch to 0x7FFFFFFF (max signed 32-bit integer) by
-        // performing a logical shift right.
-        self.asm
-            .xmm_vpsrl_rr(scratch.to_reg(), scratch, 0x1, src_lane_size);
-        // Convert max signed int to float as a reference point for saturation.
-        self.asm
-            .xmm_vcvt_rr(scratch.to_reg(), scratch, VcvtKind::I32ToF32);
-        // Convert the floats to integers and put the results in `reg2`.
-        // This is signed and not unsigned so we need to handle the
-        // value for the high bit in each lane.
-        self.asm
-            .xmm_vcvt_rr(reg.to_reg(), temp_reg, VcvtKind::F32ToI32);
-        // Set `reg` lanes to the amount that the value in the lane
-        // exceeds the maximum signed 32-bit integer.
-        self.asm
-            .xmm_vsub_rrr(reg.to_reg(), scratch.to_reg(), reg, dst_lane_size);
-        // Create mask in `scratch` for numbers that are larger than
-        // the maximum signed 32-bit integer. Lanes that don't fit
-        // in 32-bits ints will be 1.
-        self.asm.xmm_vcmpp_rrr(
-            scratch,
-            scratch.to_reg(),
-            reg.to_reg(),
-            dst_lane_size,
-            VcmpKind::Le,
-        );
-        // Convert the excess over signed 32-bits from floats to integers.
-        self.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F32ToI32);
-        // Apply large number mask to excess values which will flip the
-        // bits in any lanes that exceed signed 32-bits. Adding this
-        // flipped value to the signed value will set the high bit and
-        // the carry behavior will update the other bits correctly.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), scratch.to_reg(), scratch);
-        // Set `reg` to all 0s.
-        self.asm
-            .xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), reg.to_reg(), reg);
-        // Ensure excess values are not negative by taking max b/w
-        // excess values and zero.
-        self.asm
-            .xmm_vpmaxs_rrr(reg, scratch.to_reg(), reg.to_reg(), dst_lane_size);
+    ) -> Result<()> {
+
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Set scratch to all zeros.
+	    masm.asm
+		.xmm_vxorp_rrr(reg.to_reg(), reg.to_reg(), scratch.writable(), src_lane_size);
+	    // Clamp negative numbers to 0.
+	    masm.asm
+		.xmm_vmaxp_rrr(reg.to_reg(), scratch.inner(), reg, src_lane_size);
+	    // Create a vector of all 1s.
+	    masm.asm
+		.xmm_vpcmpeq_rrr(scratch.writable(), scratch.inner(), scratch.inner(), src_lane_size);
+	    // Set scratch to 0x7FFFFFFF (max signed 32-bit integer) by
+	    // performing a logical shift right.
+	    masm.asm
+		.xmm_vpsrl_rr(scratch.inner(), scratch.writable(), 0x1, src_lane_size);
+	    // Convert max signed int to float as a reference point for saturation.
+	    masm.asm
+		.xmm_vcvt_rr(scratch.inner(), scratch.writable(), VcvtKind::I32ToF32);
+	    // Convert the floats to integers and put the results in `reg2`.
+	    // This is signed and not unsigned so we need to handle the
+	    // value for the high bit in each lane.
+	    masm.asm
+		.xmm_vcvt_rr(reg.to_reg(), temp_reg, VcvtKind::F32ToI32);
+	    // Set `reg` lanes to the amount that the value in the lane
+	    // exceeds the maximum signed 32-bit integer.
+	    masm.asm
+		.xmm_vsub_rrr(reg.to_reg(), scratch.inner(), reg, dst_lane_size);
+	    // Create mask in `scratch` for numbers that are larger than
+	    // the maximum signed 32-bit integer. Lanes that don't fit
+	    // in 32-bits ints will be 1.
+	    masm.asm.xmm_vcmpp_rrr(
+		scratch.writable(),
+		scratch.inner(),
+		reg.to_reg(),
+		dst_lane_size,
+		VcmpKind::Le,
+	    );
+	    // Convert the excess over signed 32-bits from floats to integers.
+	    masm.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F32ToI32);
+	    // Apply large number mask to excess values which will flip the
+	    // bits in any lanes that exceed signed 32-bits. Adding this
+	    // flipped value to the signed value will set the high bit and
+	    // the carry behavior will update the other bits correctly.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), scratch.inner(), scratch.writable());
+	    // Set `reg` to all 0s.
+	    masm.asm
+		.xmm_vex_rr(AvxOpcode::Vpxor, reg.to_reg(), reg.to_reg(), reg);
+	    // Ensure excess values are not negative by taking max b/w
+	    // excess values and zero.
+	    masm.asm
+		.xmm_vpmaxs_rrr(reg, scratch.inner(), reg.to_reg(), dst_lane_size);
+	    Ok(())
+	})?;
         // Perform the addition between the signed conversion value (in
         // `reg2`) and the flipped excess value (in `reg`) to get the
         // unsigned value.
         self.asm
             .xmm_vpadd_rrr(reg.to_reg(), temp_reg.to_reg(), reg, dst_lane_size);
+	Ok(())
     }
 
-    fn v128_trunc_sat_f64x2_s_zero(&mut self, reg: WritableReg, src_lane_size: OperandSize) {
-        let scratch = writable!(regs::scratch_xmm());
-        // Create a NaN mask (1s for non-NaN, 0s for NaN).
-        self.asm.xmm_vcmpp_rrr(
-            scratch,
-            reg.to_reg(),
-            reg.to_reg(),
-            src_lane_size,
-            VcmpKind::Eq,
-        );
-        // Clamp NaN values to maximum 64-bit float that can be
-        // converted to an i32.
-        let address = self.asm.add_constant(&[
-            0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF, 0xDF, 0x41, 0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF,
-            0xDF, 0x41,
-        ]);
-        self.asm
-            .xmm_vandp_rrm(scratch.to_reg(), &address, scratch, src_lane_size);
-        // Handle the saturation for values too large to fit in an i32.
-        self.asm
-            .xmm_vminp_rrr(reg.to_reg(), scratch.to_reg(), reg, src_lane_size);
-        // Convert the floats to integers.
-        self.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F64ToI32);
+    fn v128_trunc_sat_f64x2_s_zero(&mut self, reg: WritableReg, src_lane_size: OperandSize) -> Result<()>{
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Create a NaN mask (1s for non-NaN, 0s for NaN).
+	    masm.asm.xmm_vcmpp_rrr(
+		scratch.writable(),
+		reg.to_reg(),
+		reg.to_reg(),
+		src_lane_size,
+		VcmpKind::Eq,
+	    );
+	    // Clamp NaN values to maximum 64-bit float that can be
+	    // converted to an i32.
+	    let address = masm.asm.add_constant(&[
+		0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF, 0xDF, 0x41, 0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF,
+		0xDF, 0x41,
+	    ]);
+	    masm.asm
+		.xmm_vandp_rrm(scratch.inner(), &address, scratch.writable(), src_lane_size);
+	    // Handle the saturation for values too large to fit in an i32.
+	    masm.asm
+		.xmm_vminp_rrr(reg.to_reg(), scratch.inner(), reg, src_lane_size);
+	    // Convert the floats to integers.
+	    masm.asm.xmm_vcvt_rr(reg.to_reg(), reg, VcvtKind::F64ToI32);
+
+	    Ok(())
+	})
     }
 
     fn v128_trunc_sat_f64x2_u_zero(
@@ -3237,44 +3363,46 @@ impl MacroAssembler {
         reg: WritableReg,
         src_lane_size: OperandSize,
         dst_lane_size: OperandSize,
-    ) {
-        let scratch = writable!(regs::scratch_xmm());
-        // Zero out the scratch register.
-        self.asm
-            .xmm_vxorp_rrr(scratch.to_reg(), scratch.to_reg(), scratch, src_lane_size);
-        // Clamp negative values to zero.
-        self.asm
-            .xmm_vmaxp_rrr(reg.to_reg(), scratch.to_reg(), reg, src_lane_size);
-        // Clamp value to maximum unsigned 32-bit integer value
-        // (0x41F0000000000000).
-        let address = self.asm.add_constant(&[
-            0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41, 0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF,
-            0xEF, 0x41,
-        ]);
-        self.asm
-            .xmm_vminp_rrm(reg.to_reg(), &address, reg, src_lane_size);
-        // Truncate floating point values.
-        self.asm
-            .xmm_vroundp_rri(reg.to_reg(), reg, VroundMode::TowardZero, src_lane_size);
-        // Add 2^52 (doubles store 52 bits in their mantissa) to each
-        // lane causing values in the lower bits to be shifted into
-        // position for integer conversion.
-        let address = self.asm.add_constant(&[
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x30, 0x43,
-        ]);
-        self.asm
-            .xmm_vaddp_rrm(reg.to_reg(), &address, reg, src_lane_size);
-        // Takes lanes 0 and 2 from `reg` (converted values) and lanes
-        // 0 and 2 from `scratch` (zeroes) to put the converted ints in
-        // the lower lanes and zeroes in the upper lanes.
-        self.asm.xmm_vshufp_rrri(
-            reg.to_reg(),
-            scratch.to_reg(),
-            reg,
-            0b10_00_10_00,
-            dst_lane_size,
-        );
+    ) -> Result<()> {
+	self.with_scratch::<FloatScratch, _>(|masm, scratch| {
+	    // Zero out the scratch register.
+	    masm.asm
+		.xmm_vxorp_rrr(scratch.inner(), scratch.inner(), scratch.writable(), src_lane_size);
+	    // Clamp negative values to zero.
+	    masm.asm
+		.xmm_vmaxp_rrr(reg.to_reg(), scratch.inner(), reg, src_lane_size);
+	    // Clamp value to maximum unsigned 32-bit integer value
+	    // (0x41F0000000000000).
+	    let address = masm.asm.add_constant(&[
+		0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41, 0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF,
+		0xEF, 0x41,
+	    ]);
+	    masm.asm
+		.xmm_vminp_rrm(reg.to_reg(), &address, reg, src_lane_size);
+	    // Truncate floating point values.
+	    masm.asm
+		.xmm_vroundp_rri(reg.to_reg(), reg, VroundMode::TowardZero, src_lane_size);
+	    // Add 2^52 (doubles store 52 bits in their mantissa) to each
+	    // lane causing values in the lower bits to be shifted into
+	    // position for integer conversion.
+	    let address = masm.asm.add_constant(&[
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x30, 0x43,
+	    ]);
+	    masm.asm
+		.xmm_vaddp_rrm(reg.to_reg(), &address, reg, src_lane_size);
+	    // Takes lanes 0 and 2 from `reg` (converted values) and lanes
+	    // 0 and 2 from `scratch` (zeroes) to put the converted ints in
+	    // the lower lanes and zeroes in the upper lanes.
+	    masm.asm.xmm_vshufp_rrri(
+		reg.to_reg(),
+		scratch.inner(),
+		reg,
+		0b10_00_10_00,
+		dst_lane_size,
+	    );
+	    Ok(())
+	})
     }
 
     /// Given a vector of floats where lanes with NaN values are set to all 1s

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1546,8 +1546,18 @@ impl Masm for MacroAssembler {
                 let dst = context.reg(regs::rax(), self)?;
                 let operand = context.pop_to_reg(self, None)?;
 
-                self.asm
-                    .atomic_rmw_seq(addr, operand.reg, writable!(dst), size, flags, op);
+                self.with_scratch::<IntScratch, _>(|masm, scratch| {
+                    masm.asm.atomic_rmw_seq(
+                        addr,
+                        operand.reg,
+                        writable!(dst),
+                        scratch.writable(),
+                        size,
+                        flags,
+                        op,
+                    );
+                    Ok(())
+                })?;
 
                 context.free_reg(operand.reg);
                 dst

--- a/winch/codegen/src/isa/x64/regs.rs
+++ b/winch/codegen/src/isa/x64/regs.rs
@@ -1,6 +1,7 @@
 //! X64 register definition.
 
 use crate::isa::reg::Reg;
+use crate::regset::RegBitSet;
 use regalloc2::{PReg, RegClass};
 
 const ENC_RAX: u8 = 0;
@@ -159,22 +160,70 @@ const GPR: u32 = 16;
 /// FPR count.
 const FPR: u32 = 16;
 /// GPR index bound.
-pub(crate) const MAX_GPR: u32 = GPR;
+const MAX_GPR: u32 = GPR;
 /// GPR index bound.
-pub(crate) const MAX_FPR: u32 = FPR;
-const ALLOCATABLE_GPR: u32 = (1 << GPR) - 1;
-const ALLOCATABLE_FPR: u32 = (1 << FPR) - 1;
+const MAX_FPR: u32 = FPR;
+const ALL_GPR: u32 = (1 << GPR) - 1;
+const ALL_FPR: u32 = (1 << FPR) - 1;
 /// Bitmask of non-alloctable GPRs.
 // R11: Is used as the scratch register.
 // R14: Is a pinned register, used as the instance register.
-pub(crate) const NON_ALLOCATABLE_GPR: u32 =
-    (1 << ENC_RBP) | (1 << ENC_RSP) | (1 << ENC_R11) | (1 << ENC_R14);
+const SCRATCH: u32 = 1 << ENC_R11;
+const INSTANCE: u32 = 1 << ENC_R14;
+pub(crate) const NON_ALLOCATABLE_GPR: u32 = (1 << ENC_RBP) | (1 << ENC_RSP) | SCRATCH | INSTANCE;
 
 /// Bitmask of non-alloctable FPRs.
 // xmm15: Is used as the scratch register.
-pub(crate) const NON_ALLOCATABLE_FPR: u32 = 1 << 15;
+const SCRATCH_FPR: u32 = 1 << 15;
+const NON_ALLOCATABLE_FPR: u32 = SCRATCH_FPR;
 
 /// Bitmask to represent the available general purpose registers.
-pub(crate) const ALL_GPR: u32 = ALLOCATABLE_GPR & !NON_ALLOCATABLE_GPR;
+const ALLOCATABLE_GPR: u32 = ALL_GPR & !NON_ALLOCATABLE_GPR;
 /// Bitmask to represent the available floating point registers.
-pub(crate) const ALL_FPR: u32 = ALLOCATABLE_FPR & !NON_ALLOCATABLE_FPR;
+const ALLOCATABLE_FPR: u32 = ALL_FPR & !NON_ALLOCATABLE_FPR;
+
+/// Allocatable scratch general purpose registers.
+const ALLOCATABLE_SCRATCH_GPR: u32 = SCRATCH;
+/// Non-allocatable scratch general purpose registers.
+const NON_ALLOCATABLE_SCRATCH_GPR: u32 = ALL_GPR & !SCRATCH;
+
+/// Allocatable scratch floating-point registers.
+const ALLOCATABLE_SCRATCH_FPR: u32 = SCRATCH_FPR;
+/// Non-allocatable scratch floating-point registers.
+const NON_ALLOCATABLE_SCRATCH_FPR: u32 = ALL_FPR & !SCRATCH_FPR;
+
+/// Bitset for allocatable general purpose registers.
+pub fn gpr_bit_set() -> RegBitSet {
+    RegBitSet::int(
+        ALLOCATABLE_GPR.into(),
+        NON_ALLOCATABLE_GPR.into(),
+        usize::try_from(MAX_GPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable floating point registers.
+pub fn fpr_bit_set() -> RegBitSet {
+    RegBitSet::float(
+        ALLOCATABLE_FPR.into(),
+        NON_ALLOCATABLE_FPR.into(),
+        usize::try_from(MAX_FPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable scratch general purpose registers.
+pub fn scratch_gpr_bitset() -> RegBitSet {
+    RegBitSet::int(
+        ALLOCATABLE_SCRATCH_GPR.into(),
+        NON_ALLOCATABLE_SCRATCH_GPR.into(),
+        usize::try_from(MAX_GPR).unwrap(),
+    )
+}
+
+/// Bitset for allocatable scratch floating point registers.
+pub fn scratch_fpr_bitset() -> RegBitSet {
+    RegBitSet::float(
+        ALLOCATABLE_SCRATCH_FPR.into(),
+        NON_ALLOCATABLE_SCRATCH_FPR.into(),
+        usize::try_from(MAX_FPR).unwrap(),
+    )
+}

--- a/winch/codegen/src/isa/x64/regs.rs
+++ b/winch/codegen/src/isa/x64/regs.rs
@@ -92,6 +92,7 @@ pub(crate) fn r11() -> Reg {
     gpr(ENC_R11)
 }
 
+#[deprecated]
 pub(crate) fn scratch() -> Reg {
     r11()
 }
@@ -151,6 +152,7 @@ pub(crate) fn xmm15() -> Reg {
     fpr(15)
 }
 
+#[deprecated]
 pub(crate) fn scratch_xmm() -> Reg {
     xmm15()
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -2,7 +2,7 @@ use crate::abi::{self, LocalSlot, align_to, scratch};
 use crate::codegen::{CodeGenContext, Emission, FuncEnv};
 use crate::isa::{
     CallingConvention,
-    reg::{Reg, WritableReg, writable},
+    reg::{Reg, WritableReg, writable, RegClass},
 };
 use anyhow::Result;
 use cranelift_codegen::{
@@ -191,6 +191,45 @@ pub struct StackSlot {
 impl StackSlot {
     pub fn new(offs: SPOffset, size: u32) -> Self {
         Self { offset: offs, size }
+    }
+}
+
+pub trait ScratchType {
+    /// Derive the register class from the scratch register type.
+    fn reg_class() -> RegClass;
+}
+
+/// A scratch register type of integer class.
+pub struct IntScratch;
+/// A scratch register type of floating point class.
+pub struct FloatScratch;
+
+impl ScratchType for IntScratch {
+    fn reg_class() -> RegClass {
+	RegClass::Int
+    }
+}
+
+impl ScratchType for FloatScratch {
+    fn reg_class() -> RegClass {
+	RegClass::Float
+    }
+}
+
+/// A scratch register scope.
+pub struct Scratch(Reg);
+
+impl Scratch {
+    pub fn new(r: Reg) -> Self {
+	Self(r)
+    }
+
+    pub fn inner(&self) -> Reg {
+	self.0
+    }
+
+    pub fn writable(&self) -> WritableReg {
+	writable!(self.0)
     }
 }
 
@@ -883,6 +922,7 @@ pub(crate) enum V128MulKind {
 }
 
 /// Kinds of vector negation supported by WebAssembly.
+#[derive(Copy, Clone)]
 pub(crate) enum V128NegKind {
     /// 4 lanes of 32-bit floats.
     F32x4,
@@ -1125,12 +1165,18 @@ impl Imm {
         }
     }
 
-    /// Returns true if the [`Imm`] is float.
-    pub fn is_float(&self) -> bool {
-        match self {
-            Self::F32(_) | Self::F64(_) => true,
-            _ => false,
-        }
+    /// Unwraps the underlying integer value as u64.
+    /// # Panics
+    /// This function panics if the underlying value can't be represented
+    /// as u64.
+    pub fn unwrap_as_u64(&self) -> u64 {
+	match self {
+	    Self::I32(v) => *v as u64,
+	    Self::I64(v) => *v,
+	    Self::F32(v) => *v as u64,
+	    Self::F64(v) => *v,
+	    _ => unreachable!()
+	}
     }
 
     /// Get the operand size of the immediate.
@@ -1386,6 +1432,10 @@ pub(crate) trait MacroAssembler {
         f: impl FnMut(&mut Self) -> Result<(CalleeKind, CallingConvention)>,
     ) -> Result<u32>;
 
+    /// Acquire a scratch register and execute the given callback.
+    fn with_scratch<T: ScratchType, F>(&mut self, f:  F) -> Result<()>
+	where F: FnMut(&mut Self, Scratch) -> Result<()>;
+
     /// Get stack pointer offset.
     fn sp_offset(&self) -> Result<SPOffset>;
 
@@ -1608,7 +1658,7 @@ pub(crate) trait MacroAssembler {
     fn shift_ir(
         &mut self,
         dst: WritableReg,
-        imm: u64,
+        imm: Imm,
         lhs: Reg,
         kind: ShiftKind,
         size: OperandSize,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -2,7 +2,7 @@ use crate::abi::{self, LocalSlot, align_to, scratch};
 use crate::codegen::{CodeGenContext, Emission, FuncEnv};
 use crate::isa::{
     CallingConvention,
-    reg::{Reg, WritableReg, writable, RegClass},
+    reg::{Reg, RegClass, WritableReg, writable},
 };
 use anyhow::Result;
 use cranelift_codegen::{
@@ -206,13 +206,13 @@ pub struct FloatScratch;
 
 impl ScratchType for IntScratch {
     fn reg_class() -> RegClass {
-	RegClass::Int
+        RegClass::Int
     }
 }
 
 impl ScratchType for FloatScratch {
     fn reg_class() -> RegClass {
-	RegClass::Float
+        RegClass::Float
     }
 }
 
@@ -221,15 +221,15 @@ pub struct Scratch(Reg);
 
 impl Scratch {
     pub fn new(r: Reg) -> Self {
-	Self(r)
+        Self(r)
     }
 
     pub fn inner(&self) -> Reg {
-	self.0
+        self.0
     }
 
     pub fn writable(&self) -> WritableReg {
-	writable!(self.0)
+        writable!(self.0)
     }
 }
 
@@ -1170,13 +1170,13 @@ impl Imm {
     /// This function panics if the underlying value can't be represented
     /// as u64.
     pub fn unwrap_as_u64(&self) -> u64 {
-	match self {
-	    Self::I32(v) => *v as u64,
-	    Self::I64(v) => *v,
-	    Self::F32(v) => *v as u64,
-	    Self::F64(v) => *v,
-	    _ => unreachable!()
-	}
+        match self {
+            Self::I32(v) => *v as u64,
+            Self::I64(v) => *v,
+            Self::F32(v) => *v as u64,
+            Self::F64(v) => *v,
+            _ => unreachable!(),
+        }
     }
 
     /// Get the operand size of the immediate.
@@ -1433,8 +1433,9 @@ pub(crate) trait MacroAssembler {
     ) -> Result<u32>;
 
     /// Acquire a scratch register and execute the given callback.
-    fn with_scratch<T: ScratchType, F>(&mut self, f:  F) -> Result<()>
-	where F: FnMut(&mut Self, Scratch) -> Result<()>;
+    fn with_scratch<T: ScratchType, F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnMut(&mut Self, Scratch) -> Result<()>;
 
     /// Get stack pointer offset.
     fn sp_offset(&self) -> Result<SPOffset>;

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -224,10 +224,12 @@ impl Scratch {
         Self(r)
     }
 
+    #[inline]
     pub fn inner(&self) -> Reg {
         self.0
     }
 
+    #[inline]
     pub fn writable(&self) -> WritableReg {
         writable!(self.0)
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -2048,7 +2048,7 @@ where
         // Find the innermost target and use it as the relative frame
         // for result handling below.
         //
-        // This approch ensures that
+        // This approach ensures that
         // 1. The stack pointer offset is correctly positioned
         //    according to the expectations of the innermost block end
         //    sequence.


### PR DESCRIPTION
This patch is best reviewed commit by commit.

This is a follow-up to https://github.com/bytecodealliance/wasmtime/pull/10888

Scratch registers are used throughout Winch's codebase to handle constant values that cannot be directly encoded in specific instructions. Since the encoding rules are ISA-specific, selecting instructions for these operations often requires scratch registers. Ideally, these temporary registers should be acquired without adding any register pressure to prevent value spilling. 

The objective of this change is to make it generally safer to work with scratch registers and prevent accidental clobbering of such registers.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
