### PR TITLE
Execute component lifts/lowers with Miri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ examples/.cache
 cranelift/isle/veri/veri_engine/test_output
 crates/explorer/node_modules
 tests/all/pulley_provenance_test.cwasm
+tests/all/pulley_provenance_test_component.cwasm
 /artifacts
 testcase*.wat
 testcase*.wasm

--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -7,13 +7,18 @@
 
 set -ex
 
-cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-model \
-  compile --target pulley64 ./tests/all/pulley_provenance_test.wat \
-  -o tests/all/pulley_provenance_test.cwasm \
-  -O memory-reservation=$((1 << 20)) \
-  -O memory-guard-size=0 \
-  -O signals-based-traps=n \
-  -W function-references
+compile() {
+  cargo run --no-default-features --features compile,pulley,wat,gc-drc,component-model \
+    compile --target pulley64 $1 \
+    -o ${1%.wat}.cwasm \
+    -O memory-reservation=$((1 << 20)) \
+    -O memory-guard-size=0 \
+    -O signals-based-traps=n \
+    -W function-references
+}
+
+compile ./tests/all/pulley_provenance_test.wat
+compile ./tests/all/pulley_provenance_test_component.wat
 
 MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
   cargo miri test --test all -- \

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -105,7 +105,7 @@ impl HostFunc {
     pub fn lowering(&self) -> VMLowering {
         let data = NonNull::from(&*self.func).cast();
         VMLowering {
-            callee: self.entrypoint,
+            callee: NonNull::new(self.entrypoint as *mut _).unwrap().into(),
             data: data.into(),
         }
     }

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -424,11 +424,11 @@ impl<'a> LiftContext<'a> {
         // so it's hacked around a bit. This unsafe pointer cast could be fixed
         // with more methods in more places, but it doesn't seem worth doing it
         // at this time.
-        let (calls, host_table, host_resource_data, instance) = unsafe {
-            (&mut *(store as *mut StoreOpaque))
-                .component_resource_state_with_instance(instance_handle)
-        };
-        let memory = options.memory.map(|_| options.memory(store));
+        let memory = options
+            .memory
+            .map(|_| options.memory(unsafe { &*(store as *const StoreOpaque) }));
+        let (calls, host_table, host_resource_data, instance) =
+            store.component_resource_state_with_instance(instance_handle);
 
         LiftContext {
             memory,

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -568,8 +568,10 @@ impl ComponentInstance {
 
     unsafe fn initialize_vmctx(&mut self) {
         *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
-        *self.vmctx_plus_offset_mut(self.offsets.builtins()) =
-            VmPtr::from(NonNull::from(&libcalls::VMComponentBuiltins::INIT));
+        // Initialize the built-in functions
+        static BUILTINS: libcalls::VMComponentBuiltins = libcalls::VMComponentBuiltins::INIT;
+        let ptr = BUILTINS.expose_provenance();
+        *self.vmctx_plus_offset_mut(self.offsets.builtins()) = VmPtr::from(ptr);
         *self.vmctx_plus_offset_mut(self.offsets.vm_store_context()) =
             VmPtr::from(self.store.0.as_ref().vm_store_context_ptr());
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -59,6 +59,22 @@ macro_rules! define_builtins {
             pub const INIT: VMComponentBuiltins = VMComponentBuiltins {
                 $($name: trampolines::$name,)*
             };
+
+            /// Helper to call `expose_provenance()` on all contained pointers.
+            ///
+            /// This is required to be called at least once before entering wasm
+            /// to inform the compiler that these function pointers may all be
+            /// loaded/stored and used on the "other end" to reacquire
+            /// provenance in Pulley. Pulley models hostcalls with a host
+            /// pointer as the first parameter that's a function pointer under
+            /// the hood, and this call ensures that the use of the function
+            /// pointer is considered valid.
+            pub fn expose_provenance(&self) -> NonNull<Self>{
+                $(
+                    (self.$name as *mut u8).expose_provenance();
+                )*
+                NonNull::from(self)
+            }
         }
     };
 }

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -288,6 +288,10 @@ fn pulley_provenance_test_components() -> Result<()> {
         let (result,) = guest_list.call(&mut store, (&["a", "", "b", "c"],))?;
         assert_eq!(result, ["a", "", "b", "c"]);
         guest_list.post_return(&mut store)?;
+
+        instance
+            .get_typed_func::<(), ()>(&mut store, "resource-intrinsics")?
+            .call(&mut store, ())?;
     }
     {
         use wasmtime::component::Val;

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use wasmtime::component::{self, Component};
 use wasmtime::{
     Caller, Config, Engine, Func, FuncType, Instance, Module, Store, Trap, Val, ValType,
 };
@@ -75,6 +76,15 @@ fn can_run_on_cli() -> Result<()> {
     Ok(())
 }
 
+fn provenance_test_config() -> Config {
+    let mut config = pulley_config();
+    config.wasm_function_references(true);
+    config.memory_reservation(1 << 20);
+    config.memory_guard_size(0);
+    config.signals_based_traps(false);
+    config
+}
+
 /// This is a one-size-fits-all test to test out pointer provenance in Pulley.
 ///
 /// The goal of this test is to exercise an actual wasm module being run in
@@ -102,11 +112,7 @@ fn can_run_on_cli() -> Result<()> {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn pulley_provenance_test() -> Result<()> {
-    let mut config = pulley_config();
-    config.wasm_function_references(true);
-    config.memory_reservation(1 << 20);
-    config.memory_guard_size(0);
-    config.signals_based_traps(false);
+    let config = provenance_test_config();
     let engine = Engine::new(&config)?;
     let module = if cfg!(miri) {
         unsafe { Module::deserialize_file(&engine, "./tests/all/pulley_provenance_test.cwasm")? }
@@ -179,6 +185,196 @@ fn pulley_provenance_test() -> Result<()> {
     let func = instance.get_typed_func::<Func, (i32, i32, i32)>(&mut store, "call_ref-wasm")?;
     let results = func.call(&mut store, funcref)?;
     assert_eq!(results, (1, 2, 3));
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn pulley_provenance_test_components() -> Result<()> {
+    let config = provenance_test_config();
+    let engine = Engine::new(&config)?;
+    let component = if cfg!(miri) {
+        unsafe {
+            Component::deserialize_file(
+                &engine,
+                "./tests/all/pulley_provenance_test_component.cwasm",
+            )?
+        }
+    } else {
+        Component::from_file(&engine, "./tests/all/pulley_provenance_test_component.wat")?
+    };
+    {
+        use wasmtime::component::{ComponentType, Lift, Lower};
+
+        #[derive(ComponentType, Lift, Lower, Clone, Copy, PartialEq, Debug)]
+        #[component(enum)]
+        #[repr(u8)]
+        enum E {
+            A,
+            B,
+            C,
+        }
+
+        let mut store = Store::new(&engine, ());
+        let mut linker = component::Linker::new(&engine);
+        linker
+            .root()
+            .func_wrap("host-u32", |_, (value,): (u32,)| Ok((value,)))?;
+        linker
+            .root()
+            .func_wrap("host-enum", |_, (value,): (E,)| Ok((value,)))?;
+        linker
+            .root()
+            .func_wrap("host-option", |_, (value,): (Option<u8>,)| Ok((value,)))?;
+        linker
+            .root()
+            .func_wrap("host-result", |_, (value,): (Result<u16, i64>,)| {
+                Ok((value,))
+            })?;
+        linker
+            .root()
+            .func_wrap("host-string", |_, (value,): (String,)| Ok((value,)))?;
+        linker
+            .root()
+            .func_wrap("host-list", |_, (value,): (Vec<String>,)| Ok((value,)))?;
+        let instance = linker.instantiate(&mut store, &component)?;
+
+        let guest_u32 = instance.get_typed_func::<(u32,), (u32,)>(&mut store, "guest-u32")?;
+        let guest_enum = instance.get_typed_func::<(E,), (E,)>(&mut store, "guest-enum")?;
+        let guest_option =
+            instance.get_typed_func::<(Option<u8>,), (Option<u8>,)>(&mut store, "guest-option")?;
+        let guest_result = instance.get_typed_func::<(Result<u16, i64>,), (Result<u16, i64>,)>(
+            &mut store,
+            "guest-result",
+        )?;
+        let guest_string =
+            instance.get_typed_func::<(&str,), (String,)>(&mut store, "guest-string")?;
+        let guest_list =
+            instance.get_typed_func::<(&[&str],), (Vec<String>,)>(&mut store, "guest-list")?;
+
+        let (result,) = guest_u32.call(&mut store, (42,))?;
+        assert_eq!(result, 42);
+        guest_u32.post_return(&mut store)?;
+
+        let (result,) = guest_enum.call(&mut store, (E::B,))?;
+        assert_eq!(result, E::B);
+        guest_enum.post_return(&mut store)?;
+
+        let (result,) = guest_option.call(&mut store, (None,))?;
+        assert_eq!(result, None);
+        guest_option.post_return(&mut store)?;
+        let (result,) = guest_option.call(&mut store, (Some(200),))?;
+        assert_eq!(result, Some(200));
+        guest_option.post_return(&mut store)?;
+
+        let (result,) = guest_result.call(&mut store, (Ok(10),))?;
+        assert_eq!(result, Ok(10));
+        guest_result.post_return(&mut store)?;
+        let (result,) = guest_result.call(&mut store, (Err(i64::MIN),))?;
+        assert_eq!(result, Err(i64::MIN));
+        guest_result.post_return(&mut store)?;
+
+        let (result,) = guest_string.call(&mut store, ("",))?;
+        assert_eq!(result, "");
+        guest_string.post_return(&mut store)?;
+        let (result,) = guest_string.call(&mut store, ("hello",))?;
+        assert_eq!(result, "hello");
+        guest_string.post_return(&mut store)?;
+
+        let (result,) = guest_list.call(&mut store, (&[],))?;
+        assert!(result.is_empty());
+        guest_list.post_return(&mut store)?;
+        let (result,) = guest_list.call(&mut store, (&["a", "", "b", "c"],))?;
+        assert_eq!(result, ["a", "", "b", "c"]);
+        guest_list.post_return(&mut store)?;
+    }
+    {
+        use wasmtime::component::Val;
+        let mut store = Store::new(&engine, ());
+        let mut linker = component::Linker::new(&engine);
+        linker.root().func_new("host-u32", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        linker.root().func_new("host-enum", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        linker.root().func_new("host-option", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        linker.root().func_new("host-result", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        linker.root().func_new("host-string", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        linker.root().func_new("host-list", |_, args, results| {
+            results[0] = args[0].clone();
+            Ok(())
+        })?;
+        let instance = linker.instantiate(&mut store, &component)?;
+
+        let guest_u32 = instance.get_func(&mut store, "guest-u32").unwrap();
+        let guest_enum = instance.get_func(&mut store, "guest-enum").unwrap();
+        let guest_option = instance.get_func(&mut store, "guest-option").unwrap();
+        let guest_result = instance.get_func(&mut store, "guest-result").unwrap();
+        let guest_string = instance.get_func(&mut store, "guest-string").unwrap();
+        let guest_list = instance.get_func(&mut store, "guest-list").unwrap();
+
+        let mut results = [Val::U32(0)];
+        guest_u32.call(&mut store, &[Val::U32(42)], &mut results)?;
+        assert_eq!(results[0], Val::U32(42));
+        guest_u32.post_return(&mut store)?;
+
+        guest_enum.call(&mut store, &[Val::Enum("B".into())], &mut results)?;
+        assert_eq!(results[0], Val::Enum("B".into()));
+        guest_enum.post_return(&mut store)?;
+
+        guest_option.call(&mut store, &[Val::Option(None)], &mut results)?;
+        assert_eq!(results[0], Val::Option(None));
+        guest_option.post_return(&mut store)?;
+        guest_option.call(
+            &mut store,
+            &[Val::Option(Some(Box::new(Val::U8(201))))],
+            &mut results,
+        )?;
+        assert_eq!(results[0], Val::Option(Some(Box::new(Val::U8(201)))));
+        guest_option.post_return(&mut store)?;
+
+        guest_result.call(
+            &mut store,
+            &[Val::Result(Ok(Some(Box::new(Val::U16(20)))))],
+            &mut results,
+        )?;
+        assert_eq!(results[0], Val::Result(Ok(Some(Box::new(Val::U16(20))))));
+        guest_result.post_return(&mut store)?;
+        guest_result.call(
+            &mut store,
+            &[Val::Result(Err(Some(Box::new(Val::S64(i64::MAX)))))],
+            &mut results,
+        )?;
+        assert_eq!(
+            results[0],
+            Val::Result(Err(Some(Box::new(Val::S64(i64::MAX)))))
+        );
+        guest_result.post_return(&mut store)?;
+
+        guest_string.call(&mut store, &[Val::String("B".into())], &mut results)?;
+        assert_eq!(results[0], Val::String("B".into()));
+        guest_string.post_return(&mut store)?;
+        guest_string.call(&mut store, &[Val::String("".into())], &mut results)?;
+        assert_eq!(results[0], Val::String("".into()));
+        guest_string.post_return(&mut store)?;
+
+        guest_list.call(&mut store, &[Val::List(Vec::new())], &mut results)?;
+        assert_eq!(results[0], Val::List(Vec::new()));
+        guest_list.post_return(&mut store)?;
+    }
 
     Ok(())
 }

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -211,8 +211,10 @@ fn pulley_provenance_test_components() -> Result<()> {
         #[component(enum)]
         #[repr(u8)]
         enum E {
+            #[expect(dead_code, reason = "only testing other variants")]
             A,
             B,
+            #[expect(dead_code, reason = "only testing other variants")]
             C,
         }
 

--- a/tests/all/pulley_provenance_test_component.wat
+++ b/tests/all/pulley_provenance_test_component.wat
@@ -1,0 +1,147 @@
+(component
+  (type $e' (enum "A" "B" "C"))
+  (import "host-u32" (func $host-u32 (param "x" u32) (result u32)))
+  (import "e" (type $e (eq $e')))
+  (import "host-enum" (func $host-enum (param "x" $e) (result $e)))
+  (import "host-option" (func $host-option (param "x" (option u8)) (result (option u8))))
+  (type $result (result u16 (error s64)))
+  (import "host-result" (func $host-result (param "x" $result) (result $result)))
+  (import "host-string" (func $host-string (param "x" string) (result string)))
+  (import "host-list" (func $host-list (param "x" (list string)) (result (list string))))
+
+  (core module $libc
+    (memory (export "memory") 1)
+    (global $last (mut i32) (i32.const 8))
+    (func $realloc (export "realloc")
+        (param $old_ptr i32)
+        (param $old_size i32)
+        (param $align i32)
+        (param $new_size i32)
+        (result i32)
+
+        (local $ret i32)
+
+        ;; fail if the old pointer is non-null
+        local.get $old_ptr
+        if
+          unreachable
+        end
+
+        ;; align up `$last`
+        (global.set $last
+            (i32.and
+                (i32.add
+                    (global.get $last)
+                    (i32.add
+                        (local.get $align)
+                        (i32.const -1)))
+                (i32.xor
+                    (i32.add
+                        (local.get $align)
+                        (i32.const -1))
+                    (i32.const -1))))
+
+        ;; save the current value of `$last` as the return value
+        global.get $last
+        local.set $ret
+
+        ;; bump our pointer
+        (global.set $last
+            (i32.add
+                (global.get $last)
+                (local.get $new_size)))
+
+        ;; while `memory.size` is less than `$last`, grow memory
+        ;; by one page
+        (loop $loop
+            (if
+                (i32.lt_u
+                    (i32.mul (memory.size) (i32.const 65536))
+                    (global.get $last))
+                (then
+                    i32.const 1
+                    memory.grow
+                    ;; test to make sure growth succeeded
+                    i32.const -1
+                    i32.eq
+                    if unreachable end
+
+                    br $loop)))
+
+        local.get $ret
+    )
+  )
+  (core instance $libc (instantiate $libc))
+
+  (core func $host-u32 (canon lower (func $host-u32)))
+  (core func $host-enum (canon lower (func $host-enum)))
+  (core func $host-option (canon lower (func $host-option) (memory $libc "memory")))
+  (core func $host-result (canon lower (func $host-result) (memory $libc "memory")))
+  (core func $host-string (canon lower (func $host-string)
+    (memory $libc "memory") (realloc (func $libc "realloc"))))
+  (core func $host-list (canon lower (func $host-list)
+    (memory $libc "memory") (realloc (func $libc "realloc"))))
+
+  (core module $m
+    (import "" "host-u32" (func $host-u32 (param i32) (result i32)))
+    (import "" "host-enum" (func $host-enum (param i32) (result i32)))
+    (import "" "host-option" (func $host-option (param i32 i32 i32)))
+    (import "" "host-result" (func $host-result (param i32 i64 i32)))
+    (import "" "host-string" (func $host-string (param i32 i32 i32)))
+    (import "" "host-list" (func $host-list (param i32 i32 i32)))
+
+    (func (export "guest-u32") (param i32) (result i32) local.get 0 call $host-u32)
+    (func (export "guest-enum") (param i32) (result i32) local.get 0 call $host-enum)
+    (func (export "guest-option") (param i32 i32) (result i32)
+      local.get 0
+      local.get 1
+      i32.const 100
+      call $host-option
+      i32.const 100)
+    (func (export "guest-result") (param i32 i64) (result i32)
+      local.get 0
+      local.get 1
+      i32.const 96
+      call $host-result
+      i32.const 96)
+    (func (export "guest-string") (param i32 i32) (result i32)
+      local.get 0
+      local.get 1
+      i32.const 96
+      call $host-string
+      i32.const 96)
+    (func (export "guest-list") (param i32 i32) (result i32)
+      local.get 0
+      local.get 1
+      i32.const 96
+      call $host-list
+      i32.const 96)
+  )
+
+  (core instance $i (instantiate $m
+    (with "libc" (instance $libc))
+    (with "" (instance
+        (export "host-u32" (func $host-u32))
+        (export "host-enum" (func $host-enum))
+        (export "host-option" (func $host-option))
+        (export "host-result" (func $host-result))
+        (export "host-string" (func $host-string))
+        (export "host-list" (func $host-list))
+    ))
+  ))
+  (func (export "guest-u32") (param "x" u32) (result u32)
+    (canon lift (core func $i "guest-u32")))
+  (func (export "guest-enum") (param "x" $e) (result $e)
+    (canon lift (core func $i "guest-enum")))
+  (func (export "guest-option") (param "x" (option u8)) (result (option u8))
+    (canon lift (core func $i "guest-option") (memory $libc "memory")))
+  (func (export "guest-result") (param "x" $result) (result $result)
+    (canon lift (core func $i "guest-result") (memory $libc "memory")))
+  (func (export "guest-string") (param "x" string) (result string)
+    (canon lift (core func $i "guest-string") (memory $libc "memory")
+                (realloc (func $libc "realloc"))))
+  (func (export "guest-list") (param "x" (list string)) (result (list string))
+    (canon lift (core func $i "guest-list") (memory $libc "memory")
+                (realloc (func $libc "realloc"))))
+
+)

--- a/tests/all/pulley_provenance_test_component.wat
+++ b/tests/all/pulley_provenance_test_component.wat
@@ -82,6 +82,10 @@
   (core func $host-list (canon lower (func $host-list)
     (memory $libc "memory") (realloc (func $libc "realloc"))))
 
+  (type $a (resource (rep i32)))
+  (core func $new-a (canon resource.new $a))
+  (core func $drop-a (canon resource.drop $a))
+
   (core module $m
     (import "" "host-u32" (func $host-u32 (param i32) (result i32)))
     (import "" "host-enum" (func $host-enum (param i32) (result i32)))
@@ -89,6 +93,8 @@
     (import "" "host-result" (func $host-result (param i32 i64 i32)))
     (import "" "host-string" (func $host-string (param i32 i32 i32)))
     (import "" "host-list" (func $host-list (param i32 i32 i32)))
+    (import "" "new-a" (func $new-a (param i32) (result i32)))
+    (import "" "drop-a" (func $drop-a (param i32)))
 
     (func (export "guest-u32") (param i32) (result i32) local.get 0 call $host-u32)
     (func (export "guest-enum") (param i32) (result i32) local.get 0 call $host-enum)
@@ -116,6 +122,10 @@
       i32.const 96
       call $host-list
       i32.const 96)
+
+    (func (export "resource-intrinsics")
+      (call $drop-a (call $new-a (i32.const 100)))
+    )
   )
 
   (core instance $i (instantiate $m
@@ -127,6 +137,8 @@
         (export "host-result" (func $host-result))
         (export "host-string" (func $host-string))
         (export "host-list" (func $host-list))
+        (export "new-a" (func $new-a))
+        (export "drop-a" (func $drop-a))
     ))
   ))
   (func (export "guest-u32") (param "x" u32) (result u32)
@@ -143,5 +155,7 @@
   (func (export "guest-list") (param "x" (list string)) (result (list string))
     (canon lift (core func $i "guest-list") (memory $libc "memory")
                 (realloc (func $libc "realloc"))))
+  (func (export "resource-intrinsics")
+    (canon lift (core func $i "resource-intrinsics") ))
 
 )


### PR DESCRIPTION
Historically nothing related to components has been able to run through Miri due to the limitation that components, unlike core wasm, require compiled wasm code to call between the host and the guest. With the advent of Pulley, however, this has changed! We already have a test that's run specifically on CI which precompiles a wasm module on the host and then uses the `*.cwasm` in Miri, so this does the same for components.

This adds a new test which instantiates a component and then runs lifts/lowers for some basic types with the static and dynamic host APIs. This is intended to weed out a large class of possible soundness issues but doesn't touch on all the unsafe code that we have at this time. Nevertheless there's a lot more run through Miri than before and a few minor locations were fixed up as a result. The hope is that this can serve as a basis for extending the set of component tests in Miri over time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
