### PR TITLE
c-api: component-model: Resource table, WASI

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -205,6 +205,7 @@
 #include <wasmtime/val.h>
 #include <wasmtime/async.h>
 #include <wasmtime/component.h>
+#include <wasmtime/wasip2.h>
 #include <wasmtime/wat.h>
 // IWYU pragma: end_exports
 // clang-format on

--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -142,7 +142,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instance_add_func(
  * \brief Add all WASI interfaces into the \p linker provided.
  */
 WASM_API_EXTERN wasmtime_error_t *
-wasmtime_component_linker_add_wasi(wasmtime_component_linker_t *linker);
+wasmtime_component_linker_add_wasip2(wasmtime_component_linker_t *linker);
 
 #endif // WASMTIME_FEATURE_WASI
 

--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -136,6 +136,16 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instance_add_func(
     size_t name_len, wasmtime_component_func_callback_t callback, void *data,
     void (*finalizer)());
 
+#ifdef WASMTIME_FEATURE_WASI
+
+/**
+ * \brief Add all WASI interfaces into the \p linker provided.
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_linker_add_wasi(wasmtime_component_linker_t *linker);
+
+#endif // WASMTIME_FEATURE_WASI
+
 /**
  * \brief Deletes a #wasmtime_component_linker_instance_t
  *

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -11,6 +11,7 @@
 #include <wasm.h>
 #include <wasmtime/conf.h>
 #include <wasmtime/error.h>
+#include <wasmtime/wasip2.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -191,6 +192,14 @@ wasmtime_context_get_fuel(const wasmtime_context_t *context, uint64_t *fuel);
  */
 WASM_API_EXTERN wasmtime_error_t *
 wasmtime_context_set_wasi(wasmtime_context_t *context, wasi_config_t *wasi);
+
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+WASM_API_EXTERN void
+wasmtime_context_set_wasip2(wasmtime_context_t *context,
+                            wasmtime_wasip2_config_t *config);
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
 
 #endif // WASMTIME_FEATURE_WASI
 

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -195,6 +195,14 @@ wasmtime_context_set_wasi(wasmtime_context_t *context, wasi_config_t *wasi);
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
 
+/**
+ * \brief Set the WASIP2 config for this store.
+ *
+ * This function is required if #wasmtime_component_linker_add_wasip2 is called.
+ *
+ * This function takes ownership of \p config. The caller should no longer use
+ * \p config after calling this function.
+ */
 WASM_API_EXTERN void
 wasmtime_context_set_wasip2(wasmtime_context_t *context,
                             wasmtime_wasip2_config_t *config);

--- a/crates/c-api/include/wasmtime/wasip2.h
+++ b/crates/c-api/include/wasmtime/wasip2.h
@@ -13,13 +13,27 @@
 extern "C" {
 #endif
 
+/// Config for the WASIP2 context.
 typedef struct wasmtime_wasip2_config_t wasmtime_wasip2_config_t;
 
+/**
+ * \brief Create a #wasmtime_wasip2_config_t
+ */
 WASM_API_EXTERN wasmtime_wasip2_config_t *wasmtime_wasip2_config_new();
 
+/**
+ * \brief Configures this context's stdout stream to write to the host process's
+ * stdout.
+ */
 WASM_API_EXTERN void
 wasmtime_wasip2_config_inherit_stdout(wasmtime_wasip2_config_t *config);
 
+/**
+ * \brief Delete a #wasmtime_wasip2_config_t
+ *
+ * \note This is not needed if the config is passed to
+ * #wasmtime_component_linker_add_wasip2
+ */
 WASM_API_EXTERN void
 wasmtime_wasip2_config_delete(wasmtime_wasip2_config_t *config);
 

--- a/crates/c-api/include/wasmtime/wasip2.h
+++ b/crates/c-api/include/wasmtime/wasip2.h
@@ -3,6 +3,7 @@
 #ifndef WASMTIME_WASIP2_H
 #define WASMTIME_WASIP2_H
 
+#include <wasm.h>
 #include <wasmtime/conf.h>
 
 #ifdef WASMTIME_FEATURE_WASI

--- a/crates/c-api/include/wasmtime/wasip2.h
+++ b/crates/c-api/include/wasmtime/wasip2.h
@@ -1,0 +1,32 @@
+/// \file wasmtime/wasip2.h
+
+#ifndef WASMTIME_WASIP2_H
+#define WASMTIME_WASIP2_H
+
+#include <wasmtime/conf.h>
+
+#ifdef WASMTIME_FEATURE_WASI
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct wasmtime_wasip2_config_t wasmtime_wasip2_config_t;
+
+WASM_API_EXTERN wasmtime_wasip2_config_t *wasmtime_wasip2_config_new();
+
+WASM_API_EXTERN void
+wasmtime_wasip2_config_inherit_stdout(wasmtime_wasip2_config_t *config);
+
+WASM_API_EXTERN void
+wasmtime_wasip2_config_delete(wasmtime_wasip2_config_t *config);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
+#endif // WASMTIME_FEATURE_WASI
+
+#endif // WASMTIME_WASIP2_H

--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_func(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "wasi")]
-pub unsafe extern "C" fn wasmtime_component_linker_add_wasi(
+pub unsafe extern "C" fn wasmtime_component_linker_add_wasip2(
     linker: &mut wasmtime_component_linker_t,
 ) -> Option<Box<wasmtime_error_t>> {
     let result = wasmtime_wasi::p2::add_to_linker_sync(&mut linker.linker);

--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -153,6 +153,15 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_func(
 }
 
 #[unsafe(no_mangle)]
+#[cfg(feature = "wasi")]
+pub unsafe extern "C" fn wasmtime_component_linker_add_wasi(
+    linker: &mut wasmtime_component_linker_t,
+) -> Option<Box<wasmtime_error_t>> {
+    let result = wasmtime_wasi::p2::add_to_linker_sync(&mut linker.linker);
+    crate::handle_result(result, |_| ())
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_component_linker_instance_delete(
     _linker_instance: Box<wasmtime_component_linker_instance_t>,
 ) {

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -66,6 +66,11 @@ mod wasi;
 #[cfg(feature = "wasi")]
 pub use crate::wasi::*;
 
+#[cfg(all(feature = "component-model", feature = "wasi"))]
+mod wasip2;
+#[cfg(all(feature = "component-model", feature = "wasi"))]
+pub use crate::wasip2::*;
+
 #[cfg(feature = "wat")]
 mod wat2wasm;
 #[cfg(feature = "wat")]

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -95,6 +95,26 @@ pub struct WasmtimeStoreData {
 
     /// Limits for the store.
     pub store_limits: StoreLimits,
+
+    #[cfg(feature = "component-model")]
+    pub(crate) resource_table: wasmtime::component::ResourceTable,
+
+    #[cfg(all(feature = "component-model", feature = "wasi"))]
+    pub(crate) wasi_p2: wasmtime_wasi::p2::WasiCtx,
+}
+
+#[cfg(all(feature = "component-model", feature = "wasi"))]
+impl wasmtime_wasi::p2::IoView for WasmtimeStoreData {
+    fn table(&mut self) -> &mut wasmtime_wasi::ResourceTable {
+        &mut self.resource_table
+    }
+}
+
+#[cfg(all(feature = "component-model", feature = "wasi"))]
+impl wasmtime_wasi::p2::WasiView for WasmtimeStoreData {
+    fn ctx(&mut self) -> &mut wasmtime_wasi::p2::WasiCtx {
+        &mut self.wasi_p2
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -113,6 +133,10 @@ pub extern "C" fn wasmtime_store_new(
                 hostcall_val_storage: Vec::new(),
                 wasm_val_storage: Vec::new(),
                 store_limits: StoreLimits::default(),
+                #[cfg(feature = "component-model")]
+                resource_table: wasmtime::component::ResourceTable::default(),
+                #[cfg(all(feature = "component-model", feature = "wasi"))]
+                wasi_p2: wasmtime_wasi::p2::WasiCtx::builder().build(),
             },
         ),
     })

--- a/crates/c-api/src/wasip2.rs
+++ b/crates/c-api/src/wasip2.rs
@@ -1,0 +1,21 @@
+#[repr(transparent)]
+pub struct wasmtime_wasip2_config_t {
+    pub(crate) builder: wasmtime_wasi::p2::WasiCtxBuilder,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_wasip2_config_new() -> Box<wasmtime_wasip2_config_t> {
+    Box::new(wasmtime_wasip2_config_t {
+        builder: wasmtime_wasi::p2::WasiCtxBuilder::new(),
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_wasip2_config_inherit_stdout(
+    config: &mut wasmtime_wasip2_config_t,
+) {
+    config.builder.inherit_stdout();
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_wasip2_config_delete(_: Box<wasmtime_wasip2_config_t>) {}

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_capi_test(tests FILES
   memory.cc
   instance.cc
   linker.cc
+  wasip2.cc
 )
 
 # Create a list of all wasmtime headers with `GLOB_RECURSE`, then emit a file

--- a/crates/c-api/tests/wasip2.cc
+++ b/crates/c-api/tests/wasip2.cc
@@ -1,0 +1,43 @@
+#include "component/utils.h"
+
+#include <gtest/gtest.h>
+#include <wasmtime.h>
+
+TEST(wasip2, smoke) {
+  static constexpr auto component_text = std::string_view{
+      R"END(
+(component)
+      )END",
+  };
+  const auto engine = wasm_engine_new();
+  EXPECT_NE(engine, nullptr);
+
+  const auto store = wasmtime_store_new(engine, nullptr, nullptr);
+  const auto context = wasmtime_store_context(store);
+
+  const auto cfg = wasmtime_wasip2_config_new();
+  wasmtime_wasip2_config_inherit_stdout(cfg);
+  wasmtime_context_set_wasip2(context, cfg);
+
+  wasmtime_component_t *component = nullptr;
+
+  auto err = wasmtime_component_new(
+      engine, reinterpret_cast<const uint8_t *>(component_text.data()),
+      component_text.size(), &component);
+
+  CHECK_ERR(err);
+
+  const auto linker = wasmtime_component_linker_new(engine);
+
+  wasmtime_component_linker_add_wasip2(linker);
+
+  wasmtime_component_instance_t instance = {};
+  err = wasmtime_component_linker_instantiate(linker, context, component,
+                                              &instance);
+  CHECK_ERR(err);
+
+  wasmtime_component_linker_delete(linker);
+
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+}


### PR DESCRIPTION
I've gotten quite stuck on how to do resources, so I decided to try WASI first.

Some things I'm unsure about:
- Should the context be inside an `Option` and then `expect()` in the WASI traits, or is the default context fine?
- How to specify your own context, perhaps `wasmtime_context_set_wasi_p2()`?

---
On resources, I think I'm getting stuck on `ResourceTypeKind::Host` using `TypeId`.

Would all the resources use a `CApiResource` type on the rust side, and then use a string discriminant, or something like that?

Do you have any other ideas?