### PR TITLE
aarch64: Remove closure from `Inst::load_constant`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -457,7 +457,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             // `gen_add_imm` is only ever called after register allocation has taken place, and as a
             // result it's ok to reuse the scratch2 register here. If that changes, we'll need to
             // plumb through a way to allocate temporary virtual registers
-            insts.extend(Inst::load_constant(scratch2, imm, &mut |_| scratch2));
+            insts.extend(Inst::load_constant(scratch2, imm));
             insts.push(Inst::AluRRRExtend {
                 alu_op: ALUOp::Add,
                 size: OperandSize::Size64,
@@ -542,7 +542,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             let tmp = writable_spilltmp_reg();
             // `gen_sp_reg_adjust` is called after regalloc2, so it's acceptable to reuse `tmp` for
             // intermediates in `load_constant`.
-            let const_inst = Inst::load_constant(tmp, amount, &mut |_| tmp);
+            let const_inst = Inst::load_constant(tmp, amount);
             let adj_inst = Inst::AluRRRExtend {
                 alu_op,
                 size: OperandSize::Size64,
@@ -1043,7 +1043,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let arg1 = writable_xreg(1);
         let arg2 = writable_xreg(2);
         let tmp = alloc_tmp(Self::word_type());
-        insts.extend(Inst::load_constant(tmp, size as u64, &mut alloc_tmp));
+        insts.extend(Inst::load_constant(tmp, size as u64));
         insts.push(Inst::Call {
             info: Box::new(CallInfo {
                 dest: ExternalName::LibCall(LibCall::Memcpy),
@@ -1221,8 +1221,8 @@ impl AArch64MachineDeps {
         let end = writable_tmp2_reg();
         // `gen_inline_probestack` is called after regalloc2, so it's acceptable to reuse
         // `start` and `end` as temporaries in load_constant.
-        insts.extend(Inst::load_constant(start, 0, &mut |_| start));
-        insts.extend(Inst::load_constant(end, frame_size.into(), &mut |_| end));
+        insts.extend(Inst::load_constant(start, 0));
+        insts.extend(Inst::load_constant(end, frame_size.into()));
         insts.push(Inst::StackProbeLoop {
             start,
             end: end.to_reg(),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -66,7 +66,7 @@ pub fn mem_finalize(
             } else {
                 let tmp = writable_spilltmp_reg();
                 (
-                    Inst::load_constant(tmp, off as u64, &mut |_| tmp),
+                    Inst::load_constant(tmp, off as u64),
                     AMode::RegExtended {
                         rn: basereg,
                         rm: tmp.to_reg(),
@@ -3343,7 +3343,7 @@ impl MachInstEmit for Inst {
                     debug_assert!(rd.to_reg() != tmp2_reg());
                     debug_assert!(reg != tmp2_reg());
                     let tmp = writable_tmp2_reg();
-                    for insn in Inst::load_constant(tmp, abs_offset, &mut |_| tmp).into_iter() {
+                    for insn in Inst::load_constant(tmp, abs_offset).into_iter() {
                         insn.emit(sink, emit_info, state);
                     }
                     let add = Inst::AluRRR {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -300,11 +300,9 @@ impl Assembler {
     pub fn mov_ir(&mut self, rd: WritableReg, imm: Imm, size: OperandSize) {
         match rd.to_reg().class() {
             RegClass::Int => {
-                Inst::load_constant(rd.map(Into::into), imm.unwrap_as_u64(), &mut |_| {
-                    rd.map(Into::into)
-                })
-                .into_iter()
-                .for_each(|i| self.emit(i));
+                Inst::load_constant(rd.map(Into::into), imm.unwrap_as_u64())
+                    .into_iter()
+                    .for_each(|i| self.emit(i));
             }
             RegClass::Float => {
                 match ASIMDFPModImm::maybe_from_u64(imm.unwrap_as_u64(), size.into()) {


### PR DESCRIPTION
This was added in #5366 but upon reflection I don't think that it's necessary as almost all of the definitions reuse the temporary register as the destination register as well. The original motivation looks like it's relate to the SSA-ness of instructions but I believe the way it's generated it's all SSA-valid, so this commit removes the temp allocation function and uses `rd`, the destination register, unconditionally instead.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
