### PR TITLE
A couple small `CODEOWNERS` tweaks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,9 @@
 /src/      @bytecodealliance/wasmtime-core-reviewers
 /tests/    @bytecodealliance/wasmtime-core-reviewers
 
+# WASI
+/crates/wasi* @bytecodealliance/wasmtime-wasi-reviewers
+
 # Cranelift/Winch compilers
 /cranelift/ @bytecodealliance/wasmtime-compiler-reviewers
 /winch/     @bytecodealliance/wasmtime-compiler-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,8 +38,10 @@
 /crates/wasi* @bytecodealliance/wasmtime-wasi-reviewers
 
 # Cranelift/Winch compilers
-/cranelift/ @bytecodealliance/wasmtime-compiler-reviewers
-/winch/     @bytecodealliance/wasmtime-compiler-reviewers
+/cranelift/       @bytecodealliance/wasmtime-compiler-reviewers
+/winch/           @bytecodealliance/wasmtime-compiler-reviewers
+/crates/cranelift @bytecodealliance/wasmtime-compiler-reviewers
+/crates/winch     @bytecodealliance/wasmtime-compiler-reviewers
 
 # Fuzz testing
 /fuzz/          @bytecodealliance/wasmtime-fuzz-reviewers


### PR DESCRIPTION
* Put WASI crates under the wasi-reviewers team's ownership
* Put a couple more compiler crates under the compiler team's ownership