### PR TITLE
x64: Drop the REX prefix in a few more cases

### DIFF
--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -39,7 +39,7 @@ impl<R: AsReg> Amode<R> {
     pub(crate) fn as_rex_prefix(&self, enc_reg: u8, has_w_bit: bool, uses_8bit: bool) -> RexPrefix {
         match self {
             Amode::ImmReg { base, .. } => {
-                RexPrefix::two_op(enc_reg, base.enc(), has_w_bit, uses_8bit)
+                RexPrefix::mem_op(enc_reg, base.enc(), has_w_bit, uses_8bit)
             }
             Amode::ImmRegRegShift { base, index, .. } => {
                 RexPrefix::three_op(enc_reg, index.enc(), base.enc(), has_w_bit, uses_8bit)

--- a/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/x64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -23,20 +23,23 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    %rdx, %r9
 ;;       addq    0x2a(%rip), %r9
-;;       jb      0x30
+;;       jb      0x2f
 ;;   14: cmpq    0x40(%rdi), %r9
-;;       ja      0x32
+;;       ja      0x31
 ;;   1e: addq    0x38(%rdi), %rdx
 ;;       movl    $0xffff0000, %esi
 ;;       movb    %cl, (%rdx, %rsi)
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   30: ud2
-;;   32: ud2
-;;   34: addb    %al, (%rax)
-;;   36: addb    %al, (%rax)
-;;   38: addl    %eax, (%rax)
+;;   2f: ud2
+;;   31: ud2
+;;   33: addb    %al, (%rax)
+;;   35: addb    %al, (%rax)
+;;   37: addb    %al, (%rcx)
+;;   39: addb    %bh, %bh
+;;   3b: incl    (%rax)
+;;   3d: addb    %al, (%rax)
 ;;
 ;; wasm[0]::function[1]:
 ;;       pushq   %rbp

--- a/tests/disas/winch/x64/store/oob.wat
+++ b/tests/disas/winch/x64/store/oob.wat
@@ -17,7 +17,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8d
+;;       ja      0x8c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -29,9 +29,9 @@
 ;;       movl    %ecx, %ebx
 ;;       movabsq $0x100000000, %r11
 ;;       addq    %r11, %rbx
-;;       jb      0x8f
+;;       jb      0x8e
 ;;   56: cmpq    %rdx, %rbx
-;;       ja      0x91
+;;       ja      0x90
 ;;   5f: movq    0x38(%r14), %rsi
 ;;       addq    %rcx, %rsi
 ;;       movabsq $0xffffffff, %r11
@@ -43,6 +43,6 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8d: ud2
-;;   8f: ud2
-;;   91: ud2
+;;   8c: ud2
+;;   8e: ud2
+;;   90: ud2


### PR DESCRIPTION
This commit fixes a few cases where a REX prefix is emitted for an instruction but was not actually required. The REX prefix is unconditionally emitted in situations where 8-bit registers are referenced and one of the registers referenced has an encoding between 4-7. This logic was mistakenly applied to addressing modes as well, however, where 8-bit registers are not referenced and instead 64-bit registers are used.

This commit adds a few comments, refactors a few things, and makes it such that "special registers" are not tested for operands to addressing modes (e.g. the base register).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
