### PR TITLE
x64: Migrate `xchg` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -2,6 +2,7 @@
 
 mod add;
 mod and;
+mod atomic;
 mod avg;
 mod bitmanip;
 mod cmp;
@@ -30,6 +31,7 @@ pub fn list() -> Vec<Inst> {
     let mut all = vec![];
     all.extend(add::list());
     all.extend(and::list());
+    all.extend(atomic::list());
     all.extend(avg::list());
     all.extend(bitmanip::list());
     all.extend(cmp::list());

--- a/cranelift/assembler-x64/meta/src/instructions/atomic.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/atomic.rs
@@ -1,0 +1,19 @@
+use crate::dsl::{Customization::*, Feature::*, Inst, Location::*};
+use crate::dsl::{fmt, inst, rex, rw};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        // Note that for xchg the "MR" variants are omitted from the Intel
+        // manual as they have the exact same encoding as the "RM" variant.
+        // Additionally the "O" variants are omitted as they're just exchanging
+        // registers which isn't needed by Cranelift at this time.
+        //
+        // Also note that these have a custom display implementation to swap the
+        // order of the operands to match what Capstone prints.
+        inst("xchgb", fmt("RM", [rw(r8), rw(m8)]), rex(0x86).r(), _64b | compat).custom(Display),
+        inst("xchgw", fmt("RM", [rw(r16), rw(m16)]), rex([0x66, 0x87]).r(), _64b | compat).custom(Display),
+        inst("xchgl", fmt("RM", [rw(r32), rw(m32)]), rex(0x87).r(), _64b | compat).custom(Display),
+        inst("xchgq", fmt("RM", [rw(r64), rw(m64)]), rex(0x87).w().r(), _64b).custom(Display),
+    ]
+}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -402,12 +402,6 @@
                  (mem SyntheticAmode)
                  (dst_old WritableGpr))
 
-       ;; A standard (native) `xchg src, (amode)`
-       (Xchg (size OperandSize)
-                 (operand Gpr)
-                 (mem SyntheticAmode)
-                 (dst_old WritableGpr))
-
        ;; A synthetic instruction, based on a loop around a native `lock
        ;; cmpxchg` instruction.
        ;;
@@ -4728,11 +4722,11 @@
             (_ Unit (emit (MInst.LockXadd size operand addr dst))))
         dst))
 
-(decl x64_xchg (OperandSize SyntheticAmode Gpr) Gpr)
-(rule (x64_xchg size addr operand)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.Xchg size operand addr dst))))
-        dst))
+(decl x64_xchg (Type SyntheticAmode Gpr) Gpr)
+(rule (x64_xchg $I8 addr operand) (x64_xchgb_rm operand addr))
+(rule (x64_xchg $I16 addr operand) (x64_xchgw_rm operand addr))
+(rule (x64_xchg $I32 addr operand) (x64_xchgl_rm operand addr))
+(rule (x64_xchg $I64 addr operand) (x64_xchgq_rm operand addr))
 
 (decl x64_lock_add (OperandSize Amode Gpr) SideEffectNoResult)
 (rule (x64_lock_add (OperandSize.Size8) addr reg)   (x64_lock_addb_mr_mem addr reg))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2591,25 +2591,6 @@ pub(crate) fn emit(
             emit_std_reg_mem(sink, prefix, opcodes, 2, **operand, &amode, rex, 0);
         }
 
-        Inst::Xchg {
-            size,
-            operand,
-            mem,
-            dst_old,
-        } => {
-            debug_assert_eq!(dst_old.to_reg(), *operand);
-            // xchg{b,w,l,q} %operand, (mem)
-            let (prefix, opcodes) = match size {
-                OperandSize::Size8 => (LegacyPrefixes::None, 0x86),
-                OperandSize::Size16 => (LegacyPrefixes::_66, 0x87),
-                OperandSize::Size32 => (LegacyPrefixes::None, 0x87),
-                OperandSize::Size64 => (LegacyPrefixes::None, 0x87),
-            };
-            let rex = RexFlags::from((*size, **operand));
-            let amode = mem.finalize(state.frame_layout(), sink);
-            emit_std_reg_mem(sink, prefix, opcodes, 1, **operand, &amode, rex, 0);
-        }
-
         Inst::AtomicRmwSeq {
             ty,
             op,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -852,48 +852,6 @@ fn test_x64_emit() {
         "lock xaddb %r13b, 0(%r9), dst_old=%r13b",
     ));
 
