### PR TITLE
Allow TE HTTP header

### DIFF
--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -271,13 +271,12 @@ impl<T: WasiHttpView> WasiHttpView for WasiHttpImpl<T> {
 
 /// Returns `true` when the header is forbidden according to this [`WasiHttpView`] implementation.
 pub(crate) fn is_forbidden_header(view: &mut dyn WasiHttpView, name: &HeaderName) -> bool {
-    static FORBIDDEN_HEADERS: [HeaderName; 10] = [
+    static FORBIDDEN_HEADERS: [HeaderName; 9] = [
         hyper::header::CONNECTION,
         HeaderName::from_static("keep-alive"),
         hyper::header::PROXY_AUTHENTICATE,
         hyper::header::PROXY_AUTHORIZATION,
         HeaderName::from_static("proxy-connection"),
-        hyper::header::TE,
         hyper::header::TRANSFER_ENCODING,
         hyper::header::UPGRADE,
         hyper::header::HOST,


### PR DESCRIPTION
Following up on the conversation in https://github.com/WebAssembly/wasi-http/issues/128, it sounds like removing the `TE` header from the set of forbidden headers is the required/blessed work to enable embeddings to support http2/grpc. 