### PR TITLE
docs: Update stability tiers

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -231,24 +231,24 @@ here is:
 
 | Feature                                 | Cranelift | Winch[^c] |
 |-----------------------------------------|-----------|-----------|
-| [`mutable-globals`]                     | ✅        | 🚧        |
-| [`sign-extension-ops`]                  | ✅        | 🚧        |
-| [`nontrapping-float-to-int-conversion`] | ✅        | 🚧        |
-| [`multi-value`]                         | ✅        | 🚧        |
-| [`bulk-memory`]                         | ✅        | 🚧        |
+| [`mutable-globals`]                     | ✅        | ✅        |
+| [`sign-extension-ops`]                  | ✅        | ✅        |
+| [`nontrapping-float-to-int-conversion`] | ✅        | ✅        |
+| [`multi-value`]                         | ✅        | ✅        |
+| [`bulk-memory`]                         | ✅        | ✅        |
 | [`reference-types`]                     | ✅        | ❌[^a]    |
 | [`simd`]                                | ✅        | ❌        |
-| [`component-model`]                     | ✅        | 🚧        |
+| [`component-model`]                     | ✅        | ✅        |
 | [`relaxed-simd`]                        | ✅        | ❌        |
-| [`multi-memory`]                        | ✅        | 🚧        |
+| [`multi-memory`]                        | ✅        | ✅        |
 | [`threads`]                             | ✅        | ❌        |
 | [`tail-call`]                           | ✅        | ❌        |
-| [`extended-const`]                      | ✅        | 🚧        |
-| [`memory64`]                            | ✅        | 🚧        |
+| [`extended-const`]                      | ✅        | ✅        |
+| [`memory64`]                            | ✅        | ✅        |
 | [`function-references`]                 | ✅        | ❌        |
 | [`gc`]                                  | ✅        | ❌        |
 | [`wide-arithmetic`]                     | ✅        | ❌        |
-| [`custom-page-sizes`]                   | ✅        | 🚧        |
+| [`custom-page-sizes`]                   | ✅        | ✅        |
 
 ##### s390x
 
@@ -330,9 +330,7 @@ emitting Pulley bytecode.
   new table opcodes in the [`reference-types`] proposal.
 [^b]: Pulley does not support the [`threads`] proposal because there is no known
   safe way to implement this with Rust's memory model.
-[^c]: Winch's support for aarch64 is a work-in-progress. Most of the
-  implementation is filled out but it is not yet at a feature-complete status
-  or running tests in CI.
+[^c]: Winch's support for aarch64 is complete for Core Wasm.
 
 ## Tier Details
 


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/issues/8321, marks the completion of Core Wasm support for aarch64 in Winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
