### PR TITLE
x64: Migrate `XmmUnaryRmRImm{,Vex}` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/lanes.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/lanes.rs
@@ -43,5 +43,12 @@ pub fn list() -> Vec<Inst> {
         inst("vpblendvb", fmt("RVMR", [w(xmm1), r(xmm2), r(xmm_m128), r(xmm3)]), vex(L128)._66()._0f3a().w0().op(0x4C).r().is4(), _64b | compat | avx),
         inst("vblendvps", fmt("RVMR", [w(xmm1), r(xmm2), r(xmm_m128), r(xmm3)]), vex(L128)._66()._0f3a().w0().op(0x4A).r().is4(), _64b | compat | avx),
         inst("vblendvpd", fmt("RVMR", [w(xmm1), r(xmm2), r(xmm_m128), r(xmm3)]), vex(L128)._66()._0f3a().w0().op(0x4B).r().is4(), _64b | compat | avx),
+
+        inst("pshufd", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0x66, 0x0F, 0x70]).r().ib(), _64b | compat | sse2),
+        inst("pshuflw", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0xF2, 0x0F, 0x70]).r().ib(), _64b | compat | sse2),
+        inst("pshufhw", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0xF3, 0x0F, 0x70]).r().ib(), _64b | compat | sse2),
+        inst("vpshufd", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._66()._0f().op(0x70).r().ib(), _64b | compat | avx),
+        inst("vpshuflw", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._f2()._0f().op(0x70).r().ib(), _64b | compat | avx),
+        inst("vpshufhw", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._f3()._0f().op(0x70).r().ib(), _64b | compat | avx),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -148,12 +148,6 @@
                        (src XmmMem)
                        (dst WritableXmm))
 
-       ;; XMM unary op using a VEX encoding (aka AVX) with an immediate.
-       (XmmUnaryRmRImmVex (op AvxOpcode)
-                          (src XmmMem)
-                          (dst WritableXmm)
-                          (imm u8))
-
        ;; XMM (scalar or vector) unary op (from xmm to reg/mem) using the
        ;; VEX prefix
        (XmmMovRMVex (op AvxOpcode)
@@ -206,16 +200,6 @@
        (XmmUnaryRmR (op SseOpcode)
                     (src XmmMemAligned)
                     (dst WritableXmm))
-
-       ;; XMM (scalar or vector) unary op with immediate: roundss, roundsd, etc.
-       ;;
-       ;; This differs from XMM_RM_R_IMM in that the dst register of
-       ;; XmmUnaryRmRImm is not used in the computation of the instruction dst
-       ;; value and so does not have to be a previously valid value.
-       (XmmUnaryRmRImm (op SseOpcode)
-                       (src XmmMemAligned)
-                       (imm u8)
-                       (dst WritableXmm))
 
        ;; XMM (scalar or vector) unary op that relies on the EVEX prefix.
        (XmmUnaryRmREvex (op Avx512Opcode)
@@ -622,15 +606,12 @@
             Pmaddubsw
             Pmaddwd
             Pshufb
-            Pshufd
             Ptest
             Rcpss
             Rsqrtss
             Shufps
             Ucomiss
             Ucomisd
-            Pshuflw
-            Pshufhw
             Pblendw
           ))
 
@@ -1075,17 +1056,12 @@
             Vmaxsd
             Vsqrtps
             Vsqrtpd
-            Vroundps
-            Vroundpd
             Vphaddw
             Vphaddd
             Vpunpckhdq
             Vpunpckldq
             Vpunpckhqdq
             Vpunpcklqdq
-            Vpshuflw
-            Vpshufhw
-            Vpshufd
             Vmovss
             Vmovsd
             Vmovups
@@ -1102,8 +1078,6 @@
             Vbroadcastss
             Vsqrtss
             Vsqrtsd
-            Vroundss
-            Vroundsd
             Vucomiss
             Vucomisd
             Vptest
@@ -1601,13 +1575,6 @@
             (_ Unit (emit (MInst.XmmUnaryRmRVex op src dst))))
         dst))
 