-    // Xchg
-    insns.push((
-        Inst::Xchg {
-            size: OperandSize::Size64,
-            operand: Gpr::unwrap_new(r10),
-            mem: am3.clone(),
-            dst_old: w_r10.map(Gpr::unwrap_new),
-        },
-        "4D8711",
-        "xchgq %r10, 0(%r9), dst_old=%r10",
-    ));
-    insns.push((
-        Inst::Xchg {
-            size: OperandSize::Size32,
-            operand: Gpr::unwrap_new(r11),
-            mem: am3.clone(),
-            dst_old: w_r11.map(Gpr::unwrap_new),
-        },
-        "458719",
-        "xchgl %r11d, 0(%r9), dst_old=%r11d",
-    ));
-    insns.push((
-        Inst::Xchg {
-            size: OperandSize::Size16,
-            operand: Gpr::unwrap_new(r12),
-            mem: am3.clone(),
-            dst_old: w_r12.map(Gpr::unwrap_new),
-        },
-        "66458721",
-        "xchgw %r12w, 0(%r9), dst_old=%r12w",
-    ));
-    insns.push((
-        Inst::Xchg {
-            size: OperandSize::Size8,
-            operand: Gpr::unwrap_new(r13),
-            mem: am3.clone(),
-            dst_old: w_r13.map(Gpr::unwrap_new),
-        },
-        "458629",
-        "xchgb %r13b, 0(%r9), dst_old=%r13b",
-    ));
-
     // AtomicRmwSeq
     insns.push((
         Inst::AtomicRmwSeq {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -101,7 +101,6 @@ impl Inst {
             | Inst::LoadExtName { .. }
             | Inst::LockCmpxchg { .. }
             | Inst::LockXadd { .. }
-            | Inst::Xchg { .. }
             | Inst::MovFromPReg { .. }
             | Inst::MovToPReg { .. }
             | Inst::Nop { .. }
@@ -1205,19 +1204,6 @@ impl PrettyPrint for Inst {
                 format!("lock xadd{suffix} {operand}, {mem}, dst_old={dst_old}")
             }
 
-            Inst::Xchg {
-                size,
-                operand,
-                mem,
-                dst_old,
-            } => {
-                let operand = pretty_print_reg(**operand, size.to_bytes());
-                let dst_old = pretty_print_reg(*dst_old.to_reg(), size.to_bytes());
-                let mem = mem.pretty_print(size.to_bytes());
-                let suffix = suffix_bwlq(*size);
-                format!("xchg{suffix} {operand}, {mem}, dst_old={dst_old}")
-            }
-
             Inst::AtomicRmwSeq { ty, op, .. } => {
                 let ty = ty.bits();
                 format!(
@@ -1713,17 +1699,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         }
 
         Inst::LockXadd {
-            operand,
-            mem,
-            dst_old,
-            ..
-        } => {
-            collector.reg_use(operand);
-            collector.reg_reuse_def(dst_old, 0);
-            mem.get_operands(collector);
-        }
-
-        Inst::Xchg {
             operand,
             mem,
             dst_old,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3431,7 +3431,7 @@
 ;; `Xchg` can use `xchg`
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xchg) address input)))
-      (x64_xchg (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+      (x64_xchg ty (to_amode flags address (zero_offset)) input))
 
 ;; `Add`, `Sub`, `And`, `Or` and `Xor` can use `lock`-prefixed instructions if
 ;; the old value is not required.

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -445,17 +445,6 @@ pub(crate) fn check(
             Ok(())
         }
 
-        Inst::Xchg {
-            size,
-            ref mem,
-            dst_old,
-            operand: _,
-        } => {
-            ensure_no_fact(vcode, *dst_old.to_reg())?;
-            check_store(ctx, None, mem, vcode, size.to_type())?;
-            Ok(())
-        }
-
         Inst::AtomicRmwSeq {
             ref mem,
             temp,

--- a/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
@@ -1204,7 +1204,7 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   xchgq %rax, 0(%rdi), dst_old=%rax
+;   xchgq %rax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -1231,7 +1231,7 @@ block0(v0: i64, v1: i32):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   xchgl %eax, 0(%rdi), dst_old=%eax
+;   xchgl %eax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -1258,7 +1258,7 @@ block0(v0: i64, v1: i16):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   xchgw %ax, 0(%rdi), dst_old=%ax
+;   xchgw %ax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -1285,7 +1285,7 @@ block0(v0: i64, v1: i8):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   xchgb %al, 0(%rdi), dst_old=%al
+;   xchgb %al, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1523,8 +1523,7 @@ impl Masm for MacroAssembler {
             }
             RmwOp::Xchg => {
                 let operand = context.pop_to_reg(self, None)?;
-                self.asm
-                    .xchg(addr, operand.reg, writable!(operand.reg), size, flags);
+                self.asm.xchg(addr, writable!(operand.reg), size, flags);
                 operand.reg
             }
             RmwOp::And | RmwOp::Or | RmwOp::Xor => {


### PR DESCRIPTION
This required a custom visit function because printing operands has to happen in one order to match Capstone but allocating operations has to happen in another order to satisfy regalloc, so so one of the two has to be custom.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
