### PR TITLE
Share log state amongst handles in `wasmtime serve`

### DIFF
--- a/crates/test-programs/src/bin/cli_serve_with_print.rs
+++ b/crates/test-programs/src/bin/cli_serve_with_print.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use test_programs::proxy;
+use test_programs::wasi::cli::stderr::get_stderr;
 use test_programs::wasi::http::types::{
     Fields, IncomingRequest, OutgoingResponse, ResponseOutparam,
 };
@@ -21,6 +22,13 @@ impl proxy::exports::wasi::http::incoming_handler::Guest for T {
         eprintln!("to stderr");
         eprintln!(); // empty line
         eprintln!("after empty");
+
+        let _ = get_stderr().blocking_write_and_flush(b"start a print ");
+        let _ = get_stderr().blocking_write_and_flush(b"1");
+        let _ = get_stderr().blocking_write_and_flush(b"2");
+        let _ = get_stderr().blocking_write_and_flush(b"3");
+        let _ = get_stderr().blocking_write_and_flush(b"4");
+        let _ = get_stderr().blocking_write_and_flush(b"\n");
 
         let resp = OutgoingResponse::new(Fields::new());
         ResponseOutparam::set(outparam, Ok(resp));

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1957,9 +1957,11 @@ after empty
 this is half a print to stderr
 \n\
 after empty
+start a print 1234
 this is half a print to stderr
 \n\
 after empty
+start a print 1234
 "
             ),
             "bad stderr {err}",

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1907,9 +1907,11 @@ stdout [1] :: after empty
 stderr [0] :: this is half a print to stderr
 stderr [0] :: \n\
 stderr [0] :: after empty
+stderr [0] :: start a print 1234
 stderr [1] :: this is half a print to stderr
 stderr [1] :: \n\
 stderr [1] :: after empty
+stderr [1] :: start a print 1234
 "
             ),
             "bad stderr: {err}"


### PR DESCRIPTION
This commit fixes an issue where when multiple independent stdio handles were acquired they would share different states about whether a prefix was necessary or not which could lead to confusing output. This commit fixes the log streams of `wasmtime serve` to share state amongst the various handles created by putting internal state into an `Arc` and mutating it behind the scenes in the implementation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
