### PR TITLE
Use `Pin<&mut ComponentInstance>`

### DIFF
--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -167,7 +167,7 @@ impl Func {
         Params: ComponentNamedList + Lower,
         Return: ComponentNamedList + Lift,
     {
-        let cx = InstanceType::new(instance.unwrap_or_else(|| &store[self.instance.id()]));
+        let cx = InstanceType::new(instance.unwrap_or_else(|| self.instance.id().get(store)));
         let ty = &cx.types[self.ty(store)];
 
         Params::typecheck(&InterfaceType::Tuple(ty.params), &cx)
@@ -181,7 +181,7 @@ impl Func {
     /// Get the parameter names and types for this function.
     pub fn params(&self, store: impl AsContext) -> Box<[(String, Type)]> {
         let store = store.as_context();
-        let instance = &store[self.instance.id()];
+        let instance = self.instance.id().get(store.0);
         let types = instance.component().types();
         let func_ty = &types[self.ty(store.0)];
         types[func_ty.params]
@@ -195,7 +195,7 @@ impl Func {
     /// Get the result types for this function.
     pub fn results(&self, store: impl AsContext) -> Box<[Type]> {
         let store = store.as_context();
-        let instance = &store[self.instance.id()];
+        let instance = self.instance.id().get(store.0);
         let types = instance.component().types();
         let ty = self.ty(store.0);
         types[types[ty].results]
@@ -206,7 +206,7 @@ impl Func {
     }
 
     fn ty(&self, store: &StoreOpaque) -> TypeFuncIndex {
-        let instance = &store[self.instance.id()];
+        let instance = self.instance.id().get(store);
         let (ty, _, _) = instance.component().export_lifted_function(self.index);
         ty
     }
@@ -377,7 +377,7 @@ impl Func {
         LowerParams: Copy,
         LowerReturn: Copy,
     {
-        let vminstance = &store[self.instance.id()];
+        let vminstance = self.instance.id().get(store.0);
         let (ty, def, options) = vminstance.component().export_lifted_function(self.index);
         let export = match vminstance.lookup_def(store.0, def) {
             Export::Function(f) => f,
@@ -426,7 +426,6 @@ impl Func {
 
             debug_assert!(flags.may_leave());
             flags.set_may_leave(false);
-            let instance_ptr = self.instance.instance_ptr(store.0).as_ptr();
             let mut cx = LowerContext::new(store.as_context_mut(), &options, &types, self.instance);
             cx.enter_call();
             let result = lower(
@@ -479,7 +478,7 @@ impl Func {
                 ret,
             )?;
             let ret_slice = storage_as_slice(ret);
-            (*instance_ptr).post_return_arg_set(
+            self.instance.id().get_mut(store.0).post_return_arg_set(
                 self.index,
                 match ret_slice.len() {
                     0 => ValRaw::i32(0),
@@ -550,18 +549,17 @@ impl Func {
     fn post_return_impl(&self, mut store: impl AsContextMut) -> Result<()> {
         let mut store = store.as_context_mut();
         let index = self.index;
-        let vminstance = &store.0[self.instance.id()];
+        let vminstance = self.instance.id().get(store.0);
         let (_ty, _def, options) = vminstance.component().export_lifted_function(index);
         let post_return = options.post_return.map(|i| {
             let func_ref = vminstance.runtime_post_return(i);
             ExportFunction { func_ref }
         });
-        let instance = self.instance.instance_ptr(store.0).as_ptr();
+        let mut flags = vminstance.instance_flags(options.instance);
+        let mut instance = self.instance.id().get_mut(store.0);
+        let post_return_arg = instance.as_mut().post_return_arg_take(index);
 
         unsafe {
-            let post_return_arg = (*instance).post_return_arg_take(index);
-            let mut flags = (*instance).instance_flags(options.instance);
-
             // First assert that the instance is in a "needs post return" state.
             // This will ensure that the previous action on the instance was a
             // function call above. This flag is only set after a component
@@ -612,11 +610,13 @@ impl Func {
             // of the component.
             flags.set_may_enter(true);
 
-            let (calls, host_table, _) = store.0.component_resource_state();
+            let (calls, host_table, _, instance) = store
+                .0
+                .component_resource_state_with_instance(self.instance);
             ResourceTables {
-                calls,
                 host_table: Some(host_table),
-                guest: Some((*instance).guest_tables()),
+                calls,
+                guest: Some(instance.guest_tables()),
             }
             .exit_call()?;
         }

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -179,7 +179,7 @@ where
         bail!("cannot leave component instance");
     }
 
-    let types = store[instance.id()].component().types().clone();
+    let types = instance.id().get(store.0).component().types().clone();
     let ty = &types[ty];
     let param_tys = InterfaceType::Tuple(ty.params);
     let result_tys = InterfaceType::Tuple(ty.results);
@@ -494,7 +494,7 @@ where
     let args;
     let ret_index;
 
-    let types = store[instance.id()].component().types().clone();
+    let types = instance.id().get(store.0).component().types().clone();
     let func_ty = &types[ty];
     let param_tys = &types[func_ty.params];
     let result_tys = &types[func_ty.results];

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -9,6 +9,7 @@ use crate::runtime::vm::{VMFuncRef, VMMemoryDefinition};
 use crate::store::{StoreId, StoreOpaque};
 use crate::{FuncType, StoreContextMut};
 use alloc::sync::Arc;
+use core::pin::Pin;
 use core::ptr::NonNull;
 use wasmtime_environ::component::{ComponentTypes, StringEncoding, TypeResourceTableIndex};
 
@@ -216,12 +217,12 @@ impl<'a, T: 'static> LowerContext<'a, T> {
 
     /// Returns the `&ComponentInstance` that's being lowered into.
     pub fn instance(&self) -> &ComponentInstance {
-        &self.store[self.instance.id()]
+        self.instance.id().get(self.store.0)
     }
 
     /// Returns the `&mut ComponentInstance` that's being lowered into.
-    pub fn instance_mut(&mut self) -> &mut ComponentInstance {
-        &mut self.store[self.instance.id()]
+    pub fn instance_mut(&mut self) -> Pin<&mut ComponentInstance> {
+        self.instance.id().get_mut(self.store.0)
     }
 
     /// Returns a view into memory as a mutable slice of bytes.
@@ -399,7 +400,7 @@ pub struct LiftContext<'a> {
 
     memory: Option<&'a [u8]>,
 
-    instance: &'a mut ComponentInstance,
+    instance: Pin<&'a mut ComponentInstance>,
     instance_handle: Instance,
 
     host_table: &'a mut ResourceTable,
@@ -460,8 +461,8 @@ impl<'a> LiftContext<'a> {
     }
 
     /// Returns the component instance that is being lifted from.
-    pub fn instance_mut(&mut self) -> &mut ComponentInstance {
-        self.instance
+    pub fn instance_mut(&mut self) -> Pin<&mut ComponentInstance> {
+        self.instance.as_mut()
     }
     /// Returns the component instance that is being lifted from.
     pub fn instance_handle(&self) -> Instance {
@@ -518,7 +519,7 @@ impl<'a> LiftContext<'a> {
     /// Returns instance type information for the component instance that is
     /// being lifted from.
     pub fn instance_type(&self) -> InstanceType<'_> {
-        InstanceType::new(self.instance)
+        InstanceType::new(&self.instance)
     }
 
     fn resource_tables(&mut self) -> HostResourceTables<'_> {
@@ -528,7 +529,7 @@ impl<'a> LiftContext<'a> {
                 calls: self.calls,
                 // Note that the unsafety here should be valid given the contract of
                 // `LiftContext::new`.
-                guest: Some(self.instance.guest_tables()),
+                guest: Some(self.instance.as_mut().guest_tables()),
             },
             self.host_resource_data,
         )

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1915,13 +1915,13 @@ at https://bytecodealliance.org/security.
         &mut vm::component::CallContexts,
         &mut vm::component::ResourceTable,
         &mut crate::component::HostResourceData,
-        &mut vm::component::ComponentInstance,
+        Pin<&mut vm::component::ComponentInstance>,
     ) {
         (
             &mut self.component_calls,
             &mut self.component_host_table,
             &mut self.host_resource_data,
-            &mut self.store_data[instance.id()],
+            instance.id().from_data_get_mut(&mut self.store_data),
         )
     }
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -8,6 +8,7 @@
 
 use crate::component::{Component, Instance, InstancePre, ResourceType, RuntimeImport};
 use crate::runtime::component::ComponentInstanceId;
+use crate::runtime::vm::instance::{InstanceLayout, OwnedInstance, OwnedVMContext};
 use crate::runtime::vm::vmcontext::VMFunctionBody;
 use crate::runtime::vm::{
     Export, ExportFunction, ExportGlobal, ExportGlobalKind, SendSyncPtr, VMArrayCallFunction,
@@ -17,11 +18,10 @@ use crate::runtime::vm::{
 use crate::store::{InstanceId, StoreOpaque};
 use alloc::alloc::Layout;
 use alloc::sync::Arc;
-use core::marker;
 use core::mem;
 use core::mem::offset_of;
-use core::ops::Deref;
-use core::ptr::{self, NonNull};
+use core::pin::Pin;
+use core::ptr::NonNull;
 use wasmtime_environ::component::*;
 use wasmtime_environ::{
     DefinedTableIndex, EntityIndex, Global, HostPtr, PrimaryMap, VMSharedTypeIndex, WasmValType,
@@ -45,6 +45,12 @@ pub use self::resources::{
 /// The size of the allocation for `ComponentInstance` includes the trailing
 /// `VMComponentContext` which is variably sized based on the `offsets`
 /// contained within.
+///
+/// # Pin
+///
+/// Note that this type is mutated through `Pin<&mut ComponentInstance>` in the
+/// same manner as `vm::Instance` for core modules, and see more information
+/// over there for documentation and rationale.
 #[repr(C)]
 pub struct ComponentInstance {
     /// The index within the store of where to find this component instance.
@@ -52,10 +58,6 @@ pub struct ComponentInstance {
 
     /// Size and offset information for the trailing `VMComponentContext`.
     offsets: VMComponentOffsets<HostPtr>,
-
-    /// For more information about this see the documentation on
-    /// `Instance::vmctx_self_reference`.
-    vmctx_self_reference: SendSyncPtr<VMComponentContext>,
 
     /// The component that this instance was created from.
     //
@@ -109,9 +111,9 @@ pub struct ComponentInstance {
     /// Used in `post_return_arg_set` and `post_return_arg_take` below.
     post_return_arg: Option<(ExportIndex, ValRaw)>,
 
-    /// A zero-sized field which represents the end of the struct for the actual
-    /// `VMComponentContext` to be allocated behind.
-    vmctx: VMComponentContext,
+    /// Required by `InstanceLayout`, also required to be the last field (with
+    /// repr(C))
+    vmctx: OwnedVMContext<VMComponentContext>,
 }
 
 /// Type signature for host-defined trampolines that are called from
@@ -200,10 +202,7 @@ unsafe impl VmSafe for VMLowering {}
 // Set an appropriate alignment for this structure where the most-aligned value
 // internally right now `VMGlobalDefinition` which has an alignment of 16 bytes.
 #[repr(align(16))]
-pub struct VMComponentContext {
-    /// For more information about this see the equivalent field in `VMContext`
-    _marker: marker::PhantomPinned,
-}
+pub struct VMComponentContext;
 
 impl ComponentInstance {
     /// Converts the `vmctx` provided into a `ComponentInstance` and runs the
@@ -240,85 +239,49 @@ impl ComponentInstance {
         Layout::from_size_align(size, align).unwrap()
     }
 
-    /// Initializes an uninitialized pointer to a `ComponentInstance` in
-    /// addition to its trailing `VMComponentContext`.
-    ///
-    /// The `ptr` provided must be valid for `alloc_size` bytes and will be
-    /// entirely overwritten by this function call. The `offsets` correspond to
-    /// the shape of the component being instantiated and `store` is a pointer
-    /// back to the Wasmtime store for host functions to have access to.
-    unsafe fn new_at(
-        ptr: NonNull<ComponentInstance>,
-        alloc_size: usize,
-        offsets: VMComponentOffsets<HostPtr>,
+    /// Allocates a new `ComponentInstance + VMComponentContext` pair on the
+    /// heap with `malloc` and configures it for the `component` specified.
+    pub(crate) fn new(
         id: ComponentInstanceId,
         component: &Component,
         resource_types: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
         imports: &Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
         store: NonNull<dyn VMStore>,
-    ) {
-        assert!(alloc_size >= Self::alloc_layout(&offsets).size());
-
+    ) -> OwnedComponentInstance {
+        let offsets = VMComponentOffsets::new(HostPtr, component.env_component());
         let num_instances = component.env_component().num_runtime_component_instances;
         let mut instance_resource_tables =
             PrimaryMap::with_capacity(num_instances.try_into().unwrap());
         for _ in 0..num_instances {
             instance_resource_tables.push(ResourceTable::default());
         }
-
-        ptr::write(
-            ptr.as_ptr(),
-            ComponentInstance {
-                id,
-                offsets,
-                vmctx_self_reference: SendSyncPtr::new(
-                    NonNull::new(
-                        ptr.as_ptr()
-                            .byte_add(mem::size_of::<ComponentInstance>())
-                            .cast(),
-                    )
+        let mut ret = OwnedInstance::new(ComponentInstance {
+            id,
+            offsets,
+            instance_resource_tables,
+            instances: PrimaryMap::with_capacity(
+                component
+                    .env_component()
+                    .num_runtime_instances
+                    .try_into()
                     .unwrap(),
-                ),
-                instance_resource_tables,
-                instances: PrimaryMap::with_capacity(
-                    component
-                        .env_component()
-                        .num_runtime_instances
-                        .try_into()
-                        .unwrap(),
-                ),
-                component: component.clone(),
-                resource_types,
-                imports: imports.clone(),
-                store: VMStoreRawPtr(store),
-                post_return_arg: None,
-                vmctx: VMComponentContext {
-                    _marker: marker::PhantomPinned,
-                },
-            },
-        );
-
-        (*ptr.as_ptr()).initialize_vmctx();
+            ),
+            component: component.clone(),
+            resource_types,
+            imports: imports.clone(),
+            store: VMStoreRawPtr(store),
+            post_return_arg: None,
+            vmctx: OwnedVMContext::new(),
+        });
+        unsafe {
+            ret.get_mut().initialize_vmctx();
+        }
+        ret
     }
 
+    #[inline]
     pub fn vmctx(&self) -> NonNull<VMComponentContext> {
-        let addr = &raw const self.vmctx;
-        let ret = self.vmctx_self_reference.as_ptr().with_addr(addr.addr());
-        NonNull::new(ret).unwrap()
-    }
-
-    unsafe fn vmctx_plus_offset<T: VmSafe>(&self, offset: u32) -> *const T {
-        self.vmctx()
-            .as_ptr()
-            .byte_add(usize::try_from(offset).unwrap())
-            .cast()
-    }
-
-    unsafe fn vmctx_plus_offset_mut<T: VmSafe>(&mut self, offset: u32) -> *mut T {
-        self.vmctx()
-            .as_ptr()
-            .byte_add(usize::try_from(offset).unwrap())
-            .cast()
+        InstanceLayout::vmctx(self)
     }
 
     /// Returns a pointer to the "may leave" flag for this instance specified
@@ -327,9 +290,8 @@ impl ComponentInstance {
     pub fn instance_flags(&self, instance: RuntimeComponentInstanceIndex) -> InstanceFlags {
         unsafe {
             let ptr = self
-                .vmctx_plus_offset::<VMGlobalDefinition>(self.offsets.instance_flags(instance))
-                .cast_mut();
-            InstanceFlags(SendSyncPtr::new(NonNull::new(ptr).unwrap()))
+                .vmctx_plus_offset_raw::<VMGlobalDefinition>(self.offsets.instance_flags(instance));
+            InstanceFlags(SendSyncPtr::new(ptr))
         }
     }
 
@@ -409,13 +371,13 @@ impl ComponentInstance {
     pub fn trampoline_func_ref(&self, idx: TrampolineIndex) -> NonNull<VMFuncRef> {
         unsafe {
             let offset = self.offsets.trampoline_func_ref(idx);
-            let ret = self.vmctx_plus_offset::<VMFuncRef>(offset);
+            let ret = self.vmctx_plus_offset_raw::<VMFuncRef>(offset);
             debug_assert!(
-                mem::transmute::<Option<VmPtr<VMWasmCallFunction>>, usize>((*ret).wasm_call)
+                mem::transmute::<Option<VmPtr<VMWasmCallFunction>>, usize>(ret.as_ref().wasm_call)
                     != INVALID_PTR
             );
-            debug_assert!((*ret).vmctx.as_ptr() as usize != INVALID_PTR);
-            NonNull::new(ret.cast_mut()).unwrap()
+            debug_assert!(ret.as_ref().vmctx.as_ptr() as usize != INVALID_PTR);
+            ret
         }
     }
 
@@ -428,34 +390,41 @@ impl ComponentInstance {
     /// Note that it should be a property of the component model that the `ptr`
     /// here is never needed prior to it being configured here in the instance.
     pub fn set_runtime_memory(
-        &mut self,
+        self: Pin<&mut Self>,
         idx: RuntimeMemoryIndex,
         ptr: NonNull<VMMemoryDefinition>,
     ) {
         unsafe {
-            let storage = self.vmctx_plus_offset_mut::<VmPtr<VMMemoryDefinition>>(
-                self.offsets.runtime_memory(idx),
-            );
+            let offset = self.offsets.runtime_memory(idx);
+            let storage = self.vmctx_plus_offset_mut::<VmPtr<VMMemoryDefinition>>(offset);
             debug_assert!((*storage).as_ptr() as usize == INVALID_PTR);
             *storage = ptr.into();
         }
     }
 
     /// Same as `set_runtime_memory` but for realloc function pointers.
-    pub fn set_runtime_realloc(&mut self, idx: RuntimeReallocIndex, ptr: NonNull<VMFuncRef>) {
+    pub fn set_runtime_realloc(
+        self: Pin<&mut Self>,
+        idx: RuntimeReallocIndex,
+        ptr: NonNull<VMFuncRef>,
+    ) {
         unsafe {
-            let storage =
-                self.vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(self.offsets.runtime_realloc(idx));
+            let offset = self.offsets.runtime_realloc(idx);
+            let storage = self.vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(offset);
             debug_assert!((*storage).as_ptr() as usize == INVALID_PTR);
             *storage = ptr.into();
         }
     }
 
     /// Same as `set_runtime_memory` but for async callback function pointers.
-    pub fn set_runtime_callback(&mut self, idx: RuntimeCallbackIndex, ptr: NonNull<VMFuncRef>) {
+    pub fn set_runtime_callback(
+        self: Pin<&mut Self>,
+        idx: RuntimeCallbackIndex,
+        ptr: NonNull<VMFuncRef>,
+    ) {
         unsafe {
-            let storage =
-                self.vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(self.offsets.runtime_callback(idx));
+            let offset = self.offsets.runtime_callback(idx);
+            let storage = self.vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(offset);
             debug_assert!((*storage).as_ptr() as usize == INVALID_PTR);
             *storage = ptr.into();
         }
@@ -463,13 +432,13 @@ impl ComponentInstance {
 
     /// Same as `set_runtime_memory` but for post-return function pointers.
     pub fn set_runtime_post_return(
-        &mut self,
+        self: Pin<&mut Self>,
         idx: RuntimePostReturnIndex,
         ptr: NonNull<VMFuncRef>,
     ) {
         unsafe {
-            let storage = self
-                .vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(self.offsets.runtime_post_return(idx));
+            let offset = self.offsets.runtime_post_return(idx);
+            let storage = self.vmctx_plus_offset_mut::<VmPtr<VMFuncRef>>(offset);
             debug_assert!((*storage).as_ptr() as usize == INVALID_PTR);
             *storage = ptr.into();
         }
@@ -484,15 +453,15 @@ impl ComponentInstance {
     /// Note that it should be a property of the component model that the `ptr`
     /// here is never needed prior to it being configured here in the instance.
     pub fn set_runtime_table(
-        &mut self,
+        self: Pin<&mut Self>,
         idx: RuntimeTableIndex,
         ptr: NonNull<VMTableDefinition>,
         vmctx: NonNull<VMContext>,
         index: DefinedTableIndex,
     ) {
         unsafe {
-            let storage =
-                self.vmctx_plus_offset_mut::<VMTableImport>(self.offsets.runtime_table(idx));
+            let offset = self.offsets.runtime_table(idx);
+            let storage = self.vmctx_plus_offset_mut::<VMTableImport>(offset);
             debug_assert!((*storage).vmctx.as_ptr() as usize == INVALID_PTR);
             debug_assert!((*storage).from.as_ptr() as usize == INVALID_PTR);
             *storage = VMTableImport {
@@ -505,21 +474,20 @@ impl ComponentInstance {
 
     /// Configures host runtime lowering information associated with imported f
     /// functions for the `idx` specified.
-    pub fn set_lowering(&mut self, idx: LoweredIndex, lowering: VMLowering) {
+    pub fn set_lowering(self: Pin<&mut Self>, idx: LoweredIndex, lowering: VMLowering) {
         unsafe {
-            debug_assert!(
-                *self.vmctx_plus_offset::<usize>(self.offsets.lowering_callee(idx)) == INVALID_PTR
-            );
-            debug_assert!(
-                *self.vmctx_plus_offset::<usize>(self.offsets.lowering_data(idx)) == INVALID_PTR
-            );
-            *self.vmctx_plus_offset_mut(self.offsets.lowering(idx)) = lowering;
+            let callee = self.offsets.lowering_callee(idx);
+            debug_assert!(*self.vmctx_plus_offset::<usize>(callee) == INVALID_PTR);
+            let data = self.offsets.lowering_data(idx);
+            debug_assert!(*self.vmctx_plus_offset::<usize>(data) == INVALID_PTR);
+            let offset = self.offsets.lowering(idx);
+            *self.vmctx_plus_offset_mut(offset) = lowering;
         }
     }
 
     /// Same as `set_lowering` but for the resource.drop functions.
     pub fn set_trampoline(
-        &mut self,
+        self: Pin<&mut Self>,
         idx: TrampolineIndex,
         wasm_call: NonNull<VMWasmCallFunction>,
         array_call: NonNull<VMArrayCallFunction>,
@@ -543,7 +511,7 @@ impl ComponentInstance {
     /// This is required to be called for each resource as it's defined within a
     /// component during the instantiation process.
     pub fn set_resource_destructor(
-        &mut self,
+        self: Pin<&mut Self>,
         idx: ResourceIndex,
         dtor: Option<NonNull<VMFuncRef>>,
     ) {
@@ -566,13 +534,16 @@ impl ComponentInstance {
         }
     }
 
-    unsafe fn initialize_vmctx(&mut self) {
-        *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
+    unsafe fn initialize_vmctx(mut self: Pin<&mut Self>) {
+        let offset = self.offsets.magic();
+        *self.as_mut().vmctx_plus_offset_mut(offset) = VMCOMPONENT_MAGIC;
         // Initialize the built-in functions
         static BUILTINS: libcalls::VMComponentBuiltins = libcalls::VMComponentBuiltins::INIT;
         let ptr = BUILTINS.expose_provenance();
-        *self.vmctx_plus_offset_mut(self.offsets.builtins()) = VmPtr::from(ptr);
-        *self.vmctx_plus_offset_mut(self.offsets.vm_store_context()) =
+        let offset = self.offsets.builtins();
+        *self.as_mut().vmctx_plus_offset_mut(offset) = VmPtr::from(ptr);
+        let offset = self.offsets.vm_store_context();
+        *self.as_mut().vmctx_plus_offset_mut(offset) =
             VmPtr::from(self.store.0.as_ref().vm_store_context_ptr());
 
         for i in 0..self.offsets.num_runtime_component_instances {
@@ -590,44 +561,44 @@ impl ComponentInstance {
             for i in 0..self.offsets.num_lowerings {
                 let i = LoweredIndex::from_u32(i);
                 let offset = self.offsets.lowering_callee(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
                 let offset = self.offsets.lowering_data(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_trampolines {
                 let i = TrampolineIndex::from_u32(i);
                 let offset = self.offsets.trampoline_func_ref(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_memories {
                 let i = RuntimeMemoryIndex::from_u32(i);
                 let offset = self.offsets.runtime_memory(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_reallocs {
                 let i = RuntimeReallocIndex::from_u32(i);
                 let offset = self.offsets.runtime_realloc(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_callbacks {
                 let i = RuntimeCallbackIndex::from_u32(i);
                 let offset = self.offsets.runtime_callback(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_post_returns {
                 let i = RuntimePostReturnIndex::from_u32(i);
                 let offset = self.offsets.runtime_post_return(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_resources {
                 let i = ResourceIndex::from_u32(i);
                 let offset = self.offsets.resource_destructor(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_tables {
                 let i = RuntimeTableIndex::from_u32(i);
                 let offset = self.offsets.runtime_table(i);
-                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
+                *self.as_mut().vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
         }
     }
@@ -644,8 +615,12 @@ impl ComponentInstance {
     }
 
     /// Returns a mutable reference to the resource type information.
-    pub fn resource_types_mut(&mut self) -> &mut Arc<PrimaryMap<ResourceIndex, ResourceType>> {
-        &mut self.resource_types
+    pub fn resource_types_mut(
+        self: Pin<&mut Self>,
+    ) -> &mut Arc<PrimaryMap<ResourceIndex, ResourceType>> {
+        // SAFETY: we've chosen the `Pin` guarantee of `Self` to not apply to
+        // the map returned.
+        unsafe { &mut self.get_unchecked_mut().resource_types }
     }
 
     /// Returns whether the resource that `ty` points to is owned by the
@@ -666,12 +641,17 @@ impl ComponentInstance {
     /// Returns the runtime state of resources associated with this component.
     #[inline]
     pub fn guest_tables(
-        &mut self,
+        self: Pin<&mut Self>,
     ) -> (
         &mut PrimaryMap<RuntimeComponentInstanceIndex, ResourceTable>,
         &ComponentTypes,
     ) {
-        (&mut self.instance_resource_tables, self.component.types())
+        // safety: we've chosen the `pin` guarantee of `self` to not apply to
+        // the map returned.
+        unsafe {
+            let me = self.get_unchecked_mut();
+            (&mut me.instance_resource_tables, me.component.types())
+        }
     }
 
     /// Returns the destructor and instance flags for the specified resource
@@ -700,8 +680,14 @@ impl ComponentInstance {
 
     /// Pushes a new runtime instance that's been created into
     /// `self.instances`.
-    pub fn push_instance_id(&mut self, id: InstanceId) -> RuntimeInstanceIndex {
-        self.instances.push(id)
+    pub fn push_instance_id(self: Pin<&mut Self>, id: InstanceId) -> RuntimeInstanceIndex {
+        self.instances_mut().push(id)
+    }
+
+    fn instances_mut(self: Pin<&mut Self>) -> &mut PrimaryMap<RuntimeInstanceIndex, InstanceId> {
+        // SAFETY: we've chosen the `Pin` guarantee of `Self` to not apply to
+        // the map returned.
+        unsafe { &mut self.get_unchecked_mut().instances }
     }
 
     /// Translates a `CoreDef`, a definition of a core wasm item, to an
@@ -794,9 +780,9 @@ impl ComponentInstance {
     /// # Panics
     ///
     /// This function will panic if `post_return_arg` is already set to `Some`.
-    pub fn post_return_arg_set(&mut self, index: ExportIndex, arg: ValRaw) {
+    pub fn post_return_arg_set(self: Pin<&mut Self>, index: ExportIndex, arg: ValRaw) {
         assert!(self.post_return_arg.is_none());
-        self.post_return_arg = Some((index, arg));
+        *self.post_return_arg_mut() = Some((index, arg));
     }
 
     /// Re-acquires the value originally saved via `post_return_arg_set`.
@@ -805,16 +791,52 @@ impl ComponentInstance {
     /// `post_return` function called. If an argument was previously stored and
     /// `index` matches the index that was stored then `Some(arg)` is returned.
     /// Otherwise `None` is returned.
-    pub fn post_return_arg_take(&mut self, index: ExportIndex) -> Option<ValRaw> {
-        let (expected_index, arg) = self.post_return_arg.take()?;
+    pub fn post_return_arg_take(self: Pin<&mut Self>, index: ExportIndex) -> Option<ValRaw> {
+        let post_return_arg = self.post_return_arg_mut();
+        let (expected_index, arg) = post_return_arg.take()?;
         if index != expected_index {
-            self.post_return_arg = Some((expected_index, arg));
+            *post_return_arg = Some((expected_index, arg));
             None
         } else {
             Some(arg)
         }
     }
+
+    fn post_return_arg_mut(self: Pin<&mut Self>) -> &mut Option<(ExportIndex, ValRaw)> {
+        // SAFETY: we've chosen the `Pin` guarantee of `Self` to not apply to
+        // the map returned.
+        unsafe { &mut self.get_unchecked_mut().post_return_arg }
+    }
 }
+
+// SAFETY: `layout` should describe this accurately and `OwnedVMContext` is the
+// last field of `ComponentInstance`.
+unsafe impl InstanceLayout for ComponentInstance {
+    /// Technically it is not required to `alloc_zeroed` here. The primary
+    /// reason for doing this is because a component context start is a "partly
+    /// initialized" state where pointers and such are configured as the
+    /// instantiation process continues. The component model should guarantee
+    /// that we never access uninitialized memory in the context, but to help
+    /// protect against possible bugs a zeroed allocation is done here to try to
+    /// contain use-before-initialized issues.
+    const INIT_ZEROED: bool = true;
+
+    type VMContext = VMComponentContext;
+
+    fn layout(&self) -> Layout {
+        ComponentInstance::alloc_layout(&self.offsets)
+    }
+
+    fn owned_vmctx(&self) -> &OwnedVMContext<VMComponentContext> {
+        &self.vmctx
+    }
+
+    fn owned_vmctx_mut(&mut self) -> &mut OwnedVMContext<VMComponentContext> {
+        &mut self.vmctx
+    }
+}
+
+pub type OwnedComponentInstance = OwnedInstance<ComponentInstance>;
 
 impl VMComponentContext {
     /// Moves the `self` pointer backwards to the `ComponentInstance` pointer
@@ -826,81 +848,7 @@ impl VMComponentContext {
                 as *mut ComponentInstance
         }
     }
-}
 
-/// An owned version of `ComponentInstance` which is akin to
-/// `Box<ComponentInstance>`.
-///
-/// This type can be dereferenced to `ComponentInstance` to access the
-/// underlying methods.
-pub struct OwnedComponentInstance {
-    ptr: SendSyncPtr<ComponentInstance>,
-}
-
-impl OwnedComponentInstance {
-    /// Allocates a new `ComponentInstance + VMComponentContext` pair on the
-    /// heap with `malloc` and configures it for the `component` specified.
-    pub fn new(
-        id: ComponentInstanceId,
-        component: &Component,
-        resource_types: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
-        imports: &Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
-        store: NonNull<dyn VMStore>,
-    ) -> OwnedComponentInstance {
-        let offsets = VMComponentOffsets::new(HostPtr, component.env_component());
-        let layout = ComponentInstance::alloc_layout(&offsets);
-        unsafe {
-            // Technically it is not required to `alloc_zeroed` here. The
-            // primary reason for doing this is because a component context
-            // start is a "partly initialized" state where pointers and such are
-            // configured as the instantiation process continues. The component
-            // model should guarantee that we never access uninitialized memory
-            // in the context, but to help protect against possible bugs a
-            // zeroed allocation is done here to try to contain
-            // use-before-initialized issues.
-            let ptr = alloc::alloc::alloc_zeroed(layout) as *mut ComponentInstance;
-            let ptr = NonNull::new(ptr).unwrap();
-
-            ComponentInstance::new_at(
-                ptr,
-                layout.size(),
-                offsets,
-                id,
-                component,
-                resource_types,
-                imports,
-                store,
-            );
-
-            let ptr = SendSyncPtr::new(ptr);
-            OwnedComponentInstance { ptr }
-        }
-    }
-
-    /// Returns the underlying component instance's raw pointer.
-    pub fn instance_ptr(&self) -> NonNull<ComponentInstance> {
-        self.ptr.as_non_null()
-    }
-}
-
-impl Deref for OwnedComponentInstance {
-    type Target = ComponentInstance;
-    fn deref(&self) -> &ComponentInstance {
-        unsafe { &*self.ptr.as_ptr() }
-    }
-}
-
-impl Drop for OwnedComponentInstance {
-    fn drop(&mut self) {
-        let layout = ComponentInstance::alloc_layout(&self.offsets);
-        unsafe {
-            ptr::drop_in_place(self.ptr.as_ptr());
-            alloc::alloc::dealloc(self.ptr.as_ptr().cast(), layout);
-        }
-    }
-}
-
-impl VMComponentContext {
     /// Helper function to cast between context types using a debug assertion to
     /// protect against some mistakes.
     #[inline]

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -1206,17 +1206,7 @@ mod test_vmstore_context {
 /// allocated at runtime.
 #[derive(Debug)]
 #[repr(C, align(16))] // align 16 since globals are aligned to that and contained inside
-pub struct VMContext {
-    /// There's some more discussion about this within `wasmtime/src/lib.rs` but
-    /// the idea is that we want to tell the compiler that this contains
-    /// pointers which transitively refers to itself, to suppress some
-    /// optimizations that might otherwise assume this doesn't exist.
-    ///
-    /// The self-referential pointer we care about is the `*mut Store` pointer
-    /// early on in this context, which if you follow through enough levels of
-    /// nesting, eventually can refer back to this `VMContext`
-    pub _marker: marker::PhantomPinned,
-}
+pub struct VMContext;
 
 impl VMContext {
     /// Helper function to cast between context types using a debug assertion to


### PR DESCRIPTION
This commit is the continuation of #10943 for component instances. The allocation/vmctx infrastructure was additionally refactored to be shared for both core and component instances since they behave the exact same way anyway. This further enables sharing various methods like `vmctx_plus_offset` which are pretty unsafe internally.

Like #10943 this necessitated removal of `Index` implementations because `IndexMut` is not compatible with the returned type being `Pin<&mut T>` so they were replaced by inherent `get` and `get_mut` methods on the component instance id type.

Closes #10933

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