-;; Helper for creating `XmmUnaryRmRImmVex` instructions
-(decl xmm_unary_rm_r_imm_vex (AvxOpcode XmmMem u8) Xmm)
-(rule (xmm_unary_rm_r_imm_vex op src imm)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmUnaryRmRImmVex op src dst imm))))
-        dst))
-
 ;; Helper for creating `MInst.XmmRmRImm` instructions.
 (decl xmm_rm_r_imm (SseOpcode Reg RegMem u8 OperandSize) Xmm)
 (rule (xmm_rm_r_imm op src1 src2 imm size)
@@ -1618,13 +1585,6 @@
                                            dst
                                            imm
                                            size))))
-        dst))
-
-;; Helper for constructing `XmmUnaryRmRImm` instructions.
-(decl xmm_unary_rm_r_imm (SseOpcode XmmMemAligned u8) Xmm)
-(rule (xmm_unary_rm_r_imm op src1 imm)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmUnaryRmRImm op src1 imm dst))))
         dst))
 
 ;; Helper for creating `MInst.XmmUnaryRmR` instructions.
@@ -3609,7 +3569,7 @@
 (decl x64_roundss (XmmMem RoundImm) Xmm)
 (rule 1 (x64_roundss src1 round)
         (if-let true (use_avx))
-        (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundss) src1 (encode_round_imm round)))
+        (x64_vroundss_rvmi (xmm_zero $F32X4) src1 (encode_round_imm round)))
 (rule 0 (x64_roundss src1 round)
         (x64_roundss_rmi src1 (encode_round_imm round)))
 
@@ -3617,7 +3577,7 @@
 (decl x64_roundsd (XmmMem RoundImm) Xmm)
 (rule 1 (x64_roundsd src1 round)
         (if-let true (use_avx))
-        (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundsd) src1 (encode_round_imm round)))
+        (x64_vroundsd_rvmi (xmm_zero $F64X2) src1 (encode_round_imm round)))
 (rule 0 (x64_roundsd src1 round)
         (x64_roundsd_rmi src1 (encode_round_imm round)))
 
@@ -3625,7 +3585,7 @@
 (decl x64_roundps (XmmMem RoundImm) Xmm)
 (rule 1 (x64_roundps src1 round)
       (if-let true (use_avx))
-      (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundps) src1 (encode_round_imm round)))
+      (x64_vroundps_rmi src1 (encode_round_imm round)))
 (rule (x64_roundps src1 round)
       (x64_roundps_rmi src1 (encode_round_imm round)))
 
@@ -3633,7 +3593,7 @@
 (decl x64_roundpd (XmmMem RoundImm) Xmm)
 (rule 1 (x64_roundpd src1 round)
       (if-let true (use_avx))
-      (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundpd) src1 (encode_round_imm round)))
+      (x64_vroundpd_rmi src1 (encode_round_imm round)))
 (rule 0 (x64_roundpd src1 round)
       (x64_roundpd_rmi src1 (encode_round_imm round)))
 
@@ -3666,11 +3626,10 @@
 
 ;; Helper for creating `pshufd` instructions.
 (decl x64_pshufd (XmmMem u8) Xmm)
-(rule (x64_pshufd src imm)
-      (xmm_unary_rm_r_imm (SseOpcode.Pshufd) src imm))
+(rule (x64_pshufd src imm) (x64_pshufd_a src imm))
 (rule 1 (x64_pshufd src imm)
       (if-let true (use_avx))
-      (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshufd) src imm))
+      (x64_vpshufd_a src imm))
 
 ;; Helper for creating `pshufb` instructions.
 (decl x64_pshufb (Xmm XmmMem) Xmm)
@@ -3682,19 +3641,17 @@
 
 ;; Helper for creating `pshuflw` instructions.
 (decl x64_pshuflw (XmmMem u8) Xmm)
-(rule (x64_pshuflw src imm)
-      (xmm_unary_rm_r_imm (SseOpcode.Pshuflw) src imm))
+(rule (x64_pshuflw src imm) (x64_pshuflw_a src imm))
 (rule 1 (x64_pshuflw src imm)
       (if-let true (use_avx))
-      (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshuflw) src imm))
+      (x64_vpshuflw_a src imm))
 
 ;; Helper for creating `pshufhw` instructions.
 (decl x64_pshufhw (XmmMem u8) Xmm)
