### PR TITLE
wasi-nn: update OpenVINO to v2025.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -794,7 +794,7 @@ jobs:
     - uses: ./.github/actions/install-rust
 
     # Install OpenVINO
-    - uses: abrown/install-openvino-action@v9
+    - uses: abrown/install-openvino-action@v10
       if: runner.arch == 'X64'
 
     # Install WinML for testing wasi-nn WinML backend. WinML is only available

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,9 +2463,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openvino"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f03a664ab0b6917131f5c1a787795fa4d19ad6a334caf9c96284453abdf23fd"
+checksum = "3308ec088481c27b5b521598ced2d5d5f67253d9639f5a3cce5a2ea4c4062a94"
 dependencies = [
  "openvino-finder",
  "openvino-sys",
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-finder"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d6bbb3e00d9ad3cd60bca1341665a9cfb2b6764df37c58d921627368ae32fc"
+checksum = "bba5393f3522f98d9c4703a6a73afc7feff2bf9cc00a0722957b54c44ecda5fe"
 dependencies = [
  "cfg-if",
  "log",
@@ -2483,13 +2483,12 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04315994236727c3573f7e8d8bf857e93ff373ee2e063f08aa78aceac58e3bc5"
+checksum = "da7d035914ff5c8e12d7e05982929fb275e6f06eafcbe529f316001760b08786"
 dependencies = [
  "env_logger 0.11.5",
  "libloading",
- "once_cell",
  "openvino-finder",
 ]
 

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -38,7 +38,7 @@ ort = { version = "2.0.0-rc.2", default-features = false, features = [
 tch = { version = "0.17.0", default-features = false, optional = true}
 
 [target.'cfg(target_pointer_width = "64")'.dependencies]
-openvino = { version = "0.8.0", features = [
+openvino = { version = "0.9.0", features = [
     "runtime-linking",
 ], optional = true }
 

--- a/deny.toml
+++ b/deny.toml
@@ -54,4 +54,6 @@ skip-tree = [
 
     # right now terminal_size pulls in an older version of io-lifetimes
     { name = "io-lifetimes" },
+
+    { name = "file-per-thread-logger", reason = "this uses an old version of env-logger; may be unmaintained?" }
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -37,13 +37,6 @@ wildcards = "allow"
 deny = []
 
 skip-tree = [
-    # wit-bindgen and wasmtime both depend on the wasm-tools crates, and
-    # wit-bindgen's latest release may sometimes lag behind when we bump
-    # wasmtime's dependencies on wasm-tools. wit-bindgen is only used for
-    # building component-based test programs, so we are going to ignore
-    # the multiple-versions errors it will introduce.
-    { name = "wit-bindgen", depth = 20 },
-
     # proptest depends on bitflags 1.x.x while other crates depend on 2.x.x so
     # ignore its dependency tree until it updates.
     { name = "proptest", depth = 20 },

--- a/deny.toml
+++ b/deny.toml
@@ -52,10 +52,6 @@ skip-tree = [
     # dependencies relative to Wasmtime's main dependency tree.
     { name = "witx", depth = 20 },
 
-    # The openvino-sys crate uses an older version of `pretty_env_logger` so
-    # ignore its dependency tree for now until it updates.
-    { name = "openvino-sys", depth = 20 },
-
     # They want to publish version 2.0 to upgrade `hashbrown` so in the meantime
     # it is duplicated for us.
     { name = "indexmap", depth = 2 },

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2695,6 +2695,11 @@ criteria = "safe-to-deploy"
 delta = "0.7.2 -> 0.8.0"
 notes = "No new unsafe functionality, just brings in openvino-sys changes and other minor improvements."
 
+[[audits.openvino]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.0"
+
 [[audits.openvino-finder]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -2724,6 +2729,11 @@ criteria = "safe-to-deploy"
 delta = "0.7.2 -> 0.8.0"
 notes = "No logic changes in version bump."
 
+[[audits.openvino-finder]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.0"
+
 [[audits.openvino-sys]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -2752,6 +2762,11 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.7.2 -> 0.8.0"
 notes = "This diff simply re-generates slightly newer C headers with a slightly newer version of bindgen."
+
+[[audits.openvino-sys]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.0"
 
 [[audits.ort]]
 who = "Andrew Brown <andrew.brown@intel.com>"


### PR DESCRIPTION
This updates the version of the bindings used for communicating with OpenVINO to v0.9.0 as well as the GitHub action used to install the latest version of OpenVINO (v2025.1.0) in CI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
