### PR TITLE
x64: Migrate `LockXadd` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/add.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/add.rs
@@ -79,5 +79,10 @@ pub fn list() -> Vec<Inst> {
         inst("paddusw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0xDD]).r(), _64b | compat | sse2),
         inst("phaddw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x38, 0x01]).r(), _64b | compat | ssse3),
         inst("phaddd", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x38, 0x02]).r(), _64b | compat | ssse3),
+        // `LOCK`-prefixed xadd
+        inst("lock_xaddb", fmt("MR", [rw(m8), rw(r8)]), rex([0xf0, 0x0f, 0xc0]).r(), _64b | compat).custom(Mnemonic | Visit),
+        inst("lock_xaddw", fmt("MR", [rw(m16), rw(r16)]), rex([0xf0, 0x66, 0x0f, 0xc1]).r(), _64b | compat).custom(Mnemonic | Visit),
+        inst("lock_xaddl", fmt("MR", [rw(m32), rw(r32)]), rex([0xf0, 0x0f, 0xc1]).r(), _64b | compat).custom(Mnemonic | Visit),
+        inst("lock_xaddq", fmt("MR", [rw(m64), rw(r64)]), rex([0xf0, 0x0f, 0xc1]).w().r(), _64b).custom(Mnemonic | Visit),
     ]
 }

--- a/cranelift/codegen/meta/src/gen_asm.rs
+++ b/cranelift/codegen/meta/src/gen_asm.rs
@@ -196,7 +196,7 @@ fn generate_macro_inst_fn(f: &mut Formatter, inst: &Inst) {
                         fmtln!(f, "let regs = ValueRegs::two(one, two);");
                         fmtln!(f, "AssemblerOutputs::RetValueRegs {{ inst, regs }}");
                     }
-                    (Reg(reg), Mem(_)) => {
+                    (Reg(reg), Mem(_)) | (Mem(_), Reg(reg)) => {
                         let (ty, var) = ty_var_of_reg(reg);
                         fmtln!(f, "let {var} = {reg}.as_ref().{};", access_reg(op2));
                         fmtln!(f, "AssemblerOutputs::Ret{ty} {{ inst, {var} }}");
@@ -404,7 +404,7 @@ fn isle_constructors(format: &Format) -> Vec<IsleConstructor> {
             (FixedReg(_) | Reg(_), FixedReg(_) | Reg(_)) => {
                 vec![IsleConstructor::RetValueRegs]
             }
-            (Reg(r), Mem(_)) => {
+            (Reg(r), Mem(_)) | (Mem(_), Reg(r)) => {
                 assert!(matches!(r.reg_class().unwrap(), RegClass::Gpr));
                 vec![IsleConstructor::RetGpr]
             }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -396,12 +396,6 @@
                        (dst_old_low WritableGpr)
                        (dst_old_high WritableGpr))
 
-       ;; A standard (native) `lock xadd src, (amode)`
-       (LockXadd (size OperandSize)
-                 (operand Gpr)
-                 (mem SyntheticAmode)
-                 (dst_old WritableGpr))
-
        ;; A synthetic instruction, based on a loop around a native `lock
        ;; cmpxchg` instruction.
        ;;
@@ -4716,11 +4710,11 @@
             (_ Unit (emit (MInst.LockCmpxchg16b replacement_low replacement_high expected_low expected_high addr dst_low dst_high))))
         (value_regs dst_low dst_high)))
 
-(decl x64_xadd (OperandSize SyntheticAmode Gpr) Gpr)
-(rule (x64_xadd size addr operand)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LockXadd size operand addr dst))))
-        dst))
+(decl x64_xadd (Type SyntheticAmode Gpr) Gpr)
+(rule (x64_xadd $I8 addr operand) (x64_lock_xaddb_mr addr operand))
+(rule (x64_xadd $I16 addr operand) (x64_lock_xaddw_mr addr operand))
+(rule (x64_xadd $I32 addr operand) (x64_lock_xaddl_mr addr operand))
+(rule (x64_xadd $I64 addr operand) (x64_lock_xaddq_mr addr operand))
 
 (decl x64_xchg (Type SyntheticAmode Gpr) Gpr)
 (rule (x64_xchg $I8 addr operand) (x64_xchgb_rm operand addr))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2571,26 +2571,6 @@ pub(crate) fn emit(
             );
         }
 
