### PR TITLE
Handle `uextend` in conditional trap lowerings on x64

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1894,24 +1894,24 @@
 
 ;;;; Rules for `trapz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (trapz val code))
+(rule 0 (lower (trapz (maybe_uextend val) code))
         (side_effect (trap_if_val (ZeroCond.Zero) val code)))
 
-(rule 1 (lower (trapz (icmp cc a b) code))
+(rule 1 (lower (trapz (maybe_uextend (icmp cc a b)) code))
         (side_effect (trap_if_icmp (emit_cmp (intcc_complement cc) a b) code)))
 
-(rule 1 (lower (trapz (fcmp cc a b) code))
+(rule 1 (lower (trapz (maybe_uextend (fcmp cc a b)) code))
         (side_effect (trap_if_fcmp (emit_fcmp (floatcc_complement cc) a b) code)))
 
 ;;;; Rules for `trapnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (trapnz val code))
+(rule 0 (lower (trapnz (maybe_uextend val) code))
         (side_effect (trap_if_val (ZeroCond.NonZero) val code)))
 
-(rule 1 (lower (trapnz (icmp cc a b) code))
+(rule 1 (lower (trapnz (maybe_uextend (icmp cc a b)) code))
         (side_effect (trap_if_icmp (emit_cmp cc a b) code)))
 
-(rule 1 (lower (trapnz (fcmp cc a b) code))
+(rule 1 (lower (trapnz (maybe_uextend (fcmp cc a b)) code))
         (side_effect (trap_if_fcmp (emit_fcmp cc a b) code)))
 
 ;;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -282,3 +282,125 @@ block0(v0: f64, v1: f64):
 ;   retq
 ;   ud2 ; trap: user1
 
+function %trapz_uextend_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapz v3, user1
+  return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   cmpq    %rsi, %rdi
+;   jnz #trap=user1
+;   movq %rbp, %rsp
+;   popq %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   cmpq %rsi, %rdi
+;   jne 0x12
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+
+function %trapnz_uextend_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapnz v3, user1
+  return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   cmpq    %rsi, %rdi
+;   jz #trap=user1
+;   movq %rbp, %rsp
+;   popq %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   cmpq %rsi, %rdi
+;   je 0x12
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+
+function %trapz_uextend_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapz v3, user1
+  return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   ucomisd %xmm1, %xmm0
+;   trap_if_or p, z, user1
+;   movq %rbp, %rsp
+;   popq %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomisd %xmm1, %xmm0
+;   jp 0x19
+;   jne 0x19
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+
+function %trapnz_uextend_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapnz v3, user1
+  return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   ucomisd %xmm1, %xmm0
+;   trap_if_and p, nz, user1
+;   movq %rbp, %rsp
+;   popq %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomisd %xmm1, %xmm0
+;   jp 0x14
+;   je 0x19
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: user1
+


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
