### PR TITLE
Initial component model and GC support in fused adapters

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -389,7 +389,7 @@ impl<'a> TrampolineCompiler<'a> {
 
     fn translate_task_return_call(&mut self, results: TypeTupleIndex, options: &CanonicalOptions) {
         let mem_opts = match &options.data_model {
-            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
             CanonicalOptionsDataModel::LinearMemory(opts) => opts,
         };
 
@@ -748,13 +748,14 @@ impl<'a> TrampolineCompiler<'a> {
             post_return,
             string_encoding,
             async_,
+            core_type: _,
             data_model,
         } = *options;
 
         assert!(callback.is_none());
 
         let LinearMemoryOptions { memory, realloc } = match data_model {
-            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
             CanonicalOptionsDataModel::LinearMemory(opts) => opts,
         };
 
@@ -1308,7 +1309,7 @@ impl<'a> TrampolineCompiler<'a> {
 
         if let Some(options) = options {
             let mem_opts = match options.data_model {
-                CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
                 CanonicalOptionsDataModel::LinearMemory(opts) => opts,
             };
 
@@ -1343,7 +1344,7 @@ impl<'a> TrampolineCompiler<'a> {
         info: &CanonicalAbiInfo,
     ) {
         let mem_opts = match &options.data_model {
-            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
             CanonicalOptionsDataModel::LinearMemory(opts) => opts,
         };
 
@@ -1388,7 +1389,7 @@ impl<'a> TrampolineCompiler<'a> {
         sentinel: TrapSentinel,
     ) {
         let mem_opts = match &options.data_model {
-            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
             CanonicalOptionsDataModel::LinearMemory(opts) => opts,
         };
 

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -388,6 +388,11 @@ impl<'a> TrampolineCompiler<'a> {
     }
 
     fn translate_task_return_call(&mut self, results: TypeTupleIndex, options: &CanonicalOptions) {
+        let mem_opts = match &options.data_model {
+            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::LinearMemory(opts) => opts,
+        };
+
         let args = self.builder.func.dfg.block_params(self.block0).to_vec();
         let vmctx = args[0];
 
@@ -398,7 +403,7 @@ impl<'a> TrampolineCompiler<'a> {
             .ins()
             .iconst(ir::types::I32, i64::from(results.as_u32()));
 
-        let memory = self.load_optional_memory(vmctx, options.memory);
+        let memory = self.load_optional_memory(vmctx, mem_opts.memory);
         let string_encoding = self.string_encoding(options.string_encoding);
 
         self.translate_intrinsic_libcall(
@@ -739,15 +744,19 @@ impl<'a> TrampolineCompiler<'a> {
 
         let CanonicalOptions {
             instance,
-            memory,
-            realloc,
             callback,
             post_return,
             string_encoding,
             async_,
+            data_model,
         } = *options;
 
         assert!(callback.is_none());
+
+        let LinearMemoryOptions { memory, realloc } = match data_model {
+            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::LinearMemory(opts) => opts,
+        };
 
         // vmctx: *mut VMComponentContext
         host_sig.params.push(ir::AbiParam::new(pointer_type));
@@ -1298,10 +1307,15 @@ impl<'a> TrampolineCompiler<'a> {
         let mut callee_args = vec![vmctx];
 
         if let Some(options) = options {
+            let mem_opts = match options.data_model {
+                CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                CanonicalOptionsDataModel::LinearMemory(opts) => opts,
+            };
+
             // memory: *mut VMMemoryDefinition
-            callee_args.push(self.load_memory(vmctx, options.memory.unwrap()));
+            callee_args.push(self.load_memory(vmctx, mem_opts.memory.unwrap()));
             // realloc: *mut VMFuncRef
-            callee_args.push(self.load_realloc(vmctx, options.realloc));
+            callee_args.push(self.load_realloc(vmctx, mem_opts.realloc));
             // string_encoding: StringEncoding
             callee_args.push(self.string_encoding(options.string_encoding));
             // async: bool
@@ -1328,12 +1342,17 @@ impl<'a> TrampolineCompiler<'a> {
         get_libcall: GetLibcallFn,
         info: &CanonicalAbiInfo,
     ) {
+        let mem_opts = match &options.data_model {
+            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::LinearMemory(opts) => opts,
+        };
+
         let args = self.builder.func.dfg.block_params(self.block0).to_vec();
         let vmctx = args[0];
         let mut callee_args = vec![
             vmctx,
-            self.load_memory(vmctx, options.memory.unwrap()),
-            self.load_realloc(vmctx, options.realloc),
+            self.load_memory(vmctx, mem_opts.memory.unwrap()),
+            self.load_realloc(vmctx, mem_opts.realloc),
             self.builder
                 .ins()
                 .iconst(ir::types::I8, if options.async_ { 1 } else { 0 }),
@@ -1368,12 +1387,17 @@ impl<'a> TrampolineCompiler<'a> {
         get_libcall: GetLibcallFn,
         sentinel: TrapSentinel,
     ) {
+        let mem_opts = match &options.data_model {
+            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::LinearMemory(opts) => opts,
+        };
+
         let args = self.builder.func.dfg.block_params(self.block0).to_vec();
         let vmctx = args[0];
         let mut callee_args = vec![
             vmctx,
-            self.load_memory(vmctx, options.memory.unwrap()),
-            self.load_realloc(vmctx, options.realloc),
+            self.load_memory(vmctx, mem_opts.memory.unwrap()),
+            self.load_realloc(vmctx, mem_opts.realloc),
             self.string_encoding(options.string_encoding),
             self.builder
                 .ins()

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -195,7 +195,6 @@ pub enum Export {
     LiftedFunction {
         ty: TypeFuncIndex,
         func: CoreDef,
-        func_ty: ModuleInternedTypeIndex,
         options: CanonicalOptions,
     },
     ModuleStatic {
@@ -667,7 +666,6 @@ impl LinearizeDfg<'_> {
             Export::LiftedFunction {
                 ty,
                 func,
-                func_ty,
                 options,
             } => {
                 let func = self.core_def(func);
@@ -675,7 +673,6 @@ impl LinearizeDfg<'_> {
                 info::Export::LiftedFunction {
                     ty: *ty,
                     func,
-                    func_ty: *func_ty,
                     options,
                 }
             }

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -663,11 +663,7 @@ impl LinearizeDfg<'_> {
         wasmparser_types: wasmparser::types::TypesRef<'_>,
     ) -> Result<ExportIndex> {
         let item = match export {
-            Export::LiftedFunction {
-                ty,
-                func,
-                options,
-            } => {
+            Export::LiftedFunction { ty, func, options } => {
                 let func = self.core_def(func);
                 let options = self.options(options);
                 info::Export::LiftedFunction {

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -32,6 +32,7 @@ use crate::prelude::*;
 use crate::{EntityIndex, EntityRef, ModuleInternedTypeIndex, PrimaryMap, WasmValType};
 use anyhow::Result;
 use indexmap::IndexMap;
+use info::LinearMemoryOptions;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Index;
@@ -194,6 +195,7 @@ pub enum Export {
     LiftedFunction {
         ty: TypeFuncIndex,
         func: CoreDef,
+        func_ty: ModuleInternedTypeIndex,
         options: CanonicalOptions,
     },
     ModuleStatic {
@@ -414,17 +416,29 @@ pub struct StreamInfo {
     pub payload_type: InterfaceType,
 }
 
+/// Same as `info::CanonicalOptionsDataModel`.
+#[derive(Clone, Hash, Eq, PartialEq)]
+#[expect(missing_docs, reason = "self-describing fields")]
+pub enum CanonicalOptionsDataModel {
+    Gc {
+        core_type: ModuleInternedTypeIndex,
+    },
+    LinearMemory {
+        memory: Option<MemoryId>,
+        realloc: Option<ReallocId>,
+    },
+}
+
 /// Same as `info::CanonicalOptions`
 #[derive(Clone, Hash, Eq, PartialEq)]
 #[expect(missing_docs, reason = "self-describing fields")]
 pub struct CanonicalOptions {
     pub instance: RuntimeComponentInstanceIndex,
     pub string_encoding: StringEncoding,
-    pub memory: Option<MemoryId>,
-    pub realloc: Option<ReallocId>,
     pub callback: Option<CallbackId>,
     pub post_return: Option<PostReturnId>,
     pub async_: bool,
+    pub data_model: CanonicalOptionsDataModel,
 }
 
 /// Same as `info::Resource`
@@ -651,12 +665,18 @@ impl LinearizeDfg<'_> {
         wasmparser_types: wasmparser::types::TypesRef<'_>,
     ) -> Result<ExportIndex> {
         let item = match export {
-            Export::LiftedFunction { ty, func, options } => {
+            Export::LiftedFunction {
+                ty,
+                func,
+                func_ty,
+                options,
+            } => {
                 let func = self.core_def(func);
                 let options = self.options(options);
                 info::Export::LiftedFunction {
                     ty: *ty,
                     func,
+                    func_ty: *func_ty,
                     options,
                 }
             }
@@ -686,18 +706,26 @@ impl LinearizeDfg<'_> {
     }
 
     fn options(&mut self, options: &CanonicalOptions) -> info::CanonicalOptions {
-        let memory = options.memory.map(|mem| self.runtime_memory(mem));
-        let realloc = options.realloc.map(|mem| self.runtime_realloc(mem));
+        let data_model = match options.data_model {
+            CanonicalOptionsDataModel::Gc { core_type } => {
+                info::CanonicalOptionsDataModel::Gc { core_type }
+            }
+            CanonicalOptionsDataModel::LinearMemory { memory, realloc } => {
+                info::CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
+                    memory: memory.map(|mem| self.runtime_memory(mem)),
+                    realloc: realloc.map(|mem| self.runtime_realloc(mem)),
+                })
+            }
+        };
         let callback = options.callback.map(|mem| self.runtime_callback(mem));
         let post_return = options.post_return.map(|mem| self.runtime_post_return(mem));
         info::CanonicalOptions {
             instance: options.instance,
             string_encoding: options.string_encoding,
-            memory,
-            realloc,
             callback,
             post_return,
             async_: options.async_,
+            data_model,
         }
     }
 

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -420,9 +420,7 @@ pub struct StreamInfo {
 #[derive(Clone, Hash, Eq, PartialEq)]
 #[expect(missing_docs, reason = "self-describing fields")]
 pub enum CanonicalOptionsDataModel {
-    Gc {
-        core_type: ModuleInternedTypeIndex,
-    },
+    Gc {},
     LinearMemory {
         memory: Option<MemoryId>,
         realloc: Option<ReallocId>,
@@ -438,6 +436,7 @@ pub struct CanonicalOptions {
     pub callback: Option<CallbackId>,
     pub post_return: Option<PostReturnId>,
     pub async_: bool,
+    pub core_type: ModuleInternedTypeIndex,
     pub data_model: CanonicalOptionsDataModel,
 }
 
@@ -707,9 +706,7 @@ impl LinearizeDfg<'_> {
 
     fn options(&mut self, options: &CanonicalOptions) -> info::CanonicalOptions {
         let data_model = match options.data_model {
-            CanonicalOptionsDataModel::Gc { core_type } => {
-                info::CanonicalOptionsDataModel::Gc { core_type }
-            }
+            CanonicalOptionsDataModel::Gc {} => info::CanonicalOptionsDataModel::Gc {},
             CanonicalOptionsDataModel::LinearMemory { memory, realloc } => {
                 info::CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
                     memory: memory.map(|mem| self.runtime_memory(mem)),
@@ -725,6 +722,7 @@ impl LinearizeDfg<'_> {
             callback,
             post_return,
             async_: options.async_,
+            core_type: options.core_type,
             data_model,
         }
     }

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -495,10 +495,7 @@ pub struct LinearMemoryOptions {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum CanonicalOptionsDataModel {
     /// Data is stored in GC objects.
-    Gc {
-        /// The core function type that is being lifted from / lowered to.
-        core_type: ModuleInternedTypeIndex,
-    },
+    Gc {},
 
     /// Data is stored in a linear memory.
     LinearMemory(LinearMemoryOptions),
@@ -521,6 +518,9 @@ pub struct CanonicalOptions {
 
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
+
+    /// The core function type that is being lifted from / lowered to.
+    pub core_type: ModuleInternedTypeIndex,
 
     /// The data model (GC objects or linear memory) used with these canonical
     /// options.

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -450,8 +450,6 @@ pub enum Export {
         ty: TypeFuncIndex,
         /// Which core WebAssembly export is being lifted.
         func: CoreDef,
-        /// The core function's type.
-        func_ty: ModuleInternedTypeIndex,
         /// Any options, if present, associated with this lifting.
         options: CanonicalOptions,
     },

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -450,6 +450,8 @@ pub enum Export {
         ty: TypeFuncIndex,
         /// Which core WebAssembly export is being lifted.
         func: CoreDef,
+        /// The core function's type.
+        func_ty: ModuleInternedTypeIndex,
         /// Any options, if present, associated with this lifting.
         options: CanonicalOptions,
     },
@@ -480,6 +482,28 @@ pub enum Export {
     Type(TypeDef),
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+/// Data is stored in a linear memory.
+pub struct LinearMemoryOptions {
+    /// The memory used by these options, if specified.
+    pub memory: Option<RuntimeMemoryIndex>,
+    /// The realloc function used by these options, if specified.
+    pub realloc: Option<RuntimeReallocIndex>,
+}
+
+/// The data model for objects that are not unboxed in locals.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum CanonicalOptionsDataModel {
+    /// Data is stored in GC objects.
+    Gc {
+        /// The core function type that is being lifted from / lowered to.
+        core_type: ModuleInternedTypeIndex,
+    },
+
+    /// Data is stored in a linear memory.
+    LinearMemory(LinearMemoryOptions),
+}
+
 /// Canonical ABI options associated with a lifted or lowered function.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalOptions {
@@ -489,12 +513,6 @@ pub struct CanonicalOptions {
     /// The encoding used for strings.
     pub string_encoding: StringEncoding,
 
-    /// The memory used by these options, if specified.
-    pub memory: Option<RuntimeMemoryIndex>,
-
-    /// The realloc function used by these options, if specified.
-    pub realloc: Option<RuntimeReallocIndex>,
-
     /// The async callback function used by these options, if specified.
     pub callback: Option<RuntimeCallbackIndex>,
 
@@ -503,6 +521,10 @@ pub struct CanonicalOptions {
 
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
+
+    /// The data model (GC objects or linear memory) used with these canonical
+    /// options.
+    pub data_model: CanonicalOptionsDataModel,
 }
 
 /// Possible encodings of strings within the component model.

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -140,8 +140,6 @@ pub struct Adapter {
     pub lower_options: AdapterOptions,
     /// The original core wasm function which was lifted.
     pub func: dfg::CoreDef,
-    /// The core type of the core wasm function which was lifted.
-    pub func_ty: ModuleInternedTypeIndex,
 }
 
 /// The data model for objects that are not unboxed in locals.

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -148,10 +148,7 @@ pub struct Adapter {
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum DataModel {
     /// Data is stored in GC objects.
-    Gc {
-        /// The core function type that is being lifted from / lowered to.
-        core_type: ModuleInternedTypeIndex,
-    },
+    Gc {},
 
     /// Data is stored in a linear memory.
     LinearMemory {
@@ -179,6 +176,8 @@ pub struct AdapterOptions {
     pub post_return: Option<dfg::CoreDef>,
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
+    /// The core function type that is being lifted from / lowered to.
+    pub core_type: ModuleInternedTypeIndex,
     /// The data model used by this adapter: linear memory or GC objects.
     pub data_model: DataModel,
 }
@@ -406,7 +405,7 @@ impl PartitionAdapterModules {
             self.core_def(dfg, def);
         }
         match &options.data_model {
-            DataModel::Gc { core_type: _ } => {
+            DataModel::Gc {} => {
                 // Nothing to do here yet.
             }
             DataModel::LinearMemory {

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -140,6 +140,28 @@ pub struct Adapter {
     pub lower_options: AdapterOptions,
     /// The original core wasm function which was lifted.
     pub func: dfg::CoreDef,
+    /// The core type of the core wasm function which was lifted.
+    pub func_ty: ModuleInternedTypeIndex,
+}
+
+/// The data model for objects that are not unboxed in locals.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum DataModel {
+    /// Data is stored in GC objects.
+    Gc {
+        /// The core function type that is being lifted from / lowered to.
+        core_type: ModuleInternedTypeIndex,
+    },
+
+    /// Data is stored in a linear memory.
+    LinearMemory {
+        /// An optional memory definition supplied.
+        memory: Option<dfg::CoreExport<MemoryIndex>>,
+        /// If `memory` is specified, whether it's a 64-bit memory.
+        memory64: bool,
+        /// An optional definition of `realloc` to used.
+        realloc: Option<dfg::CoreDef>,
+    },
 }
 
 /// Configuration options which can be specified as part of the canonical ABI
@@ -151,18 +173,14 @@ pub struct AdapterOptions {
     pub instance: RuntimeComponentInstanceIndex,
     /// How strings are encoded.
     pub string_encoding: StringEncoding,
-    /// An optional memory definition supplied.
-    pub memory: Option<dfg::CoreExport<MemoryIndex>>,
-    /// If `memory` is specified, whether it's a 64-bit memory.
-    pub memory64: bool,
-    /// An optional definition of `realloc` to used.
-    pub realloc: Option<dfg::CoreDef>,
     /// The async callback function used by these options, if specified.
     pub callback: Option<dfg::CoreDef>,
     /// An optional definition of a `post-return` to use.
     pub post_return: Option<dfg::CoreDef>,
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
+    /// The data model used by this adapter: linear memory or GC objects.
+    pub data_model: DataModel,
 }
 
 impl<'data> Translator<'_, 'data> {
@@ -381,17 +399,28 @@ impl PartitionAdapterModules {
     }
 
     fn adapter_options(&mut self, dfg: &dfg::ComponentDfg, options: &AdapterOptions) {
-        if let Some(memory) = &options.memory {
-            self.core_export(dfg, memory);
-        }
-        if let Some(def) = &options.realloc {
-            self.core_def(dfg, def);
-        }
         if let Some(def) = &options.callback {
             self.core_def(dfg, def);
         }
         if let Some(def) = &options.post_return {
             self.core_def(dfg, def);
+        }
+        match &options.data_model {
+            DataModel::Gc { core_type: _ } => {
+                // Nothing to do here yet.
+            }
+            DataModel::LinearMemory {
+                memory,
+                memory64: _,
+                realloc,
+            } => {
+                if let Some(memory) = memory {
+                    self.core_export(dfg, memory);
+                }
+                if let Some(def) = realloc {
+                    self.core_def(dfg, def);
+                }
+            }
         }
     }
 

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -198,11 +198,6 @@ struct Options {
     data_model: DataModel,
 }
 
-enum Context {
-    Lift,
-    Lower,
-}
-
 /// Representation of a "helper function" which may be generated as part of
 /// generating an adapter trampoline.
 ///
@@ -292,7 +287,7 @@ impl<'a> Module<'a> {
         // Import the core wasm function which was lifted using its appropriate
         // signature since the exported function this adapter generates will
         // call the lifted function.
-        let signature = self.types.signature(&lift, Context::Lift);
+        let signature = self.types.signature(&lift);
         let ty = self
             .core_types
             .function(&signature.params, &signature.results);

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -29,8 +29,11 @@ impl ComponentTypesBuilder {
     pub(super) fn signature(&self, options: &AdapterOptions, context: Context) -> Signature {
         let mem_opts = match &options.options.data_model {
             DataModel::LinearMemory(mem_opts) => mem_opts,
-            DataModel::Gc { core_type } => {
-                match &self.module_types_builder()[*core_type].composite_type.inner {
+            DataModel::Gc {} => {
+                match &self.module_types_builder()[options.options.core_type]
+                    .composite_type
+                    .inner
+                {
                     crate::WasmCompositeInnerType::Func(f) => {
                         return Signature {
                             params: f.params().iter().map(|ty| self.val_type(ty)).collect(),

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -27,8 +27,8 @@ use crate::fact::signature::Signature;
 use crate::fact::transcode::Transcoder;
 use crate::fact::traps::Trap;
 use crate::fact::{
-    AdapterData, Body, Context, Function, FunctionId, Helper, HelperLocation, HelperType, Module,
-    Options,
+    AdapterData, Body, Context, Function, FunctionId, Helper, HelperLocation, HelperType,
+    LinearMemoryOptions, Module, Options,
 };
 use crate::prelude::*;
 use crate::{FuncIndex, GlobalIndex};
@@ -38,6 +38,8 @@ use std::mem;
 use std::ops::Range;
 use wasm_encoder::{BlockType, Encode, Instruction, Instruction::*, MemArg, ValType};
 use wasmtime_component_util::{DiscriminantSize, FlagsSize};
+
+use super::DataModel;
 
 const MAX_STRING_BYTE_LENGTH: u32 = 1 << 31;
 const UTF16_TAG: u32 = 1 << 31;
@@ -292,10 +294,11 @@ pub(super) fn compile_helper(module: &mut Module<'_>, result: FunctionId, helper
             nlocals += 1;
             Source::Memory(Memory {
                 opts: &helper.src.opts,
-                addr: TempLocal::new(0, helper.src.opts.ptr()),
+                addr: TempLocal::new(0, helper.src.opts.data_model.unwrap_memory().ptr()),
                 offset: 0,
             })
         }
+        HelperLocation::StructField | HelperLocation::ArrayElement => todo!("CM+GC"),
     };
     let dst_flat;
     let dst = match helper.dst.loc {
@@ -314,10 +317,14 @@ pub(super) fn compile_helper(module: &mut Module<'_>, result: FunctionId, helper
             nlocals += 1;
             Destination::Memory(Memory {
                 opts: &helper.dst.opts,
-                addr: TempLocal::new(nlocals - 1, helper.dst.opts.ptr()),
+                addr: TempLocal::new(
+                    nlocals - 1,
+                    helper.dst.opts.data_model.unwrap_memory().ptr(),
+                ),
                 offset: 0,
             })
         }
+        HelperLocation::StructField | HelperLocation::ArrayElement => todo!("CM+GC"),
     };
     let mut compiler = Compiler {
         types: module.types,
@@ -349,6 +356,16 @@ enum Source<'a> {
     /// This value is stored in linear memory described by the `Memory`
     /// structure.
     Memory(Memory<'a>),
+
+    /// This value is stored in a GC struct field described by the `GcStruct`
+    /// structure.
+    #[allow(dead_code, reason = "CM+GC is still WIP")]
+    Struct(GcStruct<'a>),
+
+    /// This value is stored in a GC array element described by the `GcArray`
+    /// structure.
+    #[allow(dead_code, reason = "CM+GC is still WIP")]
+    Array(GcArray<'a>),
 }
 
 /// Same as `Source` but for where values are translated into.
@@ -362,6 +379,16 @@ enum Destination<'a> {
 
     /// This value is to be placed in linear memory described by `Memory`.
     Memory(Memory<'a>),
+
+    /// This value is to be placed in a GC struct field described by the
+    /// `GcStruct` structure.
+    #[allow(dead_code, reason = "CM+GC is still WIP")]
+    Struct(GcStruct<'a>),
+
+    /// This value is to be placed in a GC array element described by the
+    /// `GcArray` structure.
+    #[allow(dead_code, reason = "CM+GC is still WIP")]
+    Array(GcArray<'a>),
 }
 
 struct Stack<'a> {
@@ -385,6 +412,24 @@ struct Memory<'a> {
     /// A "static" offset that will be baked into wasm instructions for where
     /// memory loads/stores happen.
     offset: u32,
+}
+
+impl<'a> Memory<'a> {
+    fn mem_opts(&self) -> &'a LinearMemoryOptions {
+        self.opts.data_model.unwrap_memory()
+    }
+}
+
+/// Representation of where a value is coming from or going to in a GC struct.
+struct GcStruct<'a> {
+    opts: &'a Options,
+    // TODO: more fields to come in the future.
+}
+
+/// Representation of where a value is coming from or going to in a GC array.
+struct GcArray<'a> {
+    opts: &'a Options,
+    // TODO: more fields to come in the future.
 }
 
 impl<'a, 'b> Compiler<'a, 'b> {
@@ -478,7 +523,10 @@ impl<'a, 'b> Compiler<'a, 'b> {
         let prepare = self.module.import_prepare_call(
             &adapter.name,
             &lower_sig.params,
-            adapter.lift.options.memory,
+            match adapter.lift.options.data_model {
+                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::LinearMemory(LinearMemoryOptions { memory, .. }) => memory,
+            },
         );
 
         self.flush_code();
@@ -820,11 +868,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
             // If there are too many parameters then that means the parameters
             // are actually a tuple stored in linear memory addressed by the
             // first parameter local.
+            let lower_mem_opts = lower_opts.data_model.unwrap_memory();
             let (addr, ty) = param_locals[0];
-            assert_eq!(ty, lower_opts.ptr());
+            assert_eq!(ty, lower_mem_opts.ptr());
             let align = src_tys
                 .iter()
-                .map(|t| self.types.align(lower_opts, t))
+                .map(|t| self.types.align(lower_mem_opts, t))
                 .max()
                 .unwrap_or(1);
             Source::Memory(self.memory_operand(lower_opts, TempLocal::new(addr, ty), align))
@@ -834,16 +883,21 @@ impl<'a, 'b> Compiler<'a, 'b> {
             Destination::Stack(flat, lift_opts)
         } else {
             let abi = CanonicalAbiInfo::record(dst_tys.iter().map(|t| self.types.canonical_abi(t)));
-            let (size, align) = if lift_opts.memory64 {
-                (abi.size64, abi.align64)
-            } else {
-                (abi.size32, abi.align32)
-            };
+            match lift_opts.data_model {
+                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::LinearMemory(LinearMemoryOptions { memory64, .. }) => {
+                    let (size, align) = if memory64 {
+                        (abi.size64, abi.align64)
+                    } else {
+                        (abi.size32, abi.align32)
+                    };
 
-            // If there are too many parameters then space is allocated in the
-            // destination module for the parameters via its `realloc` function.
-            let size = MallocSize::Const(size);
-            Destination::Memory(self.malloc(lift_opts, size, align))
+                    // If there are too many parameters then space is allocated in the
+                    // destination module for the parameters via its `realloc` function.
+                    let size = MallocSize::Const(size);
+                    Destination::Memory(self.malloc(lift_opts, size, align))
+                }
+            }
         };
 
         let srcs = src
@@ -903,9 +957,10 @@ impl<'a, 'b> Compiler<'a, 'b> {
             // return value of the function itself. The imported function will
             // return a linear memory address at which the values can be read
             // from.
+            let lift_mem_opts = lift_opts.data_model.unwrap_memory();
             let align = src_tys
                 .iter()
-                .map(|t| self.types.align(lift_opts, t))
+                .map(|t| self.types.align(lift_mem_opts, t))
                 .max()
                 .unwrap_or(1);
             assert_eq!(
@@ -917,7 +972,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 }
             );
             let (addr, ty) = result_locals[0];
-            assert_eq!(ty, lift_opts.ptr());
+            assert_eq!(ty, lift_opts.data_model.unwrap_memory().ptr());
             Source::Memory(self.memory_operand(lift_opts, TempLocal::new(addr, ty), align))
         };
 
@@ -927,13 +982,14 @@ impl<'a, 'b> Compiler<'a, 'b> {
             // This is slightly different than `translate_params` where the
             // return pointer was provided by the caller of this function
             // meaning the last parameter local is a pointer into linear memory.
+            let lower_mem_opts = lower_opts.data_model.unwrap_memory();
             let align = dst_tys
                 .iter()
-                .map(|t| self.types.align(lower_opts, t))
+                .map(|t| self.types.align(lower_mem_opts, t))
                 .max()
                 .unwrap_or(1);
             let (addr, ty) = *param_locals.last().expect("no retptr");
-            assert_eq!(ty, lower_opts.ptr());
+            assert_eq!(ty, lower_opts.data_model.unwrap_memory().ptr());
             Destination::Memory(self.memory_operand(lower_opts, TempLocal::new(addr, ty), align))
         };
 
@@ -1115,6 +1171,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                         self.push_mem_addr(mem);
                         HelperLocation::Memory
                     }
+                    Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
                 };
                 let dst_loc = match dst {
                     Destination::Stack(..) => HelperLocation::Stack,
@@ -1122,6 +1179,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                         self.push_mem_addr(mem);
                         HelperLocation::Memory
                     }
+                    Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
                 };
                 // Generate a `FunctionId` corresponding to the `Helper`
                 // configuration that is necessary here. This will ideally be a
@@ -1177,8 +1235,8 @@ impl<'a, 'b> Compiler<'a, 'b> {
     fn push_mem_addr(&mut self, mem: &Memory<'_>) {
         self.instruction(LocalGet(mem.addr.idx));
         if mem.offset != 0 {
-            self.ptr_uconst(mem.opts, mem.offset);
-            self.ptr_add(mem.opts);
+            self.ptr_uconst(mem.mem_opts(), mem.offset);
+            self.ptr_add(mem.mem_opts());
         }
     }
 
@@ -1194,12 +1252,14 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i32_load8u(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         self.instruction(Select);
 
         match dst {
             Destination::Memory(mem) => self.i32_store8(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1220,6 +1280,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
             Source::Stack(stack) => {
                 self.stack_get(stack, ValType::I32);
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         if needs_mask {
             self.instruction(I32Const(i32::from(mask)));
@@ -1228,6 +1289,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Memory(mem) => self.i32_store8(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1241,10 +1303,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.stack_get(stack, ValType::I32);
                 self.instruction(I32Extend8S);
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.i32_store8(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1265,6 +1329,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
             Source::Stack(stack) => {
                 self.stack_get(stack, ValType::I32);
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         if needs_mask {
             self.instruction(I32Const(i32::from(mask)));
@@ -1273,6 +1338,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Memory(mem) => self.i32_store16(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1286,10 +1352,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.stack_get(stack, ValType::I32);
                 self.instruction(I32Extend16S);
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.i32_store16(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1304,6 +1372,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i32_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         if mask != 0xffffffff {
             self.instruction(I32Const(mask as i32));
@@ -1312,6 +1381,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Memory(mem) => self.i32_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1322,10 +1392,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i32_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.i32_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1336,10 +1408,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i64_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I64),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.i64_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I64),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1350,10 +1424,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i64_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I64),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.i64_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I64),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1364,10 +1440,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.f32_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::F32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.f32_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::F32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1378,10 +1456,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.f64_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::F64),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         match dst {
             Destination::Memory(mem) => self.f64_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::F64),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -1390,6 +1470,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i32_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         let local = self.local_set_new_tmp(ValType::I32);
 
@@ -1433,6 +1514,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.i32_store(mem);
             }
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
 
         self.free_temp_local(local);
@@ -1443,6 +1525,15 @@ impl<'a, 'b> Compiler<'a, 'b> {
         let src_opts = src.opts();
         let dst_opts = dst.opts();
 
+        let src_mem_opts = match &src_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         // Load the pointer/length of this string into temporary locals. These
         // will be referenced a good deal so this just makes it easier to deal
         // with them consistently below rather than trying to reload from memory
@@ -1450,16 +1541,17 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Stack(s) => {
                 assert_eq!(s.locals.len(), 2);
-                self.stack_get(&s.slice(0..1), src_opts.ptr());
-                self.stack_get(&s.slice(1..2), src_opts.ptr());
+                self.stack_get(&s.slice(0..1), src_mem_opts.ptr());
+                self.stack_get(&s.slice(1..2), src_mem_opts.ptr());
             }
             Source::Memory(mem) => {
                 self.ptr_load(mem);
-                self.ptr_load(&mem.bump(src_opts.ptr_size().into()));
+                self.ptr_load(&mem.bump(src_mem_opts.ptr_size().into()));
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
-        let src_len = self.local_set_new_tmp(src_opts.ptr());
-        let src_ptr = self.local_set_new_tmp(src_opts.ptr());
+        let src_len = self.local_set_new_tmp(src_mem_opts.ptr());
+        let src_ptr = self.local_set_new_tmp(src_mem_opts.ptr());
         let src_str = WasmString {
             ptr: src_ptr,
             len: src_len,
@@ -1476,7 +1568,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
             },
 
             StringEncoding::Utf16 => {
-                self.verify_aligned(src_opts, src_str.ptr.idx, 2);
+                self.verify_aligned(src_mem_opts, src_str.ptr.idx, 2);
                 match dst_opts.string_encoding {
                     StringEncoding::Utf8 => {
                         self.string_deflate_to_utf8(&src_str, FE::Utf16, dst_opts)
@@ -1491,21 +1583,21 @@ impl<'a, 'b> Compiler<'a, 'b> {
             }
 
             StringEncoding::CompactUtf16 => {
-                self.verify_aligned(src_opts, src_str.ptr.idx, 2);
+                self.verify_aligned(src_mem_opts, src_str.ptr.idx, 2);
 
                 // Test the tag big to see if this is a utf16 or a latin1 string
                 // at runtime...
                 self.instruction(LocalGet(src_str.len.idx));
-                self.ptr_uconst(src_opts, UTF16_TAG);
-                self.ptr_and(src_opts);
-                self.ptr_if(src_opts, BlockType::Empty);
+                self.ptr_uconst(src_mem_opts, UTF16_TAG);
+                self.ptr_and(src_mem_opts);
+                self.ptr_if(src_mem_opts, BlockType::Empty);
 
                 // In the utf16 block unset the upper bit from the length local
                 // so further calculations have the right value. Afterwards the
                 // string transcode proceeds assuming utf16.
                 self.instruction(LocalGet(src_str.len.idx));
-                self.ptr_uconst(src_opts, UTF16_TAG);
-                self.ptr_xor(src_opts);
+                self.ptr_uconst(src_mem_opts, UTF16_TAG);
+                self.ptr_xor(src_mem_opts);
                 self.instruction(LocalSet(src_str.len.idx));
                 let s1 = match dst_opts.string_encoding {
                     StringEncoding::Utf8 => {
@@ -1552,9 +1644,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Stack(s, _) => {
                 self.instruction(LocalGet(dst_str.ptr.idx));
-                self.stack_set(&s[..1], dst_opts.ptr());
+                self.stack_set(&s[..1], dst_mem_opts.ptr());
                 self.instruction(LocalGet(dst_str.len.idx));
-                self.stack_set(&s[1..], dst_opts.ptr());
+                self.stack_set(&s[1..], dst_mem_opts.ptr());
             }
             Destination::Memory(mem) => {
                 self.instruction(LocalGet(mem.addr.idx));
@@ -1562,8 +1654,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.ptr_store(mem);
                 self.instruction(LocalGet(mem.addr.idx));
                 self.instruction(LocalGet(dst_str.len.idx));
-                self.ptr_store(&mem.bump(dst_opts.ptr_size().into()));
+                self.ptr_store(&mem.bump(dst_mem_opts.ptr_size().into()));
             }
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
 
         self.free_temp_local(src_str.ptr);
@@ -1594,6 +1687,19 @@ impl<'a, 'b> Compiler<'a, 'b> {
         assert!(dst_enc.width() >= src_enc.width());
         self.validate_string_length(src, dst_enc);
 
+        let src_mem_opts = {
+            match &src.opts.data_model {
+                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::LinearMemory(opts) => opts,
+            }
+        };
+        let dst_mem_opts = {
+            match &dst_opts.data_model {
+                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::LinearMemory(opts) => opts,
+            }
+        };
+
         // Calculate the source byte length given the size of each code
         // unit. Note that this shouldn't overflow given
         // `validate_string_length` above.
@@ -1603,9 +1709,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
         } else {
             assert_eq!(src_enc.width(), 2);
             self.instruction(LocalGet(src.len.idx));
-            self.ptr_uconst(src.opts, 1);
-            self.ptr_shl(src.opts);
-            let tmp = self.local_set_new_tmp(src.opts.ptr());
+            self.ptr_uconst(src_mem_opts, 1);
+            self.ptr_shl(src_mem_opts);
+            let tmp = self.local_set_new_tmp(src.opts.data_model.unwrap_memory().ptr());
             let ret = tmp.idx;
             src_byte_len_tmp = Some(tmp);
             ret
@@ -1613,14 +1719,18 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
         // Convert the source code units length to the destination byte
         // length type.
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
+        self.convert_src_len_to_dst(
+            src.len.idx,
+            src.opts.data_model.unwrap_memory().ptr(),
+            dst_opts.data_model.unwrap_memory().ptr(),
+        );
+        let dst_len = self.local_tee_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
         if dst_enc.width() > 1 {
             assert_eq!(dst_enc.width(), 2);
-            self.ptr_uconst(dst_opts, 1);
-            self.ptr_shl(dst_opts);
+            self.ptr_uconst(dst_mem_opts, 1);
+            self.ptr_shl(dst_mem_opts);
         }
-        let dst_byte_len = self.local_set_new_tmp(dst_opts.ptr());
+        let dst_byte_len = self.local_set_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
 
         // Allocate space in the destination using the calculated byte
         // length.
@@ -1685,14 +1795,27 @@ impl<'a, 'b> Compiler<'a, 'b> {
         src_enc: FE,
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
+        let src_mem_opts = match &src.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         self.validate_string_length(src, src_enc);
 
         // Optimistically assume that the code unit length of the source is
         // all that's needed in the destination. Perform that allocation
         // here and proceed to transcoding below.
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
-        let dst_byte_len = self.local_set_new_tmp(dst_opts.ptr());
+        self.convert_src_len_to_dst(
+            src.len.idx,
+            src.opts.data_model.unwrap_memory().ptr(),
+            dst_opts.data_model.unwrap_memory().ptr(),
+        );
+        let dst_len = self.local_tee_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
+        let dst_byte_len = self.local_set_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
 
         let dst = {
             let dst_mem = self.malloc(dst_opts, MallocSize::Local(dst_byte_len.idx), 1);
@@ -1709,9 +1832,9 @@ impl<'a, 'b> Compiler<'a, 'b> {
             FE::Latin1 => src.len.idx,
             FE::Utf16 => {
                 self.instruction(LocalGet(src.len.idx));
-                self.ptr_uconst(src.opts, 1);
-                self.ptr_shl(src.opts);
-                let tmp = self.local_set_new_tmp(src.opts.ptr());
+                self.ptr_uconst(src_mem_opts, 1);
+                self.ptr_shl(src_mem_opts);
+                let tmp = self.local_set_new_tmp(src.opts.data_model.unwrap_memory().ptr());
                 let ret = tmp.idx;
                 src_byte_len_tmp = Some(tmp);
                 ret
@@ -1734,14 +1857,14 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(LocalGet(dst_byte_len.idx));
         self.instruction(Call(transcode.as_u32()));
         self.instruction(LocalSet(dst.len.idx));
-        let src_len_tmp = self.local_set_new_tmp(src.opts.ptr());
+        let src_len_tmp = self.local_set_new_tmp(src.opts.data_model.unwrap_memory().ptr());
 
         // Test if the source was entirely transcoded by comparing
         // `src_len_tmp`, the number of code units transcoded from the
         // source, with `src_len`, the original number of code units.
         self.instruction(LocalGet(src_len_tmp.idx));
         self.instruction(LocalGet(src.len.idx));
-        self.ptr_ne(src.opts);
+        self.ptr_ne(src_mem_opts);
         self.instruction(If(BlockType::Empty));
 
         // Here a worst-case reallocation is performed to grow `dst_mem`.
@@ -1749,18 +1872,22 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // fits within the maximum size of strings.
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 1); // align
+        self.ptr_uconst(dst_mem_opts, 1); // align
         let factor = match src_enc {
             FE::Latin1 => 2,
             FE::Utf16 => 3,
             _ => unreachable!(),
         };
         self.validate_string_length_u8(src, factor);
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        self.ptr_uconst(dst_opts, factor.into());
-        self.ptr_mul(dst_opts);
+        self.convert_src_len_to_dst(
+            src.len.idx,
+            src.opts.data_model.unwrap_memory().ptr(),
+            dst_opts.data_model.unwrap_memory().ptr(),
+        );
+        self.ptr_uconst(dst_mem_opts, factor.into());
+        self.ptr_mul(dst_mem_opts);
         self.instruction(LocalTee(dst_byte_len.idx));
-        self.instruction(Call(dst_opts.realloc.unwrap().as_u32()));
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
 
         // Verify that the destination is still in-bounds
@@ -1773,26 +1900,26 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(LocalGet(src.ptr.idx));
         self.instruction(LocalGet(src_len_tmp.idx));
         if let FE::Utf16 = src_enc {
-            self.ptr_uconst(src.opts, 1);
-            self.ptr_shl(src.opts);
+            self.ptr_uconst(src_mem_opts, 1);
+            self.ptr_shl(src_mem_opts);
         }
-        self.ptr_add(src.opts);
+        self.ptr_add(src_mem_opts);
         self.instruction(LocalGet(src.len.idx));
         self.instruction(LocalGet(src_len_tmp.idx));
-        self.ptr_sub(src.opts);
+        self.ptr_sub(src_mem_opts);
         self.instruction(LocalGet(dst.ptr.idx));
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_add(dst.opts);
+        self.ptr_add(dst_mem_opts);
         self.instruction(LocalGet(dst_byte_len.idx));
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_sub(dst.opts);
+        self.ptr_sub(dst_mem_opts);
         self.instruction(Call(transcode.as_u32()));
 
         // Add the second result, the amount of destination units encoded,
         // to `dst_len` so it's an accurate reflection of the final size of
         // the destination buffer.
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_add(dst.opts);
+        self.ptr_add(dst_mem_opts);
         self.instruction(LocalSet(dst.len.idx));
 
         // In debug mode verify the first result consumed the entire string,
@@ -1800,8 +1927,8 @@ impl<'a, 'b> Compiler<'a, 'b> {
         if self.module.debug {
             self.instruction(LocalGet(src.len.idx));
             self.instruction(LocalGet(src_len_tmp.idx));
-            self.ptr_sub(src.opts);
-            self.ptr_ne(src.opts);
+            self.ptr_sub(src_mem_opts);
+            self.ptr_ne(src_mem_opts);
             self.instruction(If(BlockType::Empty));
             self.trap(Trap::AssertFailed("should have finished encoding"));
             self.instruction(End);
@@ -1812,13 +1939,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // Perform a downsizing if the worst-case size was too large
         self.instruction(LocalGet(dst.len.idx));
         self.instruction(LocalGet(dst_byte_len.idx));
-        self.ptr_ne(dst.opts);
+        self.ptr_ne(dst_mem_opts);
         self.instruction(If(BlockType::Empty));
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 1); // align
+        self.ptr_uconst(dst_mem_opts, 1); // align
         self.instruction(LocalGet(dst.len.idx)); // new_size
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
         self.instruction(End);
 
@@ -1829,7 +1956,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
             self.instruction(LocalGet(dst.len.idx));
             self.instruction(LocalGet(dst_byte_len.idx));
-            self.ptr_ne(dst_opts);
+            self.ptr_ne(dst_mem_opts);
             self.instruction(If(BlockType::Empty));
             self.trap(Trap::AssertFailed("should have finished encoding"));
             self.instruction(End);
@@ -1865,12 +1992,25 @@ impl<'a, 'b> Compiler<'a, 'b> {
         src: &WasmString<'_>,
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
+        let src_mem_opts = match &src.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         self.validate_string_length(src, FE::Utf16);
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
-        self.ptr_uconst(dst_opts, 1);
-        self.ptr_shl(dst_opts);
-        let dst_byte_len = self.local_set_new_tmp(dst_opts.ptr());
+        self.convert_src_len_to_dst(
+            src.len.idx,
+            src_mem_opts.ptr(),
+            dst_opts.data_model.unwrap_memory().ptr(),
+        );
+        let dst_len = self.local_tee_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
+        self.ptr_uconst(dst_mem_opts, 1);
+        self.ptr_shl(dst_mem_opts);
+        let dst_byte_len = self.local_set_new_tmp(dst_opts.data_model.unwrap_memory().ptr());
         let dst = {
             let dst_mem = self.malloc(dst_opts, MallocSize::Local(dst_byte_len.idx), 2);
             WasmString {
@@ -1897,17 +2037,22 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // Note that the byte length of the final allocation we
         // want is twice the code unit length returned by the
         // transcoding function.
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst.opts.ptr());
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_ne(dst_opts);
+        self.ptr_ne(dst_mem_opts);
         self.instruction(If(BlockType::Empty));
         self.instruction(LocalGet(dst.ptr.idx));
         self.instruction(LocalGet(dst_byte_len.idx));
-        self.ptr_uconst(dst.opts, 2);
+        self.ptr_uconst(dst_mem_opts, 2);
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_uconst(dst.opts, 1);
-        self.ptr_shl(dst.opts);
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.ptr_uconst(dst_mem_opts, 1);
+        self.ptr_shl(dst_mem_opts);
+        self.instruction(Call(match dst.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(LinearMemoryOptions { realloc, .. }) => {
+                realloc.unwrap().as_u32()
+            }
+        }));
         self.instruction(LocalSet(dst.ptr.idx));
         self.instruction(End); // end of shrink-to-fit
 
@@ -1934,12 +2079,21 @@ impl<'a, 'b> Compiler<'a, 'b> {
         src: &WasmString<'_>,
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
+        let src_mem_opts = match &src.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         self.validate_string_length(src, FE::Utf16);
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
-        self.ptr_uconst(dst_opts, 1);
-        self.ptr_shl(dst_opts);
-        let dst_byte_len = self.local_set_new_tmp(dst_opts.ptr());
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+        let dst_len = self.local_tee_new_tmp(dst_mem_opts.ptr());
+        self.ptr_uconst(dst_mem_opts, 1);
+        self.ptr_shl(dst_mem_opts);
+        let dst_byte_len = self.local_set_new_tmp(dst_mem_opts.ptr());
         let dst = {
             let dst_mem = self.malloc(dst_opts, MallocSize::Local(dst_byte_len.idx), 2);
             WasmString {
@@ -1949,8 +2103,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
             }
         };
 
-        self.convert_src_len_to_dst(dst_byte_len.idx, dst.opts.ptr(), src.opts.ptr());
-        let src_byte_len = self.local_set_new_tmp(src.opts.ptr());
+        self.convert_src_len_to_dst(
+            dst_byte_len.idx,
+            dst.opts.data_model.unwrap_memory().ptr(),
+            src_mem_opts.ptr(),
+        );
+        let src_byte_len = self.local_set_new_tmp(src_mem_opts.ptr());
 
         self.validate_string_inbounds(src, src_byte_len.idx);
         self.validate_string_inbounds(&dst, dst_byte_len.idx);
@@ -1966,10 +2124,10 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // source code unit length.
         if self.module.debug {
             self.instruction(LocalGet(dst.len.idx));
-            self.ptr_uconst(dst.opts, !UTF16_TAG);
-            self.ptr_and(dst.opts);
-            self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst.opts.ptr());
-            self.ptr_ne(dst.opts);
+            self.ptr_uconst(dst_mem_opts, !UTF16_TAG);
+            self.ptr_and(dst_mem_opts);
+            self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+            self.ptr_ne(dst_mem_opts);
             self.instruction(If(BlockType::Empty));
             self.trap(Trap::AssertFailed("expected equal code units"));
             self.instruction(End);
@@ -1979,16 +2137,16 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // should be appropriately sized. Bail out of the "is this string
         // empty" block and fall through otherwise to resizing.
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_uconst(dst.opts, UTF16_TAG);
-        self.ptr_and(dst.opts);
-        self.ptr_br_if(dst.opts, 0);
+        self.ptr_uconst(dst_mem_opts, UTF16_TAG);
+        self.ptr_and(dst_mem_opts);
+        self.ptr_br_if(dst_mem_opts, 0);
 
         // Here `realloc` is used to downsize the string
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 2); // align
+        self.ptr_uconst(dst_mem_opts, 2); // align
         self.instruction(LocalGet(dst.len.idx)); // new_size
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
 
         self.free_temp_local(dst_byte_len);
@@ -2009,10 +2167,19 @@ impl<'a, 'b> Compiler<'a, 'b> {
         src_enc: FE,
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
+        let src_mem_opts = match &src.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst_opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         self.validate_string_length(src, src_enc);
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst_opts.ptr());
-        let dst_len = self.local_tee_new_tmp(dst_opts.ptr());
-        let dst_byte_len = self.local_set_new_tmp(dst_opts.ptr());
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+        let dst_len = self.local_tee_new_tmp(dst_mem_opts.ptr());
+        let dst_byte_len = self.local_set_new_tmp(dst_mem_opts.ptr());
         let dst = {
             let dst_mem = self.malloc(dst_opts, MallocSize::Local(dst_byte_len.idx), 2);
             WasmString {
@@ -2040,13 +2207,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(LocalGet(dst.ptr.idx));
         self.instruction(Call(transcode_latin1.as_u32()));
         self.instruction(LocalSet(dst.len.idx));
-        let src_len_tmp = self.local_set_new_tmp(src.opts.ptr());
+        let src_len_tmp = self.local_set_new_tmp(src_mem_opts.ptr());
 
         // If the source was entirely consumed then the transcode completed
         // and all that's necessary is to optionally shrink the buffer.
         self.instruction(LocalGet(src_len_tmp.idx));
         self.instruction(LocalGet(src.len.idx));
-        self.ptr_eq(src.opts);
+        self.ptr_eq(src_mem_opts);
         self.instruction(If(BlockType::Empty)); // if latin1-or-utf16 block
 
         // Test if the original byte length of the allocation is the same as
@@ -2054,13 +2221,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // with a call to `realloc`.
         self.instruction(LocalGet(dst_byte_len.idx));
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_ne(dst.opts);
+        self.ptr_ne(dst_mem_opts);
         self.instruction(If(BlockType::Empty));
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 2); // align
+        self.ptr_uconst(dst_mem_opts, 2); // align
         self.instruction(LocalGet(dst.len.idx)); // new_size
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
         self.instruction(End);
 
@@ -2080,12 +2247,12 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // size.
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 2); // align
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst.opts.ptr());
-        self.ptr_uconst(dst.opts, 1);
-        self.ptr_shl(dst.opts);
+        self.ptr_uconst(dst_mem_opts, 2); // align
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+        self.ptr_uconst(dst_mem_opts, 1);
+        self.ptr_shl(dst_mem_opts);
         self.instruction(LocalTee(dst_byte_len.idx));
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
 
         // Call the host utf16 transcoding function. This will inflate the
@@ -2094,15 +2261,15 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(LocalGet(src.ptr.idx));
         self.instruction(LocalGet(src_len_tmp.idx));
         if let FE::Utf16 = src_enc {
-            self.ptr_uconst(src.opts, 1);
-            self.ptr_shl(src.opts);
+            self.ptr_uconst(src_mem_opts, 1);
+            self.ptr_shl(src_mem_opts);
         }
-        self.ptr_add(src.opts);
+        self.ptr_add(src_mem_opts);
         self.instruction(LocalGet(src.len.idx));
         self.instruction(LocalGet(src_len_tmp.idx));
-        self.ptr_sub(src.opts);
+        self.ptr_sub(src_mem_opts);
         self.instruction(LocalGet(dst.ptr.idx));
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst.opts.ptr());
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
         self.instruction(LocalGet(dst.len.idx));
         self.instruction(Call(transcode_utf16.as_u32()));
         self.instruction(LocalSet(dst.len.idx));
@@ -2115,23 +2282,23 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // byte buffer size is `2*src_len` so the `2` factor isn't checked
         // here, just the lengths.
         self.instruction(LocalGet(dst.len.idx));
-        self.convert_src_len_to_dst(src.len.idx, src.opts.ptr(), dst.opts.ptr());
-        self.ptr_ne(dst.opts);
+        self.convert_src_len_to_dst(src.len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+        self.ptr_ne(dst_mem_opts);
         self.instruction(If(BlockType::Empty));
         self.instruction(LocalGet(dst.ptr.idx)); // old_ptr
         self.instruction(LocalGet(dst_byte_len.idx)); // old_size
-        self.ptr_uconst(dst.opts, 2); // align
+        self.ptr_uconst(dst_mem_opts, 2); // align
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_uconst(dst.opts, 1);
-        self.ptr_shl(dst.opts);
-        self.instruction(Call(dst.opts.realloc.unwrap().as_u32()));
+        self.ptr_uconst(dst_mem_opts, 1);
+        self.ptr_shl(dst_mem_opts);
+        self.instruction(Call(dst_mem_opts.realloc.unwrap().as_u32()));
         self.instruction(LocalSet(dst.ptr.idx));
         self.instruction(End);
 
         // Tag the returned pointer as utf16
         self.instruction(LocalGet(dst.len.idx));
-        self.ptr_uconst(dst.opts, UTF16_TAG);
-        self.ptr_or(dst.opts);
+        self.ptr_uconst(dst_mem_opts, UTF16_TAG);
+        self.ptr_or(dst_mem_opts);
         self.instruction(LocalSet(dst.len.idx));
 
         self.instruction(End); // end latin1-or-utf16 block
@@ -2147,12 +2314,17 @@ impl<'a, 'b> Compiler<'a, 'b> {
     }
 
     fn validate_string_length_u8(&mut self, s: &WasmString<'_>, dst: u8) {
+        let mem_opts = match &s.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         // Check to see if the source byte length is out of bounds in
         // which case a trap is generated.
         self.instruction(LocalGet(s.len.idx));
         let max = MAX_STRING_BYTE_LENGTH / u32::from(dst);
-        self.ptr_uconst(s.opts, max);
-        self.ptr_ge_u(s.opts);
+        self.ptr_uconst(mem_opts, max);
+        self.ptr_ge_u(mem_opts);
         self.instruction(If(BlockType::Empty));
         self.trap(Trap::StringLengthTooBig);
         self.instruction(End);
@@ -2164,22 +2336,43 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst: &WasmString<'_>,
         op: Transcode,
     ) -> FuncIndex {
-        self.module.import_transcoder(Transcoder {
-            from_memory: src.opts.memory.unwrap(),
-            from_memory64: src.opts.memory64,
-            to_memory: dst.opts.memory.unwrap(),
-            to_memory64: dst.opts.memory64,
-            op,
-        })
+        match (src.opts.data_model, dst.opts.data_model) {
+            (DataModel::Gc { core_type: _ }, _) | (_, DataModel::Gc { core_type: _ }) => {
+                todo!("CM+GC")
+            }
+            (
+                DataModel::LinearMemory(LinearMemoryOptions {
+                    memory64: src64,
+                    memory: src_mem,
+                    realloc: _,
+                }),
+                DataModel::LinearMemory(LinearMemoryOptions {
+                    memory64: dst64,
+                    memory: dst_mem,
+                    realloc: _,
+                }),
+            ) => self.module.import_transcoder(Transcoder {
+                from_memory: src_mem.unwrap(),
+                from_memory64: src64,
+                to_memory: dst_mem.unwrap(),
+                to_memory64: dst64,
+                op,
+            }),
+        }
     }
 
     fn validate_string_inbounds(&mut self, s: &WasmString<'_>, byte_len: u32) {
-        self.validate_memory_inbounds(s.opts, s.ptr.idx, byte_len, Trap::StringLengthOverflow)
+        match &s.opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => {
+                self.validate_memory_inbounds(opts, s.ptr.idx, byte_len, Trap::StringLengthOverflow)
+            }
+        }
     }
 
     fn validate_memory_inbounds(
         &mut self,
-        opts: &Options,
+        opts: &LinearMemoryOptions,
         ptr_local: u32,
         byte_len_local: u32,
         trap: Trap,
@@ -2238,6 +2431,15 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst_ty: &InterfaceType,
         dst: &Destination,
     ) {
+        let src_mem_opts = match &src.opts().data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+        let dst_mem_opts = match &dst.opts().data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(opts) => opts,
+        };
+
         let src_element_ty = &self.types[src_ty].element;
         let dst_element_ty = match dst_ty {
             InterfaceType::List(r) => &self.types[*r].element,
@@ -2245,8 +2447,8 @@ impl<'a, 'b> Compiler<'a, 'b> {
         };
         let src_opts = src.opts();
         let dst_opts = dst.opts();
-        let (src_size, src_align) = self.types.size_align(src_opts, src_element_ty);
-        let (dst_size, dst_align) = self.types.size_align(dst_opts, dst_element_ty);
+        let (src_size, src_align) = self.types.size_align(src_mem_opts, src_element_ty);
+        let (dst_size, dst_align) = self.types.size_align(dst_mem_opts, dst_element_ty);
 
         // Load the pointer/length of this list into temporary locals. These
         // will be referenced a good deal so this just makes it easier to deal
@@ -2255,32 +2457,33 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Stack(s) => {
                 assert_eq!(s.locals.len(), 2);
-                self.stack_get(&s.slice(0..1), src_opts.ptr());
-                self.stack_get(&s.slice(1..2), src_opts.ptr());
+                self.stack_get(&s.slice(0..1), src_mem_opts.ptr());
+                self.stack_get(&s.slice(1..2), src_mem_opts.ptr());
             }
             Source::Memory(mem) => {
                 self.ptr_load(mem);
-                self.ptr_load(&mem.bump(src_opts.ptr_size().into()));
+                self.ptr_load(&mem.bump(src_mem_opts.ptr_size().into()));
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
-        let src_len = self.local_set_new_tmp(src_opts.ptr());
-        let src_ptr = self.local_set_new_tmp(src_opts.ptr());
+        let src_len = self.local_set_new_tmp(src_mem_opts.ptr());
+        let src_ptr = self.local_set_new_tmp(src_mem_opts.ptr());
 
         // Create a `Memory` operand which will internally assert that the
         // `src_ptr` value is properly aligned.
         let src_mem = self.memory_operand(src_opts, src_ptr, src_align);
 
         // Calculate the source/destination byte lengths into unique locals.
-        let src_byte_len = self.calculate_list_byte_len(src_opts, src_len.idx, src_size);
+        let src_byte_len = self.calculate_list_byte_len(src_mem_opts, src_len.idx, src_size);
         let dst_byte_len = if src_size == dst_size {
-            self.convert_src_len_to_dst(src_byte_len.idx, src_opts.ptr(), dst_opts.ptr());
-            self.local_set_new_tmp(dst_opts.ptr())
-        } else if src_opts.ptr() == dst_opts.ptr() {
-            self.calculate_list_byte_len(dst_opts, src_len.idx, dst_size)
+            self.convert_src_len_to_dst(src_byte_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+            self.local_set_new_tmp(dst_mem_opts.ptr())
+        } else if src_mem_opts.ptr() == dst_mem_opts.ptr() {
+            self.calculate_list_byte_len(dst_mem_opts, src_len.idx, dst_size)
         } else {
-            self.convert_src_len_to_dst(src_byte_len.idx, src_opts.ptr(), dst_opts.ptr());
-            let tmp = self.local_set_new_tmp(dst_opts.ptr());
-            let ret = self.calculate_list_byte_len(dst_opts, tmp.idx, dst_size);
+            self.convert_src_len_to_dst(src_byte_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+            let tmp = self.local_set_new_tmp(dst_mem_opts.ptr());
+            let ret = self.calculate_list_byte_len(dst_mem_opts, tmp.idx, dst_size);
             self.free_temp_local(tmp);
             ret
         };
@@ -2294,13 +2497,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
         // With all the pointers and byte lengths verity that both the source
         // and the destination buffers are in-bounds.
         self.validate_memory_inbounds(
-            src_opts,
+            src_mem_opts,
             src_mem.addr.idx,
             src_byte_len.idx,
             Trap::ListByteLengthOverflow,
         );
         self.validate_memory_inbounds(
-            dst_opts,
+            dst_mem_opts,
             dst_mem.addr.idx,
             dst_byte_len.idx,
             Trap::ListByteLengthOverflow,
@@ -2319,15 +2522,15 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
             // Set the `remaining` local and only continue if it's > 0
             self.instruction(LocalGet(src_len.idx));
-            let remaining = self.local_tee_new_tmp(src_opts.ptr());
-            self.ptr_eqz(src_opts);
+            let remaining = self.local_tee_new_tmp(src_mem_opts.ptr());
+            self.ptr_eqz(src_mem_opts);
             self.instruction(BrIf(0));
 
             // Initialize the two destination pointers to their initial values
             self.instruction(LocalGet(src_mem.addr.idx));
-            let cur_src_ptr = self.local_set_new_tmp(src_opts.ptr());
+            let cur_src_ptr = self.local_set_new_tmp(src_mem_opts.ptr());
             self.instruction(LocalGet(dst_mem.addr.idx));
-            let cur_dst_ptr = self.local_set_new_tmp(dst_opts.ptr());
+            let cur_dst_ptr = self.local_set_new_tmp(dst_mem_opts.ptr());
 
             self.instruction(Loop(BlockType::Empty));
 
@@ -2347,24 +2550,24 @@ impl<'a, 'b> Compiler<'a, 'b> {
             // Update the two loop pointers
             if src_size > 0 {
                 self.instruction(LocalGet(cur_src_ptr.idx));
-                self.ptr_uconst(src_opts, src_size);
-                self.ptr_add(src_opts);
+                self.ptr_uconst(src_mem_opts, src_size);
+                self.ptr_add(src_mem_opts);
                 self.instruction(LocalSet(cur_src_ptr.idx));
             }
             if dst_size > 0 {
                 self.instruction(LocalGet(cur_dst_ptr.idx));
-                self.ptr_uconst(dst_opts, dst_size);
-                self.ptr_add(dst_opts);
+                self.ptr_uconst(dst_mem_opts, dst_size);
+                self.ptr_add(dst_mem_opts);
                 self.instruction(LocalSet(cur_dst_ptr.idx));
             }
 
             // Update the remaining count, falling through to break out if it's zero
             // now.
             self.instruction(LocalGet(remaining.idx));
-            self.ptr_iconst(src_opts, -1);
-            self.ptr_add(src_opts);
+            self.ptr_iconst(src_mem_opts, -1);
+            self.ptr_add(src_mem_opts);
             self.instruction(LocalTee(remaining.idx));
-            self.ptr_br_if(src_opts, 0);
+            self.ptr_br_if(src_mem_opts, 0);
             self.instruction(End); // end of loop
             self.instruction(End); // end of block
 
@@ -2377,18 +2580,19 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Stack(s, _) => {
                 self.instruction(LocalGet(dst_mem.addr.idx));
-                self.stack_set(&s[..1], dst_opts.ptr());
-                self.convert_src_len_to_dst(src_len.idx, src_opts.ptr(), dst_opts.ptr());
-                self.stack_set(&s[1..], dst_opts.ptr());
+                self.stack_set(&s[..1], dst_mem_opts.ptr());
+                self.convert_src_len_to_dst(src_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+                self.stack_set(&s[1..], dst_mem_opts.ptr());
             }
             Destination::Memory(mem) => {
                 self.instruction(LocalGet(mem.addr.idx));
                 self.instruction(LocalGet(dst_mem.addr.idx));
                 self.ptr_store(mem);
                 self.instruction(LocalGet(mem.addr.idx));
-                self.convert_src_len_to_dst(src_len.idx, src_opts.ptr(), dst_opts.ptr());
-                self.ptr_store(&mem.bump(dst_opts.ptr_size().into()));
+                self.convert_src_len_to_dst(src_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+                self.ptr_store(&mem.bump(dst_mem_opts.ptr_size().into()));
             }
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
 
         self.free_temp_local(src_len);
@@ -2398,7 +2602,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
     fn calculate_list_byte_len(
         &mut self,
-        opts: &Options,
+        opts: &LinearMemoryOptions,
         len_local: u32,
         elt_size: u32,
     ) -> TempLocal {
@@ -2696,6 +2900,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 DiscriminantSize::Size2 => self.i32_load16u(mem),
                 DiscriminantSize::Size4 => self.i32_load(mem),
             },
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         let tmp = self.local_tee_new_tmp(ValType::I32);
 
@@ -2721,6 +2926,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                     DiscriminantSize::Size4 => self.i32_store(mem),
                 }
             }
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
         self.free_temp_local(tmp);
     }
@@ -2825,6 +3031,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 }
             },
             Destination::Memory(_) => BlockType::Empty,
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         };
         self.instruction(Block(outer_block_ty));
 
@@ -2850,6 +3057,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 DiscriminantSize::Size2 => self.i32_load16u(mem),
                 DiscriminantSize::Size4 => self.i32_load(mem),
             },
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
 
         // Generate the `br_table` for the discriminant. Each case has an
@@ -2888,6 +3096,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                     DiscriminantSize::Size2 => self.i32_store16(mem),
                     DiscriminantSize::Size4 => self.i32_store(mem),
                 },
+                Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
             }
 
             let src_payload = src.payload_src(self.types, src_info, src_ty);
@@ -3028,6 +3237,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match src {
             Source::Memory(mem) => self.i32_load(mem),
             Source::Stack(stack) => self.stack_get(stack, ValType::I32),
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
         self.instruction(I32Const(src_ty as i32));
         self.instruction(I32Const(dst_ty as i32));
@@ -3035,6 +3245,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         match dst {
             Destination::Memory(mem) => self.i32_store(mem),
             Destination::Stack(stack, _) => self.stack_set(stack, ValType::I32),
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -3069,7 +3280,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(GlobalSet(flags_global.as_u32()));
     }
 
-    fn verify_aligned(&mut self, opts: &Options, addr_local: u32, align: u32) {
+    fn verify_aligned(&mut self, opts: &LinearMemoryOptions, addr_local: u32, align: u32) {
         // If the alignment is 1 then everything is trivially aligned and the
         // check can be omitted.
         if align == 1 {
@@ -3085,36 +3296,42 @@ impl<'a, 'b> Compiler<'a, 'b> {
     }
 
     fn assert_aligned(&mut self, ty: &InterfaceType, mem: &Memory) {
+        let mem_opts = mem.mem_opts();
         if !self.module.debug {
             return;
         }
-        let align = self.types.align(mem.opts, ty);
+        let align = self.types.align(mem_opts, ty);
         if align == 1 {
             return;
         }
         assert!(align.is_power_of_two());
         self.instruction(LocalGet(mem.addr.idx));
-        self.ptr_uconst(mem.opts, mem.offset);
-        self.ptr_add(mem.opts);
-        self.ptr_uconst(mem.opts, align - 1);
-        self.ptr_and(mem.opts);
-        self.ptr_if(mem.opts, BlockType::Empty);
+        self.ptr_uconst(mem_opts, mem.offset);
+        self.ptr_add(mem_opts);
+        self.ptr_uconst(mem_opts, align - 1);
+        self.ptr_and(mem_opts);
+        self.ptr_if(mem_opts, BlockType::Empty);
         self.trap(Trap::AssertFailed("pointer not aligned"));
         self.instruction(End);
     }
 
     fn malloc<'c>(&mut self, opts: &'c Options, size: MallocSize, align: u32) -> Memory<'c> {
-        let realloc = opts.realloc.unwrap();
-        self.ptr_uconst(opts, 0);
-        self.ptr_uconst(opts, 0);
-        self.ptr_uconst(opts, align);
-        match size {
-            MallocSize::Const(size) => self.ptr_uconst(opts, size),
-            MallocSize::Local(idx) => self.instruction(LocalGet(idx)),
+        match &opts.data_model {
+            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::LinearMemory(mem_opts) => {
+                let realloc = mem_opts.realloc.unwrap();
+                self.ptr_uconst(mem_opts, 0);
+                self.ptr_uconst(mem_opts, 0);
+                self.ptr_uconst(mem_opts, align);
+                match size {
+                    MallocSize::Const(size) => self.ptr_uconst(mem_opts, size),
+                    MallocSize::Local(idx) => self.instruction(LocalGet(idx)),
+                }
+                self.instruction(Call(realloc.as_u32()));
+                let addr = self.local_set_new_tmp(mem_opts.ptr());
+                self.memory_operand(opts, addr, align)
+            }
         }
-        self.instruction(Call(realloc.as_u32()));
-        let addr = self.local_set_new_tmp(opts.ptr());
-        self.memory_operand(opts, addr, align)
     }
 
     fn memory_operand<'c>(&mut self, opts: &'c Options, addr: TempLocal, align: u32) -> Memory<'c> {
@@ -3123,7 +3340,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
             offset: 0,
             opts,
         };
-        self.verify_aligned(opts, ret.addr.idx, align);
+        self.verify_aligned(opts.data_model.unwrap_memory(), ret.addr.idx, align);
         ret
     }
 
@@ -3354,14 +3571,14 @@ impl<'a, 'b> Compiler<'a, 'b> {
     }
 
     fn ptr_load(&mut self, mem: &Memory) {
-        if mem.opts.memory64 {
+        if mem.mem_opts().memory64 {
             self.i64_load(mem);
         } else {
             self.i32_load(mem);
         }
     }
 
-    fn ptr_add(&mut self, opts: &Options) {
+    fn ptr_add(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Add);
         } else {
@@ -3369,7 +3586,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_sub(&mut self, opts: &Options) {
+    fn ptr_sub(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Sub);
         } else {
@@ -3377,7 +3594,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_mul(&mut self, opts: &Options) {
+    fn ptr_mul(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Mul);
         } else {
@@ -3385,7 +3602,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_ge_u(&mut self, opts: &Options) {
+    fn ptr_ge_u(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64GeU);
         } else {
@@ -3393,7 +3610,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_lt_u(&mut self, opts: &Options) {
+    fn ptr_lt_u(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64LtU);
         } else {
@@ -3401,7 +3618,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_shl(&mut self, opts: &Options) {
+    fn ptr_shl(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Shl);
         } else {
@@ -3409,7 +3626,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_eqz(&mut self, opts: &Options) {
+    fn ptr_eqz(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Eqz);
         } else {
@@ -3417,7 +3634,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_uconst(&mut self, opts: &Options, val: u32) {
+    fn ptr_uconst(&mut self, opts: &LinearMemoryOptions, val: u32) {
         if opts.memory64 {
             self.instruction(I64Const(val.into()));
         } else {
@@ -3425,7 +3642,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_iconst(&mut self, opts: &Options, val: i32) {
+    fn ptr_iconst(&mut self, opts: &LinearMemoryOptions, val: i32) {
         if opts.memory64 {
             self.instruction(I64Const(val.into()));
         } else {
@@ -3433,7 +3650,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_eq(&mut self, opts: &Options) {
+    fn ptr_eq(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Eq);
         } else {
@@ -3441,7 +3658,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_ne(&mut self, opts: &Options) {
+    fn ptr_ne(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Ne);
         } else {
@@ -3449,7 +3666,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_and(&mut self, opts: &Options) {
+    fn ptr_and(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64And);
         } else {
@@ -3457,7 +3674,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_or(&mut self, opts: &Options) {
+    fn ptr_or(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Or);
         } else {
@@ -3465,7 +3682,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_xor(&mut self, opts: &Options) {
+    fn ptr_xor(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
             self.instruction(I64Xor);
         } else {
@@ -3473,7 +3690,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_if(&mut self, opts: &Options, ty: BlockType) {
+    fn ptr_if(&mut self, opts: &LinearMemoryOptions, ty: BlockType) {
         if opts.memory64 {
             self.instruction(I64Const(0));
             self.instruction(I64Ne);
@@ -3481,7 +3698,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(If(ty));
     }
 
-    fn ptr_br_if(&mut self, opts: &Options, depth: u32) {
+    fn ptr_br_if(&mut self, opts: &LinearMemoryOptions, depth: u32) {
         if opts.memory64 {
             self.instruction(I64Const(0));
             self.instruction(I64Ne);
@@ -3522,7 +3739,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
     }
 
     fn ptr_store(&mut self, mem: &Memory) {
-        if mem.opts.memory64 {
+        if mem.mem_opts().memory64 {
             self.i64_store(mem);
         } else {
             self.i32_store(mem);
@@ -3564,6 +3781,8 @@ impl<'a> Source<'a> {
                 offset += cnt;
                 Source::Stack(stack.slice((offset - cnt) as usize..offset as usize))
             }
+            Source::Struct(_) => todo!(),
+            Source::Array(_) => todo!(),
         })
     }
 
@@ -3583,13 +3802,14 @@ impl<'a> Source<'a> {
                 Source::Stack(s.slice(1..s.locals.len()).slice(0..flat_len))
             }
             Source::Memory(mem) => {
-                let mem = if mem.opts.memory64 {
+                let mem = if mem.mem_opts().memory64 {
                     mem.bump(info.payload_offset64)
                 } else {
                     mem.bump(info.payload_offset32)
                 };
                 Source::Memory(mem)
             }
+            Source::Struct(_) | Source::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -3597,6 +3817,8 @@ impl<'a> Source<'a> {
         match self {
             Source::Stack(s) => s.opts,
             Source::Memory(mem) => mem.opts,
+            Source::Struct(s) => s.opts,
+            Source::Array(a) => a.opts,
         }
     }
 }
@@ -3623,6 +3845,8 @@ impl<'a> Destination<'a> {
                 offset += cnt;
                 Destination::Stack(&s[(offset - cnt) as usize..offset as usize], opts)
             }
+            Destination::Struct(_) => todo!(),
+            Destination::Array(_) => todo!(),
         })
     }
 
@@ -3642,13 +3866,14 @@ impl<'a> Destination<'a> {
                 Destination::Stack(&s[1..][..flat_len], opts)
             }
             Destination::Memory(mem) => {
-                let mem = if mem.opts.memory64 {
+                let mem = if mem.mem_opts().memory64 {
                     mem.bump(info.payload_offset64)
                 } else {
                     mem.bump(info.payload_offset32)
                 };
                 Destination::Memory(mem)
             }
+            Destination::Struct(_) | Destination::Array(_) => todo!("CM+GC"),
         }
     }
 
@@ -3656,6 +3881,8 @@ impl<'a> Destination<'a> {
         match self {
             Destination::Stack(_, opts) => opts,
             Destination::Memory(mem) => mem.opts,
+            Destination::Struct(s) => s.opts,
+            Destination::Array(a) => a.opts,
         }
     }
 }
@@ -3667,7 +3894,7 @@ fn next_field_offset<'a>(
     mem: &Memory<'a>,
 ) -> Memory<'a> {
     let abi = types.canonical_abi(field);
-    let offset = if mem.opts.memory64 {
+    let offset = if mem.mem_opts().memory64 {
         abi.next_field64(offset)
     } else {
         abi.next_field32(offset)
@@ -3680,7 +3907,7 @@ impl<'a> Memory<'a> {
         MemArg {
             offset: u64::from(self.offset),
             align,
-            memory_index: self.opts.memory.unwrap().as_u32(),
+            memory_index: self.mem_opts().memory.unwrap().as_u32(),
         }
     }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -27,7 +27,7 @@ use crate::fact::signature::Signature;
 use crate::fact::transcode::Transcoder;
 use crate::fact::traps::Trap;
 use crate::fact::{
-    AdapterData, Body, Context, Function, FunctionId, Helper, HelperLocation, HelperType,
+    AdapterData, Body, Function, FunctionId, Helper, HelperLocation, HelperType,
     LinearMemoryOptions, Module, Options,
 };
 use crate::prelude::*;
@@ -89,8 +89,8 @@ pub(super) fn compile(module: &mut Module<'_>, adapter: &AdapterData) {
         module: &'b mut Module<'a>,
         adapter: &AdapterData,
     ) -> (Compiler<'a, 'b>, Signature, Signature) {
-        let lower_sig = module.types.signature(&adapter.lower, Context::Lower);
-        let lift_sig = module.types.signature(&adapter.lift, Context::Lift);
+        let lower_sig = module.types.signature(&adapter.lower);
+        let lift_sig = module.types.signature(&adapter.lift);
         let ty = module
             .core_types
             .function(&lower_sig.params, &lower_sig.results);
@@ -243,7 +243,7 @@ pub(super) fn compile(module: &mut Module<'_>, adapter: &AdapterData) {
             // `async-return` function to write the result to the caller's
             // linear memory and deliver a `STATUS_RETURNED` event to the
             // caller.
-            let lift_sig = module.types.signature(&adapter.lift, Context::Lift);
+            let lift_sig = module.types.signature(&adapter.lift);
             let start = async_start_adapter(module);
             let return_ = async_return_adapter(module);
             let (compiler, lower_sig, ..) = compiler(module, adapter);

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -524,7 +524,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
             &adapter.name,
             &lower_sig.params,
             match adapter.lift.options.data_model {
-                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::Gc {} => todo!("CM+GC"),
                 DataModel::LinearMemory(LinearMemoryOptions { memory, .. }) => memory,
             },
         );
@@ -884,7 +884,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         } else {
             let abi = CanonicalAbiInfo::record(dst_tys.iter().map(|t| self.types.canonical_abi(t)));
             match lift_opts.data_model {
-                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::Gc {} => todo!("CM+GC"),
                 DataModel::LinearMemory(LinearMemoryOptions { memory64, .. }) => {
                     let (size, align) = if memory64 {
                         (abi.size64, abi.align64)
@@ -1526,11 +1526,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         let dst_opts = dst.opts();
 
         let src_mem_opts = match &src_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -1689,13 +1689,13 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
         let src_mem_opts = {
             match &src.opts.data_model {
-                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::Gc {} => todo!("CM+GC"),
                 DataModel::LinearMemory(opts) => opts,
             }
         };
         let dst_mem_opts = {
             match &dst_opts.data_model {
-                DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+                DataModel::Gc {} => todo!("CM+GC"),
                 DataModel::LinearMemory(opts) => opts,
             }
         };
@@ -1796,11 +1796,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
         let src_mem_opts = match &src.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -1993,11 +1993,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
         let src_mem_opts = match &src.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -2048,7 +2048,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.ptr_uconst(dst_mem_opts, 1);
         self.ptr_shl(dst_mem_opts);
         self.instruction(Call(match dst.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(LinearMemoryOptions { realloc, .. }) => {
                 realloc.unwrap().as_u32()
             }
@@ -2080,11 +2080,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
         let src_mem_opts = match &src.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -2168,11 +2168,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst_opts: &'c Options,
     ) -> WasmString<'c> {
         let src_mem_opts = match &src.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst_opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -2315,7 +2315,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
     fn validate_string_length_u8(&mut self, s: &WasmString<'_>, dst: u8) {
         let mem_opts = match &s.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -2337,7 +2337,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         op: Transcode,
     ) -> FuncIndex {
         match (src.opts.data_model, dst.opts.data_model) {
-            (DataModel::Gc { core_type: _ }, _) | (_, DataModel::Gc { core_type: _ }) => {
+            (DataModel::Gc {}, _) | (_, DataModel::Gc {}) => {
                 todo!("CM+GC")
             }
             (
@@ -2363,7 +2363,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
     fn validate_string_inbounds(&mut self, s: &WasmString<'_>, byte_len: u32) {
         match &s.opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => {
                 self.validate_memory_inbounds(opts, s.ptr.idx, byte_len, Trap::StringLengthOverflow)
             }
@@ -2432,11 +2432,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         dst: &Destination,
     ) {
         let src_mem_opts = match &src.opts().data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
         let dst_mem_opts = match &dst.opts().data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(opts) => opts,
         };
 
@@ -3317,7 +3317,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
     fn malloc<'c>(&mut self, opts: &'c Options, size: MallocSize, align: u32) -> Memory<'c> {
         match &opts.data_model {
-            DataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            DataModel::Gc {} => todo!("CM+GC"),
             DataModel::LinearMemory(mem_opts) => {
                 let realloc = mem_opts.realloc.unwrap();
                 self.ptr_uconst(mem_opts, 0);

--- a/crates/environ/src/scopevec.rs
+++ b/crates/environ/src/scopevec.rs
@@ -57,6 +57,11 @@ impl<T> ScopeVec<T> {
         // all of `data` after the data has been pushed onto our internal list.
         unsafe { core::slice::from_raw_parts_mut(ptr, len) }
     }
+
+    /// Iterate over items in this `ScopeVec`, consuming ownership.
+    pub fn into_iter(self) -> impl ExactSizeIterator<Item = Box<[T]>> {
+        self.data.into_inner().into_iter()
+    }
 }
 
 #[cfg(test)]

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -143,6 +143,7 @@ impl Config {
             component_model_async_builtins,
             component_model_async_stackful,
             component_model_error_context,
+            component_model_gc,
             simd,
             exceptions,
             legacy_exceptions,
@@ -166,6 +167,7 @@ impl Config {
         self.module_config.component_model_error_context =
             component_model_error_context.unwrap_or(false);
         self.module_config.legacy_exceptions = legacy_exceptions.unwrap_or(false);
+        self.module_config.component_model_gc = component_model_gc.unwrap_or(false);
 
         // Enable/disable proposals that wasm-smith has knobs for which will be
         // read when creating `wasmtime::Config`.

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -20,6 +20,7 @@ pub struct ModuleConfig {
     pub component_model_async_builtins: bool,
     pub component_model_async_stackful: bool,
     pub component_model_error_context: bool,
+    pub component_model_gc: bool,
     pub legacy_exceptions: bool,
 }
 
@@ -70,6 +71,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
             component_model_async_builtins: false,
             component_model_async_stackful: false,
             component_model_error_context: false,
+            component_model_gc: false,
             legacy_exceptions: false,
             function_references_enabled: config.gc_enabled,
             config,

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -41,6 +41,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         component_model_async_builtins,
         component_model_async_stackful,
         component_model_error_context,
+        component_model_gc,
         nan_canonicalization,
         simd,
         exceptions,
@@ -67,6 +68,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let component_model_async_builtins = component_model_async_builtins.unwrap_or(false);
     let component_model_async_stackful = component_model_async_stackful.unwrap_or(false);
     let component_model_error_context = component_model_error_context.unwrap_or(false);
+    let component_model_gc = component_model_gc.unwrap_or(false);
     let nan_canonicalization = nan_canonicalization.unwrap_or(false);
     let relaxed_simd = relaxed_simd.unwrap_or(false);
     let legacy_exceptions = legacy_exceptions.unwrap_or(false);
@@ -101,6 +103,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         .wasm_component_model_async_builtins(component_model_async_builtins)
         .wasm_component_model_async_stackful(component_model_async_stackful)
         .wasm_component_model_error_context(component_model_error_context)
+        .wasm_component_model_gc(component_model_gc)
         .wasm_exceptions(exceptions)
         .wasm_stack_switching(stack_switching)
         .cranelift_nan_canonicalization(nan_canonicalization);

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -245,6 +245,7 @@ macro_rules! foreach_config_option {
             component_model_async_builtins
             component_model_async_stackful
             component_model_error_context
+            component_model_gc
             simd
             gc_types
             exceptions

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -15,13 +15,13 @@ use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
 use std::path::Path;
-use wasmtime_environ::TypeTrace;
 use wasmtime_environ::component::{
     AllCallFunc, CanonicalOptions, CompiledComponentInfo, ComponentArtifacts, ComponentTypes,
     CoreDef, Export, ExportIndex, GlobalInitializer, InstantiateModule, NameMapNoIntern,
     StaticModuleIndex, TrampolineIndex, TypeComponentIndex, TypeFuncIndex, VMComponentOffsets,
 };
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
+use wasmtime_environ::{ModuleInternedTypeIndex, TypeTrace};
 
 /// A compiled WebAssembly Component.
 ///
@@ -834,9 +834,19 @@ impl Component {
     pub(crate) fn export_lifted_function(
         &self,
         export: ExportIndex,
-    ) -> (TypeFuncIndex, &CoreDef, &CanonicalOptions) {
+    ) -> (
+        TypeFuncIndex,
+        &CoreDef,
+        ModuleInternedTypeIndex,
+        &CanonicalOptions,
+    ) {
         match &self.env_component().export_items[export] {
-            Export::LiftedFunction { ty, func, options } => (*ty, func, options),
+            Export::LiftedFunction {
+                ty,
+                func,
+                func_ty,
+                options,
+            } => (*ty, func, *func_ty, options),
             _ => unreachable!(),
         }
     }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -15,13 +15,13 @@ use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
 use std::path::Path;
+use wasmtime_environ::TypeTrace;
 use wasmtime_environ::component::{
     AllCallFunc, CanonicalOptions, CompiledComponentInfo, ComponentArtifacts, ComponentTypes,
     CoreDef, Export, ExportIndex, GlobalInitializer, InstantiateModule, NameMapNoIntern,
     StaticModuleIndex, TrampolineIndex, TypeComponentIndex, TypeFuncIndex, VMComponentOffsets,
 };
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
-use wasmtime_environ::{ModuleInternedTypeIndex, TypeTrace};
 
 /// A compiled WebAssembly Component.
 ///
@@ -834,19 +834,9 @@ impl Component {
     pub(crate) fn export_lifted_function(
         &self,
         export: ExportIndex,
-    ) -> (
-        TypeFuncIndex,
-        &CoreDef,
-        ModuleInternedTypeIndex,
-        &CanonicalOptions,
-    ) {
+    ) -> (TypeFuncIndex, &CoreDef, &CanonicalOptions) {
         match &self.env_component().export_items[export] {
-            Export::LiftedFunction {
-                ty,
-                func,
-                func_ty,
-                options,
-            } => (*ty, func, *func_ty, options),
+            Export::LiftedFunction { ty, func, options } => (*ty, func, options),
             _ => unreachable!(),
         }
     }

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -208,7 +208,7 @@ impl Func {
 
     fn ty(&self, store: &StoreOpaque) -> TypeFuncIndex {
         let instance = self.instance.id().get(store);
-        let (ty, _, _, _) = instance.component().export_lifted_function(self.index);
+        let (ty, _, _) = instance.component().export_lifted_function(self.index);
         ty
     }
 
@@ -380,7 +380,7 @@ impl Func {
     {
         let vminstance = self.instance.id().get(store.0);
         let component = vminstance.component().clone();
-        let (ty, def, _core_ty, options) = component.export_lifted_function(self.index);
+        let (ty, def, options) = component.export_lifted_function(self.index);
 
         let mem_opts = match options.data_model {
             CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
@@ -559,7 +559,7 @@ impl Func {
         let mut store = store.as_context_mut();
         let index = self.index;
         let vminstance = self.instance.id().get(store.0);
-        let (_ty, _def, _core_ty, options) = vminstance.component().export_lifted_function(index);
+        let (_ty, _def, options) = vminstance.component().export_lifted_function(index);
         let post_return = options.post_return.map(|i| {
             let func_ref = vminstance.runtime_post_return(i);
             ExportFunction { func_ref }

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -383,7 +383,7 @@ impl Func {
         let (ty, def, _core_ty, options) = component.export_lifted_function(self.index);
 
         let mem_opts = match options.data_model {
-            CanonicalOptionsDataModel::Gc { core_type: _ } => todo!("CM+GC"),
+            CanonicalOptionsDataModel::Gc {} => todo!("CM+GC"),
             CanonicalOptionsDataModel::LinearMemory(opts) => opts,
         };
 

--- a/tests/misc_testsuite/component-model-gc/empty.wast
+++ b/tests/misc_testsuite/component-model-gc/empty.wast
@@ -1,0 +1,130 @@
+;;! component_model_gc = true
+;;! gc = true
+;;! reference_types = true
+;;! gc_types = true
+;;! multi_memory = true
+
+;; GC calling GC.
+(component
+  (component $A
+    (core module $m
+      (func (export "f"))
+    )
+    (core instance $i (instantiate $m))
+
+    (core type $ty (func))
+    (func (export "f")
+      (canon lift (core func $i "f") gc)
+    )
+  )
+
+  (component $B
+    (import "f" (func $f))
+
+    (core type $ty (func))
+    (core func $f' (canon lower (func $f) gc (core-type $ty)))
+
+    (core module $m
+      (import "" "f" (func $f))
+      (func (export "f")
+        call $f
+      )
+    )
+
+    (core instance $i (instantiate $m
+      (with "" (instance (export "f" (func $f'))))
+    ))
+
+    (func (export "f") (canon lift (core func $i "f")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+
+  (func (export "f") (alias export $b "f"))
+)
+
+(assert_return (invoke "f"))
+
+;; GC calling linear memory.
+(component
+  (component $A
+    (core module $m
+      (func (export "f"))
+    )
+    (core instance $i (instantiate $m))
+
+    (core type $ty (func))
+    (func (export "f")
+      (canon lift (core func $i "f"))
+    )
+  )
+
+  (component $B
+    (import "f" (func $f))
+
+    (core type $ty (func))
+    (core func $f' (canon lower (func $f) gc (core-type $ty)))
+
+    (core module $m
+      (import "" "f" (func $f))
+      (func (export "f")
+        call $f
+      )
+    )
+
+    (core instance $i (instantiate $m
+      (with "" (instance (export "f" (func $f'))))
+    ))
+
+    (func (export "f") (canon lift (core func $i "f")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+
+  (func (export "f") (alias export $b "f"))
+)
+
+(assert_return (invoke "f"))
+
+;; Linear memory calling GC.
+(component
+  (component $A
+    (core module $m
+      (func (export "f"))
+    )
+    (core instance $i (instantiate $m))
+
+    (core type $ty (func))
+    (func (export "f")
+      (canon lift (core func $i "f") gc)
+    )
+  )
+
+  (component $B
+    (import "f" (func $f))
+
+    (core func $f' (canon lower (func $f)))
+
+    (core module $m
+      (import "" "f" (func $f))
+      (func (export "f")
+        call $f
+      )
+    )
+
+    (core instance $i (instantiate $m
+      (with "" (instance (export "f" (func $f'))))
+    ))
+
+    (func (export "f") (canon lift (core func $i "f")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+
+  (func (export "f") (alias export $b "f"))
+)
+
+(assert_return (invoke "f"))


### PR DESCRIPTION
This lays down the initial infrastructure for support for GC in our fused adapters for the component model. We keep track of whether each lifted/lowered function wants args/results as GC values or in linear memory. We additionally plumb through the core function types of the functions being lifted and lowered for (eventual) use with GC adapters.

Ultimately, this commit is enough to fuse together lifted and lowered functions where one or both are using the GC variant of the canonical ABI. Attempting to actually pass arguments will hit `todo!()`s. The work of implementing those `todo!()`s is left to future commits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
