### PR TITLE
Fix a Miri provenance issue in the drc collector

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -961,10 +961,11 @@ impl VMGcRefTableAlloc {
     /// Reset this bump region, retaining any underlying allocation, but moving
     /// the bump pointer and limit to their default positions.
     fn reset(&mut self) {
-        self.next = SendSyncPtr::new(NonNull::new(self.chunk.as_mut_ptr()).unwrap());
-        self.end = SendSyncPtr::new(
-            NonNull::new(unsafe { self.chunk.as_mut_ptr().add(self.chunk.len()) }).unwrap(),
-        );
+        let len = self.chunk.len();
+        let next = NonNull::new(self.chunk.as_mut_ptr()).unwrap();
+        let end = unsafe { next.add(len) };
+        self.next = SendSyncPtr::new(next);
+        self.end = SendSyncPtr::new(end);
     }
 }
 


### PR DESCRIPTION
The `VMGcRefTableAlloc::reset` method called `self.chunk.as_mut_ptr()` twice but the second call invalidated the first call, so the fix here is to derive both pointers from the same original pointer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
