### PR TITLE
Add a dummy impl of fibers for Miri

### DIFF
--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -22,6 +22,9 @@ cfg_if::cfg_if! {
     if #[cfg(not(feature = "std"))] {
         mod nostd;
         use nostd as imp;
+    } else if #[cfg(miri)] {
+        mod miri;
+        use miri as imp;
     } else if #[cfg(windows)] {
         mod windows;
         use windows as imp;
@@ -139,11 +142,28 @@ pub struct Suspend<Resume, Yield, Return> {
     _phantom: PhantomData<(Resume, Yield, Return)>,
 }
 
+/// A structure that is stored on a stack frame of a call to `Fiber::resume`.
+///
+/// This is used to both transmit data to a fiber (the resume step) as well as
+/// acquire data from a fiber (the suspension step).
 enum RunResult<Resume, Yield, Return> {
+    /// The fiber is currently executing meaning it picked up whatever it was
+    /// resuming with and hasn't yet completed.
     Executing,
+
+    /// Resume: resume with this value. Called for each invocation of
+    /// `Fiber::resume`.
     Resuming(Resume),
+
+    /// Suspend: the fiber hasn't finished but has provided the following value
+    /// during its suspension.
     Yield(Yield),
+
+    /// Suspend: the fiber has completed with the provided value and can no
+    /// longer be resumed.
     Returned(Return),
+
+    /// Suspend: the fiber execution panicked.
     #[cfg(feature = "std")]
     Panicked(Box<dyn core::any::Any + Send>),
 }
@@ -245,31 +265,32 @@ impl<Resume, Yield, Return> Suspend<Resume, Yield, Return> {
         };
 
         #[cfg(feature = "std")]
-        {
+        let result = {
             use std::panic::{self, AssertUnwindSafe};
             let result = panic::catch_unwind(AssertUnwindSafe(|| (func)(initial, &mut suspend)));
-            suspend.inner.switch::<Resume, Yield, Return>(match result {
+            match result {
                 Ok(result) => RunResult::Returned(result),
                 Err(panic) => RunResult::Panicked(panic),
-            });
-        }
+            }
+        };
+
         // Note that it is sound to omit the `catch_unwind` here: it
         // will not result in unwinding going off the top of the fiber
         // stack, because the code on the fiber stack is invoked via
         // an extern "C" boundary which will panic on unwinds.
         #[cfg(not(feature = "std"))]
-        {
-            let result = (func)(initial, &mut suspend);
-            suspend
-                .inner
-                .switch::<Resume, Yield, Return>(RunResult::Returned(result));
-        }
+        let result = RunResult::Returned((func)(initial, &mut suspend));
+
+        suspend.inner.exit::<Resume, Yield, Return>(result);
     }
 }
 
 impl<A, B, C> Drop for Fiber<'_, A, B, C> {
     fn drop(&mut self) {
         debug_assert!(self.done.get(), "fiber dropped without finishing");
+        unsafe {
+            self.inner.drop::<A, B, C>();
+        }
     }
 }
 
@@ -353,6 +374,8 @@ mod tests {
                 || cfg!(target_arch = "arm")
                 // asan does weird things
                 || cfg!(asan)
+                // miri is a bit of a stretch to get working here
+                || cfg!(miri)
             );
         }
 