-        Inst::LockXadd {
-            size,
-            operand,
-            mem,
-            dst_old,
-        } => {
-            debug_assert_eq!(dst_old.to_reg(), *operand);
-            // lock xadd{b,w,l,q} %operand, (mem)
-            // Note that 0xF0 is the Lock prefix.
-            let (prefix, opcodes) = match size {
-                OperandSize::Size8 => (LegacyPrefixes::_F0, 0x0FC0),
-                OperandSize::Size16 => (LegacyPrefixes::_66F0, 0x0FC1),
-                OperandSize::Size32 => (LegacyPrefixes::_F0, 0x0FC1),
-                OperandSize::Size64 => (LegacyPrefixes::_F0, 0x0FC1),
-            };
-            let rex = RexFlags::from((*size, **operand));
-            let amode = mem.finalize(state.frame_layout(), sink);
-            emit_std_reg_mem(sink, prefix, opcodes, 2, **operand, &amode, rex, 0);
-        }
-
         Inst::AtomicRmwSeq {
             ty,
             op,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -103,8 +103,6 @@ fn test_x64_emit() {
     let r9 = regs::r9();
     let r10 = regs::r10();
     let r11 = regs::r11();
-    let r12 = regs::r12();
-    let r13 = regs::r13();
     let r14 = regs::r14();
     let r15 = regs::r15();
 

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -136,10 +136,7 @@ fn test_x64_emit() {
     let _w_rbp = Writable::<Reg>::from_reg(rbp);
     let w_r8 = Writable::<Reg>::from_reg(r8);
     let w_r9 = Writable::<Reg>::from_reg(r9);
-    let w_r10 = Writable::<Reg>::from_reg(r10);
     let w_r11 = Writable::<Reg>::from_reg(r11);
-    let w_r12 = Writable::<Reg>::from_reg(r12);
-    let w_r13 = Writable::<Reg>::from_reg(r13);
     let w_r14 = Writable::<Reg>::from_reg(r14);
     let w_r15 = Writable::<Reg>::from_reg(r15);
 
@@ -808,48 +805,6 @@ fn test_x64_emit() {
         },
         "F0480FC78CF1C7CFFFFF",
         "lock cmpxchg16b -12345(%rcx,%rsi,8), replacement=%rcx:%rbx, expected=%rdx:%rax, dst_old=%rdx:%rax",
-    ));
-
-    // LockXadd
-    insns.push((
-        Inst::LockXadd {
-            size: OperandSize::Size64,
-            operand: Gpr::unwrap_new(r10),
-            mem: am3.clone(),
-            dst_old: w_r10.map(Gpr::unwrap_new),
-        },
-        "F04D0FC111",
-        "lock xaddq %r10, 0(%r9), dst_old=%r10",
-    ));
-    insns.push((
-        Inst::LockXadd {
-            size: OperandSize::Size32,
-            operand: Gpr::unwrap_new(r11),
-            mem: am3.clone(),
-            dst_old: w_r11.map(Gpr::unwrap_new),
-        },
-        "F0450FC119",
-        "lock xaddl %r11d, 0(%r9), dst_old=%r11d",
-    ));
-    insns.push((
-        Inst::LockXadd {
-            size: OperandSize::Size16,
-            operand: Gpr::unwrap_new(r12),
-            mem: am3.clone(),
-            dst_old: w_r12.map(Gpr::unwrap_new),
-        },
-        "66F0450FC121",
-        "lock xaddw %r12w, 0(%r9), dst_old=%r12w",
-    ));
-    insns.push((
-        Inst::LockXadd {
-            size: OperandSize::Size8,
-            operand: Gpr::unwrap_new(r13),
-            mem: am3.clone(),
-            dst_old: w_r13.map(Gpr::unwrap_new),
-        },
-        "F0450FC029",
-        "lock xaddb %r13b, 0(%r9), dst_old=%r13b",
     ));
 
     // AtomicRmwSeq

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -100,7 +100,6 @@ impl Inst {
             | Inst::LoadEffectiveAddress { .. }
             | Inst::LoadExtName { .. }
             | Inst::LockCmpxchg { .. }
-            | Inst::LockXadd { .. }
             | Inst::MovFromPReg { .. }
             | Inst::MovToPReg { .. }
             | Inst::Nop { .. }
@@ -1191,19 +1190,6 @@ impl PrettyPrint for Inst {
                 )
             }
 
-            Inst::LockXadd {
-                size,
-                operand,
-                mem,
-                dst_old,
-            } => {
-                let operand = pretty_print_reg(**operand, size.to_bytes());
-                let dst_old = pretty_print_reg(*dst_old.to_reg(), size.to_bytes());
-                let mem = mem.pretty_print(size.to_bytes());
-                let suffix = suffix_bwlq(*size);
-                format!("lock xadd{suffix} {operand}, {mem}, dst_old={dst_old}")
-            }
-
             Inst::AtomicRmwSeq { ty, op, .. } => {
                 let ty = ty.bits();
                 format!(
@@ -1695,17 +1681,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_fixed_use(expected_high, regs::rdx());
             collector.reg_fixed_def(dst_old_low, regs::rax());
             collector.reg_fixed_def(dst_old_high, regs::rdx());
-            mem.get_operands(collector);
-        }
-
-        Inst::LockXadd {
-            operand,
-            mem,
-            dst_old,
-            ..
-        } => {
-            collector.reg_use(operand);
-            collector.reg_reuse_def(dst_old, 0);
             mem.get_operands(collector);
         }
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3424,10 +3424,10 @@
 ;; `Add` and `Sub` can use `lock xadd`
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Add) address input)))
-      (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) input))
+      (x64_xadd ty (to_amode flags address (zero_offset)) input))
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Sub) address input)))
-      (x64_xadd (raw_operand_size_of_type ty) (to_amode flags address (zero_offset)) (x64_neg ty input)))
+      (x64_xadd ty (to_amode flags address (zero_offset)) (x64_neg ty input)))
 ;; `Xchg` can use `xchg`
 (rule 1 (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw (little_or_native_endian flags) (AtomicRmwOp.Xchg) address input)))

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -434,17 +434,6 @@ pub(crate) fn check(
             Ok(())
         }
 
