### PR TITLE
x64: Fix float lowering for `scalar_to_vector`

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4780,12 +4780,14 @@
 
 ;; Rules for `scalar_to_vector` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Case 1: when moving a scalar float, we simply move from one XMM register
-;; to another, expecting the register allocator to elide this. Here we
-;; assume that the upper bits of a scalar float have not been munged with
-;; (the same assumption the old backend makes).
-(rule 1 (lower (scalar_to_vector src @ (value_type (ty_scalar_float _))))
-      src)
+;; Case 1: when moving a scalar float the `movss` and `movsd` variants with
+;; xmm-register-to-xmm-register semantics are used to modify only the low bits
+;; of a guaranteed-zero register. This ensures that the upper bits are cleared
+;; as the upper bits of `src` in a register are otherwise undefined.
+(rule 1 (lower (scalar_to_vector src @ (value_type $F32)))
+  (x64_movss_regmove (xmm_zero $F32X4) src))
+(rule 1 (lower (scalar_to_vector src @ (value_type $F64)))
+  (x64_movsd_regmove (xmm_zero $F64X2) src))
 
 ;; Case 2: when moving a scalar value of any other type, use MOVD to zero
 ;; the upper lanes.

--- a/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
@@ -67,14 +67,22 @@ block0(v0: f64, v1: f64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addsd %xmm1, %xmm0
-;   movabsq $9221120237041090560, %r9
-;   movq %r9, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmppd   $3, %xmm7, %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movabsq $9221120237041090560, %rcx
+;   movq %rcx, %xmm6
+;   uninit  %xmm5
+;   xorpd %xmm5, %xmm5
+;   movsd %xmm6, %xmm5
+;   uninit  %xmm0
+;   xorpd %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movsd %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmppd   $3, %xmm6, %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -85,14 +93,20 @@ block0(v0: f64, v1: f64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addsd %xmm1, %xmm0
-;   movabsq $0x7ff8000000000000, %r9
-;   movq %r9, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpunordpd %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movabsq $0x7ff8000000000000, %rcx
+;   movq %rcx, %xmm6
+;   xorpd %xmm5, %xmm5
+;   movsd %xmm6, %xmm5
+;   xorpd %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movsd %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpunordpd %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -108,14 +122,22 @@ block0(v0: f32, v1: f32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addss %xmm1, %xmm0
-;   movl    $2143289344, %r9d
-;   movd %r9d, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpps   $3, %xmm7, %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movl    $2143289344, %ecx
+;   movd %ecx, %xmm6
+;   uninit  %xmm5
+;   xorps %xmm5, %xmm5
+;   movss %xmm6, %xmm5
+;   uninit  %xmm0
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movss %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpps   $3, %xmm6, %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -126,14 +148,20 @@ block0(v0: f32, v1: f32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addss %xmm1, %xmm0
-;   movl $0x7fc00000, %r9d
-;   movd %r9d, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpunordps %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movl $0x7fc00000, %ecx
+;   movd %ecx, %xmm6
+;   xorps %xmm5, %xmm5
+;   movss %xmm6, %xmm5
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movss %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpunordps %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
@@ -67,14 +67,22 @@ block0(v0: f64, v1: f64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addsd %xmm1, %xmm0
-;   movabsq $9221120237041090560, %r9
-;   movq %r9, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmppd   $3, %xmm7, %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movabsq $9221120237041090560, %rcx
+;   movq %rcx, %xmm6
+;   uninit  %xmm5
+;   xorpd %xmm5, %xmm5
+;   movsd %xmm6, %xmm5
+;   uninit  %xmm0
+;   xorpd %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movsd %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmppd   $3, %xmm6, %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -85,14 +93,20 @@ block0(v0: f64, v1: f64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addsd %xmm1, %xmm0
-;   movabsq $0x7ff8000000000000, %r9
-;   movq %r9, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpunordpd %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movabsq $0x7ff8000000000000, %rcx
+;   movq %rcx, %xmm6
+;   xorpd %xmm5, %xmm5
+;   movsd %xmm6, %xmm5
+;   xorpd %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movsd %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpunordpd %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -108,14 +122,22 @@ block0(v0: f32, v1: f32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addss %xmm1, %xmm0
-;   movl    $2143289344, %r9d
-;   movd %r9d, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpps   $3, %xmm7, %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movl    $2143289344, %ecx
+;   movd %ecx, %xmm6
+;   uninit  %xmm5
+;   xorps %xmm5, %xmm5
+;   movss %xmm6, %xmm5
+;   uninit  %xmm0
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movss %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpps   $3, %xmm6, %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -126,14 +148,20 @@ block0(v0: f32, v1: f32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addss %xmm1, %xmm0
-;   movl $0x7fc00000, %r9d
-;   movd %r9d, %xmm1
 ;   movdqa %xmm0, %xmm7
-;   cmpunordps %xmm0, %xmm7
-;   movdqa %xmm0, %xmm5
-;   movdqa %xmm7, %xmm0
-;   pblendvb %xmm0, %xmm1, %xmm5
-;   movdqa %xmm5, %xmm0
+;   movl $0x7fc00000, %ecx
+;   movd %ecx, %xmm6
+;   xorps %xmm5, %xmm5
+;   movss %xmm6, %xmm5
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm7, %xmm6
+;   movss %xmm6, %xmm0
+;   movdqa %xmm0, %xmm6
+;   cmpunordps %xmm0, %xmm6
+;   movdqa %xmm0, %xmm3
+;   movdqa %xmm6, %xmm0
+;   pblendvb %xmm0, %xmm5, %xmm3
+;   movdqa %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
@@ -62,13 +62,19 @@ block0(v0: f64, v1: f64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addsd %xmm1, %xmm0
-;   movdqa %xmm0, %xmm7
-;   movabsq $9221120237041090560, %r11
-;   movq %r11, %xmm5
+;   movabsq $9221120237041090560, %r8
+;   movq %r8, %xmm1
+;   uninit  %xmm6
+;   xorpd %xmm6, %xmm6
+;   movsd %xmm1, %xmm6
+;   uninit  %xmm7
+;   xorpd %xmm7, %xmm7
+;   movsd %xmm0, %xmm7
+;   movdqa %xmm7, %xmm0
 ;   cmppd   $3, %xmm0, %xmm7, %xmm0
-;   andpd %xmm0, %xmm5
+;   andpd %xmm0, %xmm6
 ;   andnpd %xmm7, %xmm0
-;   orpd %xmm5, %xmm0
+;   orpd %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -79,13 +85,17 @@ block0(v0: f64, v1: f64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addsd %xmm1, %xmm0
-;   movdqa %xmm0, %xmm7
-;   movabsq $0x7ff8000000000000, %r11
-;   movq %r11, %xmm5
+;   movabsq $0x7ff8000000000000, %r8
+;   movq %r8, %xmm1
+;   xorpd %xmm6, %xmm6
+;   movsd %xmm1, %xmm6
+;   xorpd %xmm7, %xmm7
+;   movsd %xmm0, %xmm7
+;   movdqa %xmm7, %xmm0
 ;   cmpunordpd %xmm7, %xmm0
-;   andpd %xmm0, %xmm5
+;   andpd %xmm0, %xmm6
 ;   andnpd %xmm7, %xmm0
-;   orpd %xmm5, %xmm0
+;   orpd %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -101,13 +111,19 @@ block0(v0: f32, v1: f32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   addss %xmm1, %xmm0
-;   movdqa %xmm0, %xmm7
-;   movl    $2143289344, %r11d
-;   movd %r11d, %xmm5
+;   movl    $2143289344, %r8d
+;   movd %r8d, %xmm1
+;   uninit  %xmm6
+;   xorps %xmm6, %xmm6
+;   movss %xmm1, %xmm6
+;   uninit  %xmm7
+;   xorps %xmm7, %xmm7
+;   movss %xmm0, %xmm7
+;   movdqa %xmm7, %xmm0
 ;   cmpps   $3, %xmm0, %xmm7, %xmm0
-;   andps %xmm0, %xmm5
+;   andps %xmm0, %xmm6
 ;   andnps %xmm7, %xmm0
-;   orps %xmm5, %xmm0
+;   orps %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -118,13 +134,17 @@ block0(v0: f32, v1: f32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   addss %xmm1, %xmm0
-;   movdqa %xmm0, %xmm7
-;   movl $0x7fc00000, %r11d
-;   movd %r11d, %xmm5
+;   movl $0x7fc00000, %r8d
+;   movd %r8d, %xmm1
+;   xorps %xmm6, %xmm6
+;   movss %xmm1, %xmm6
+;   xorps %xmm7, %xmm7
+;   movss %xmm0, %xmm7
+;   movdqa %xmm7, %xmm0
 ;   cmpunordps %xmm7, %xmm0
-;   andps %xmm0, %xmm5
+;   andps %xmm0, %xmm6
 ;   andnps %xmm7, %xmm0
-;   orps %xmm5, %xmm0
+;   orps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -322,6 +322,11 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   movdqa %xmm0, %xmm5
+;   uninit  %xmm0
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm5, %xmm7
+;   movss %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -331,6 +336,10 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   xorps %xmm0, %xmm0
+;   movdqa %xmm5, %xmm7
+;   movss %xmm7, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
+++ b/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
@@ -1,0 +1,62 @@
+;; This is a test case from #11024
+
+test interpret
+test run
+set opt_level=none
+set preserve_frame_pointers=true
+set enable_multi_ret_implicit_sret=true
+target aarch64
+target s390x
+target x86_64
+target x86_64 sse42
+target x86_64 sse42 has_avx
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
+
+function u1:1() -> f64 fast {
+    ss0 = explicit_slot 32
+
+block0():
+    v1 = f64const 0x1.d707d3c2dd690p-1
+
+    v7 = stack_addr.i64 ss0
+    v8 = load.f32x4 little v7+8
+    return v1
+}
+function %main() -> i64x2,f64,f64x2 fast {
+    ss0 = explicit_slot 32
+    ss1 = explicit_slot 32
+    sig0 = () -> f64 fast
+    fn0 = u1:1 sig0
+    const0 = 0x655a67ef3826115b29aeb0d774a11922
+
+block0:
+
+    v1 = iconst.i64 -8142416529737083292
+    v2 = vconst.i64x2 const0
+
+    v3 = stack_addr.i64 ss0
+    v4 = stack_addr.i64 ss1
+
+    store little v1, v3
+    store little v1, v3+8
+    store little v1, v3+16
+    store little v1, v3+24
+
+    store little v1, v4
+    store little v1, v4+8
+    store little v1, v4+16
+    store little v1, v4+24
+
+    v5 = stack_addr.i64 ss1
+    atomic_store little v1, v5
+
+    v6 = fcvt_from_uint.f64 v1
+    v7 = scalar_to_vector.f64x2 v6
+
+    v8 = call fn0()
+    return v2,v6,v7
+}
+
+
+; run: %main() == [0x655a67ef3826115b29aeb0d774a11922, 0x1.1e00a69cf7813p63, 0x000000000000000043e1e00a69cf7813]

--- a/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
+++ b/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
@@ -10,8 +10,9 @@ target s390x
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
-target riscv64 has_v
-target riscv64 has_v has_c has_zcb
+;; FIXME(#11011 maybe?) this test doesn't work on risc-v
+:target riscv64 has_v
+;target riscv64 has_v has_c has_zcb
 
 function u1:1() -> f64 fast {
     ss0 = explicit_slot 32

--- a/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
+++ b/cranelift/filetests/filetests/runtests/scalar-to-vector-upper-bits-zero.clif
@@ -11,8 +11,8 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 ;; FIXME(#11011 maybe?) this test doesn't work on risc-v
-:target riscv64 has_v
-;target riscv64 has_v has_c has_zcb
+;:target riscv64 has_v
+;;target riscv64 has_v has_c has_zcb
 
 function u1:1() -> f64 fast {
     ss0 = explicit_slot 32


### PR DESCRIPTION
The current logic traces back to #2489 but I think has been buggy ever since. The semantics of the CLIF `scalar_to_vector` instruction is that the upper bits are zeroed in the resulting vector but Cranelift otherwise leaves the upper bits of registers undefined. This means that a float scalar to vector must actively zero the upper bits rather than leave the preserved.

Closes #11024

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
