### PR TITLE
wasi-nn: Update WIT

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -73,6 +73,6 @@ rm -rf $cache_dir
 # Separately (for now), vendor the `wasi-nn` WIT files since their retrieval is
 # slightly different than above.
 repo=https://raw.githubusercontent.com/WebAssembly/wasi-nn
-revision=0.2.0-rc-2024-08-19
+revision=0.2.0-rc-2024-10-28
 curl -L $repo/$revision/wasi-nn.witx -o crates/wasi-nn/witx/wasi-nn.witx
 curl -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit

--- a/crates/test-programs/src/bin/nn_wit_image_classification_onnx.rs
+++ b/crates/test-programs/src/bin/nn_wit_image_classification_onnx.rs
@@ -12,7 +12,7 @@ pub fn main() -> Result<()> {
     )?;
     let tensor = fs::read("fixture/000000062808.rgb")
         .context("the tensor file to be mapped to the fixture directory")?;
-    let results = wit::classify(graph, ("input", tensor), "output")?;
+    let results = wit::classify(graph, ("input", tensor))?;
     let top_five = &sort_results(&results)[..5];
     // 963 is "meat loaf, meatloaf."
     // https://github.com/onnx/models/blob/bec48b6a70e5e9042c0badbaafefe4454e072d08/validated/vision/classification/synset.txt#L963

--- a/crates/test-programs/src/bin/nn_wit_image_classification_openvino.rs
+++ b/crates/test-programs/src/bin/nn_wit_image_classification_openvino.rs
@@ -14,11 +14,7 @@ pub fn main() -> Result<()> {
     )?;
     let tensor = fs::read("fixture/tensor.bgr")
         .context("the tensor file to be mapped to the fixture directory")?;
-    let results = wit::classify(
-        graph,
-        ("input", tensor),
-        "MobilenetV2/Predictions/Reshape_1",
-    )?;
+    let results = wit::classify(graph, ("input", tensor))?;
     let top_five = &sort_results(&results)[..5];
     println!("found results, sorted top 5: {top_five:?}");
     Ok(())