--- a/crates/fiber/src/miri.rs
+++ b/crates/fiber/src/miri.rs
@@ -1,0 +1,251 @@
+//! A dummy implementation of fibers when running with MIRI to use a separate
+//! thread as the implementation of a fiber.
+//!
+//! Note that this technically isn't correct because it means that the code
+//! running in the fiber won't share TLS variables with the code managing the
+//! fiber, but it's enough for now.
+//!
+//! The general idea is that a thread is held in a suspended state to hold the
+//! state of the stack on that thread. When a fiber is resumed that thread
+//! starts executing and the caller stops. When a fiber suspends then that
+//! thread stops and the original caller returns. There's still possible minor
+//! amounts of parallelism but in general they should be quite scoped and not
+//! visible from the caller/callee really.
+//!
+//! An issue was opened at rust-lang/miri#4392 for a possible extension to miri
+//! to support stack-switching in a first-class manner.
+
+use crate::{Result, RunResult, RuntimeFiberStack};
+use std::boxed::Box;
+use std::cell::Cell;
+use std::io;
+use std::mem;
+use std::ops::Range;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{self, JoinHandle};
+
+pub type Error = io::Error;
+
+pub struct FiberStack(usize);
+
+impl FiberStack {
+    pub fn new(size: usize, _zeroed: bool) -> Result<Self> {
+        Ok(FiberStack(size))
+    }
+
+    pub unsafe fn from_raw_parts(_base: *mut u8, _guard_size: usize, _len: usize) -> Result<Self> {
+        Err(io::ErrorKind::Unsupported.into())
+    }
+
+    pub fn is_from_raw_parts(&self) -> bool {
+        false
+    }
+
+    pub fn from_custom(_custom: Box<dyn RuntimeFiberStack>) -> Result<Self> {
+        Err(io::ErrorKind::Unsupported.into())
+    }
+
+    pub fn top(&self) -> Option<*mut u8> {
+        None
+    }
+
+    pub fn range(&self) -> Option<Range<usize>> {
+        None
+    }
+
+    pub fn guard_range(&self) -> Option<Range<*mut u8>> {
+        None
+    }
+}
+
+pub struct Fiber {
+    state: *const u8,
+    thread: Option<JoinHandle<()>>,
+}
+
+pub struct Suspend {
+    state: *const u8,
+}
+
+/// Shared state, inside an `Arc`, between `Fiber` and `Suspend`.
+struct SharedFiberState<A, B, C> {
+    cond: Condvar,
+    state: Mutex<State<A, B, C>>,
+}
+
+enum State<A, B, C> {
+    /// No current state, or otherwise something is waiting for something else
+    /// to happen.
+    None,
+
+    /// The fiber is being resumed with this result.
+    ResumeWith(RunResult<A, B, C>),
+
+    /// The fiber is being suspended with this result
+    SuspendWith(RunResult<A, B, C>),
+
+    /// The fiber needs to exit (part of drop).
+    Exiting,
+}
+
+unsafe impl<A, B, C> Send for State<A, B, C> {}
+unsafe impl<A, B, C> Sync for State<A, B, C> {}
+
+struct IgnoreSendSync<T>(T);
+
+unsafe impl<T> Send for IgnoreSendSync<T> {}
+unsafe impl<T> Sync for IgnoreSendSync<T> {}
+
+fn run<F, A, B, C>(state: Arc<SharedFiberState<A, B, C>>, func: IgnoreSendSync<F>)
+where
+    F: FnOnce(A, &mut super::Suspend<A, B, C>) -> C,
+{
+    // Wait for the initial message of what to initially invoke `func` with.
+    let init = {
+        let mut lock = state.state.lock().unwrap();
+        lock = state
+            .cond
+            .wait_while(lock, |msg| !matches!(msg, State::ResumeWith(_)))
+            .unwrap();
+        match mem::replace(&mut *lock, State::None) {
+            State::ResumeWith(RunResult::Resuming(init)) => init,
+            _ => unreachable!(),
+        }
+    };
+
+    // Execute this fiber through `Suspend::execute` and once that's done
+    // deallocate the `state` that we have.
+    let state = Arc::into_raw(state);
+    super::Suspend::<A, B, C>::execute(
+        Suspend {
+            state: state.cast(),
+        },
+        init,
+        func.0,
+    );
+    unsafe {
+        drop(Arc::from_raw(state));
+    }
+}
+
+impl Fiber {
+    pub fn new<F, A, B, C>(stack: &FiberStack, func: F) -> Result<Self>
+    where
+        F: FnOnce(A, &mut super::Suspend<A, B, C>) -> C,
+    {
+        // Allocate shared state between the fiber and the suspension argument.
+        let state = Arc::new(SharedFiberState::<A, B, C> {
+            cond: Condvar::new(),
+            state: Mutex::new(State::None),
+        });
+
+        // Note the use of `spawn_unchecked` to work around `Send`. Technically
+        // a lie as we are sure enough sending values across threads. We don't
+        // have many other tools in MIRI though to allocate separate call stacks
+        // so we're doing the best we can.
+        let thread = unsafe {
+            thread::Builder::new()
+                .stack_size(stack.0)
+                .spawn_unchecked({
+                    let state = state.clone();
+                    let func = IgnoreSendSync(func);
+                    move || run(state, func)
+                })
+                .unwrap()
+        };
+
+        // Cast the fiber back into a raw pointer to lose the type parameters
+        // which our storage container does not have access to. Additionally
+        // save off the thread so the dtor here can join the thread.
+        Ok(Fiber {
+            state: Arc::into_raw(state).cast(),
+            thread: Some(thread),
+        })
+    }
+
+    pub(crate) fn resume<A, B, C>(&self, _stack: &FiberStack, result: &Cell<RunResult<A, B, C>>) {
+        let my_state = unsafe { self.state() };
+        let mut lock = my_state.state.lock().unwrap();
+
+        // Swap `result` into our `lock`, then wake up the actual fiber.
+        *lock = State::ResumeWith(result.replace(RunResult::Executing));
+        my_state.cond.notify_one();
+
+        // Wait for the fiber to finish
+        lock = my_state
+            .cond
+            .wait_while(lock, |l| !matches!(l, State::SuspendWith(_)))
+            .unwrap();
+
+        // Swap the state in our `lock` back into `result`.
+        let message = match mem::replace(&mut *lock, State::None) {
+            State::SuspendWith(msg) => msg,
+            _ => unreachable!(),
+        };
+        result.set(message);
+    }
+
+    unsafe fn state<A, B, C>(&self) -> &SharedFiberState<A, B, C> {
+        unsafe { &*(self.state as *const SharedFiberState<A, B, C>) }
+    }
+
+    pub(crate) unsafe fn drop<A, B, C>(&mut self) {
+        let state = unsafe { self.state::<A, B, C>() };
+
+        // Store an indication that we expect the fiber to exit, then wake it up
+        // if it's waiting.
+        *state.state.lock().unwrap() = State::Exiting;
+        state.cond.notify_one();
+
+        // Wait for the child thread to complete.
+        self.thread.take().unwrap().join().unwrap();
+
+        // Clean up our state using the type parameters we know of here.
+        unsafe {
+            drop(Arc::from_raw(
+                self.state.cast::<SharedFiberState<A, B, C>>(),
+            ));
+        }
+    }
+}
+
+impl Suspend {
+    fn suspend<A, B, C>(&mut self, result: RunResult<A, B, C>) -> State<A, B, C> {
+        let state = unsafe { self.state() };
+        let mut lock = state.state.lock().unwrap();
+
+        // Our fiber state should be empty, and after verifying that store what
+        // we are suspending with.
+        assert!(matches!(*lock, State::None));
+        *lock = State::SuspendWith(result);
+        state.cond.notify_one();
+
+        // Wait for the resumption to come back, which is returned from this
+        // method.
+        lock = state
+            .cond
+            .wait_while(lock, |s| {
+                !matches!(s, State::ResumeWith(_) | State::Exiting)
+            })
+            .unwrap();
+        mem::replace(&mut *lock, State::None)
+    }
+
+    pub(crate) fn switch<A, B, C>(&mut self, result: RunResult<A, B, C>) -> A {
+        match self.suspend(result) {
+            State::ResumeWith(RunResult::Resuming(a)) => a,
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn exit<A, B, C>(&mut self, result: RunResult<A, B, C>) {
+        match self.suspend(result) {
+            State::Exiting => {}
+            _ => unreachable!(),
+        }
+    }
+
+    unsafe fn state<A, B, C>(&self) -> &SharedFiberState<A, B, C> {
+        unsafe { &*(self.state as *const SharedFiberState<A, B, C>) }
+    }
+}

--- a/crates/fiber/src/nostd.rs
+++ b/crates/fiber/src/nostd.rs
@@ -159,6 +159,8 @@ impl Fiber {
             addr.write(0);
         }
     }
+
+    pub(crate) unsafe fn drop<A, B, C>(&mut self) {}
 }
 
 impl Suspend {
@@ -171,6 +173,11 @@ impl Suspend {
 
             self.take_resume::<A, B, C>()
         }
+    }
+
+    pub(crate) fn exit<A, B, C>(&mut self, result: RunResult<A, B, C>) {
+        self.switch(result);
+        unreachable!();
     }
 
     unsafe fn take_resume<A, B, C>(&self) -> A {

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -276,6 +276,8 @@ impl Fiber {
             addr.write(0);
         }
     }
