### PR TITLE
Prefix `Lift` and `Lower` trait methods with `memory_`

### DIFF
--- a/crates/test-util/src/component.rs
+++ b/crates/test-util/src/component.rs
@@ -93,27 +93,27 @@ macro_rules! forward_impls {
         }
 
         unsafe impl Lower for $a {
-            fn lower<U>(
+            fn linear_lower_to_flat<U>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
                 dst: &mut MaybeUninit<Self::Lower>,
             ) -> Result<()> {
-                <$b as Lower>::lower(&self.0, cx, ty, dst)
+                <$b as Lower>::linear_lower_to_flat(&self.0, cx, ty, dst)
             }
 
-            fn store<U>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType, offset: usize) -> Result<()> {
-                <$b as Lower>::store(&self.0, cx, ty, offset)
+            fn linear_lower_to_memory<U>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType, offset: usize) -> Result<()> {
+                <$b as Lower>::linear_lower_to_memory(&self.0, cx, ty, offset)
             }
         }
 
         unsafe impl Lift for $a {
-            fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
-                Ok(Self(<$b as Lift>::lift(cx, ty, src)?))
+            fn linear_lift_from_flat(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+                Ok(Self(<$b as Lift>::linear_lift_from_flat(cx, ty, src)?))
             }
 
-            fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
-                Ok(Self(<$b as Lift>::load(cx, ty, bytes)?))
+            fn linear_lift_from_memory(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+                Ok(Self(<$b as Lift>::linear_lift_from_memory(cx, ty, bytes)?))
             }
         }
 

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -364,10 +364,10 @@ where
 
         fn lift_params(&self, cx: &mut LiftContext<'_>, ty: InterfaceType) -> Result<P> {
             match self.lift_src() {
-                Src::Direct(storage) => P::lift(cx, ty, storage),
+                Src::Direct(storage) => P::linear_lift_from_flat(cx, ty, storage),
                 Src::Indirect(ptr) => {
                     let ptr = validate_inbounds::<P>(cx.memory(), ptr)?;
-                    P::load(cx, ty, &cx.memory()[ptr..][..P::SIZE32])
+                    P::linear_lift_from_memory(cx, ty, &cx.memory()[ptr..][..P::SIZE32])
                 }
             }
         }
@@ -395,10 +395,10 @@ where
             ret: R,
         ) -> Result<()> {
             match self.lower_dst() {
-                Dst::Direct(storage) => ret.lower(cx, ty, storage),
+                Dst::Direct(storage) => ret.linear_lower_to_flat(cx, ty, storage),
                 Dst::Indirect(ptr) => {
                     let ptr = validate_inbounds::<R>(cx.as_slice_mut(), ptr)?;
-                    ret.store(cx, ty, ptr)
+                    ret.linear_lower_to_memory(cx, ty, ptr)
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -277,7 +277,7 @@ where
         dst: &mut MaybeUninit<Params::Lower>,
     ) -> Result<()> {
         assert!(Params::flatten_count() <= MAX_FLAT_PARAMS);
-        params.lower(cx, ty, dst)?;
+        params.linear_lower_to_flat(cx, ty, dst)?;
         Ok(())
     }
 
@@ -303,7 +303,7 @@ where
         // Note that `realloc` will bake in a check that the returned pointer is
         // in-bounds.
         let ptr = cx.realloc(0, 0, Params::ALIGN32, Params::SIZE32)?;
-        params.store(cx, ty, ptr)?;
+        params.linear_lower_to_memory(cx, ty, ptr)?;
 
         // Note that the pointer here is stored as a 64-bit integer. This allows
         // this to work with either 32 or 64-bit memories. For a 32-bit memory
@@ -330,7 +330,7 @@ where
         dst: &Return::Lower,
     ) -> Result<Return> {
         assert!(Return::flatten_count() <= MAX_FLAT_RESULTS);
-        Return::lift(cx, ty, dst)
+        Return::linear_lift_from_flat(cx, ty, dst)
     }
 
     /// Lift the result of a function where the result is stored indirectly on
@@ -352,7 +352,7 @@ where
             .get(ptr..)
             .and_then(|b| b.get(..Return::SIZE32))
             .ok_or_else(|| anyhow::anyhow!("pointer out of bounds of memory"))?;
-        Return::load(cx, ty, bytes)
+        Return::linear_lift_from_memory(cx, ty, bytes)
     }
 
     /// See [`Func::post_return`]