--- a/crates/test-programs/src/bin/nn_wit_image_classification_openvino_named.rs
+++ b/crates/test-programs/src/bin/nn_wit_image_classification_openvino_named.rs
@@ -6,11 +6,7 @@ pub fn main() -> Result<()> {
     let graph = wit::load_by_name("fixtures")?;
     let tensor: Vec<u8> = fs::read("fixture/tensor.bgr")
         .context("the tensor file to be mapped to the fixture directory")?;
-    let results = wit::classify(
-        graph,
-        ("input", tensor),
-        "MobilenetV2/Predictions/Reshape_1",
-    )?;
+    let results = wit::classify(graph, ("input", tensor))?;
     let top_five = &sort_results(&results)[..5];
     println!("found results, sorted top 5: {top_five:?}");
     Ok(())

--- a/crates/test-programs/src/bin/nn_wit_image_classification_pytorch.rs
+++ b/crates/test-programs/src/bin/nn_wit_image_classification_pytorch.rs
@@ -12,7 +12,7 @@ pub fn main() -> Result<()> {
     )?;
     let tensor = fs::read("fixture/kitten.tensor")
         .context("the tensor file to be mapped to the fixture directory")?;
-    let output_buffer = wit::classify(graph, ("input", tensor), "output")?;
+    let output_buffer = wit::classify(graph, ("input", tensor))?;
     let result = softmax(output_buffer);
     let top_five = &sort_results(&result)[..5];
     assert_eq!(top_five[0].class_id(), 281);

--- a/crates/test-programs/src/bin/nn_wit_image_classification_winml_named.rs
+++ b/crates/test-programs/src/bin/nn_wit_image_classification_winml_named.rs
@@ -6,7 +6,7 @@ pub fn main() -> Result<()> {
     let graph = wit::load_by_name("mobilenet")?;
     let tensor = fs::read("fixture/tensor.bgr")
         .context("the tensor file to be mapped to the fixture directory")?;
-    let results = wit::classify(graph, ("input", tensor), "output")?;
+    let results = wit::classify(graph, ("input", tensor))?;
     let top_five = &sort_results(&results)[..5];
     println!("found results, sorted top 5: {top_five:?}");
     assert_eq!(top_five[0].class_id(), 284);

--- a/crates/test-programs/src/nn.rs
+++ b/crates/test-programs/src/nn.rs
@@ -40,18 +40,18 @@ pub mod wit {
 
     /// Run a wasi-nn inference using a simple classifier model (single input,
     /// single output).
-    pub fn classify(graph: Graph, input: (&str, Vec<u8>), output: &str) -> Result<Vec<f32>> {
+    pub fn classify(graph: Graph, input: (&str, Vec<u8>)) -> Result<Vec<f32>> {
         let context = graph.init_execution_context().map_err(err_as_anyhow)?;
         println!("[nn] created wasi-nn execution context with ID: {context:?}");
 
         // Many classifiers have a single input; currently, this test suite also
         // uses tensors of the same shape, though this is not usually the case.
         let tensor = Tensor::new(&vec![1, 3, 224, 224], TensorType::Fp32, &input.1);
-        context.set_input(input.0, tensor).map_err(err_as_anyhow)?;
-        println!("[nn] set input tensor: {} bytes", input.1.len());
+        println!("[nn] input tensor: {} bytes", input.1.len());
 
         let before = Instant::now();
-        context.compute().map_err(err_as_anyhow)?;
+        let input_tuple = (input.0.to_string(), tensor);
+        let output_tensors = context.compute(vec![input_tuple]).unwrap();
         println!(
             "[nn] executed graph inference in {} ms",
             before.elapsed().as_millis()
@@ -60,7 +60,7 @@ pub mod wit {
         // Many classifiers emit probabilities as floating point values; here we
         // convert the raw bytes to `f32` knowing all models used here use that
         // type.
-        let output = context.get_output(output).map_err(err_as_anyhow)?;
+        let output = &output_tensors[0].1;
         println!(
             "[nn] retrieved output tensor: {} bytes",
             output.data().len()

--- a/crates/wasi-nn/examples/classification-component-onnx/src/main.rs
+++ b/crates/wasi-nn/examples/classification-component-onnx/src/main.rs
@@ -42,16 +42,19 @@ fn main() {
         TensorType::Fp32,
         &data,
     );
-    exec_context.set_input("data", tensor).unwrap();
-    println!("Set input tensor");
-
+    let input_tensor = vec!(("data".to_string(), tensor));
     // Execute the inferencing
-    exec_context.compute().unwrap();
+    let output_tensor_vec = exec_context.compute(input_tensor).unwrap();
     println!("Executed graph inference");
 
-    // Get the inferencing result (bytes) and convert it to f32
-    println!("Getting inferencing output");
-    let output_data = exec_context.get_output("squeezenet0_flatten0_reshape0").unwrap().data();
+    let output_tensor = output_tensor_vec.iter().find_map(|(tensor_name, tensor)| {
+        if tensor_name == "squeezenet0_flatten0_reshape0" {
+            Some(tensor)
+        } else {
+            None
+        }
+    });
+    let output_data = output_tensor.expect("No output tensor").data();
 
     println!("Retrieved output data with length: {}", output_data.len());
     let output_f32 = bytes_to_f32_vec(output_data);

--- a/crates/wasi-nn/src/backend/mod.rs
+++ b/crates/wasi-nn/src/backend/mod.rs
@@ -78,9 +78,15 @@ pub trait BackendGraph: Send + Sync {
 /// A [BackendExecutionContext] performs the actual inference; this is the
 /// backing implementation for a user-facing execution context.
 pub trait BackendExecutionContext: Send + Sync {
+    // WITX functions
     fn set_input(&mut self, id: Id, tensor: &Tensor) -> Result<(), BackendError>;
-    fn compute(&mut self) -> Result<(), BackendError>;
     fn get_output(&mut self, id: Id) -> Result<Tensor, BackendError>;
+
+    // Functions which work for both WIT and WITX
+    fn compute(
+        &mut self,
+        inputs: Option<Vec<NamedTensor>>,
+    ) -> Result<Option<Vec<NamedTensor>>, BackendError>;
 }
 
 /// An identifier for a tensor in a [Graph].
@@ -127,4 +133,9 @@ fn read(path: &Path) -> anyhow::Result<Vec<u8>> {
     let mut buffer = vec![];
     file.read_to_end(&mut buffer)?;
     Ok(buffer)
+}
+
+pub struct NamedTensor {
+    pub name: String,
+    pub tensor: Tensor,
 }

--- a/crates/wasi-nn/src/backend/onnx.rs
+++ b/crates/wasi-nn/src/backend/onnx.rs
@@ -1,7 +1,9 @@
 //! Implements a `wasi-nn` [`BackendInner`] using ONNX via the `ort` crate.
 
-use super::{BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner};
-use crate::backend::{Id, read};
+use super::{
+    BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, NamedTensor,
+};
+use crate::backend::{read, Id};
 use crate::wit::types::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
 use anyhow::Context;
@@ -131,25 +133,99 @@ impl BackendExecutionContext for OnnxExecutionContext {
         Ok(())
     }
 
-    fn compute(&mut self) -> Result<(), BackendError> {
-        let mut session_inputs: Vec<ort::SessionInputValue<'_>> = vec![];
-        for i in &self.inputs {
-            session_inputs.extend(to_input_value(i)?);
+    fn compute(
+        &mut self,
+        inputs: Option<Vec<NamedTensor>>,
+    ) -> Result<Option<Vec<NamedTensor>>, BackendError> {
+        match inputs {
+            // WIT
+            Some(inputs) => {
+                for slot in &mut self.inputs {
+                    slot.tensor = None;
+                }
+                for input in &inputs {
+                    let index = self
+                        .inputs
+                        .iter()
+                        .position(|slot| slot.shape.name == input.name);
+                    let index = match index {
+                        Some(idx) => idx,
+                        None => {
+                            // Try to convert name to index
+                            if let Ok(idx) = input.name.parse::<usize>() {
+                                if idx < self.inputs.len() {
+                                    idx
+                                } else {
+                                    return Err(BackendError::BackendAccess(anyhow::anyhow!(
+                                        "Input index out of range: {}",
+                                        idx
+                                    )));
+                                }
+                            } else {
+                                return Err(BackendError::BackendAccess(anyhow::anyhow!(
+                                    "Unknown input tensor name: {}",
+                                    input.name
+                                )));
+                            }
+                        }
+                    };
+
+                    let input_slot = &mut self.inputs[index];
+                    if let Err(e) = input_slot.shape.matches(&input.tensor) {
+                        return Err(e.into());
+                    }
+                    input_slot.tensor.replace(input.tensor.clone());
+                }
+
+                let mut session_inputs: Vec<ort::SessionInputValue<'_>> = vec![];
+                for i in &self.inputs {
+                    session_inputs.extend(to_input_value(i)?);
+                }
+                let session = self.session.lock().unwrap();
+                let session_outputs = session.run(session_inputs.as_slice())?;
+
+                let mut output_tensors = Vec::new();
+                for i in 0..self.outputs.len() {
+                    // TODO: fix preexisting gap--this only handles f32 tensors.
+                    let raw: (Vec<i64>, &[f32]) = session_outputs[i].try_extract_raw_tensor()?;
+                    let f32s = raw.1.to_vec();
+                    let output = &mut self.outputs[i];
+                    let tensor = Tensor {
+                        dimensions: output.shape.dimensions_as_u32()?,
+                        ty: output.shape.ty,
+                        data: f32_vec_to_bytes(f32s),
+                    };
+                    output.tensor.replace(tensor.clone());
+                    output_tensors.push(NamedTensor {
+                        name: output.shape.name.clone(),
+                        tensor,
+                    });
+                }
+                Ok(Some(output_tensors))
+            }
+
+            // WITX
+            None => {
+                let mut session_inputs: Vec<ort::SessionInputValue<'_>> = vec![];
+                for i in &self.inputs {
+                    session_inputs.extend(to_input_value(i)?);
+                }
+                let session = self.session.lock().unwrap();
+                let session_outputs = session.run(session_inputs.as_slice())?;
+                for i in 0..self.outputs.len() {
+                    // TODO: fix preexisting gap--this only handles f32 tensors.
+                    let raw: (Vec<i64>, &[f32]) = session_outputs[i].try_extract_raw_tensor()?;
+                    let f32s = raw.1.to_vec();
+                    let output = &mut self.outputs[i];
+                    output.tensor.replace(Tensor {
+                        dimensions: output.shape.dimensions_as_u32()?,
+                        ty: output.shape.ty,
+                        data: f32_vec_to_bytes(f32s),
+                    });
+                }
+                Ok(None)
+            }
         }
-        let session = self.session.lock().unwrap();
-        let session_outputs = session.run(session_inputs.as_slice())?;
-        for i in 0..self.outputs.len() {
-            // TODO: fix preexisting gap--this only handles f32 tensors.
-            let raw: (Vec<i64>, &[f32]) = session_outputs[i].try_extract_raw_tensor()?;
-            let f32s = raw.1.to_vec();
-            let output = &mut self.outputs[i];
-            output.tensor.replace(Tensor {
-                dimensions: output.shape.dimensions_as_u32()?,
-                ty: output.shape.ty,
-                data: f32_vec_to_bytes(f32s),
-            });
-        }
-        Ok(())
     }
 
     fn get_output(&mut self, id: Id) -> Result<Tensor, BackendError> {

--- a/crates/wasi-nn/src/backend/onnx.rs
+++ b/crates/wasi-nn/src/backend/onnx.rs
@@ -3,7 +3,7 @@
 use super::{
     BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, NamedTensor,
 };
-use crate::backend::{read, Id};
+use crate::backend::{Id, read};
 use crate::wit::types::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
 use anyhow::Context;

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,8 +1,8 @@
 //! Implements a `wasi-nn` [`BackendInner`] using OpenVINO.
 
 use super::{
-    read, BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, Id,
-    NamedTensor,
+    BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, Id,
+    NamedTensor, read,
 };
 use crate::wit::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,7 +1,8 @@
 //! Implements a `wasi-nn` [`BackendInner`] using OpenVINO.
 
 use super::{
-    BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, Id, read,
+    read, BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, Id,
+    NamedTensor,
 };
 use crate::wit::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
@@ -80,12 +81,12 @@ impl BackendGraph for OpenvinoGraph {
         let mut compiled_model = self.0.lock().unwrap();
         let infer_request = compiled_model.create_infer_request()?;
         let box_: Box<dyn BackendExecutionContext> =
-            Box::new(OpenvinoExecutionContext(infer_request));
+            Box::new(OpenvinoExecutionContext(infer_request, self.0.clone()));
         Ok(box_.into())
     }
 }
 
-struct OpenvinoExecutionContext(openvino::InferRequest);
+struct OpenvinoExecutionContext(openvino::InferRequest, Arc<Mutex<openvino::CompiledModel>>);
 
 impl BackendExecutionContext for OpenvinoExecutionContext {
     fn set_input(&mut self, id: Id, tensor: &Tensor) -> Result<(), BackendError> {
@@ -108,9 +109,70 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
         Ok(())
     }
 
-    fn compute(&mut self) -> Result<(), BackendError> {
-        self.0.infer()?;
-        Ok(())
+    fn compute(
+        &mut self,
+        inputs: Option<Vec<NamedTensor>>,
+    ) -> Result<Option<Vec<NamedTensor>>, BackendError> {
+        match inputs {
+            // WIT
+            Some(inputs) => {
+                // Process all named inputs
+                for input in &inputs {
+                    let precision = input.tensor.ty.into();
+                    let dimensions = input
+                        .tensor
+                        .dimensions
+                        .iter()
+                        .map(|&d| d as i64)
+                        .collect::<Vec<_>>();
+                    let shape = Shape::new(&dimensions)?;
+                    let mut new_tensor = OvTensor::new(precision, &shape)?;
+                    let buffer = new_tensor.get_raw_data_mut()?;
+                    buffer.copy_from_slice(&input.tensor.data);
+
+                    self.0.set_tensor(&input.name, &new_tensor)?;
+                }
+
+                // Run inference
+                self.0.infer()?;
+
+                // Get all outputs
+                let compiled_model = self.1.lock().unwrap();
+                let output_count = compiled_model.get_output_size()?;
+
+                let mut output_tensors = Vec::new();
+                for i in 0..output_count {
+                    let output_tensor = self.0.get_output_tensor_by_index(i)?;
+
+                    let dimensions = output_tensor
+                        .get_shape()?
+                        .get_dimensions()
+                        .iter()
+                        .map(|&dim| dim as u32)
+                        .collect::<Vec<u32>>();
+
+                    let ty = output_tensor.get_element_type()?.try_into()?;
+                    let data = output_tensor.get_raw_data()?.to_vec();
+
+                    // Currently openvino backend returns output index only, not output tensor name
+                    output_tensors.push(NamedTensor {
+                        name: format!("{}", i),
+                        tensor: Tensor {
+                            dimensions,
+                            ty,
+                            data,
+                        },
+                    });
+                }
+                Ok(Some(output_tensors))
+            }
+
+            // WITX
+            None => {
+                self.0.infer()?;
+                Ok(None)
+            }
+        }
     }
 
     fn get_output(&mut self, id: Id) -> Result<Tensor, BackendError> {

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -156,7 +156,7 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
 
                     // Currently openvino backend returns output index only, not output tensor name
                     output_tensors.push(NamedTensor {
-                        name: format!("{}", i),
+                        name: format!("{i}"),
                         tensor: Tensor {
                             dimensions,
                             ty,

--- a/crates/wasi-nn/src/backend/winml.rs
+++ b/crates/wasi-nn/src/backend/winml.rs
@@ -9,6 +9,7 @@
 
 use crate::backend::{
     BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, Id,
+    NamedTensor,
 };
 use crate::wit::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
@@ -148,9 +149,70 @@ impl BackendExecutionContext for WinMLExecutionContext {
         Ok(())
     }
 
-    fn compute(&mut self) -> Result<(), BackendError> {
-        self.result = Some(self.session.Evaluate(&self.binding, &HSTRING::new())?);
-        Ok(())
+    fn compute(
+        &mut self,
+        inputs: Option<Vec<NamedTensor>>,
+    ) -> Result<Option<Vec<NamedTensor>>, BackendError> {
+        match inputs {
+            Some(inputs) => {
+                // Clear previous bindings
+                self.binding = LearningModelBinding::CreateFromSession(&self.session)?;
+
+                let input_features = self.session.Model()?.InputFeatures()?;
+                for input in &inputs {
+                    let index = input_features
+                        .clone()
+                        .into_iter()
+                        .position(|d| d.Name().unwrap() == input.name)
+                        .ok_or_else(|| {
+                            BackendError::BackendAccess(anyhow::anyhow!(
+                                "Unknown input tensor name: {}",
+                                input.name
+                            ))
+                        })? as u32;
+
+                    let input_feature = input_features.GetAt(index)?;
+                    let inspectable = to_inspectable(&input.tensor)?;
+                    self.binding.Bind(&input_feature.Name()?, &inspectable)?;
+                }
+
+                self.result = Some(self.session.Evaluate(&self.binding, &HSTRING::new())?);
+
+                let output_features = self.session.Model()?.OutputFeatures()?;
+                let mut output_tensors = Vec::new();
+                for i in 0..output_features.Size()? {
+                    let output_feature = output_features.GetAt(i)?;
+                    let tensor_kind = match output_feature.Kind()? {
+                        windows::AI::MachineLearning::LearningModelFeatureKind::Tensor => {
+                            output_feature
+                                .cast::<TensorFeatureDescriptor>()?
+                                .TensorKind()?
+                        }
+                        _ => unimplemented!(
+                            "the WinML backend only supports tensors, found: {:?}",
+                            output_feature.Kind()
+                        ),
+                    };
+                    let tensor = to_tensor(
+                        self.result
+                            .as_ref()
+                            .unwrap()
+                            .Outputs()?
+                            .Lookup(&output_feature.Name()?)?,
+                        tensor_kind,
+                    )?;
+                    output_tensors.push(NamedTensor {
+                        name: output_feature.Name()?.to_string(),
+                        tensor,
+                    });
+                }
+                Ok(Some(output_tensors))
+            }
+            None => {
+                self.result = Some(self.session.Evaluate(&self.binding, &HSTRING::new())?);
+                Ok(None)
+            }
+        }
     }
 
     fn get_output(&mut self, id: Id) -> Result<Tensor, BackendError> {

--- a/crates/wasi-nn/tests/check/pytorch.rs
+++ b/crates/wasi-nn/tests/check/pytorch.rs
@@ -1,4 +1,4 @@
-use super::{artifacts_dir, download, DOWNLOAD_LOCK};
+use super::{DOWNLOAD_LOCK, artifacts_dir, download};
 use anyhow::{Context, Result};
 use std::{env, fs};
 

--- a/crates/wasi-nn/tests/check/pytorch.rs
+++ b/crates/wasi-nn/tests/check/pytorch.rs
@@ -1,5 +1,5 @@
-use super::{DOWNLOAD_LOCK, artifacts_dir, download};
-use anyhow::{Context, Result, bail};
+use super::{artifacts_dir, download, DOWNLOAD_LOCK};
+use anyhow::{Context, Result};
 use std::{env, fs};
 
 /// Return `Ok` if we find the cached MobileNet test artifacts; this will

--- a/crates/wasi-nn/wit/wasi-nn.wit
+++ b/crates/wasi-nn/wit/wasi-nn.wit
@@ -1,4 +1,4 @@
-package wasi:nn@0.2.0-rc-2024-08-19;
+package wasi:nn@0.2.0-rc-2024-10-28;
 
 /// `wasi-nn` is a WASI API for performing machine learning (ML) inference. The API is not (yet)
 /// capable of performing ML training. WebAssembly programs that want to use a host's ML
@@ -110,25 +110,19 @@ interface graph {
 /// `graph` to input tensors before `compute`-ing an inference:
 interface inference {
     use errors.{error};
-    use tensor.{tensor, tensor-data};
+    use tensor.{tensor};
+
+    /// Identify a tensor by name; this is necessary to associate tensors to
+    /// graph inputs and outputs.
+    type named-tensor = tuple<string, tensor>;
 
     /// Bind a `graph` to the input and output tensors for an inference.
     ///
     /// TODO: this may no longer be necessary in WIT
     /// (https://github.com/WebAssembly/wasi-nn/issues/43)
     resource graph-execution-context {
-        /// Define the inputs to use for inference.
-        set-input: func(name: string, tensor: tensor) -> result<_, error>;
-
         /// Compute the inference on the given inputs.
-        ///
-        /// Note the expected sequence of calls: `set-input`, `compute`, `get-output`. TODO: this
-        /// expectation could be removed as a part of
-        /// https://github.com/WebAssembly/wasi-nn/issues/43.
-        compute: func() -> result<_, error>;
-
-        /// Extract the outputs after inference.
-        get-output: func(name: string) -> result<tensor, error>;
+        compute: func(inputs: list<named-tensor>) -> result<list<named-tensor>, error>;
     }
 }
 


### PR DESCRIPTION
- Update WIT to latest
- Updated WIT removes `set-input`, `get-output` functions, modifies `compute` to accept Vec of `NamedTensor` parameter representing input tensors, and return Vec of `NamedTensor` representing output tensor.
- Due to divergence from WITX, `compute` handles both wit and witx depending on if input tensors in form of Vec<NamedTensor> is provided.
- `set-input`, `get-output` functions remain in the code for WITX support.
- Update all backends
- Update WIT tests, onnx example