### PR TITLE
pulley: Don't record explicit traps for frames

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -555,17 +555,7 @@ fn pulley_emit<P>(
             *start_offset = sink.cur_offset();
         }
 
-        Inst::Raw { raw } => {
-            match raw {
-                RawInst::PushFrame
-                | RawInst::StackAlloc32 { .. }
-                | RawInst::PushFrameSave { .. } => {
-                    sink.add_trap(ir::TrapCode::STACK_OVERFLOW);
-                }
-                _ => {}
-            }
-            super::generated::emit(raw, sink)
-        }
+        Inst::Raw { raw } => super::generated::emit(raw, sink),
 
         Inst::EmitIsland { space_needed } => {
             if sink.island_needed(*space_needed) {

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -473,6 +473,7 @@ fn trap(vm: &mut Vm, pc: NonNull<u8>, kind: Option<TrapKind>, setjmp: Setjmp) {
                     TrapKind::BadConversionToInteger => Trap::BadConversionToInteger,
                     TrapKind::MemoryOutOfBounds => Trap::MemoryOutOfBounds,
                     TrapKind::DisabledOpcode => Trap::DisabledOpcode,
+                    TrapKind::StackOverflow => Trap::StackOverflow,
                 };
                 s.set_jit_trap(regs, None, trap);
             }

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -958,6 +958,7 @@ mod done {
         BadConversionToInteger,
         MemoryOutOfBounds,
         DisabledOpcode,
+        StackOverflow,
     }
 
     impl MachineState {
@@ -1075,7 +1076,7 @@ impl Interpreter<'_> {
         let sp_raw = sp as usize;
         let base_raw = self.state.stack.base() as usize;
         if sp_raw < base_raw {
-            return self.done_trap::<I>();
+            return self.done_trap_kind::<I>(Some(TrapKind::StackOverflow));
         }
         self.set_sp_unchecked(sp);
         ControlFlow::Continue(())

--- a/tests/disas/pulley/pulley64_memory32.wat
+++ b/tests/disas/pulley/pulley64_memory32.wat
@@ -59,7 +59,6 @@
 )
 ;; wasm[0]::function[0]::load8:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x47
 ;;       xload64le_o32 x6, x0, 56
@@ -70,7 +69,6 @@
 ;;
 ;; wasm[0]::function[1]::load16:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x4f
 ;;       xload64le_o32 x6, x0, 56
@@ -81,7 +79,6 @@
 ;;
 ;; wasm[0]::function[2]::load32:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x57
 ;;       xload64le_o32 x6, x0, 56
@@ -92,7 +89,6 @@
 ;;
 ;; wasm[0]::function[3]::load64:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x5f
 ;;       xload64le_o32 x6, x0, 56
@@ -103,7 +99,6 @@
 ;;
 ;; wasm[0]::function[4]::store8:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x69
 ;;       xload64le_o32 x6, x0, 56
@@ -114,7 +109,6 @@
 ;;
 ;; wasm[0]::function[5]::store16:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x73
 ;;       xload64le_o32 x6, x0, 56
@@ -125,7 +119,6 @@
 ;;
 ;; wasm[0]::function[6]::store32:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x7d
 ;;       xload64le_o32 x6, x0, 56
@@ -136,7 +129,6 @@
 ;;
 ;; wasm[0]::function[7]::store64:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x87
 ;;       xload64le_o32 x6, x0, 56
@@ -147,7 +139,6 @@
 ;;
 ;; wasm[0]::function[8]::load8_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x8f
 ;;       xload64le_o32 x6, x0, 56
@@ -158,7 +149,6 @@
 ;;
 ;; wasm[0]::function[9]::load16_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x97
 ;;       xload64le_o32 x6, x0, 56
@@ -169,7 +159,6 @@
 ;;
 ;; wasm[0]::function[10]::load32_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0x9f
 ;;       xload64le_o32 x6, x0, 56
@@ -180,7 +169,6 @@
 ;;
 ;; wasm[0]::function[11]::load64_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0xa7
 ;;       xload64le_o32 x6, x0, 56
@@ -191,7 +179,6 @@
 ;;
 ;; wasm[0]::function[12]::store8_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0xb1
 ;;       xload64le_o32 x6, x0, 56
@@ -202,7 +189,6 @@
 ;;
 ;; wasm[0]::function[13]::store16_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0xbb
 ;;       xload64le_o32 x6, x0, 56
@@ -213,7 +199,6 @@
 ;;
 ;; wasm[0]::function[14]::store32_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0xc5
 ;;       xload64le_o32 x6, x0, 56
@@ -224,7 +209,6 @@
 ;;
 ;; wasm[0]::function[15]::store64_offset:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x5, x0, 64
 ;;       ╰─╼ addrmap: 0xcf
 ;;       xload64le_o32 x6, x0, 56
@@ -235,7 +219,6 @@
 ;;
 ;; wasm[0]::function[16]::load16_two:
 ;;       push_frame
-;;       ╰─╼ trap: StackOverflow
 ;;       xload64le_o32 x7, x0, 64
 ;;       ╰─╼ addrmap: 0xd7
 ;;       xload64le_o32 x8, x0, 56


### PR DESCRIPTION
This can all happen automatically in the interpreter, so no need to otherwise record these traps unnecessarily.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
