### PR TITLE
x64: Migrate some no-operand instructions

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/encoding.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/encoding.rs
@@ -462,7 +462,7 @@ impl<const N: usize> From<[u8; N]> for Opcodes {
             [0x0f, primary] => (true, *primary, None),
             [0x0f, primary, secondary] => (true, *primary, Some(*secondary)),
             _ => panic!(
-                "invalid opcodes after prefix; expected [opcode], [0x0f, opcode], or [0x0f, opcode, opcode], found {remaining:?}"
+                "invalid opcodes after prefix; expected [opcode], [0x0f, opcode], or [0x0f, opcode, opcode], found {remaining:x?}"
             ),
         };
         Self {

--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -17,13 +17,10 @@
 ///
 /// These model what the reference manual calls "instruction operand encodings,"
 /// usually defined in a table after an instruction's opcodes.
-pub fn fmt(
-    name: impl Into<String>,
-    operands: impl IntoIterator<Item = impl Into<Operand>>,
-) -> Format {
+pub fn fmt(name: impl Into<String>, operands: impl IntoIterator<Item = Operand>) -> Format {
     Format {
         name: name.into(),
-        operands: operands.into_iter().map(Into::into).collect(),
+        operands: operands.into_iter().collect(),
         eflags: Eflags::default(),
     }
 }

--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -189,6 +189,9 @@ impl dsl::Inst {
                 fmtln!(f, "crate::custom::visit::{}(self, visitor)", self.name());
                 return;
             }
+            if self.format.operands.is_empty() {
+                fmtln!(f, "let _ = visitor;");
+            }
             for o in &self.format.operands {
                 let mutability = o.mutability.generate_snake_case();
                 let reg = o.location.reg_class();

--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -189,9 +189,6 @@ impl dsl::Inst {
                 fmtln!(f, "crate::custom::visit::{}(self, visitor)", self.name());
                 return;
             }
-            if self.format.operands.is_empty() {
-                fmtln!(f, "let _ = visitor;");
-            }
             for o in &self.format.operands {
                 let mutability = o.mutability.generate_snake_case();
                 let reg = o.location.reg_class();

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -11,6 +11,7 @@ mod div;
 mod lanes;
 mod max;
 mod min;
+mod misc;
 mod mov;
 mod mul;
 mod neg;
@@ -41,6 +42,7 @@ pub fn list() -> Vec<Inst> {
     all.extend(lanes::list());
     all.extend(max::list());
     all.extend(min::list());
+    all.extend(misc::list());
     all.extend(mov::list());
     all.extend(mul::list());
     all.extend(neg::list());

--- a/cranelift/assembler-x64/meta/src/instructions/misc.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/misc.rs
@@ -10,5 +10,6 @@ pub fn list() -> Vec<Inst> {
 
         inst("hlt", fmt("ZO", []), rex([0xf4]), _64b | compat),
         inst("ud2", fmt("ZO", []), rex([0x0f, 0x0b]), _64b | compat).has_trap(),
+        inst("int3", fmt("ZO", []), rex([0xcc]), _64b | compat),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/misc.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/misc.rs
@@ -1,0 +1,14 @@
+use crate::dsl::{Feature::*, Inst};
+use crate::dsl::{fmt, inst, rex};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("mfence", fmt("ZO", []), rex([0x0f, 0xae, 0xf0]), _64b | compat | sse2),
+        inst("sfence", fmt("ZO", []), rex([0x0f, 0xae, 0xf8]), _64b | compat),
+        inst("lfence", fmt("ZO", []), rex([0x0f, 0xae, 0xe8]), _64b | compat | sse2),
+
+        inst("hlt", fmt("ZO", []), rex([0xf4]), _64b | compat),
+        inst("ud2", fmt("ZO", []), rex([0x0f, 0x0b]), _64b | compat).has_trap(),
+    ]
+}

--- a/cranelift/assembler-x64/meta/src/instructions/nop.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/nop.rs
@@ -1,26 +1,25 @@
-use crate::dsl::{Customization::*, Feature::*, Inst, Location::*, Operand};
+use crate::dsl::{Customization::*, Feature::*, Inst, Location::*};
 use crate::dsl::{fmt, inst, r, rex};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
-    let none: [Operand; 0] = [];
     vec![
         // Provide the manual-defined versions of `NOP`, though we skip the
         // `rm16` format since it has the same encoding as `rm32`.
-        inst("nop", fmt("ZO", none), rex(0x90), _64b | compat),
+        inst("nop", fmt("ZO", []), rex(0x90), _64b | compat),
         inst("nopl", fmt("M", [r(rm32)]), rex([0x0F, 0x1F]).digit(0), _64b | compat),
         // Though the manual specifies limited encodings of `NOP` (above), it
         // recommends specific multi-byte sequenced got emitting `NOP`s between
         // 2 and 9 bytes long. The following "helper" instructions emit those
         // recommended sequences using custom functions.
-        inst("nop", fmt("1B", none), rex(0x90), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("2B", none), rex([0x66, 0x90]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("3B", none), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("4B", none), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("5B", none), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("6B", none), rex([0x66, 0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("7B", none), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("8B", none), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
-        inst("nop", fmt("9B", none), rex([0x66, 0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("1B", []), rex(0x90), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("2B", []), rex([0x66, 0x90]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("3B", []), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("4B", []), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("5B", []), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("6B", []), rex([0x66, 0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("7B", []), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("8B", []), rex([0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
+        inst("nop", fmt("9B", []), rex([0x66, 0x0F, 0x1F]), _64b | compat).custom(Encode | Display),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3786,10 +3786,6 @@
             (_ Unit (emit (MInst.LoadEffectiveAddress addr dst (operand_size_of_type_32_64 ty)))))
         dst))
 
-;; Helper for creating `ud2` instructions.
-(decl x64_ud2 (TrapCode) SideEffectNoResult)
-(rule (x64_ud2 code) (x64_ud2_zo code))
-
 ;; Helper for creating `lzcnt` instructions.
 (decl x64_lzcnt (Type GprMem) Gpr)
 (rule (x64_lzcnt $I16 src) (x64_lzcntw_rm src))
@@ -4686,9 +4682,6 @@
 (extern extractor ty_int_bool_or_ref ty_int_bool_or_ref)
 
 ;;;; Atomics ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl x64_mfence () SideEffectNoResult)
-(rule (x64_mfence) (x64_mfence_zo))
 
 (decl x64_cmpxchg (Type Gpr Gpr SyntheticAmode) Gpr)
 (rule (x64_cmpxchg $I8 expected replacement addr) (x64_lock_cmpxchgb_mr addr replacement expected))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -332,13 +332,6 @@
                  (cc2 CC)
                  (trap_code TrapCode))
 
-       ;; A debug trap.
-       (Hlt)
-
-       ;; An instruction that will always trigger the illegal instruction
-       ;; exception.
-       (Ud2 (trap_code TrapCode))
-
        ;; Loads an external symbol in a register, with a relocation:
        ;;
        ;; movq $name@GOTPCREL(%rip), dst    if PIC is enabled, or
@@ -424,9 +417,6 @@
                          (dst_old_low WritableGpr)
                          (dst_old_high WritableGpr))
 
-       ;; A memory fence (mfence, lfence or sfence).
-       (Fence (kind FenceKind))
-
        ;; =========================================
        ;; Meta-instructions generating no code.
 
@@ -484,11 +474,6 @@
             Size16
             Size32
             Size64))
-
-(type FenceKind extern
-      (enum MFence
-            LFence
-            SFence))
 
 (type BoxCallInfo extern (enum))
 (type BoxCallIndInfo extern (enum))
@@ -3803,13 +3788,11 @@
 
 ;; Helper for creating `ud2` instructions.
 (decl x64_ud2 (TrapCode) SideEffectNoResult)
-(rule (x64_ud2 code)
-      (SideEffectNoResult.Inst (MInst.Ud2 code)))
+(rule (x64_ud2 code) (x64_ud2_zo code))
 
 ;; Helper for creating `hlt` instructions.
 (decl x64_hlt () SideEffectNoResult)
-(rule (x64_hlt)
-      (SideEffectNoResult.Inst (MInst.Hlt)))
+(rule (x64_hlt) (x64_hlt_zo))
 
 ;; Helper for creating `lzcnt` instructions.
 (decl x64_lzcnt (Type GprMem) Gpr)
@@ -4709,8 +4692,7 @@
 ;;;; Atomics ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl x64_mfence () SideEffectNoResult)
-(rule (x64_mfence)
-      (SideEffectNoResult.Inst (MInst.Fence (FenceKind.MFence))))
+(rule (x64_mfence) (x64_mfence_zo))
 
 (decl x64_cmpxchg (Type Gpr Gpr SyntheticAmode) Gpr)
 (rule (x64_cmpxchg $I8 expected replacement addr) (x64_lock_cmpxchgb_mr addr replacement expected))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3790,10 +3790,6 @@
 (decl x64_ud2 (TrapCode) SideEffectNoResult)
 (rule (x64_ud2 code) (x64_ud2_zo code))
 
-;; Helper for creating `hlt` instructions.
-(decl x64_hlt () SideEffectNoResult)
-(rule (x64_hlt) (x64_hlt_zo))
-
 ;; Helper for creating `lzcnt` instructions.
 (decl x64_lzcnt (Type GprMem) Gpr)
 (rule (x64_lzcnt $I16 src) (x64_lzcntw_rm src))

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1524,15 +1524,3 @@ impl OperandSize {
         }
     }
 }
-
-/// An x64 memory fence kind.
-#[derive(Clone)]
-#[allow(dead_code)]
-pub enum FenceKind {
-    /// `mfence` instruction ("Memory Fence")
-    MFence,
-    /// `lfence` instruction ("Load Fence")
-    LFence,
-    /// `sfence` instruction ("Store Fence")
-    SFence,
-}

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2369,8 +2369,7 @@ pub(crate) fn emit(
                 inst.emit(sink, info, state);
             } else {
                 // Trap.
-                let inst = Inst::trap(TrapCode::INTEGER_OVERFLOW);
-                inst.emit(sink, info, state);
+                asm::inst::ud2_zo::new(TrapCode::INTEGER_OVERFLOW).emit(sink, info, state);
             }
 
             // Now handle large inputs.
@@ -2721,25 +2720,6 @@ pub(crate) fn emit(
 
             // jnz again
             one_way_jmp(sink, CC::NZ, again_label);
-        }
-
-        Inst::Fence { kind } => {
-            sink.put1(0x0F);
-            sink.put1(0xAE);
-            match kind {
-                FenceKind::MFence => sink.put1(0xF0), // mfence = 0F AE F0
-                FenceKind::LFence => sink.put1(0xE8), // lfence = 0F AE E8
-                FenceKind::SFence => sink.put1(0xF8), // sfence = 0F AE F8
-            }
-        }
-
-        Inst::Hlt => {
-            sink.put1(0xcc);
-        }
-
-        Inst::Ud2 { trap_code } => {
-            sink.add_trap(*trap_code);
-            sink.put_data(Inst::TRAP_OPCODE);
         }
 
         Inst::ElfTlsGetAddr { symbol, dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -745,36 +745,8 @@ fn test_x64_emit() {
         "atomically { %rdx:%rax = 0(%r9); 0(%r9) = %rcx:%rbx }",
     ));
 
-    // Fence
-    insns.push((
-        Inst::Fence {
-            kind: FenceKind::MFence,
-        },
-        "0FAEF0",
-        "mfence",
-    ));
-    insns.push((
-        Inst::Fence {
-            kind: FenceKind::LFence,
-        },
-        "0FAEE8",
-        "lfence",
-    ));
-    insns.push((
-        Inst::Fence {
-            kind: FenceKind::SFence,
-        },
-        "0FAEF8",
-        "sfence",
-    ));
-
     // ========================================================
     // Misc instructions.
-
-    insns.push((Inst::Hlt, "CC", "hlt"));
-
-    let trap_code = TrapCode::INTEGER_OVERFLOW;
-    insns.push((Inst::Ud2 { trap_code }, "0F0B", "ud2 int_ovf"));
 
     insns.push((
         Inst::ElfTlsGetAddr {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1890,7 +1890,7 @@
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (trap code))
-      (side_effect (x64_ud2 code)))
+      (side_effect (x64_ud2_zo code)))
 
 ;;;; Rules for `trapz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3360,7 +3360,7 @@
 ;; Rules for `fence` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (fence))
-      (side_effect (x64_mfence)))
+      (side_effect (x64_mfence_zo)))
 
 ;; Rules for `func_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3398,7 +3398,7 @@
                            address))
       (side_effect (side_effect_concat
        (x64_movrm ty (to_amode flags address (zero_offset)) value)
-       (x64_mfence))))
+       (x64_mfence_zo))))
 ;; Lower 128-bit `atomic_store` using `cmpxchg16b`.
 (rule 1 (lower (atomic_store (little_or_native_endian flags) value @ (value_type $I128) address))
       (if-let true (use_cmpxchg16b))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2605,7 +2605,7 @@
 ;; Rules for `debugtrap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (debugtrap))
-      (side_effect (x64_hlt)))
+      (side_effect (x64_int3_zo)))
 
 ;; Rules for `x86_pmaddubsw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -371,9 +371,7 @@ pub(crate) fn check(
         | Inst::JmpCondOr { .. }
         | Inst::TrapIf { .. }
         | Inst::TrapIfAnd { .. }
-        | Inst::TrapIfOr { .. }
-        | Inst::Hlt {}
-        | Inst::Ud2 { .. } => Ok(()),
+        | Inst::TrapIfOr { .. } => Ok(()),
         Inst::Rets { .. } => Ok(()),
 
         Inst::ReturnCallUnknown { .. } => Ok(()),
@@ -445,8 +443,6 @@ pub(crate) fn check(
             check_store(ctx, None, mem, vcode, I128)?;
             Ok(())
         }
-
-        Inst::Fence { .. } => Ok(()),
 
         Inst::XmmUninitializedValue { dst } => {
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -11,7 +11,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   ud2 user1
+;   ud2  ;; trap=1
 ;
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -18,9 +18,9 @@ use cranelift_codegen::{
         x64::{
             AtomicRmwSeqOp, EmitInfo, EmitState, Inst,
             args::{
-                self, Amode, Avx512Opcode, AvxOpcode, CC, CmpOpcode, ExtMode, FenceKind,
-                FromWritableReg, Gpr, GprMem, GprMemImm, RegMem, RegMemImm, SyntheticAmode,
-                WritableGpr, WritableXmm, Xmm, XmmMem, XmmMemImm,
+                self, Amode, Avx512Opcode, AvxOpcode, CC, CmpOpcode, ExtMode, FromWritableReg, Gpr,
+                GprMem, GprMemImm, RegMem, RegMemImm, SyntheticAmode, WritableGpr, WritableXmm,
+                Xmm, XmmMem, XmmMemImm,
             },
             encoding::rex::{RexFlags, encode_modrm},
             external::{PairedGpr, PairedXmm},
@@ -1600,7 +1600,8 @@ impl Assembler {
 
     /// Emit a trap instruction.
     pub fn trap(&mut self, code: TrapCode) {
-        self.emit(Inst::Ud2 { trap_code: code })
+        let inst = asm::inst::ud2_zo::new(code).into();
+        self.emit(Inst::External { inst });
     }
 
     /// Conditional trap.
@@ -1766,8 +1767,10 @@ impl Assembler {
         });
     }
 
-    pub fn fence(&mut self, kind: FenceKind) {
-        self.emit(Inst::Fence { kind });
+    pub fn mfence(&mut self) {
+        self.emit(Inst::External {
+            inst: asm::inst::mfence_zo::new().into(),
+        });
     }
 
     /// Extract a value from `src` into `dst` (zero extended) determined by `lane`.

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -40,7 +40,7 @@ use cranelift_codegen::{
         unwind::UnwindInst,
         x64::{
             AtomicRmwSeqOp,
-            args::{Avx512Opcode, AvxOpcode, CC, FenceKind},
+            args::{Avx512Opcode, AvxOpcode, CC},
             settings as x64_settings,
         },
     },
@@ -276,7 +276,7 @@ impl Masm for MacroAssembler {
                 // To stay consistent with cranelift, we emit a normal store followed by a mfence,
                 // although, we could probably just emit a xchg.
                 self.store_impl(src.into(), dst, size, UNTRUSTED_FLAGS)?;
-                self.asm.fence(FenceKind::MFence);
+                self.asm.mfence();
             }
             StoreKind::VectorLane(LaneSelector { lane, size }) => {
                 self.ensure_has_avx()?;
@@ -1933,7 +1933,7 @@ impl Masm for MacroAssembler {
     }
 
     fn fence(&mut self) -> Result<()> {
-        self.asm.fence(FenceKind::MFence);
+        self.asm.mfence();
         Ok(())
     }
 


### PR DESCRIPTION
Fences, hlt, and ud2 are now all in the new assembler.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
