### PR TITLE
winch(aarch64) Run integration tests in winch-aarch64

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -151,6 +151,7 @@ impl Config {
             nan_canonicalization: _,
             gc_types: _,
             stack_switching: _,
+            ..
         } = test.config;
 
         // Enable/disable some proposals that aren't configurable in wasm-smith

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -151,7 +151,7 @@ impl Config {
             nan_canonicalization: _,
             gc_types: _,
             stack_switching: _,
-            ..
+            spec_test: _,
         } = test.config;
 
         // Enable/disable some proposals that aren't configurable in wasm-smith

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -198,7 +198,6 @@ impl ToTokens for Fn {
 
 pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let mut test_config = TestConfig::default();
-    test_config.flags.integration = Some(true);
 
     let config_parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("strategies") {

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -198,6 +198,7 @@ impl ToTokens for Fn {
 
 pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let mut test_config = TestConfig::default();
+    test_config.flags.integration = Some(true);
 
     let config_parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("strategies") {
@@ -220,17 +221,7 @@ pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
-    let mut tests = if test_config.strategies == [Compiler::Winch] {
-        vec![quote! {
-            // This prevents dead code warning when the macro is invoked as:
-            //     #[wasmtime_test(strategies(only(Winch))]
-            // Given that Winch only fully supports x86_64.
-            #[allow(dead_code)]
-            #func
-        }]
-    } else {
-        vec![quote! { #func }]
-    };
+    let mut tests = vec![quote! { #func }];
     let attrs = &func.attrs;
 
     let test_attr = test_config

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -220,7 +220,17 @@ pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
-    let mut tests = vec![quote! { #func }];
+    let mut tests = if test_config.strategies == [Compiler::Winch] {
+        vec![quote! {
+            // This prevents dead code warning when the macro is invoked as:
+            //     #[wasmtime_test(strategies(only(Winch))]
+            // Given that Winch only fully supports x86_64 / aarch64.
+            #[allow(dead_code)]
+            #func
+        }]
+    } else {
+        vec![quote! { #func }]
+    };
     let attrs = &func.attrs;
 
     let test_attr = test_config

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -243,7 +243,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
         // Winch currently only offers support for x64, and it requires
         // signals-based-traps which MIRI disables so disable winch tests on MIRI
         let target = if *strategy == Compiler::Winch {
-            quote! { #[cfg(all(target_arch = "x86_64", not(miri)))] }
+            quote! { #[cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), not(miri)))] }
         } else {
             quote! {}
         };

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -49,6 +49,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
 
         hogs_memory: _,
         gc_types: _,
+        ..
     } = *test_config;
     // Note that all of these proposals/features are currently default-off to
     // ensure that we annotate all tests accurately with what features they

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -49,7 +49,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
 
         hogs_memory: _,
         gc_types: _,
-        ..
+        spec_test: _,
     } = *test_config;
     // Note that all of these proposals/features are currently default-off to
     // ensure that we annotate all tests accurately with what features they

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -249,6 +249,7 @@ macro_rules! foreach_config_option {
             exceptions
             legacy_exceptions
             stack_switching
+        integration
         }
     };
 }
@@ -270,7 +271,6 @@ macro_rules! define_test_config {
                 }
             )*
         }
-
     }
 }
 
@@ -361,8 +361,8 @@ impl Compiler {
                 if cfg!(target_arch = "aarch64") {
                     return unsupported_base
                         || config.wide_arithmetic()
-                        || config.threads()
-                        || config.simd();
+                        || (config.simd() && config.integration())
+                        || config.threads();
                 }
 
                 false

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -72,6 +72,7 @@ fn add_tests(tests: &mut Vec<WastTest>, path: &Path, has_config: bool) -> Result
 
 fn spec_test_config(test: &Path) -> TestConfig {
     let mut ret = TestConfig::default();
+    ret.spec_test = Some(true);
     match spec_proposal_from_path(test) {
         Some("multi-memory") => {
             ret.multi_memory = Some(true);
@@ -249,7 +250,7 @@ macro_rules! foreach_config_option {
             exceptions
             legacy_exceptions
             stack_switching
-        integration
+            spec_test
         }
     };
 }
@@ -361,7 +362,7 @@ impl Compiler {
                 if cfg!(target_arch = "aarch64") {
                     return unsupported_base
                         || config.wide_arithmetic()
-                        || (config.simd() && config.integration())
+                        || (config.simd() && !config.spec_test())
                         || config.threads();
                 }
 

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -359,7 +359,7 @@ impl Compiler {
                 }
 
                 if cfg!(target_arch = "aarch64") {
-                    return unsupported_base || config.wide_arithmetic() || config.threads();
+                    return unsupported_base || config.wide_arithmetic() || config.threads() || config.simd();
                 }
 
                 false

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -359,7 +359,10 @@ impl Compiler {
                 }
 
                 if cfg!(target_arch = "aarch64") {
-                    return unsupported_base || config.wide_arithmetic() || config.threads() || config.simd();
+                    return unsupported_base
+                        || config.wide_arithmetic()
+                        || config.threads()
+                        || config.simd();
                 }
 
                 false

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2001,7 +2001,7 @@ fn call_wasm_getting_subtype_func_return(config: &mut Config) -> anyhow::Result<
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(simd), strategies(not(Winch)))]
+#[wasmtime_test(wasm_features(simd))]
 #[cfg_attr(miri, ignore)]
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128(config: &mut Config) -> anyhow::Result<()> {

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2001,7 +2001,7 @@ fn call_wasm_getting_subtype_func_return(config: &mut Config) -> anyhow::Result<
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(simd))]
+#[wasmtime_test(wasm_features(simd), strategies(not(Winch)))]
 #[cfg_attr(miri, ignore)]
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128(config: &mut Config) -> anyhow::Result<()> {

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -133,7 +133,7 @@ fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
             test_traps(&mut store, &funcs, 65536, &mem);
             test_traps(&mut store, &funcs, u32::MAX, &mem);
         }
-	Ok::<_, wasmtime::Error>(())
+        Ok::<_, wasmtime::Error>(())
     })?;
 
     Ok(())

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -114,8 +114,8 @@ fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
         }
     }
 
-    engines.par_iter().for_each(|engine| {
-        let module = module(&engine).unwrap();
+    engines.par_iter().try_for_each(|engine| {
+        let module = module(&engine)?;
 
         for (min, max) in [(1, Some(2)), (1, None)].iter() {
             let mut store = Store::new(&engine, ());
@@ -133,7 +133,8 @@ fn offsets_static_dynamic_oh_my(config: &mut Config) -> Result<()> {
             test_traps(&mut store, &funcs, 65536, &mem);
             test_traps(&mut store, &funcs, u32::MAX, &mem);
         }
-    });
+	Ok::<_, wasmtime::Error>(())
+    })?;
 
     Ok(())
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -410,12 +410,12 @@ impl Masm for MacroAssembler {
         let size = kind.derive_operand_size();
         self.with_aligned_sp(|masm| match &kind {
             LoadKind::Operand(_) => {
-		if size == OperandSize::S128 {
-		    bail!(CodeGenError::UnimplementedWasmLoadKind)
-		} else {
-		    Ok(masm.asm.uload(src, dst, size, UNTRUSTED_FLAGS))
-		}
-	    },
+                if size == OperandSize::S128 {
+                    bail!(CodeGenError::UnimplementedWasmLoadKind)
+                } else {
+                    Ok(masm.asm.uload(src, dst, size, UNTRUSTED_FLAGS))
+                }
+            }
             LoadKind::Splat(_) => bail!(CodeGenError::UnimplementedWasmLoadKind),
             LoadKind::ScalarExtend(extend_kind) => {
                 if extend_kind.signed() {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -409,7 +409,13 @@ impl Masm for MacroAssembler {
     fn wasm_load(&mut self, src: Self::Address, dst: WritableReg, kind: LoadKind) -> Result<()> {
         let size = kind.derive_operand_size();
         self.with_aligned_sp(|masm| match &kind {
-            LoadKind::Operand(_) => Ok(masm.asm.uload(src, dst, size, UNTRUSTED_FLAGS)),
+            LoadKind::Operand(_) => {
+		if size == OperandSize::S128 {
+		    bail!(CodeGenError::UnimplementedWasmLoadKind)
+		} else {
+		    Ok(masm.asm.uload(src, dst, size, UNTRUSTED_FLAGS))
+		}
+	    },
             LoadKind::Splat(_) => bail!(CodeGenError::UnimplementedWasmLoadKind),
             LoadKind::ScalarExtend(extend_kind) => {
                 if extend_kind.signed() {


### PR DESCRIPTION
This commit closes https://github.com/bytecodealliance/wasmtime/issues/8321

With https://github.com/bytecodealliance/wasmtime/pull/11013, Winch passes all spec tests for Core Wasm on Aarch64.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
