### PR TITLE
wasmtime: Fix rendering of `Cache` and `CacheConfig` docs

### DIFF
--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -310,7 +310,7 @@ static CACHE_IMPROPER_CONFIG_ERROR_MSG: &str =
 
 macro_rules! generate_setting_getter {
     ($setting:ident: $setting_type:ty) => {
-        /// Returns `$setting`.
+        #[doc = concat!("Returns ", "`", stringify!($setting), "`.")]
         ///
         /// Panics if the cache is disabled.
         pub fn $setting(&self) -> $setting_type {

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -36,7 +36,7 @@ pub struct Cache {
 
 macro_rules! generate_config_setting_getter {
     ($setting:ident: $setting_type:ty) => {
-        /// Returns `$setting`.
+        #[doc = concat!("Returns ", "`", stringify!($setting), "`.")]
         ///
         /// Panics if the cache is disabled.
         pub fn $setting(&self) -> $setting_type {


### PR DESCRIPTION
Use the setting name rather than `$setting` for documentation rendering.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