+
+    pub(crate) unsafe fn drop<A, B, C>(&mut self) {}
 }
 
 impl Suspend {
@@ -292,6 +294,11 @@ impl Suspend {
 
             self.take_resume::<A, B, C>()
         }
+    }
+
+    pub(crate) fn exit<A, B, C>(&mut self, result: RunResult<A, B, C>) {
+        self.switch(result);
+        unreachable!()
     }
 
     unsafe fn take_resume<A, B, C>(&self) -> A {

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -147,6 +147,8 @@ impl Fiber {
             }
         }
     }
+
+    pub(crate) unsafe fn drop<A, B, C>(&mut self) {}
 }
 
 impl Drop for Fiber {
@@ -168,6 +170,12 @@ impl Suspend {
             self.take_resume::<A, B, C>()
         }
     }
+
+    pub(crate) fn exit<A, B, C>(&mut self, result: RunResult<A, B, C>) {
+        self.switch(result);
+        unreachable!()
+    }
+
     unsafe fn take_resume<A, B, C>(&self) -> A {
         unsafe {
             match (*self.result_location::<A, B, C>()).replace(RunResult::Executing) {

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use anyhow::{anyhow, bail};
 use std::future::Future;
 use std::pin::Pin;
@@ -139,6 +137,7 @@ async fn smoke_host_func_with_suspension() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn recursive_call() {
     let mut store = async_store();
     let func_ty = FuncType::new(store.engine(), None, None);
@@ -186,6 +185,7 @@ async fn recursive_call() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn suspend_while_suspending() {
     let mut store = async_store();
 
@@ -291,6 +291,7 @@ async fn cancel_during_run() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn iloop_with_fuel() {
     let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let mut store = Store::new(&engine, ());
@@ -314,6 +315,7 @@ async fn iloop_with_fuel() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn fuel_eventually_finishes() {
     let engine = Engine::new(Config::new().async_support(true).consume_fuel(true)).unwrap();
     let mut store = Store::new(&engine, ());
@@ -395,6 +397,7 @@ async fn async_host_func_with_pooling_stacks() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn async_mpk_protection() -> Result<()> {
     let _ = env_logger::try_init();
 
@@ -494,6 +497,7 @@ where
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn resume_separate_thread() {
     // This test will poll the following future on two threads. Simulating a
     // trap requires accessing TLS info, so that should be preserved correctly.
@@ -522,6 +526,7 @@ async fn resume_separate_thread() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn resume_separate_thread2() {
     // This test will poll the following future on two threads. Catching a
     // signal requires looking up TLS information to determine whether it's a
@@ -553,6 +558,7 @@ async fn resume_separate_thread2() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn resume_separate_thread3() {
     let _ = env_logger::try_init();
 
@@ -614,6 +620,7 @@ async fn resume_separate_thread3() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn recursive_async() -> Result<()> {
     let _ = env_logger::try_init();
     let mut store = async_store();
@@ -650,6 +657,7 @@ async fn recursive_async() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn linker_module_command() -> Result<()> {
     let mut store = async_store();
     let mut linker = Linker::new(store.engine());
@@ -692,6 +700,7 @@ async fn linker_module_command() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn linker_module_reactor() -> Result<()> {
     let mut store = async_store();
     let mut linker = Linker::new(store.engine());
@@ -781,6 +790,7 @@ where
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn non_stacky_async_activations() -> Result<()> {
     let mut config = Config::new();
     config.async_support(true);
@@ -919,6 +929,7 @@ async fn non_stacky_async_activations() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn gc_preserves_externref_on_historical_async_stacks() -> Result<()> {
     let _ = env_logger::try_init();
 
@@ -992,6 +1003,7 @@ async fn gc_preserves_externref_on_historical_async_stacks() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn async_gc_with_func_new_and_func_wrap() -> Result<()> {
     let _ = env_logger::try_init();
 

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))]
-
 use crate::async_functions::{PollOnce, execute_across_threads};
 use anyhow::Result;
 use wasmtime::component::*;
@@ -8,6 +6,7 @@ use wasmtime_component_util::REALLOC_AND_FREE;
 
 /// This is super::func::thunks, except with an async store.
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn smoke() -> Result<()> {
     let component = r#"
         (component
@@ -49,6 +48,7 @@ async fn smoke() -> Result<()> {
 
 /// Handle an import function, created using component::Linker::func_wrap_async.
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn smoke_func_wrap() -> Result<()> {
     let component = r#"
         (component
@@ -103,6 +103,7 @@ async fn smoke_func_wrap() -> Result<()> {
 // Overall a yield should happen during malloc which should be an "interesting
 // situation" with respect to the runtime.
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn resume_separate_thread() -> Result<()> {
     let mut config = wasmtime_test_util::component::config();
     config.async_support(true);
@@ -179,6 +180,7 @@ async fn resume_separate_thread() -> Result<()> {
 // Overall a yield should happen during malloc which should be an "interesting
 // situation" with respect to the runtime.
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn poll_through_wasm_activation() -> Result<()> {
     let mut config = wasmtime_test_util::component::config();
     config.async_support(true);
@@ -246,6 +248,7 @@ async fn poll_through_wasm_activation() -> Result<()> {
 
 /// Test async drop method for host resources.
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn drop_resource_async() -> Result<()> {
     use std::sync::Arc;
     use std::sync::Mutex;


### PR DESCRIPTION
This commit extends the `wasmtime-internal-fiber` crate with an implementation for Miri. Previously this was entirely unsupported because fibers use inline assembly. The implementation with Miri spawns a separate thread and keeps it in a suspended state with locks to model a suspended stack. This technically isn't correct because TLS variables will be wrong, but it's "correct enough" for our usage in Wasmtime. In the end this enables running more tests in Miri which is always a good thing, and a number of loose odds and ends were cleaned up relate to our unsafe management of async state.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