-        Inst::LockXadd {
-            size,
-            ref mem,
-            dst_old,
-            operand: _,
-        } => {
-            ensure_no_fact(vcode, *dst_old.to_reg())?;
-            check_store(ctx, None, mem, vcode, size.to_type())?;
-            Ok(())
-        }
-
         Inst::AtomicRmwSeq {
             ref mem,
             temp,

--- a/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic-rmw.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   lock xaddq %rax, 0(%rdi), dst_old=%rax
+;   lock xaddq %rax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -39,7 +39,7 @@ block0(v0: i64, v1: i32):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   lock xaddl %eax, 0(%rdi), dst_old=%eax
+;   lock xaddl %eax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -66,7 +66,7 @@ block0(v0: i64, v1: i16):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   lock xaddw %ax, 0(%rdi), dst_old=%ax
+;   lock xaddw %ax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -93,7 +93,7 @@ block0(v0: i64, v1: i8):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq %rsi, %rax
-;   lock xaddb %al, 0(%rdi), dst_old=%al
+;   lock xaddb %al, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -221,7 +221,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   negq %rsi
 ;   movq %rsi, %rax
-;   lock xaddq %rax, 0(%rdi), dst_old=%rax
+;   lock xaddq %rax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -250,7 +250,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   negl %esi
 ;   movq %rsi, %rax
-;   lock xaddl %eax, 0(%rdi), dst_old=%eax
+;   lock xaddl %eax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -279,7 +279,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   negw %si
 ;   movq %rsi, %rax
-;   lock xaddw %ax, 0(%rdi), dst_old=%ax
+;   lock xaddw %ax, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret
@@ -308,7 +308,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   negb %sil
 ;   movq %rsi, %rax
-;   lock xaddb %al, 0(%rdi), dst_old=%al
+;   lock xaddb %al, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   ret

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1511,14 +1511,14 @@ impl Masm for MacroAssembler {
             RmwOp::Add => {
                 let operand = context.pop_to_reg(self, None)?;
                 self.asm
-                    .lock_xadd(addr, operand.reg, writable!(operand.reg), size, flags);
+                    .lock_xadd(addr, writable!(operand.reg), size, flags);
                 operand.reg
             }
             RmwOp::Sub => {
                 let operand = context.pop_to_reg(self, None)?;
                 self.asm.neg(operand.reg, writable!(operand.reg), size);
                 self.asm
-                    .lock_xadd(addr, operand.reg, writable!(operand.reg), size, flags);
+                    .lock_xadd(addr, writable!(operand.reg), size, flags);
                 operand.reg
             }
             RmwOp::Xchg => {


### PR DESCRIPTION
This required a custom mnemonic implementation to handle the `lock` prefix and then this also required a custom visit implementation because Intel says the memory operand comes first but regalloc requires the register operand comes first.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
