### PR TITLE
Refine `VMArrayCallNative`

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1019,11 +1019,7 @@ impl Func {
         params_and_returns: NonNull<[ValRaw]>,
     ) -> Result<()> {
         invoke_wasm_and_catch_traps(store, |caller, vm| {
-            func_ref.as_ref().array_call(
-                vm,
-                VMOpaqueContext::from_vmcontext(caller),
-                params_and_returns,
-            )
+            func_ref.as_ref().array_call(vm, caller, params_and_returns)
         })
     }
 
@@ -2304,7 +2300,7 @@ impl HostContext {
 
     unsafe extern "C" fn array_call_trampoline<T, F, P, R>(
         callee_vmctx: NonNull<VMOpaqueContext>,
-        caller_vmctx: NonNull<VMOpaqueContext>,
+        caller_vmctx: NonNull<VMContext>,
         args: NonNull<ValRaw>,
         args_len: usize,
     ) -> bool
@@ -2369,10 +2365,7 @@ impl HostContext {
 
         // With nothing else on the stack move `run` into this
         // closure and then run it as part of `Caller::with`.
-        crate::runtime::vm::catch_unwind_and_record_trap(move || {
-            let caller_vmctx = VMContext::from_opaque(caller_vmctx);
-            Caller::with(caller_vmctx, run)
-        })
+        crate::runtime::vm::catch_unwind_and_record_trap(move || Caller::with(caller_vmctx, run))
     }
 }
 

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -1,6 +1,6 @@
 use super::invoke_wasm_and_catch_traps;
 use crate::prelude::*;
-use crate::runtime::vm::{VMFuncRef, VMOpaqueContext};
+use crate::runtime::vm::VMFuncRef;
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{
     AsContext, AsContextMut, Engine, Func, FuncType, HeapType, NoFunc, RefType, StoreContextMut,
@@ -221,9 +221,7 @@ where
             let storage = storage.cast::<ValRaw>();
             let storage = core::ptr::slice_from_raw_parts_mut(storage, storage_len);
             let storage = NonNull::new(storage).unwrap();
-            func_ref
-                .as_ref()
-                .array_call(vm, VMOpaqueContext::from_vmcontext(caller), storage)
+            func_ref.as_ref().array_call(vm, caller, storage)
         });
 
         let (_, storage) = captures;

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -2,7 +2,7 @@ use crate::linker::{Definition, DefinitionType};
 use crate::prelude::*;
 use crate::runtime::vm::{
     self, Imports, ModuleRuntimeInfo, VMFuncRef, VMFunctionImport, VMGlobalImport, VMMemoryImport,
-    VMOpaqueContext, VMTableImport, VMTagImport,
+    VMTableImport, VMTagImport,
 };
 use crate::store::{AllocateInstanceKind, InstanceId, StoreInstanceId, StoreOpaque};
 use crate::types::matching;
@@ -331,11 +331,9 @@ impl Instance {
         let caller_vmctx = instance.vmctx();
         unsafe {
             super::func::invoke_wasm_and_catch_traps(store, |_default_caller, vm| {
-                f.func_ref.as_ref().array_call(
-                    vm,
-                    VMOpaqueContext::from_vmcontext(caller_vmctx),
-                    NonNull::from(&mut []),
-                )
+                f.func_ref
+                    .as_ref()
+                    .array_call(vm, caller_vmctx, NonNull::from(&mut []))
             })?;
         }
         Ok(())

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -23,7 +23,7 @@ struct TrampolineState<F> {
 /// Also shepherds panics and traps across Wasm.
 unsafe extern "C" fn array_call_shim<F>(
     vmctx: NonNull<VMOpaqueContext>,
-    caller_vmctx: NonNull<VMOpaqueContext>,
+    caller_vmctx: NonNull<VMContext>,
     values_vec: NonNull<ValRaw>,
     values_vec_len: usize,
 ) -> bool
@@ -41,7 +41,7 @@ where
         debug_assert!(state.is::<TrampolineState<F>>());
         let state = &*(state as *const _ as *const TrampolineState<F>);
         let mut values_vec = NonNull::slice_from_raw_parts(values_vec, values_vec_len);
-        (state.func)(VMContext::from_opaque(caller_vmctx), values_vec.as_mut())
+        (state.func)(caller_vmctx, values_vec.as_mut())
     })
 }
 

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -188,7 +188,7 @@ impl InterpreterRef<'_> {
         mut self,
         mut bytecode: NonNull<u8>,
         callee: NonNull<VMOpaqueContext>,