-(rule (x64_pshufhw src imm)
-      (xmm_unary_rm_r_imm (SseOpcode.Pshufhw) src imm))
+(rule (x64_pshufhw src imm) (x64_pshufhw_a src imm))
 (rule 1 (x64_pshufhw src imm)
       (if-let true (use_avx))
-      (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshufhw) src imm))
+      (x64_vpshufhw_a src imm))
 
 ;; Helper for creating `shufps` instructions.
 (decl x64_shufps (Xmm XmmMem u8) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1104,17 +1104,12 @@ impl AvxOpcode {
             | AvxOpcode::Vmaxsd
             | AvxOpcode::Vsqrtps
             | AvxOpcode::Vsqrtpd
-            | AvxOpcode::Vroundpd
-            | AvxOpcode::Vroundps
             | AvxOpcode::Vphaddw
             | AvxOpcode::Vphaddd
             | AvxOpcode::Vpunpckldq
             | AvxOpcode::Vpunpckhdq
             | AvxOpcode::Vpunpcklqdq
             | AvxOpcode::Vpunpckhqdq
-            | AvxOpcode::Vpshuflw
-            | AvxOpcode::Vpshufhw
-            | AvxOpcode::Vpshufd
             | AvxOpcode::Vmovss
             | AvxOpcode::Vmovsd
             | AvxOpcode::Vmovups
@@ -1128,8 +1123,6 @@ impl AvxOpcode {
             | AvxOpcode::Vbroadcastss
             | AvxOpcode::Vsqrtss
             | AvxOpcode::Vsqrtsd
-            | AvxOpcode::Vroundss
-            | AvxOpcode::Vroundsd
             | AvxOpcode::Vunpcklpd
             | AvxOpcode::Vptest
             | AvxOpcode::Vucomiss

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -137,7 +137,6 @@ impl Inst {
             Inst::XmmRmR { op, .. }
             | Inst::XmmRmRUnaligned { op, .. }
             | Inst::XmmRmRImm { op, .. }
-            | Inst::XmmUnaryRmRImm { op, .. }
             | Inst::XmmUnaryRmR { op, .. } => smallvec![op.available_from()],
 
             Inst::XmmUnaryRmREvex { op, .. }
@@ -149,7 +148,6 @@ impl Inst {
             | Inst::XmmRmRVex3 { op, .. }
             | Inst::XmmRmRImmVex { op, .. }
             | Inst::XmmUnaryRmRVex { op, .. }
-            | Inst::XmmUnaryRmRImmVex { op, .. }
             | Inst::XmmMovRMVex { op, .. }
             | Inst::XmmMovRMImmVex { op, .. }
             | Inst::XmmToGprImmVex { op, .. }
@@ -604,29 +602,11 @@ impl PrettyPrint for Inst {
                 format!("{op} {src}, {dst}")
             }
 
-            Inst::XmmUnaryRmRImm {
-                op, src, dst, imm, ..
-            } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size());
-                let src = src.pretty_print(op.src_size());
-                let op = ljustify(op.to_string());
-                format!("{op} ${imm}, {src}, {dst}")
-            }
-
             Inst::XmmUnaryRmRVex { op, src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
-            }
-
-            Inst::XmmUnaryRmRImmVex {
-                op, src, dst, imm, ..
-            } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
-                let src = src.pretty_print(8);
-                let op = ljustify(op.to_string());
-                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmUnaryRmREvex { op, src, dst, .. } => {
@@ -1448,14 +1428,13 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_fixed_use(dividend, regs::rax());
             collector.reg_fixed_def(dst, regs::rax());
         }
-        Inst::XmmUnaryRmR { src, dst, .. } | Inst::XmmUnaryRmRImm { src, dst, .. } => {
+        Inst::XmmUnaryRmR { src, dst, .. } => {
             collector.reg_def(dst);
             src.get_operands(collector);
         }
         Inst::XmmUnaryRmREvex { src, dst, .. }
         | Inst::XmmUnaryRmRImmEvex { src, dst, .. }
-        | Inst::XmmUnaryRmRVex { src, dst, .. }
-        | Inst::XmmUnaryRmRImmVex { src, dst, .. } => {
+        | Inst::XmmUnaryRmRVex { src, dst, .. } => {
             collector.reg_def(dst);
             src.get_operands(collector);
         }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -200,9 +200,6 @@ pub(crate) fn check(
         Inst::XmmRmR { dst, ref src2, .. }
         | Inst::XmmUnaryRmR {
             dst, src: ref src2, ..
-        }
-        | Inst::XmmUnaryRmRImm {
-            dst, src: ref src2, ..
         } => {
             match <&RegMem>::from(src2) {
                 RegMem::Mem { addr } => {
@@ -248,12 +245,6 @@ pub(crate) fn check(
             ..
         }
         | Inst::XmmUnaryRmRVex {
-            op,
-            dst,
-            src: ref src2,
-            ..
-        }
-        | Inst::XmmUnaryRmRImmVex {
             op,
             dst,
             src: ref src2,

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -166,7 +166,7 @@ block0(v0: f128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq %xmm0, %rax
-;   pshufd  $238, %xmm0, %xmm4
+;   pshufd $0xee, %xmm0, %xmm4
 ;   movq %xmm4, %rdx
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -224,7 +224,7 @@ block0(v0: i64x2):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq %xmm0, %rax
-;   pshufd  $238, %xmm0, %xmm4
+;   pshufd $0xee, %xmm0, %xmm4
 ;   movq %xmm4, %rdx
 ;   movq    %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
@@ -11,7 +11,9 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundss $2, %xmm0, %xmm0
+;   uninit  %xmm2
+;   vxorps  %xmm2, %xmm2, %xmm4
+;   vroundss $0x2, %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -21,7 +23,8 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   vroundss $2, %xmm0, %xmm0, %xmm0
+;   vxorps %xmm2, %xmm2, %xmm4
+;   vroundss $2, %xmm0, %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -36,7 +39,9 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundsd $2, %xmm0, %xmm0
+;   uninit  %xmm2
+;   vxorpd  %xmm2, %xmm2, %xmm4
+;   vroundsd $0x2, %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -46,7 +51,8 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   vroundsd $2, %xmm0, %xmm0, %xmm0
+;   vxorpd %xmm2, %xmm2, %xmm4
+;   vroundsd $2, %xmm0, %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -61,7 +67,7 @@ block0(v0: f32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundps $2, %xmm0, %xmm0
+;   vroundps $0x2, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -86,7 +92,7 @@ block0(v0: f64x2):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundpd $2, %xmm0, %xmm0
+;   vroundpd $0x2, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
@@ -111,7 +111,7 @@ block0(v0: f32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $1, %xmm0, %xmm0
+;   vpshufd $0x1, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -136,7 +136,7 @@ block0(v0: f64x2):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $238, %xmm0, %xmm0
+;   vpshufd $0xee, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -111,7 +111,7 @@ block0(v0: f32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $1, %xmm0, %xmm0
+;   pshufd $0x1, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -136,7 +136,7 @@ block0(v0: f64x2):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $238, %xmm0, %xmm0
+;   pshufd $0xee, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
@@ -169,7 +169,7 @@ block0(v0: i64x2):
 ;   vxorpd  %xmm2, %xmm2, %xmm4
 ;   vmovq %xmm0, %r9
 ;   vcvtsi2sdq %r9, %xmm4, %xmm1
-;   vpshufd $238, %xmm0, %xmm2
+;   vpshufd $0xee, %xmm0, %xmm2
 ;   vmovq %xmm2, %rcx
 ;   vcvtsi2sdq %rcx, %xmm4, %xmm6
 ;   vunpcklpd %xmm1, %xmm6, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -1212,7 +1212,7 @@ block0(v0: i64x2):
 ;   movq %xmm6, %r9
 ;   movdqa %xmm1, %xmm0
 ;   cvtsi2sdq %r9, %xmm0
-;   pshufd  $238, %xmm6, %xmm2
+;   pshufd $0xee, %xmm6, %xmm2
 ;   movq %xmm2, %rcx
 ;   cvtsi2sdq %rcx, %xmm1
 ;   unpcklpd %xmm1, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/float-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-avx.clif
@@ -365,7 +365,7 @@ block0(v0: f32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundps $1, %xmm0, %xmm0
+;   vroundps $0x1, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -390,7 +390,7 @@ block0(v0: f64x2):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vroundpd $1, %xmm0, %xmm0
+;   vroundpd $0x1, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -73,29 +73,29 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   call    *%r8
 ;   movdqu <offset:1>+(%rsp), %xmm4
 ;   movdqu %xmm0, <offset:1>+0x50(%rsp)
-;   pshufd  $1, %xmm4, %xmm0
+;   pshufd $0x1, %xmm4, %xmm0
 ;   movdqu <offset:1>+0x10(%rsp), %xmm1
-;   pshufd  $1, %xmm1, %xmm1
+;   pshufd $0x1, %xmm1, %xmm1
 ;   movdqu <offset:1>+0x20(%rsp), %xmm2
-;   pshufd  $1, %xmm2, %xmm2
+;   pshufd $0x1, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r9
 ;   call    *%r9
 ;   movdqu <offset:1>+(%rsp), %xmm4
 ;   movdqu %xmm0, <offset:1>+0x30(%rsp)
-;   pshufd  $2, %xmm4, %xmm0
+;   pshufd $0x2, %xmm4, %xmm0
 ;   movdqu <offset:1>+0x10(%rsp), %xmm1
-;   pshufd  $2, %xmm1, %xmm1
+;   pshufd $0x2, %xmm1, %xmm1
 ;   movdqu <offset:1>+0x20(%rsp), %xmm2
-;   pshufd  $2, %xmm2, %xmm2
+;   pshufd $0x2, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r10
 ;   call    *%r10
 ;   movdqu <offset:1>+(%rsp), %xmm4
 ;   movdqu %xmm0, <offset:1>+0x40(%rsp)
-;   pshufd  $3, %xmm4, %xmm0
+;   pshufd $0x3, %xmm4, %xmm0
 ;   movdqu <offset:1>+0x10(%rsp), %xmm1
-;   pshufd  $3, %xmm1, %xmm1
+;   pshufd $0x3, %xmm1, %xmm1
 ;   movdqu <offset:1>+0x20(%rsp), %xmm2
-;   pshufd  $3, %xmm2, %xmm2
+;   pshufd $0x3, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r11
 ;   call    *%r11
 ;   movdqa %xmm0, %xmm2
@@ -180,11 +180,11 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   call    *%r8
 ;   movdqu %xmm0, <offset:1>+0x30(%rsp)
 ;   movdqu <offset:1>+(%rsp), %xmm0
-;   pshufd  $238, %xmm0, %xmm0
+;   pshufd $0xee, %xmm0, %xmm0
 ;   movdqu <offset:1>+0x10(%rsp), %xmm1
-;   pshufd  $238, %xmm1, %xmm1
+;   pshufd $0xee, %xmm1, %xmm1
 ;   movdqu <offset:1>+0x20(%rsp), %xmm2
-;   pshufd  $238, %xmm2, %xmm2
+;   pshufd $0xee, %xmm2, %xmm2
 ;   load_ext_name %FmaF64+0, %r9
 ;   call    *%r9
 ;   movdqa %xmm0, %xmm6

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $160, %xmm0, %xmm0
+;   pshufd $0xa0, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -148,7 +148,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $39, %xmm0, %xmm0
+;   pshufd $0x27, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -176,7 +176,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $135, %xmm1, %xmm0
+;   pshufd $0x87, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -404,7 +404,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshuflw $27, %xmm0, %xmm0
+;   pshuflw $0x1b, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -432,7 +432,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshuflw $187, %xmm0, %xmm0
+;   pshuflw $0xbb, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -460,7 +460,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshuflw $27, %xmm1, %xmm0
+;   pshuflw $0x1b, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -488,7 +488,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshuflw $119, %xmm1, %xmm0
+;   pshuflw $0x77, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -516,7 +516,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufhw $27, %xmm0, %xmm0
+;   pshufhw $0x1b, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -544,7 +544,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufhw $119, %xmm0, %xmm0
+;   pshufhw $0x77, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -572,7 +572,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufhw $27, %xmm1, %xmm0
+;   pshufhw $0x1b, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -600,7 +600,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufhw $119, %xmm1, %xmm0
+;   pshufhw $0x77, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -609,8 +609,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $250, %xmm0, %xmm3
-;   vpshufd $250, %xmm1, %xmm5
+;   vpshufd $0xfa, %xmm0, %xmm3
+;   vpshufd $0xfa, %xmm1, %xmm5
 ;   vpmuldq %xmm3, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -640,8 +640,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $80, %xmm0, %xmm3
-;   vpshufd $80, %xmm1, %xmm5
+;   vpshufd $0x50, %xmm0, %xmm3
+;   vpshufd $0x50, %xmm1, %xmm5
 ;   vpmuludq %xmm3, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -1345,7 +1345,7 @@ block0(v0: f64x2):
 ;   vxorpd  %xmm2, %xmm2, %xmm4
 ;   vmaxpd  %xmm0, %xmm4, %xmm6
 ;   vminpd  %xmm6, const(0), %xmm0
-;   vroundpd $3, %xmm0, %xmm2
+;   vroundpd $0x3, %xmm0, %xmm2
 ;   vaddpd (%rip), %xmm2, %xmm5
 ;   vshufps $136, %xmm5, %xmm4, %xmm0
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -746,9 +746,9 @@ block0(v0: i64x2):
 ; block0:
 ;   movdqa %xmm0, %xmm2
 ;   psrad $0x1, %xmm2
-;   pshufd  $237, %xmm2, %xmm4
+;   pshufd $0xed, %xmm2, %xmm4
 ;   psrlq $0x1, %xmm0
-;   pshufd  $232, %xmm0, %xmm0
+;   pshufd $0xe8, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -780,9 +780,9 @@ block0(v0: i64x2):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $237, %xmm0, %xmm5
+;   pshufd $0xed, %xmm0, %xmm5
 ;   psrad $0x1f, %xmm0
-;   pshufd  $237, %xmm0, %xmm6
+;   pshufd $0xed, %xmm0, %xmm6
 ;   movdqa %xmm5, %xmm0
 ;   punpckldq %xmm6, %xmm0
 ;   movq    %rbp, %rsp
@@ -816,9 +816,9 @@ block0(v0: i64x2):
 ; block0:
 ;   movdqa %xmm0, %xmm2
 ;   psrad $0x1f, %xmm2
-;   pshufd  $237, %xmm2, %xmm4
+;   pshufd $0xed, %xmm2, %xmm4
 ;   psrad $0x16, %xmm0
-;   pshufd  $237, %xmm0, %xmm0
+;   pshufd $0xed, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -852,9 +852,9 @@ block0(v0: i64x2):
 ; block0:
 ;   movdqa %xmm0, %xmm2
 ;   psrad $0x1f, %xmm2
-;   pshufd  $237, %xmm2, %xmm4
+;   pshufd $0xed, %xmm2, %xmm4
 ;   psrad $0x4, %xmm0
-;   pshufd  $237, %xmm0, %xmm0
+;   pshufd $0xed, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -190,8 +190,8 @@ block0:
 ; block0:
 ;   movl    $65535, %ecx
 ;   movd %ecx, %xmm1
-;   pshuflw $0, %xmm1, %xmm3
-;   pshufd  $0, %xmm3, %xmm0
+;   pshuflw $0x0, %xmm1, %xmm3
+;   pshufd $0x0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -220,7 +220,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movd %edi, %xmm2
-;   pshufd  $0, %xmm2, %xmm0
+;   pshufd $0x0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -246,7 +246,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $68, %xmm0, %xmm0
+;   pshufd $0x44, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -42,8 +42,8 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovd %edi, %xmm2
-;   vpshuflw $0, %xmm2, %xmm4
-;   vpshufd $0, %xmm4, %xmm0
+;   vpshuflw $0x0, %xmm2, %xmm4
+;   vpshufd $0x0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -71,7 +71,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovd %edi, %xmm2
-;   vpshufd $0, %xmm2, %xmm0
+;   vpshufd $0x0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -98,7 +98,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovq %rdi, %xmm2
-;   vpshufd $68, %xmm2, %xmm0
+;   vpshufd $0x44, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -149,7 +149,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $68, %xmm0, %xmm0
+;   vpshufd $0x44, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -209,8 +209,8 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm2
 ;   vpinsrw $0x0, (%rdi), %xmm2, %xmm4
-;   vpshuflw $0, %xmm4, %xmm6
-;   vpshufd $0, %xmm6, %xmm0
+;   vpshuflw $0x0, %xmm4, %xmm6
+;   vpshufd $0x0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
@@ -93,7 +93,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovq %rdi, %xmm2
-;   vpshufd $68, %xmm2, %xmm0
+;   vpshufd $0x44, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -144,7 +144,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vpshufd $68, %xmm0, %xmm0
+;   vpshufd $0x44, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -42,8 +42,8 @@ block0(v0: i16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movd %edi, %xmm2
-;   pshuflw $0, %xmm2, %xmm4
-;   pshufd  $0, %xmm4, %xmm0
+;   pshuflw $0x0, %xmm2, %xmm4
+;   pshufd $0x0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -71,7 +71,7 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movd %edi, %xmm2
-;   pshufd  $0, %xmm2, %xmm0
+;   pshufd $0x0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -98,7 +98,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq %rdi, %xmm2
-;   pshufd  $68, %xmm2, %xmm0
+;   pshufd $0x44, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -149,7 +149,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $68, %xmm0, %xmm0
+;   pshufd $0x44, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -209,8 +209,8 @@ block0(v0: i64):
 ; block0:
 ;   uninit  %xmm3
 ;   pinsrw $0x0, (%rdi), %xmm3
-;   pshuflw $0, %xmm3, %xmm6
-;   pshufd  $0, %xmm6, %xmm0
+;   pshuflw $0x0, %xmm3, %xmm6
+;   pshufd $0x0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -85,8 +85,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $250, %xmm0, %xmm0
-;   pshufd  $250, %xmm1, %xmm5
+;   pshufd $0xfa, %xmm0, %xmm0
+;   pshufd $0xfa, %xmm1, %xmm5
 ;   pmuldq %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -184,8 +184,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $80, %xmm0, %xmm0
-;   pshufd  $80, %xmm1, %xmm5
+;   pshufd $0x50, %xmm0, %xmm0
+;   pshufd $0x50, %xmm1, %xmm5
 ;   pmuldq %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -289,8 +289,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $250, %xmm0, %xmm0
-;   pshufd  $250, %xmm1, %xmm5
+;   pshufd $0xfa, %xmm0, %xmm0
+;   pshufd $0xfa, %xmm1, %xmm5
 ;   pmuludq %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
@@ -388,8 +388,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $80, %xmm0, %xmm0
-;   pshufd  $80, %xmm1, %xmm5
+;   pshufd $0x50, %xmm0, %xmm0
+;   pshufd $0x50, %xmm1, %xmm5
 ;   pmuludq %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -140,7 +140,7 @@ block0(v0: i32x4):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pshufd  $238, %xmm0, %xmm2
+;   pshufd $0xee, %xmm0, %xmm2
 ;   pmovsxdq %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp


### PR DESCRIPTION
This required definitions for `{v,}pshuf{lw,hw,d}` as well as reusing existing definitions for `vround*` instructions. While no other changes were needed in the assembler itself there was one minor ISLE change: the `vrounds{s,d}` instructions have a register operand that is used to copy to the upper bits of the result and this was not previously modeled in ISLE. Instead during emission the destination had its upper bits preserved, but this has proven to be problematic in the past where the upper bits being carried from previous instructions can cause unintended data dependencies and drastically slowing down tight loops. This commit fills in this operand with `xmm_zero` which means the upper bits will now be zeroed and any data dependencies from before will be severed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
