### PR TITLE
Re-enable removed testing onnx from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -778,7 +778,7 @@ jobs:
   test_wasi_nn:
     strategy:
       matrix:
-        feature: ["openvino"]
+        feature: ["openvino", "onnx"]
         os: ["ubuntu-24.04", "windows-2025"]
         include:
           - os: windows-2025


### PR DESCRIPTION
This PR is raised to re-enable the testing of onnx in the CI according to the discussion in https://github.com/bytecodealliance/wasmtime/pull/10411.
