### PR TITLE
Minor updates to testing in Miri

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1092,7 +1092,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - crate: "wasmtime --features pulley"
+          - crate: "wasmtime"
           - crate: "wasmtime-cli"
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -43,8 +43,9 @@ fn main() {
     // to rustc. That means that conditional dependencies enabled in
     // `Cargo.toml` (or other features) by `pulley` aren't activated, which is
     // why the `pulley` feature of this crate depends on nothing else.
-    custom_cfg("default_target_pulley", !has_host_compiler_backend);
-    if !has_host_compiler_backend {
+    let default_target_pulley = !has_host_compiler_backend || miri;
+    custom_cfg("default_target_pulley", default_target_pulley);
+    if default_target_pulley {
         println!("cargo:rustc-cfg=feature=\"pulley\"");
     }
 }

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -470,9 +470,9 @@ mod test {
         Ok(())
     }
 
+    // Note that this test runs on a platform that is known to use Cranelift
     #[test]
-    #[cfg(target_arch = "x86_64")] // test on a platform that is known to use
-    // Cranelift
+    #[cfg(all(target_arch = "x86_64", not(miri)))]
     fn test_os_mismatch() -> Result<()> {
         let engine = Engine::default();
         let mut metadata = Metadata::new(&engine);
@@ -597,9 +597,9 @@ Caused by:
         Ok(())
     }
 
+    /// This test is only run a platform that is known to implement threads
     #[test]
-    #[cfg(target_arch = "x86_64")] // test on a platform that is known to
-    // implement threads
+    #[cfg(all(target_arch = "x86_64", not(miri)))]
     fn test_feature_mismatch() -> Result<()> {
         let mut config = Config::new();
         config.wasm_threads(true);

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2580,6 +2580,7 @@ mod tests {
     use crate::{Module, Store};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn hash_key_is_stable_across_duplicate_store_data_entries() -> Result<()> {
         let mut store = Store::<()>::default();
         let module = Module::new(

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -491,6 +491,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // takes 30s+ in miri
     fn binary_operands() {
         let mut i = 0;
         for src2 in XReg::RANGE {

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -101,6 +101,7 @@ fn cannot_serialize_exported_module() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn usable_exported_modules() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -352,6 +352,7 @@ fn i31ref_as_anyref_global_ty() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn instantiate_global_with_subtype() -> Result<()> {
     let mut config = Config::new();
     config.wasm_function_references(true);

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -24,6 +24,7 @@ fn link_undefined() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_unknown_import_error() -> Result<()> {
     let mut store = Store::<()>::default();
     let linker = Linker::new(store.engine());

--- a/tests/all/threads.rs
+++ b/tests/all/threads.rs
@@ -23,6 +23,7 @@ pub fn engine() -> Option<Engine> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_instantiate_shared_memory() -> Result<()> {
     let wat = r#"(module (memory 1 1 shared))"#;
     let Some(engine) = engine() else {
@@ -35,6 +36,7 @@ fn test_instantiate_shared_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_import_shared_memory() -> Result<()> {
     let wat = r#"(module (import "env" "memory" (memory 1 5 shared)))"#;
     let Some(engine) = engine() else {
@@ -48,6 +50,7 @@ fn test_import_shared_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_export_shared_memory() -> Result<()> {
     let wat = r#"(module (memory (export "memory") 1 5 shared))"#;
     let Some(engine) = engine() else {
@@ -137,6 +140,7 @@ fn test_probe_shared_memory_size() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_multi_memory() -> Result<()> {
     let wat = r#"(module
         (import "env" "imported" (memory $imported 5 10 shared))


### PR DESCRIPTION
* Use Pulley by default when Miri is enabled.
* Fail wasm module compilation with functions by default in Miri to prevent accidentally having super slow test in CI.
* Update some tests from fallout of the above two points, also ignore a slow test in Pulley.



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
