### PR TITLE
stack-switching: fix continuation chain walking for backtraces

### DIFF
--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -262,24 +262,17 @@ impl Backtrace {
         // are continuations, due to the initial stack having one, too.
         assert_eq!(stack_limits_vec.len(), continuations_vec.len() + 1);
 
-        for (conts, &parent_limits) in continuations_vec
-            .chunks(2)
-            .zip(stack_limits_vec.iter().skip(1))
-        {
+        for i in 0..continuations_vec.len() {
             // The continuation whose control context we want to
             // access, to get information about how to continue
             // execution in its parent.
-            let continuation = conts[0];
-            let continuation = unsafe { &*continuation };
+            let continuation = unsafe { &*continuations_vec[i] };
 
             // The stack limits describing the parent of `continuation`.
-            let parent_limits = unsafe { &*parent_limits };
+            let parent_limits = unsafe { &*stack_limits_vec[i + 1] };
 
-            // The parent of `continuation`, if the parent is itself a
-            // continuation. Otherwise, if `continuation` is the last
-            // continuation (i.e., its parent is the initial stack), this is
-            // None.
-            let parent_continuation = conts.get(1).map(|&p| unsafe { &*p });
+            // The parent of `continuation` if present not the last in the chain.
+            let parent_continuation = continuations_vec.get(i + 1).map(|&c| unsafe { &*c });
 
             let fiber_stack = continuation.fiber_stack();
             let resume_pc = fiber_stack.control_context_instruction_pointer();


### PR DESCRIPTION
A refactor during the stack switching runtime changes introduced a defect not present in the base stack switching code.  The `chunks` iterator call ends up skipping elements and the `windows` call would require pulling in something like `itertools::zip_longest` to work, so I just restored an impl closer to the original (but with more fine-grained unsafe calls).

This code has coverage but only in the final round of stack switching changes.

---

Original Discussion: https://github.com/bytecodealliance/wasmtime/pull/10388#discussion_r2114747895.  I didn't look closely enough when I took on this approach and w/o testing this slipped through (though can't really be hit yet).

Failing Test with current main + cranelift changes + tests: https://github.com/posborne/wasmtime/actions/runs/15538863221/job/43744530801#step:19:1165

CC @frank-emrich, @dhil 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
