### PR TITLE
fix: do not collect backtrace on each `gc_runtime` access

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -688,12 +688,8 @@ impl Engine {
         self.inner.allocator.as_ref()
     }
 
-    pub(crate) fn gc_runtime(&self) -> Result<&Arc<dyn GcRuntime>> {
-        if let Some(rt) = &self.inner.gc_runtime {
-            Ok(rt)
-        } else {
-            bail!("no GC runtime: GC disabled at compile time or configuration time")
-        }
+    pub(crate) fn gc_runtime(&self) -> Option<&Arc<dyn GcRuntime>> {
+        self.inner.gc_runtime.as_ref()
     }
 
     pub(crate) fn profiler(&self) -> &dyn crate::profiling_agent::ProfilingAgent {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1399,12 +1399,13 @@ impl StoreOpaque {
 
             // Then, allocate the actual GC heap, passing in that memory
             // storage.
-            let (index, heap) = engine.allocator().allocate_gc_heap(
-                engine,
-                &**engine.gc_runtime()?,
-                mem_alloc_index,
-                mem,
-            )?;
+            let gc_runtime = engine
+                .gc_runtime()
+                .context("no GC runtime: GC disabled at compile time or configuration time")?;
+            let (index, heap) =
+                engine
+                    .allocator()
+                    .allocate_gc_heap(engine, &**gc_runtime, mem_alloc_index, mem)?;
 
             Ok(GcStore::new(index, heap))
         }

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -133,7 +133,7 @@ impl Engine {
 
         let engine = self.clone();
         let registry = engine.signatures();
-        let gc_runtime = engine.gc_runtime().ok().map(|rt| &**rt);
+        let gc_runtime = engine.gc_runtime().map(|rt| &**rt);
 
         // First, register these types in this engine's registry.
         let (rec_groups, types) = registry
@@ -336,7 +336,7 @@ impl RegisteredType {
         let (entry, index, ty, layout) = {
             log::trace!("RegisteredType::new({ty:?})");
 
-            let gc_runtime = engine.gc_runtime().ok().map(|rt| &**rt);
+            let gc_runtime = engine.gc_runtime().map(|rt| &**rt);
             let mut inner = engine.signatures().0.write();
 
             // It shouldn't be possible for users to construct non-canonical


### PR DESCRIPTION
This is something I've discovered profiling a Wasmtime embedding with `wasm32-unknown-unknown` modules. Currently, `gc_runtime` accessor returns an `anyhow::Result`, which triggers a backtrace collection, when `gc` is disabled (e.g. when `gc` feature is not set)

With `gc` feature disabled:
https://share.firefox.dev/3FTmlgN (note the `anyhow::error::msg` and related `_Unwind_IteratePhdrCallback`)

With `gc`, `gc-null`, `gc-drc` features enabled:
https://share.firefox.dev/3HGyEh5

To alleviate this, return an `Option` from the accessor, since in most cases, it's used as an `Option` anyway and there is only one case when error is returned when it is not set