@@ -530,7 +530,8 @@ pub unsafe trait ComponentVariant: ComponentType {
 /// be an internal implementation detail of Wasmtime at this time. It's
 /// recommended to use the `#[derive(Lower)]` implementation instead.
 pub unsafe trait Lower: ComponentType {
-    /// Performs the "lower" function in the canonical ABI.
+    /// Performs the "lower" function in the linear memory version of the
+    /// canonical ABI.
     ///
     /// This method will lower the current value into a component. The `lower`
     /// function performs a "flat" lowering into the `dst` specified which is
@@ -548,14 +549,15 @@ pub unsafe trait Lower: ComponentType {
     ///
     /// This will only be called if `typecheck` passes for `Op::Lower`.
     #[doc(hidden)]
-    fn lower<T>(
+    fn linear_lower_to_flat<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
         dst: &mut MaybeUninit<Self::Lower>,
     ) -> Result<()>;
 
-    /// Performs the "store" operation in the canonical ABI.
+    /// Performs the "store" operation in the linear memory version of the
+    /// canonical ABI.
     ///
     /// This function will store `self` into the linear memory described by
     /// `cx` at the `offset` provided.
@@ -573,7 +575,7 @@ pub unsafe trait Lower: ComponentType {
     ///
     /// This will only be called if `typecheck` passes for `Op::Lower`.
     #[doc(hidden)]
-    fn store<T>(
+    fn linear_lower_to_memory<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -589,7 +591,7 @@ pub unsafe trait Lower: ComponentType {
     /// which can avoid some extra fluff and use a pattern that's more easily
     /// optimizable by LLVM.
     #[doc(hidden)]
-    fn store_list<T>(
+    fn linear_store_list_to_memory<T>(
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
         mut offset: usize,
@@ -599,7 +601,7 @@ pub unsafe trait Lower: ComponentType {
         Self: Sized,
     {
         for item in items {
-            item.store(cx, ty, offset)?;
+            item.linear_lower_to_memory(cx, ty, offset)?;
             offset += Self::SIZE32;
         }
         Ok(())
@@ -623,7 +625,8 @@ pub unsafe trait Lower: ComponentType {
 /// be an internal implementation detail of Wasmtime at this time. It's
 /// recommended to use the `#[derive(Lift)]` implementation instead.
 pub unsafe trait Lift: Sized + ComponentType {
-    /// Performs the "lift" operation in the canonical ABI.
+    /// Performs the "lift" operation in the linear memory version of the
+    /// canonical ABI.
     ///
     /// This function performs a "flat" lift operation from the `src` specified
     /// which is a sequence of core wasm values. The lifting operation will
@@ -639,9 +642,14 @@ pub unsafe trait Lift: Sized + ComponentType {
     /// Note that this has a default implementation but if `typecheck` passes
     /// for `Op::Lift` this needs to be overridden.
     #[doc(hidden)]
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self>;
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self>;
 
-    /// Performs the "load" operation in the canonical ABI.
+    /// Performs the "load" operation in the linear memory version of the
+    /// canonical ABI.
     ///
     /// This will read the `bytes` provided, which are a sub-slice into the
     /// linear memory described by `cx`. The `bytes` array provided is
@@ -655,7 +663,11 @@ pub unsafe trait Lift: Sized + ComponentType {
     /// Note that this has a default implementation but if `typecheck` passes
     /// for `Op::Lift` this needs to be overridden.
     #[doc(hidden)]
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self>;
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self>;
 
     /// Converts `list` into a `Vec<T>`, used in `Lift for Vec<T>`.
     ///
@@ -663,7 +675,10 @@ pub unsafe trait Lift: Sized + ComponentType {
     /// which can avoid some extra fluff and use a pattern that's more easily
     /// optimizable by LLVM.
     #[doc(hidden)]
-    fn load_list(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>>
+    fn linear_lift_list_from_memory(
+        cx: &mut LiftContext<'_>,
+        list: &WasmList<Self>,
+    ) -> Result<Vec<Self>>
     where
         Self: Sized,
     {
@@ -704,22 +719,22 @@ forward_type_impls! {
 macro_rules! forward_lowers {
     ($(($($generics:tt)*) $a:ty => $b:ty,)*) => ($(
         unsafe impl <$($generics)*> Lower for $a {
-            fn lower<U>(
+            fn linear_lower_to_flat<U>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
                 dst: &mut MaybeUninit<Self::Lower>,
             ) -> Result<()> {
-                <$b as Lower>::lower(self, cx, ty, dst)
+                <$b as Lower>::linear_lower_to_flat(self, cx, ty, dst)
             }
 
-            fn store<U>(
+            fn linear_lower_to_memory<U>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
                 offset: usize,
             ) -> Result<()> {
-                <$b as Lower>::store(self, cx, ty, offset)
+                <$b as Lower>::linear_lower_to_memory(self, cx, ty, offset)
             }
         }
     )*)
@@ -738,13 +753,13 @@ macro_rules! forward_string_lifts {
     ($($a:ty,)*) => ($(
         unsafe impl Lift for $a {
             #[inline]
-            fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
-                Ok(<WasmStr as Lift>::lift(cx, ty, src)?.to_str_from_memory(cx.memory())?.into())
+            fn linear_lift_from_flat(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+                Ok(<WasmStr as Lift>::linear_lift_from_flat(cx, ty, src)?.to_str_from_memory(cx.memory())?.into())
             }
 
             #[inline]
-            fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
-                Ok(<WasmStr as Lift>::load(cx, ty, bytes)?.to_str_from_memory(cx.memory())?.into())
+            fn linear_lift_from_memory(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+                Ok(<WasmStr as Lift>::linear_lift_from_memory(cx, ty, bytes)?.to_str_from_memory(cx.memory())?.into())
             }
         }
     )*)
@@ -760,14 +775,14 @@ forward_string_lifts! {
 macro_rules! forward_list_lifts {
     ($($a:ty,)*) => ($(
         unsafe impl <T: Lift> Lift for $a {
-            fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
-                let list = <WasmList::<T> as Lift>::lift(cx, ty, src)?;
-                Ok(T::load_list(cx, &list)?.into())
+            fn linear_lift_from_flat(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+                let list = <WasmList::<T> as Lift>::linear_lift_from_flat(cx, ty, src)?;
+                Ok(T::linear_lift_list_from_memory(cx, &list)?.into())
             }
 
-            fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
-                let list = <WasmList::<T> as Lift>::load(cx, ty, bytes)?;
-                Ok(T::load_list(cx, &list)?.into())
+            fn linear_lift_from_memory(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+                let list = <WasmList::<T> as Lift>::linear_lift_from_memory(cx, ty, bytes)?;
+                Ok(T::linear_lift_list_from_memory(cx, &list)?.into())
             }
         }
     )*)
@@ -800,7 +815,7 @@ macro_rules! integers {
         unsafe impl Lower for $primitive {
             #[inline]
             #[allow(trivial_numeric_casts)]
-            fn lower<T>(
+            fn linear_lower_to_flat<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
@@ -812,7 +827,7 @@ macro_rules! integers {
             }
 
             #[inline]
-            fn store<T>(
+            fn linear_lower_to_memory<T>(
                 &self,
                 cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
@@ -824,7 +839,7 @@ macro_rules! integers {
                 Ok(())
             }
 
-            fn store_list<T>(
+            fn linear_store_list_to_memory<T>(
                 cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
                 offset: usize,
@@ -865,19 +880,19 @@ macro_rules! integers {
         unsafe impl Lift for $primitive {
             #[inline]
             #[allow(trivial_numeric_casts, clippy::cast_possible_truncation)]
-            fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+            fn linear_lift_from_flat(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 Ok(src.$get() as $primitive)
             }
 
             #[inline]
-            fn load(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+            fn linear_lift_from_memory(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
                 Ok($primitive::from_le_bytes(bytes.try_into().unwrap()))
             }
 
-            fn load_list(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>> {
+            fn linear_lift_list_from_memory(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>> {
                 Ok(
                     list._as_le_slice(cx.memory())
                         .iter()
@@ -917,7 +932,7 @@ macro_rules! floats {
 
         unsafe impl Lower for $float {
             #[inline]
-            fn lower<T>(
+            fn linear_lower_to_flat<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
@@ -929,7 +944,7 @@ macro_rules! floats {
             }
 
             #[inline]
-            fn store<T>(
+            fn linear_lower_to_memory<T>(
                 &self,
                 cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
@@ -942,7 +957,7 @@ macro_rules! floats {
                 Ok(())
             }
 
-            fn store_list<T>(
+            fn linear_store_list_to_memory<T>(
                 cx: &mut LowerContext<'_, T>,
                 ty: InterfaceType,
                 offset: usize,
@@ -978,19 +993,19 @@ macro_rules! floats {
 
         unsafe impl Lift for $float {
             #[inline]
-            fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+            fn linear_lift_from_flat(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 Ok($float::from_bits(src.$get_float()))
             }
 
             #[inline]
-            fn load(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+            fn linear_lift_from_memory(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
                 Ok($float::from_le_bytes(bytes.try_into().unwrap()))
             }
 
-            fn load_list(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>> where Self: Sized {
+            fn linear_lift_list_from_memory(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>> where Self: Sized {
                 // See comments in `WasmList::get` for the panicking indexing
                 let byte_size = list.len * mem::size_of::<Self>();
                 let bytes = &cx.memory()[list.ptr..][..byte_size];
@@ -1033,7 +1048,7 @@ unsafe impl ComponentType for bool {
 }
 
 unsafe impl Lower for bool {
-    fn lower<T>(
+    fn linear_lower_to_flat<T>(
         &self,
         _cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1044,7 +1059,7 @@ unsafe impl Lower for bool {
         Ok(())
     }
 
-    fn store<T>(
+    fn linear_lower_to_memory<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1059,7 +1074,11 @@ unsafe impl Lower for bool {
 
 unsafe impl Lift for bool {
     #[inline]
-    fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        _cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::Bool));
         match src.get_i32() {
             0 => Ok(false),
@@ -1068,7 +1087,11 @@ unsafe impl Lift for bool {
     }
 
     #[inline]
-    fn load(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        _cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::Bool));
         match bytes[0] {
             0 => Ok(false),
@@ -1092,7 +1115,7 @@ unsafe impl ComponentType for char {
 
 unsafe impl Lower for char {
     #[inline]
-    fn lower<T>(
+    fn linear_lower_to_flat<T>(
         &self,
         _cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1104,7 +1127,7 @@ unsafe impl Lower for char {
     }
 
     #[inline]
-    fn store<T>(
+    fn linear_lower_to_memory<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1119,13 +1142,21 @@ unsafe impl Lower for char {
 
 unsafe impl Lift for char {
     #[inline]
-    fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        _cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::Char));
         Ok(char::try_from(src.get_u32())?)
     }
 
     #[inline]
-    fn load(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        _cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::Char));
         debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
         let bits = u32::from_le_bytes(bytes.try_into().unwrap());
@@ -1153,7 +1184,7 @@ unsafe impl ComponentType for str {
 }
 
 unsafe impl Lower for str {
-    fn lower<T>(
+    fn linear_lower_to_flat<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1168,7 +1199,7 @@ unsafe impl Lower for str {
         Ok(())
     }
 
-    fn store<T>(
+    fn linear_lower_to_memory<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -1448,7 +1479,11 @@ unsafe impl ComponentType for WasmStr {
 
 unsafe impl Lift for WasmStr {
     #[inline]
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::String));
         // FIXME(#4311): needs memory64 treatment
         let ptr = src[0].get_u32();
@@ -1458,7 +1493,11 @@ unsafe impl Lift for WasmStr {
     }
 
     #[inline]
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::String));
         debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
         // FIXME(#4311): needs memory64 treatment
@@ -1489,7 +1528,7 @@ unsafe impl<T> Lower for [T]
 where
     T: Lower,
 {
-    fn lower<U>(
+    fn linear_lower_to_flat<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -1507,7 +1546,7 @@ where
         Ok(())
     }
 
-    fn store<U>(
+    fn linear_lower_to_memory<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -1554,7 +1593,7 @@ where
         .checked_mul(elem_size)
         .ok_or_else(|| anyhow!("size overflow copying a list"))?;
     let ptr = cx.realloc(0, 0, T::ALIGN32, size)?;
-    T::store_list(cx, ty, ptr, list)?;
+    T::linear_store_list_to_memory(cx, ty, ptr, list)?;
     Ok((ptr, list.len()))
 }
 
@@ -1653,7 +1692,7 @@ impl<T: Lift> WasmList<T> {
         // unchecked indexing if we're confident enough and it's actually a perf
         // issue one day.
         let bytes = &cx.memory()[self.ptr + index * T::SIZE32..][..T::SIZE32];
-        Some(T::load(cx, self.elem, bytes))
+        Some(T::linear_lift_from_memory(cx, self.elem, bytes))
     }
 
     /// Returns an iterator over the elements of this list.
@@ -1740,7 +1779,11 @@ unsafe impl<T: ComponentType> ComponentType for WasmList<T> {
 }
 
 unsafe impl<T: Lift> Lift for WasmList<T> {
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         let elem = match ty {
             InterfaceType::List(i) => cx.types[i].element,
             _ => bad_type_info(),
@@ -1752,7 +1795,11 @@ unsafe impl<T: Lift> Lift for WasmList<T> {
         WasmList::new(ptr, len, cx, elem)
     }
 
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         let elem = match ty {
             InterfaceType::List(i) => cx.types[i].element,
             _ => bad_type_info(),
@@ -1978,7 +2025,7 @@ unsafe impl<T> Lower for Option<T>
 where
     T: Lower,
 {
-    fn lower<U>(
+    fn linear_lower_to_flat<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -2003,13 +2050,13 @@ where
             }
             Some(val) => {
                 map_maybe_uninit!(dst.A1).write(ValRaw::i32(1));
-                val.lower(cx, payload, map_maybe_uninit!(dst.A2))?;
+                val.linear_lower_to_flat(cx, payload, map_maybe_uninit!(dst.A2))?;
             }
         }
         Ok(())
     }
 
-    fn store<U>(
+    fn linear_lower_to_memory<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -2026,7 +2073,11 @@ where
             }
             Some(val) => {
                 cx.get::<1>(offset)[0] = 1;
-                val.store(cx, payload, offset + (Self::INFO.payload_offset32 as usize))?;
+                val.linear_lower_to_memory(
+                    cx,
+                    payload,
+                    offset + (Self::INFO.payload_offset32 as usize),
+                )?;
             }
         }
         Ok(())
@@ -2037,19 +2088,27 @@ unsafe impl<T> Lift for Option<T>
 where
     T: Lift,
 {
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         let payload = match ty {
             InterfaceType::Option(ty) => cx.types[ty].ty,
             _ => bad_type_info(),
         };
         Ok(match src.A1.get_i32() {
             0 => None,
-            1 => Some(T::lift(cx, payload, &src.A2)?),
+            1 => Some(T::linear_lift_from_flat(cx, payload, &src.A2)?),
             _ => bail!("invalid option discriminant"),
         })
     }
 
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
         let payload_ty = match ty {
             InterfaceType::Option(ty) => cx.types[ty].ty,
@@ -2059,7 +2118,7 @@ where
         let payload = &bytes[Self::INFO.payload_offset32 as usize..];
         match discrim {
             0 => Ok(None),
-            1 => Ok(Some(T::load(cx, payload_ty, payload)?)),
+            1 => Ok(Some(T::linear_lift_from_memory(cx, payload_ty, payload)?)),
             _ => bail!("invalid option discriminant"),
         }
     }
@@ -2150,7 +2209,7 @@ where
     T: Lower,
     E: Lower,
 {
-    fn lower<U>(
+    fn linear_lower_to_flat<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -2233,7 +2292,7 @@ where
                         map_maybe_uninit!(dst.payload),
                         |payload| map_maybe_uninit!(payload.ok),
                         |dst| match ok {
-                            Some(ok) => e.lower(cx, ok, dst),
+                            Some(ok) => e.linear_lower_to_flat(cx, ok, dst),
                             None => Ok(()),
                         },
                     )
@@ -2246,7 +2305,7 @@ where
                         map_maybe_uninit!(dst.payload),
                         |payload| map_maybe_uninit!(payload.err),
                         |dst| match err {
-                            Some(err) => e.lower(cx, err, dst),
+                            Some(err) => e.linear_lower_to_flat(cx, err, dst),
                             None => Ok(()),
                         },
                     )
@@ -2255,7 +2314,7 @@ where
         }
     }
 
-    fn store<U>(
+    fn linear_lower_to_memory<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
@@ -2274,13 +2333,13 @@ where
             Ok(e) => {
                 cx.get::<1>(offset)[0] = 0;
                 if let Some(ok) = ok {
-                    e.store(cx, ok, offset + payload_offset)?;
+                    e.linear_lower_to_memory(cx, ok, offset + payload_offset)?;
                 }
             }
             Err(e) => {
                 cx.get::<1>(offset)[0] = 1;
                 if let Some(err) = err {
-                    e.store(cx, err, offset + payload_offset)?;
+                    e.linear_lower_to_memory(cx, err, offset + payload_offset)?;
                 }
             }
         }
@@ -2294,7 +2353,11 @@ where
     E: Lift,
 {
     #[inline]
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
         let (ok, err) = match ty {
             InterfaceType::Result(ty) => {
                 let ty = &cx.types[ty];
@@ -2329,7 +2392,11 @@ where
     }
 
     #[inline]
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
         debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
         let discrim = bytes[0];
         let payload = &bytes[Self::INFO.payload_offset32 as usize..];
@@ -2353,7 +2420,7 @@ where
     T: Lift,
 {
     match ty {
-        Some(ty) => T::lift(cx, ty, src),
+        Some(ty) => T::linear_lift_from_flat(cx, ty, src),
         None => Ok(empty_lift()),
     }
 }
@@ -2363,7 +2430,7 @@ where
     T: Lift,
 {
     match ty {
-        Some(ty) => T::load(cx, ty, bytes),
+        Some(ty) => T::linear_lift_from_memory(cx, ty, bytes),
         None => Ok(empty_lift()),
     }
 }
@@ -2458,7 +2525,7 @@ macro_rules! impl_component_ty_for_tuples {
         unsafe impl<$($t,)*> Lower for ($($t,)*)
             where $($t: Lower),*
         {
-            fn lower<U>(
+            fn linear_lower_to_flat<U>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
@@ -2472,12 +2539,12 @@ macro_rules! impl_component_ty_for_tuples {
                 let mut _types = types.iter();
                 $(
                     let ty = *_types.next().unwrap_or_else(bad_type_info);
-                    $t.lower(cx, ty, map_maybe_uninit!(_dst.$t))?;
+                    $t.linear_lower_to_flat(cx, ty, map_maybe_uninit!(_dst.$t))?;
                 )*
                 Ok(())
             }
 
-            fn store<U>(
+            fn linear_lower_to_memory<U>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
@@ -2492,7 +2559,7 @@ macro_rules! impl_component_ty_for_tuples {
                 let mut _types = types.iter();
                 $(
                     let ty = *_types.next().unwrap_or_else(bad_type_info);
-                    $t.store(cx, ty, $t::ABI.next_field32_size(&mut _offset))?;
+                    $t.linear_lower_to_memory(cx, ty, $t::ABI.next_field32_size(&mut _offset))?;
                 )*
                 Ok(())
             }
@@ -2503,14 +2570,14 @@ macro_rules! impl_component_ty_for_tuples {
             where $($t: Lift),*
         {
             #[inline]
-            fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, _src: &Self::Lower) -> Result<Self> {
+            fn linear_lift_from_flat(cx: &mut LiftContext<'_>, ty: InterfaceType, _src: &Self::Lower) -> Result<Self> {
                 let types = match ty {
                     InterfaceType::Tuple(t) => &cx.types[t].types,
                     _ => bad_type_info(),
                 };
                 let mut _types = types.iter();
                 Ok(($(
-                    $t::lift(
+                    $t::linear_lift_from_flat(
                         cx,
                         *_types.next().unwrap_or_else(bad_type_info),
                         &_src.$t,
@@ -2519,7 +2586,7 @@ macro_rules! impl_component_ty_for_tuples {
             }
 
             #[inline]
-            fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
+            fn linear_lift_from_memory(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
                 let types = match ty {
                     InterfaceType::Tuple(t) => &cx.types[t].types,
@@ -2529,7 +2596,7 @@ macro_rules! impl_component_ty_for_tuples {
                 let mut _offset = 0;
                 $(
                     let ty = *_types.next().unwrap_or_else(bad_type_info);
-                    let $t = $t::load(cx, ty, &bytes[$t::ABI.next_field32_size(&mut _offset)..][..$t::SIZE32])?;
+                    let $t = $t::linear_lift_from_memory(cx, ty, &bytes[$t::ABI.next_field32_size(&mut _offset)..][..$t::SIZE32])?;
                 )*
                 Ok(($($t,)*))
             }

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -849,35 +849,43 @@ unsafe impl<T: 'static> ComponentType for Resource<T> {
 }
 
 unsafe impl<T: 'static> Lower for Resource<T> {
-    fn lower<U>(
+    fn linear_lower_to_flat<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
         dst: &mut MaybeUninit<Self::Lower>,
     ) -> Result<()> {
         self.lower_to_index(cx, ty)?
-            .lower(cx, InterfaceType::U32, dst)
+            .linear_lower_to_flat(cx, InterfaceType::U32, dst)
     }
 
-    fn store<U>(
+    fn linear_lower_to_memory<U>(
         &self,
         cx: &mut LowerContext<'_, U>,
         ty: InterfaceType,
         offset: usize,
     ) -> Result<()> {
         self.lower_to_index(cx, ty)?
-            .store(cx, InterfaceType::U32, offset)
+            .linear_lower_to_memory(cx, InterfaceType::U32, offset)
     }
 }
 
 unsafe impl<T: 'static> Lift for Resource<T> {
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
-        let index = u32::lift(cx, InterfaceType::U32, src)?;
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
+        let index = u32::linear_lift_from_flat(cx, InterfaceType::U32, src)?;
         Resource::lift_from_index(cx, ty, index)
     }
 
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
-        let index = u32::load(cx, InterfaceType::U32, bytes)?;
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
+        let index = u32::linear_lift_from_memory(cx, InterfaceType::U32, bytes)?;
         Resource::lift_from_index(cx, ty, index)
     }
 }
@@ -1130,35 +1138,43 @@ unsafe impl ComponentType for ResourceAny {
 }
 
 unsafe impl Lower for ResourceAny {
-    fn lower<T>(
+    fn linear_lower_to_flat<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
         dst: &mut MaybeUninit<Self::Lower>,
     ) -> Result<()> {
         self.lower_to_index(cx, ty)?
-            .lower(cx, InterfaceType::U32, dst)
+            .linear_lower_to_flat(cx, InterfaceType::U32, dst)
     }
 
-    fn store<T>(
+    fn linear_lower_to_memory<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
         offset: usize,
     ) -> Result<()> {
         self.lower_to_index(cx, ty)?
-            .store(cx, InterfaceType::U32, offset)
+            .linear_lower_to_memory(cx, InterfaceType::U32, offset)
     }
 }
 
 unsafe impl Lift for ResourceAny {
-    fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
-        let index = u32::lift(cx, InterfaceType::U32, src)?;
+    fn linear_lift_from_flat(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        src: &Self::Lower,
+    ) -> Result<Self> {
+        let index = u32::linear_lift_from_flat(cx, InterfaceType::U32, src)?;
         ResourceAny::lift_from_index(cx, ty, index)
     }
 
-    fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
-        let index = u32::load(cx, InterfaceType::U32, bytes)?;
+    fn linear_lift_from_memory(
+        cx: &mut LiftContext<'_>,
+        ty: InterfaceType,
+        bytes: &[u8],
+    ) -> Result<Self> {
+        let index = u32::linear_lift_from_memory(cx, InterfaceType::U32, bytes)?;
         ResourceAny::lift_from_index(cx, ty, index)
     }
 }

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -96,26 +96,30 @@ impl Val {
         src: &mut Iter<'_, ValRaw>,
     ) -> Result<Val> {
         Ok(match ty {
-            InterfaceType::Bool => Val::Bool(bool::lift(cx, ty, next(src))?),
-            InterfaceType::S8 => Val::S8(i8::lift(cx, ty, next(src))?),
-            InterfaceType::U8 => Val::U8(u8::lift(cx, ty, next(src))?),
-            InterfaceType::S16 => Val::S16(i16::lift(cx, ty, next(src))?),
-            InterfaceType::U16 => Val::U16(u16::lift(cx, ty, next(src))?),
-            InterfaceType::S32 => Val::S32(i32::lift(cx, ty, next(src))?),
-            InterfaceType::U32 => Val::U32(u32::lift(cx, ty, next(src))?),
-            InterfaceType::S64 => Val::S64(i64::lift(cx, ty, next(src))?),
-            InterfaceType::U64 => Val::U64(u64::lift(cx, ty, next(src))?),
-            InterfaceType::Float32 => Val::Float32(f32::lift(cx, ty, next(src))?),
-            InterfaceType::Float64 => Val::Float64(f64::lift(cx, ty, next(src))?),
-            InterfaceType::Char => Val::Char(char::lift(cx, ty, next(src))?),
+            InterfaceType::Bool => Val::Bool(bool::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::S8 => Val::S8(i8::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::U8 => Val::U8(u8::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::S16 => Val::S16(i16::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::U16 => Val::U16(u16::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::S32 => Val::S32(i32::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::U32 => Val::U32(u32::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::S64 => Val::S64(i64::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::U64 => Val::U64(u64::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::Float32 => Val::Float32(f32::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::Float64 => Val::Float64(f64::linear_lift_from_flat(cx, ty, next(src))?),
+            InterfaceType::Char => Val::Char(char::linear_lift_from_flat(cx, ty, next(src))?),
             InterfaceType::Own(_) | InterfaceType::Borrow(_) => {
-                Val::Resource(ResourceAny::lift(cx, ty, next(src))?)
+                Val::Resource(ResourceAny::linear_lift_from_flat(cx, ty, next(src))?)
             }
-            InterfaceType::String => Val::String(<_>::lift(cx, ty, &[*next(src), *next(src)])?),
+            InterfaceType::String => Val::String(<_>::linear_lift_from_flat(
+                cx,
+                ty,
+                &[*next(src), *next(src)],
+            )?),
             InterfaceType::List(i) => {
                 // FIXME(#4311): needs memory64 treatment
-                let ptr = u32::lift(cx, InterfaceType::U32, next(src))? as usize;
-                let len = u32::lift(cx, InterfaceType::U32, next(src))? as usize;
+                let ptr = u32::linear_lift_from_flat(cx, InterfaceType::U32, next(src))? as usize;
+                let len = u32::linear_lift_from_flat(cx, InterfaceType::U32, next(src))? as usize;
                 load_list(cx, i, ptr, len)?
             }
             InterfaceType::Record(i) => Val::Record(
@@ -192,7 +196,7 @@ impl Val {
                         ty,
                         &mut flags,
                         i * 32,
-                        u32::lift(cx, InterfaceType::U32, next(src))?,
+                        u32::linear_lift_from_flat(cx, InterfaceType::U32, next(src))?,
                     );
                 }
 
@@ -207,21 +211,21 @@ impl Val {
     /// Deserialize a value of this type from the heap.
     pub(crate) fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Val> {
         Ok(match ty {
-            InterfaceType::Bool => Val::Bool(bool::load(cx, ty, bytes)?),
-            InterfaceType::S8 => Val::S8(i8::load(cx, ty, bytes)?),
-            InterfaceType::U8 => Val::U8(u8::load(cx, ty, bytes)?),
-            InterfaceType::S16 => Val::S16(i16::load(cx, ty, bytes)?),
-            InterfaceType::U16 => Val::U16(u16::load(cx, ty, bytes)?),
-            InterfaceType::S32 => Val::S32(i32::load(cx, ty, bytes)?),
-            InterfaceType::U32 => Val::U32(u32::load(cx, ty, bytes)?),
-            InterfaceType::S64 => Val::S64(i64::load(cx, ty, bytes)?),
-            InterfaceType::U64 => Val::U64(u64::load(cx, ty, bytes)?),
-            InterfaceType::Float32 => Val::Float32(f32::load(cx, ty, bytes)?),
-            InterfaceType::Float64 => Val::Float64(f64::load(cx, ty, bytes)?),
-            InterfaceType::Char => Val::Char(char::load(cx, ty, bytes)?),
-            InterfaceType::String => Val::String(<_>::load(cx, ty, bytes)?),
+            InterfaceType::Bool => Val::Bool(bool::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::S8 => Val::S8(i8::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::U8 => Val::U8(u8::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::S16 => Val::S16(i16::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::U16 => Val::U16(u16::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::S32 => Val::S32(i32::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::U32 => Val::U32(u32::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::S64 => Val::S64(i64::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::U64 => Val::U64(u64::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::Float32 => Val::Float32(f32::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::Float64 => Val::Float64(f64::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::Char => Val::Char(char::linear_lift_from_memory(cx, ty, bytes)?),
+            InterfaceType::String => Val::String(<_>::linear_lift_from_memory(cx, ty, bytes)?),
             InterfaceType::Own(_) | InterfaceType::Borrow(_) => {
-                Val::Resource(ResourceAny::load(cx, ty, bytes)?)
+                Val::Resource(ResourceAny::linear_lift_from_memory(cx, ty, bytes)?)
             }
             InterfaceType::List(i) => {
                 // FIXME(#4311): needs memory64 treatment
@@ -302,16 +306,16 @@ impl Val {
                 match FlagsSize::from_count(ty.names.len()) {
                     FlagsSize::Size0 => {}
                     FlagsSize::Size1 => {
-                        let bits = u8::load(cx, InterfaceType::U8, bytes)?;
+                        let bits = u8::linear_lift_from_memory(cx, InterfaceType::U8, bytes)?;
                         push_flags(ty, &mut flags, 0, u32::from(bits));
                     }
                     FlagsSize::Size2 => {
-                        let bits = u16::load(cx, InterfaceType::U16, bytes)?;
+                        let bits = u16::linear_lift_from_memory(cx, InterfaceType::U16, bytes)?;
                         push_flags(ty, &mut flags, 0, u32::from(bits));
                     }
                     FlagsSize::Size4Plus(n) => {
                         for i in 0..n {
-                            let bits = u32::load(
+                            let bits = u32::linear_lift_from_memory(
                                 cx,
                                 InterfaceType::U32,
                                 &bytes[usize::from(i) * 4..][..4],
@@ -336,39 +340,63 @@ impl Val {
         dst: &mut IterMut<'_, MaybeUninit<ValRaw>>,
     ) -> Result<()> {
         match (ty, self) {
-            (InterfaceType::Bool, Val::Bool(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::Bool, Val::Bool(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::Bool, _) => unexpected(ty, self),
-            (InterfaceType::S8, Val::S8(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::S8, Val::S8(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::S8, _) => unexpected(ty, self),
-            (InterfaceType::U8, Val::U8(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::U8, Val::U8(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::U8, _) => unexpected(ty, self),
-            (InterfaceType::S16, Val::S16(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::S16, Val::S16(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::S16, _) => unexpected(ty, self),
-            (InterfaceType::U16, Val::U16(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::U16, Val::U16(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::U16, _) => unexpected(ty, self),
-            (InterfaceType::S32, Val::S32(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::S32, Val::S32(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::S32, _) => unexpected(ty, self),
-            (InterfaceType::U32, Val::U32(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::U32, Val::U32(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::U32, _) => unexpected(ty, self),
-            (InterfaceType::S64, Val::S64(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::S64, Val::S64(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::S64, _) => unexpected(ty, self),
-            (InterfaceType::U64, Val::U64(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::U64, Val::U64(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::U64, _) => unexpected(ty, self),
-            (InterfaceType::Float32, Val::Float32(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::Float32, Val::Float32(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::Float32, _) => unexpected(ty, self),
-            (InterfaceType::Float64, Val::Float64(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::Float64, Val::Float64(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::Float64, _) => unexpected(ty, self),
-            (InterfaceType::Char, Val::Char(value)) => value.lower(cx, ty, next_mut(dst)),
+            (InterfaceType::Char, Val::Char(value)) => {
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
+            }
             (InterfaceType::Char, _) => unexpected(ty, self),
             // NB: `lower` on `ResourceAny` does its own type-checking, so skip
             // looking at it here.
             (InterfaceType::Borrow(_) | InterfaceType::Own(_), Val::Resource(value)) => {
-                value.lower(cx, ty, next_mut(dst))
+                value.linear_lower_to_flat(cx, ty, next_mut(dst))
             }
             (InterfaceType::Borrow(_) | InterfaceType::Own(_), _) => unexpected(ty, self),
             (InterfaceType::String, Val::String(value)) => {
                 let my_dst = &mut MaybeUninit::<[ValRaw; 2]>::uninit();
-                value.lower(cx, ty, my_dst)?;
+                value.linear_lower_to_flat(cx, ty, my_dst)?;
                 let my_dst = unsafe { my_dst.assume_init() };
                 next_mut(dst).write(my_dst[0]);
                 next_mut(dst).write(my_dst[1]);
@@ -451,36 +479,42 @@ impl Val {
         debug_assert!(offset % usize::try_from(cx.types.canonical_abi(&ty).align32)? == 0);
 
         match (ty, self) {
-            (InterfaceType::Bool, Val::Bool(value)) => value.store(cx, ty, offset),
+            (InterfaceType::Bool, Val::Bool(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::Bool, _) => unexpected(ty, self),
-            (InterfaceType::U8, Val::U8(value)) => value.store(cx, ty, offset),
+            (InterfaceType::U8, Val::U8(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::U8, _) => unexpected(ty, self),
-            (InterfaceType::S8, Val::S8(value)) => value.store(cx, ty, offset),
+            (InterfaceType::S8, Val::S8(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::S8, _) => unexpected(ty, self),
-            (InterfaceType::U16, Val::U16(value)) => value.store(cx, ty, offset),
+            (InterfaceType::U16, Val::U16(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::U16, _) => unexpected(ty, self),
-            (InterfaceType::S16, Val::S16(value)) => value.store(cx, ty, offset),
+            (InterfaceType::S16, Val::S16(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::S16, _) => unexpected(ty, self),
-            (InterfaceType::U32, Val::U32(value)) => value.store(cx, ty, offset),
+            (InterfaceType::U32, Val::U32(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::U32, _) => unexpected(ty, self),
-            (InterfaceType::S32, Val::S32(value)) => value.store(cx, ty, offset),
+            (InterfaceType::S32, Val::S32(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::S32, _) => unexpected(ty, self),
-            (InterfaceType::U64, Val::U64(value)) => value.store(cx, ty, offset),
+            (InterfaceType::U64, Val::U64(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::U64, _) => unexpected(ty, self),
-            (InterfaceType::S64, Val::S64(value)) => value.store(cx, ty, offset),
+            (InterfaceType::S64, Val::S64(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::S64, _) => unexpected(ty, self),
-            (InterfaceType::Float32, Val::Float32(value)) => value.store(cx, ty, offset),
+            (InterfaceType::Float32, Val::Float32(value)) => {
+                value.linear_lower_to_memory(cx, ty, offset)
+            }
             (InterfaceType::Float32, _) => unexpected(ty, self),
-            (InterfaceType::Float64, Val::Float64(value)) => value.store(cx, ty, offset),
+            (InterfaceType::Float64, Val::Float64(value)) => {
+                value.linear_lower_to_memory(cx, ty, offset)
+            }
             (InterfaceType::Float64, _) => unexpected(ty, self),
-            (InterfaceType::Char, Val::Char(value)) => value.store(cx, ty, offset),
+            (InterfaceType::Char, Val::Char(value)) => value.linear_lower_to_memory(cx, ty, offset),
             (InterfaceType::Char, _) => unexpected(ty, self),
-            (InterfaceType::String, Val::String(value)) => value.store(cx, ty, offset),
+            (InterfaceType::String, Val::String(value)) => {
+                value.linear_lower_to_memory(cx, ty, offset)
+            }
             (InterfaceType::String, _) => unexpected(ty, self),
 
             // NB: resources do type-checking when they lower.
             (InterfaceType::Borrow(_) | InterfaceType::Own(_), Val::Resource(value)) => {
-                value.store(cx, ty, offset)
+                value.linear_lower_to_memory(cx, ty, offset)
             }
             (InterfaceType::Borrow(_) | InterfaceType::Own(_), _) => unexpected(ty, self),
             (InterfaceType::List(ty), Val::List(values)) => {
@@ -552,20 +586,20 @@ impl Val {
                 let storage = flags_to_storage(ty, flags)?;
                 match FlagsSize::from_count(ty.names.len()) {
                     FlagsSize::Size0 => {}
-                    FlagsSize::Size1 => {
-                        u8::try_from(storage[0])
-                            .unwrap()
-                            .store(cx, InterfaceType::U8, offset)?
-                    }
-                    FlagsSize::Size2 => {
-                        u16::try_from(storage[0])
-                            .unwrap()
-                            .store(cx, InterfaceType::U16, offset)?
-                    }
+                    FlagsSize::Size1 => u8::try_from(storage[0]).unwrap().linear_lower_to_memory(
+                        cx,
+                        InterfaceType::U8,
+                        offset,
+                    )?,
+                    FlagsSize::Size2 => u16::try_from(storage[0]).unwrap().linear_lower_to_memory(
+                        cx,
+                        InterfaceType::U16,
+                        offset,
+                    )?,
                     FlagsSize::Size4Plus(_) => {
                         let mut offset = offset;
                         for value in storage {
-                            value.store(cx, InterfaceType::U32, offset)?;
+                            value.linear_lower_to_memory(cx, InterfaceType::U32, offset)?;
                             offset += 4;
                         }
                     }
@@ -807,17 +841,16 @@ impl GenericVariant<'_> {
 
     fn store<T>(&self, cx: &mut LowerContext<'_, T>, offset: usize) -> Result<()> {
         match self.info.size {
-            DiscriminantSize::Size1 => {
-                u8::try_from(self.discriminant)
-                    .unwrap()
-                    .store(cx, InterfaceType::U8, offset)?
+            DiscriminantSize::Size1 => u8::try_from(self.discriminant)
+                .unwrap()
+                .linear_lower_to_memory(cx, InterfaceType::U8, offset)?,
+            DiscriminantSize::Size2 => u16::try_from(self.discriminant)
+                .unwrap()
+                .linear_lower_to_memory(cx, InterfaceType::U16, offset)?,
+            DiscriminantSize::Size4 => {
+                self.discriminant
+                    .linear_lower_to_memory(cx, InterfaceType::U32, offset)?
             }
-            DiscriminantSize::Size2 => {
-                u16::try_from(self.discriminant)
-                    .unwrap()
-                    .store(cx, InterfaceType::U16, offset)?
-            }
-            DiscriminantSize::Size4 => self.discriminant.store(cx, InterfaceType::U32, offset)?,
         }
 
         if let Some((value, ty)) = self.payload {
@@ -866,9 +899,19 @@ fn load_variant(
     bytes: &[u8],
 ) -> Result<(u32, Option<Box<Val>>)> {
     let discriminant = match info.size {
-        DiscriminantSize::Size1 => u32::from(u8::load(cx, InterfaceType::U8, &bytes[..1])?),
-        DiscriminantSize::Size2 => u32::from(u16::load(cx, InterfaceType::U16, &bytes[..2])?),
-        DiscriminantSize::Size4 => u32::load(cx, InterfaceType::U32, &bytes[..4])?,
+        DiscriminantSize::Size1 => u32::from(u8::linear_lift_from_memory(
+            cx,
+            InterfaceType::U8,
+            &bytes[..1],
+        )?),
+        DiscriminantSize::Size2 => u32::from(u16::linear_lift_from_memory(
+            cx,
+            InterfaceType::U16,
+            &bytes[..2],
+        )?),
+        DiscriminantSize::Size4 => {
+            u32::linear_lift_from_memory(cx, InterfaceType::U32, &bytes[..4])?
+        }
     };
     let case_ty = types.nth(discriminant as usize).ok_or_else(|| {
         anyhow!(


### PR DESCRIPTION
This is to distinguish them from the GC versions that will be added in follow up commits.

No functional changes here, just renaming.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