-        caller: NonNull<VMOpaqueContext>,
+        caller: NonNull<VMContext>,
         args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         // Initialize argument registers with the ABI arguments.

--- a/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
@@ -5,7 +5,7 @@
 //! having these structures plumbed around.
 
 use crate::runtime::Uninhabited;
-use crate::runtime::vm::VMOpaqueContext;
+use crate::runtime::vm::{VMContext, VMOpaqueContext};
 use crate::{Engine, ValRaw};
 use core::marker;
 use core::mem;
@@ -46,7 +46,7 @@ impl InterpreterRef<'_> {
         self,
         _bytecode: NonNull<u8>,
         _callee: NonNull<VMOpaqueContext>,
-        _caller: NonNull<VMOpaqueContext>,
+        _caller: NonNull<VMContext>,
         _args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         match self.empty {}

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -66,7 +66,7 @@ use std::ops::Range;
 use std::ptr;
 
 use crate::runtime::vm::stack_switching::VMHostArray;
-use crate::runtime::vm::{VMContext, VMFuncRef, VMOpaqueContext, ValRaw};
+use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Allocator {
@@ -311,7 +311,7 @@ unsafe extern "C" fn fiber_start(
 ) {
     unsafe {
         let func_ref = func_ref.as_ref().expect("Non-null function reference");
-        let caller_vmxtx = VMOpaqueContext::from_vmcontext(NonNull::new_unchecked(caller_vmctx));
+        let caller_vmxtx = NonNull::new_unchecked(caller_vmctx);
         let args = &mut *args;
         let params_and_returns: NonNull<[ValRaw]> = if args.capacity == 0 {
             NonNull::from(&[])

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -44,7 +44,7 @@ use wasmtime_environ::{
 /// * `false` if this call failed and a trap was recorded in TLS.
 pub type VMArrayCallNative = unsafe extern "C" fn(
     NonNull<VMOpaqueContext>,
-    NonNull<VMOpaqueContext>,
+    NonNull<VMContext>,
     NonNull<ValRaw>,
     usize,
 ) -> bool;
@@ -871,7 +871,7 @@ impl VMFuncRef {
     pub unsafe fn array_call(
         &self,
         pulley: Option<InterpreterRef<'_>>,
-        caller: NonNull<VMOpaqueContext>,
+        caller: NonNull<VMContext>,
         args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         match pulley {
@@ -883,7 +883,7 @@ impl VMFuncRef {
     unsafe fn array_call_interpreted(
         &self,
         vm: InterpreterRef<'_>,
-        caller: NonNull<VMOpaqueContext>,
+        caller: NonNull<VMContext>,
         args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         // If `caller` is actually a `VMArrayCallHostFuncContext` then skip the
@@ -905,7 +905,7 @@ impl VMFuncRef {
     #[inline]
     unsafe fn array_call_native(
         &self,
-        caller: NonNull<VMOpaqueContext>,
+        caller: NonNull<VMContext>,
         args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
         union GetNativePointer {


### PR DESCRIPTION
This commit refines the definition of the `VMArrayCallNative` type which is the type signature of array-call functions which are used for entering and exiting wasm. The first two parameters of this function are the callee/caller VMContext values but they are both ascribed as `VMOpaqueContext`. This is because for the `callee` it's not known exactly what type the pointer has except within the context of the defining function, so this value was not changed.

For the `caller` parameter though it's always the case that the value passed in is indeed a `VMContext`. This commit reflects this fact in the type signature and removes a number of now-unnecessary casts.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
