### PR TITLE
Fix another case of Miri unsoundness

### DIFF
--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -378,11 +378,13 @@ impl Func {
         LowerReturn: Copy,
     {
         let vminstance = self.instance.id().get(store.0);
-        let (ty, def, options) = vminstance.component().export_lifted_function(self.index);
-        let export = match vminstance.lookup_def(store.0, def) {
+        let component = vminstance.component().clone();
+        let (ty, def, options) = component.export_lifted_function(self.index);
+        let export = match self.instance.lookup_vmdef(store.0, def) {
             Export::Function(f) => f,
             _ => unreachable!(),
         };
+        let vminstance = self.instance.id().get(store.0);
         let component_instance = options.instance;
         let memory = options
             .memory
@@ -408,7 +410,7 @@ impl Func {
         assert!(mem::align_of_val(map_maybe_uninit!(space.params)) == val_align);
         assert!(mem::align_of_val(map_maybe_uninit!(space.ret)) == val_align);
 
-        let types = vminstance.component().types().clone();
+        let types = component.types();
         let mut flags = vminstance.instance_flags(component_instance);
 
         unsafe {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1019,7 +1019,7 @@ impl Func {
         params_and_returns: NonNull<[ValRaw]>,
     ) -> Result<()> {
         invoke_wasm_and_catch_traps(store, |caller, vm| {
-            func_ref.as_ref().array_call(vm, caller, params_and_returns)
+            VMFuncRef::array_call(func_ref, vm, caller, params_and_returns)
         })
     }
 

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -221,7 +221,7 @@ where
             let storage = storage.cast::<ValRaw>();
             let storage = core::ptr::slice_from_raw_parts_mut(storage, storage_len);
             let storage = NonNull::new(storage).unwrap();
-            func_ref.as_ref().array_call(vm, caller, storage)
+            VMFuncRef::array_call(*func_ref, vm, caller, storage)
         });
 
         let (_, storage) = captures;

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -839,7 +839,7 @@ unsafe fn array_init_data(
 #[cfg(feature = "gc")]
 unsafe fn array_new_elem(
     store: &mut dyn VMStore,
-    instance: Pin<&mut Instance>,
+    mut instance: Pin<&mut Instance>,
     array_type_index: u32,
     elem_index: u32,
     src: u32,
@@ -878,7 +878,7 @@ unsafe fn array_new_elem(
                         .ok_or_else(|| Trap::TableOutOfBounds)?
                         .iter()
                         .map(|f| {
-                            let raw_func_ref = instance.get_func_ref(*f);
+                            let raw_func_ref = instance.as_mut().get_func_ref(*f);
                             let func = raw_func_ref.map(|p| Func::from_vm_func_ref(store, p));
                             Val::FuncRef(func)
                         }),
@@ -915,7 +915,7 @@ unsafe fn array_new_elem(
 #[cfg(feature = "gc")]
 unsafe fn array_init_elem(
     store: &mut dyn VMStore,
-    instance: Pin<&mut Instance>,
+    mut instance: Pin<&mut Instance>,
     array_type_index: u32,
     array: u32,
     dst: u32,
@@ -971,7 +971,7 @@ unsafe fn array_init_elem(
             .ok_or_else(|| Trap::TableOutOfBounds)?
             .iter()
             .map(|f| {
-                let raw_func_ref = instance.get_func_ref(*f);
+                let raw_func_ref = instance.as_mut().get_func_ref(*f);
                 let func = raw_func_ref.map(|p| Func::from_vm_func_ref(&store, p));
                 Val::FuncRef(func)
             })

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -189,6 +189,10 @@ fn pulley_provenance_test() -> Result<()> {
     let results = func.call(&mut store, funcref)?;
     assert_eq!(results, (1, 2, 3));
 
+    instance
+        .get_typed_func::<(), ()>(&mut store, "ref-func-myself")?
+        .call(&mut store, ())?;
+
     Ok(())
 }
 

--- a/tests/all/pulley_provenance_test.wat
+++ b/tests/all/pulley_provenance_test.wat
@@ -90,4 +90,8 @@
     (drop (table.get $t2 (i32.const 1)))
     (drop (table.get $t2 (i32.const 0)))
   )
+
+  (func $me (export "ref-func-myself")
+    (drop (ref.func $me))
+  )
 )


### PR DESCRIPTION
This commit fixes another issue we've discovered in the wasip3 prototyping repository about a code pattern in wasm which Miri flags as un-sound. Specifically what happened was:

* Invocation of WebAssembly went through `VMFuncRef::array_call` which takes a `&self` parameter.

* Inside of WebAssembly though a `ref.func` instruction, or anything else that references the original exported function, will re-initialize the `VMFuncRef` which writes the `&self` up the stack, which is not sound.

Fixing this required changing the signature of `array_call` from `&self` to `me: NonNull<VMFuncRef>`, and the signature was already `unsafe` so this is a new unsafe contract for that signature.

In fixing this, however, it was discovered that a mistake was made in #10943 where some internal functions for re-initializing a `VMFuncRef` relied on the previous signature of `&mut self` but that PR switche to `&self`. This PR corrects these signatures to `Pin<&mut Self>` and then plumbs around the necessary changes, notably causing some refactoring in component-related bits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
