### PR TITLE
x64: Migrate cmp/test to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -598,6 +598,17 @@ pub enum Eflags {
     RW,
 }
 
+impl Eflags {
+    /// Returns whether this represents a writes to any bit in the EFLAGS
+    /// register.
+    pub fn is_write(&self) -> bool {
+        match self {
+            Eflags::None | Eflags::R => false,
+            Eflags::W | Eflags::RW => true,
+        }
+    }
+}
+
 impl Default for Eflags {
     fn default() -> Self {
         Self::None

--- a/cranelift/assembler-x64/meta/src/instructions/cmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cmp.rs
@@ -1,5 +1,5 @@
 use crate::dsl::{Customization::*, Eflags::*, Feature::*, Inst, Location::*, VexLength::*};
-use crate::dsl::{align, fmt, inst, r, rex, rw, vex, w};
+use crate::dsl::{align, fmt, inst, r, rex, rw, sxl, sxq, sxw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -28,5 +28,38 @@ pub fn list() -> Vec<Inst> {
         inst("cmpss", fmt("A", [rw(xmm1), r(xmm_m32), r(imm8)]), rex([0xF3, 0x0F, 0xC2]).r().ib(), _64b | compat | sse).custom(Display),
         inst("ucomisd", fmt("A", [r(xmm1), r(xmm_m64)]).flags(W), rex([0x66, 0x0F, 0x2E]).r(), _64b | compat | sse2),
         inst("ucomiss", fmt("A", [r(xmm1), r(xmm_m32)]).flags(W), rex([0x0F, 0x2E]).r(), _64b | compat | sse),
+
+        inst("cmpb", fmt("I", [r(al), r(imm8)]).flags(W), rex([0x3C]).ib(), _64b | compat),
+        inst("cmpw", fmt("I", [r(ax), r(imm16)]).flags(W), rex([0x66, 0x3D]).iw(), _64b | compat),
+        inst("cmpl", fmt("I", [r(eax), r(imm32)]).flags(W), rex([0x3D]).id(), _64b | compat),
+        inst("cmpq", fmt("I", [r(rax), r(sxq(imm32))]).flags(W), rex([0x3D]).w().id(), _64b),
+        inst("cmpb", fmt("MI", [r(rm8), r(imm8)]).flags(W), rex([0x80]).digit(7).ib(), _64b | compat),
+        inst("cmpw", fmt("MI", [r(rm16), r(imm16)]).flags(W), rex([0x66, 0x81]).digit(7).iw(), _64b | compat),
+        inst("cmpl", fmt("MI", [r(rm32), r(imm32)]).flags(W), rex([0x81]).digit(7).id(), _64b | compat),
+        inst("cmpq", fmt("MI", [r(rm64), r(sxq(imm32))]).flags(W), rex([0x81]).w().digit(7).id(), _64b),
+        inst("cmpw", fmt("MI_SXB", [r(rm16), r(sxw(imm8))]).flags(W), rex([0x66, 0x83]).digit(7).ib(), _64b | compat),
+        inst("cmpl", fmt("MI_SXB", [r(rm32), r(sxl(imm8))]).flags(W), rex([0x83]).digit(7).ib(), _64b | compat),
+        inst("cmpq", fmt("MI_SXB", [r(rm64), r(sxq(imm8))]).flags(W), rex([0x83]).w().digit(7).ib(), _64b),
+        inst("cmpb", fmt("MR", [r(rm8), r(r8)]).flags(W), rex([0x38]), _64b | compat),
+        inst("cmpw", fmt("MR", [r(rm16), r(r16)]).flags(W), rex([0x66, 0x39]), _64b | compat),
+        inst("cmpl", fmt("MR", [r(rm32), r(r32)]).flags(W), rex([0x39]), _64b | compat),
+        inst("cmpq", fmt("MR", [r(rm64), r(r64)]).flags(W), rex([0x39]).w(), _64b),
+        inst("cmpb", fmt("RM", [r(r8), r(rm8)]).flags(W), rex([0x3A]), _64b | compat),
+        inst("cmpw", fmt("RM", [r(r16), r(rm16)]).flags(W), rex([0x66, 0x3B]), _64b | compat),
+        inst("cmpl", fmt("RM", [r(r32), r(rm32)]).flags(W), rex([0x3B]), _64b | compat),
+        inst("cmpq", fmt("RM", [r(r64), r(rm64)]).flags(W), rex([0x3B]).w(), _64b),
+
+        inst("testb", fmt("I", [r(al), r(imm8)]).flags(W), rex([0xA8]).ib(), _64b | compat),
+        inst("testw", fmt("I", [r(ax), r(imm16)]).flags(W), rex([0x66, 0xA9]).iw(), _64b | compat),
+        inst("testl", fmt("I", [r(eax), r(imm32)]).flags(W), rex([0xA9]).id(), _64b | compat),
+        inst("testq", fmt("I", [r(rax), r(sxq(imm32))]).flags(W), rex([0xA9]).w().id(), _64b),
+        inst("testb", fmt("MI", [r(rm8), r(imm8)]).flags(W), rex([0xF6]).digit(0).ib(), _64b | compat),
+        inst("testw", fmt("MI", [r(rm16), r(imm16)]).flags(W), rex([0x66, 0xF7]).digit(0).iw(), _64b | compat),
+        inst("testl", fmt("MI", [r(rm32), r(imm32)]).flags(W), rex([0xF7]).digit(0).id(), _64b | compat),
+        inst("testq", fmt("MI", [r(rm64), r(sxq(imm32))]).flags(W), rex([0xF7]).w().digit(0).id(), _64b),
+        inst("testb", fmt("MR", [r(rm8), r(r8)]).flags(W), rex([0x84]), _64b | compat),
+        inst("testw", fmt("MR", [r(rm16), r(r16)]).flags(W), rex([0x66, 0x85]), _64b | compat),
+        inst("testl", fmt("MR", [r(rm32), r(r32)]).flags(W), rex([0x85]), _64b | compat),
+        inst("testq", fmt("MR", [r(rm64), r(r64)]).flags(W), rex([0x85]).w(), _64b | compat),
     ]
 }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -474,7 +474,13 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn gen_stack_lower_bound_trap(limit_reg: Reg) -> SmallInstVec<Self::I> {
         smallvec![
-            Inst::cmp_rmi_r(OperandSize::Size64, limit_reg, RegMemImm::reg(regs::rsp())),
+            Inst::External {
+                inst: asm::inst::cmpq_rm::new(
+                    Gpr::unwrap_new(limit_reg),
+                    Gpr::unwrap_new(regs::rsp())
+                )
+                .into(),
+            },
             Inst::TrapIf {
                 // NBE == "> unsigned"; args above are reversed; this tests limit_reg > rsp.
                 cc: CC::NBE,

--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -577,13 +577,3 @@ pub(crate) fn emit_std_reg_reg<BS: ByteSink + ?Sized>(
     let enc_e = reg_enc(reg_e);
     emit_std_enc_enc(sink, prefixes, opcodes, num_opcodes, enc_g, enc_e, rex);
 }
-
-/// Write a suitable number of bits from an imm64 to the sink.
-pub(crate) fn emit_simm<BS: ByteSink + ?Sized>(sink: &mut BS, size: u8, simm32: u32) {
-    match size {
-        8 | 4 => sink.put4(simm32),
-        2 => sink.put2(simm32 as u16),
-        1 => sink.put1(simm32 as u8),
-        _ => unreachable!(),
-    }
-}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -44,12 +44,6 @@
                              (dst WritableGpr)
                              (size OperandSize))
 
-       ;; Integer comparisons/tests: cmp or test (b w l q) (reg addr imm) reg.
-       (CmpRmiR (size OperandSize) ;; 1, 2, 4, or 8
-                (opcode CmpOpcode)
-                (src1 Gpr)
-                (src2 GprMemImm))
-
        ;; Materializes the requested condition code in the destination reg.
        (Setcc (cc CC)
               (dst WritableGpr))
@@ -516,10 +510,6 @@
             Shufps
             Pblendw
           ))
-
-(type CmpOpcode extern
-      (enum Cmp
-            Test))
 
 (type RegMemImm extern
       (enum
@@ -2553,24 +2543,25 @@
 (rule (x64_bswap $I32 src) (x64_bswapl_o src))
 (rule (x64_bswap $I64 src) (x64_bswapq_o src))
 
-;; Helper for creating `MInst.CmpRmiR` instructions.
-(decl cmp_rmi_r (OperandSize CmpOpcode Gpr GprMemImm) ProducesFlags)
-(rule (cmp_rmi_r size opcode src1 src2)
-      (ProducesFlags.ProducesFlagsSideEffect
-       (MInst.CmpRmiR size
-                      opcode
-                      src1
-                      src2)))
-
 ;; Helper for creating `cmp` instructions.
-(decl x64_cmp (OperandSize Gpr GprMemImm) ProducesFlags)
-(rule (x64_cmp size src1 src2)
-      (cmp_rmi_r size (CmpOpcode.Cmp) src1 src2))
+(decl x64_cmp (Type Gpr GprMemImm) ProducesFlags)
 
-;; Helper for creating `cmp` instructions with an immediate.
-(decl x64_cmp_imm (OperandSize Gpr u32) ProducesFlags)
-(rule (x64_cmp_imm size src1 src2)
-      (x64_cmp size src1 (RegMemImm.Imm src2)))
+;; If the rhs is an immediate try to use the 8-bit form if the immediate fits.
+(rule 2 (x64_cmp $I16 src1 (is_simm8 src2)) (x64_cmpw_mi_sxb src1 src2))
+(rule 2 (x64_cmp $I32 src1 (is_simm8 src2)) (x64_cmpl_mi_sxb src1 src2))
+(rule 2 (x64_cmp $I64 src1 (is_simm8 src2)) (x64_cmpq_mi_sxb src1 src2))
+
+;; Base case: rhs is an immediate
+(rule 1 (x64_cmp $I8 src1 (is_imm8 src2)) (x64_cmpb_mi src1 src2))
+(rule 1 (x64_cmp $I16 src1 (is_imm16 src2)) (x64_cmpw_mi src1 src2))
+(rule 1 (x64_cmp $I32 src1 (is_imm32 src2)) (x64_cmpl_mi src1 src2))
+(rule 1 (x64_cmp $I64 src1 (is_simm32 src2)) (x64_cmpq_mi src1 src2))
+
+;; Base case: rhs is a GprMem operand.
+(rule 0 (x64_cmp $I8 src1 (is_gpr_mem src2)) (x64_cmpb_rm src1 src2))
+(rule 0 (x64_cmp $I16 src1 (is_gpr_mem src2)) (x64_cmpw_rm src1 src2))
+(rule 0 (x64_cmp $I32 src1 (is_gpr_mem src2)) (x64_cmpl_rm src1 src2))
+(rule 0 (x64_cmp $I64 src1 (is_gpr_mem src2)) (x64_cmpq_rm src1 src2))
 
 ;; Helper for creating `MInst.XmmCmpRmR` instructions.
 (decl xmm_cmp_rm_r (SseOpcode Xmm XmmMem) ProducesFlags)
@@ -2586,10 +2577,8 @@
 
 ;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
 (decl x64_ucomis (Type Xmm XmmMem) ProducesFlags)
-(rule (x64_ucomis $F32 src1 src2)
-      (asm_produce_flags_side_effect (x64_ucomiss_a_raw src1 src2)))
-(rule (x64_ucomis $F64 src1 src2)
-      (asm_produce_flags_side_effect (x64_ucomisd_a_raw src1 src2)))
+(rule (x64_ucomis $F32 src1 src2) (x64_ucomiss_a src1 src2))
+(rule (x64_ucomis $F64 src1 src2) (x64_ucomisd_a src1 src2))
 (rule 1 (x64_ucomis $F32 src1 src2)
         (if-let true (use_avx))
         (xmm_cmp_rm_r_vex (AvxOpcode.Vucomiss) src1 src2))
@@ -2598,9 +2587,17 @@
         (xmm_cmp_rm_r_vex (AvxOpcode.Vucomisd) src1 src2))
 
 ;; Helper for creating `test` instructions.
-(decl x64_test (OperandSize Gpr GprMemImm) ProducesFlags)
-(rule (x64_test size src1 src2)
-      (cmp_rmi_r size (CmpOpcode.Test) src1 src2))
+(decl x64_test (Type Gpr GprMemImm) ProducesFlags)
+
+(rule 1 (x64_test $I8 src1 (is_imm8 src2)) (x64_testb_mi src1 src2))
+(rule 1 (x64_test $I16 src1 (is_imm16 src2)) (x64_testw_mi src1 src2))
+(rule 1 (x64_test $I32 src1 (is_imm32 src2)) (x64_testl_mi src1 src2))
+(rule 1 (x64_test $I64 src1 (is_simm32 src2)) (x64_testq_mi src1 src2))
+
+(rule 0 (x64_test $I8 src1 (is_gpr_mem src2)) (x64_testb_mr src2 src1))
+(rule 0 (x64_test $I16 src1 (is_gpr_mem src2)) (x64_testw_mr src2 src1))
+(rule 0 (x64_test $I32 src1 (is_gpr_mem src2)) (x64_testl_mr src2 src1))
+(rule 0 (x64_test $I64 src1 (is_gpr_mem src2)) (x64_testq_mr src2 src1))
 
 ;; Helper for creating `ptest` instructions.
 (decl x64_ptest (Xmm XmmMem) ProducesFlags)
@@ -4355,16 +4352,15 @@
 
 (decl trap_if_val (ZeroCond Value TrapCode) SideEffectNoResult)
 (rule (trap_if_val zero_cond a @ (value_type (fits_in_64 ty)) tc)
-  (let ((size OperandSize (raw_operand_size_of_type ty))
-        (a Gpr (put_in_reg a))
-        (producer ProducesFlags (x64_test size a a)))
+  (let ((a Gpr (put_in_reg a))
+        (producer ProducesFlags (x64_test ty a a)))
         (with_flags_side_effect producer (trap_if (zero_cond_to_cc zero_cond) tc))))
 
 (rule 1 (trap_if_val zero_cond a @ (value_type $I128) tc)
   (let ((a_lo Gpr (value_regs_get_gpr a 0))
         (a_hi Gpr (value_regs_get_gpr a 1))
         (a_or Gpr (x64_or $I64 a_hi a_lo))
-        (producer ProducesFlags (x64_test (OperandSize.Size64) a_or a_or)))
+        (producer ProducesFlags (x64_testq_mr a_or a_or)))
         (with_flags_side_effect producer (trap_if (zero_cond_to_cc zero_cond) tc))))
 
 ;; Helper for creating `movddup` instructions
@@ -4492,26 +4488,22 @@
 ;; For GPR-held values we only need to emit `CMP + SETCC`. We rely here on
 ;; Cranelift's verification that `a` and `b` are of the same type.
 (rule 0 (emit_cmp cc a @ (value_type ty) b)
-      (let ((size OperandSize (raw_operand_size_of_type ty)))
-        (icmp_cond_result (x64_cmp size a b) cc)))
+        (icmp_cond_result (x64_cmp ty a b) cc))
 
 ;; As a special case, swap the arguments to the comparison when the LHS is a
 ;; constant. This ensures that we avoid moving the constant into a register when
 ;; performing the comparison.
 (rule 1 (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
-      (let ((size OperandSize (raw_operand_size_of_type ty)))
-        (icmp_cond_result (x64_cmp size b a) (intcc_swap_args cc))))
+        (icmp_cond_result (x64_cmp ty b a) (intcc_swap_args cc)))
 
 ;; Special case: use the test instruction for comparisons with 0.
 (rule 2 (emit_cmp cc a @ (value_type ty) (u64_from_iconst 0))
-      (let ((size OperandSize (raw_operand_size_of_type ty))
-            (a Gpr (put_in_reg a)))
-        (icmp_cond_result (x64_test size a a) cc)))
+      (let ((a Gpr (put_in_reg a)))
+        (icmp_cond_result (x64_test ty a a) cc)))
 
 (rule 3 (emit_cmp cc (u64_from_iconst 0) b @ (value_type ty))
-      (let ((size OperandSize (raw_operand_size_of_type ty))
-            (b Gpr (put_in_reg b)))
-        (icmp_cond_result (x64_test size b b) (intcc_swap_args cc))))
+      (let ((b Gpr (put_in_reg b)))
+        (icmp_cond_result (x64_test ty b b) (intcc_swap_args cc))))
 
 ;; For I128 values (held in two GPRs), the instruction sequences depend on what
 ;; kind of condition is tested.
@@ -4548,7 +4540,7 @@
 (rule 0 (emit_cmp_i128 cc a_hi a_lo b_hi b_lo)
         (icmp_cond_result
           (produces_flags_concat
-            (x64_cmp (OperandSize.Size64) a_lo b_lo)
+            (x64_cmpq_rm a_lo b_lo)
             (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Sbb) $I64 a_hi b_hi))
           cc))
 

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -624,13 +624,6 @@ impl RegMemImm {
         Self::Imm { simm32 }
     }
 
-    /// Asserts that in register mode, the reg class is the one that's expected.
-    pub(crate) fn assert_regclass_is(&self, expected_reg_class: RegClass) {
-        if let Self::Reg { reg } = self {
-            debug_assert_eq!(reg.class(), expected_reg_class);
-        }
-    }
-
     /// Add the regs mentioned by `self` to `collector`.
     pub(crate) fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
         match self {
@@ -727,15 +720,6 @@ impl PrettyPrint for RegMem {
             RegMem::Mem { addr, .. } => addr.pretty_print(size),
         }
     }
-}
-
-#[derive(Clone, Copy, PartialEq)]
-/// Comparison operations.
-pub enum CmpOpcode {
-    /// CMP instruction: compute `a - b` and set flags from result.
-    Cmp,
-    /// TEST instruction: compute `a & b` and set flags from result.
-    Test,
 }
 
 #[derive(Debug)]

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2433,15 +2433,15 @@ pub(crate) fn emit(
                     // cmp %r_temp, %r_operand
                     let temp = temp.to_reg();
                     match *ty {
-                        types::I8 => asm::inst::cmpb_rm::new(operand, temp).emit(sink, info, state),
+                        types::I8 => asm::inst::cmpb_mr::new(operand, temp).emit(sink, info, state),
                         types::I16 => {
-                            asm::inst::cmpw_rm::new(operand, temp).emit(sink, info, state)
+                            asm::inst::cmpw_mr::new(operand, temp).emit(sink, info, state)
                         }
                         types::I32 => {
-                            asm::inst::cmpl_rm::new(operand, temp).emit(sink, info, state)
+                            asm::inst::cmpl_mr::new(operand, temp).emit(sink, info, state)
                         }
                         types::I64 => {
-                            asm::inst::cmpq_rm::new(operand, temp).emit(sink, info, state)
+                            asm::inst::cmpq_mr::new(operand, temp).emit(sink, info, state)
                         }
                         _ => unreachable!(),
                     }
@@ -2538,7 +2538,7 @@ pub(crate) fn emit(
                 RmwOp::Umin | RmwOp::Umax | RmwOp::Smin | RmwOp::Smax => {
                     // Do a comparison with LHS temp and RHS operand.
                     // Note the opposite argument orders.
-                    asm::inst::cmpq_rm::new(temp_low.to_reg(), operand_low).emit(sink, info, state);
+                    asm::inst::cmpq_mr::new(temp_low.to_reg(), operand_low).emit(sink, info, state);
                     // This will clobber `temp_high`
                     asm::inst::sbbq_rm::new(temp_high, operand_high).emit(sink, info, state);
                     // Restore the clobbered value

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -583,9 +583,7 @@
                                  amt)))
             (zero Gpr (imm $I64 0))
             ;; Nullify the carry if we are shifting in by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64)
-                                              amt
-                                              (RegMemImm.Imm 127))
+            (carry_ Gpr (with_flags_reg (x64_testq_mi amt 127)
                                         (cmove $I64
                                                (CC.Z)
                                                zero
@@ -595,7 +593,7 @@
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the low bits are zero and the high bits are our
         ;; low bits.
-        (with_flags (x64_test (OperandSize.Size64) amt (RegMemImm.Imm 64))
+        (with_flags (x64_testq_mi amt 64)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted zero)
                      (cmove $I64 (CC.Z) hi_shifted_ lo_shifted)))))
@@ -694,14 +692,14 @@
             (zero Gpr (imm $I64 0))
 
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64) amt (RegMemImm.Imm 127))
+            (carry_ Gpr (with_flags_reg (x64_testq_mi amt 127)
                                         (cmove $I64 (CC.Z) zero carry)))
             ;; Add the carry bits into the lo.
             (lo_shifted_ Gpr (x64_or $I64 carry_ lo_shifted)))
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are zero and the lo bits are what
         ;; would otherwise be our hi bits.
-        (with_flags (x64_test (OperandSize.Size64) amt (RegMemImm.Imm 64))
+        (with_flags (x64_testq_mi amt 64)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
                      (cmove $I64 (CC.Z) hi_shifted zero)))))
@@ -802,7 +800,7 @@
                                  (imm $I64 64)
                                  amt)))
             ;; Nullify the carry if we are shifting by a multiple of 128.
-            (carry_ Gpr (with_flags_reg (x64_test (OperandSize.Size64) amt (RegMemImm.Imm 127))
+            (carry_ Gpr (with_flags_reg (x64_testq_mi amt 127)
                                         (cmove $I64 (CC.Z) (imm $I64 0) carry)))
             ;; Add the carry into the low half.
             (lo_shifted_ Gpr (x64_or $I64 lo_shifted carry_))
@@ -811,7 +809,7 @@
         ;; Combine the two shifted halves. However, if we are shifting by >= 64
         ;; (modulo 128), then the hi bits are all sign bits and the lo bits are
         ;; what would otherwise be our hi bits.
-        (with_flags (x64_test (OperandSize.Size64) amt (RegMemImm.Imm 64))
+        (with_flags (x64_testq_mi amt 64)
                     (consumes_flags_concat
                      (cmove $I64 (CC.Z) lo_shifted_ hi_shifted)
                      (cmove $I64 (CC.Z) hi_shifted sign_bits)))))
@@ -1745,14 +1743,13 @@
 
 (decl cmp_and_choose (Type CC Value Value) ValueRegs)
 (rule (cmp_and_choose (fits_in_64 ty) cc x y)
-      (let ((size OperandSize (raw_operand_size_of_type ty))
-            ;; We need to put x and y in registers explicitly because
+      (let( ;; We need to put x and y in registers explicitly because
             ;; we use the values more than once. Hence, even if these
             ;; are "unique uses" at the CLIF level and would otherwise
             ;; allow for load-op merging, here we cannot do that.
             (x_reg Reg x)
             (y_reg Reg y))
-        (with_flags_reg (x64_cmp size y_reg x_reg)
+        (with_flags_reg (x64_cmp ty y_reg x_reg)
                         (cmove ty cc y_reg x_reg))))
 
 (rule -1 (lower (has_type (fits_in_64 ty) (umin x y)))
@@ -2211,11 +2208,10 @@
 ;; to be the final, default lowerings if no other patterns matched above.
 
 (rule -1 (lower (has_type ty (select c @ (value_type (fits_in_64 a_ty)) x y)))
-      (let ((size OperandSize (raw_operand_size_of_type a_ty))
-            ;; N.B.: disallow load-op fusion, see above. TODO:
-            ;; https://github.com/bytecodealliance/wasmtime/issues/3953.
+      (let ( ;; N.B.: disallow load-op fusion, see above. TODO:
+             ;; https://github.com/bytecodealliance/wasmtime/issues/3953.
             (gpr_c Gpr (put_in_gpr c)))
-           (with_flags (x64_test size gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
+           (with_flags (x64_test a_ty gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
 
 (rule -2 (lower (has_type ty (select c @ (value_type $I128) x y)))
       (let ((cond_result IcmpCondResult (cmp_zero_i128 (CC.Z) c)))
@@ -2257,7 +2253,7 @@
                             (RegMemImm.Imm 64)))
             (result_lo Gpr
               (with_flags_reg
-               (x64_cmp_imm (OperandSize.Size64) upper 64)
+               (x64_cmpq_mi_sxb upper 64)
                (cmove $I64 (CC.NZ) upper lower))))
         (value_regs result_lo (imm $I64 0))))
 
@@ -2296,7 +2292,7 @@
                             (RegMemImm.Imm 64)))
             (result_lo Gpr
               (with_flags_reg
-               (x64_cmp_imm (OperandSize.Size64) lower 64)
+               (x64_cmpq_mi_sxb lower 64)
                (cmove $I64 (CC.Z) upper lower))))
         (value_regs result_lo (imm $I64 0))))
 
@@ -3627,19 +3623,17 @@
 
 (decl cmp_zero_int_bool_ref (Value) ProducesFlags)
 (rule (cmp_zero_int_bool_ref val @ (value_type ty))
-      (let ((size OperandSize (raw_operand_size_of_type ty))
-            (src Gpr val))
-        (x64_test size src src)))
+      (let ((src Gpr val))
+        (x64_test ty src src)))
 
 ;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower_branch (br_table idx @ (value_type ty) _) (jump_table_targets default_target jt_targets))
-      (let ((size OperandSize (raw_operand_size_of_type ty))
-            (jt_size u32 (jump_table_size jt_targets))
+      (let ((jt_size u32 (jump_table_size jt_targets))
             (size_reg Reg (imm ty jt_size))
             (idx_reg Gpr (extend_to_gpr idx $I64 (ExtendKind.Zero)))
             (clamped_idx Reg (with_flags_reg
-              (x64_cmp size idx_reg size_reg)
+              (x64_cmp ty idx_reg size_reg)
               (cmove ty (CC.B) idx_reg size_reg))))
       (emit_side_effect (jmp_table_seq ty clamped_idx default_target jt_targets))))
 
@@ -3649,9 +3643,8 @@
       (select_icmp (emit_cmp cc a b) x y))
 
 (rule -1 (lower (has_type ty (select_spectre_guard c @ (value_type (fits_in_64 a_ty)) x y)))
-      (let ((size OperandSize (raw_operand_size_of_type a_ty))
-            (gpr_c Gpr (put_in_gpr c)))
-        (with_flags (x64_test size gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
+      (let ((gpr_c Gpr (put_in_gpr c)))
+        (with_flags (x64_test a_ty gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
 
 (rule -2 (lower (has_type ty (select_spectre_guard c @ (value_type $I128) x y)))
       (let ((cond_result IcmpCondResult (cmp_zero_i128 (CC.Z) c)))
@@ -4438,7 +4431,7 @@
       (let (
           (val Reg val)
           (_ InstOutput (side_effect (with_flags_side_effect
-            (x64_test (raw_operand_size_of_type ty) val val)
+            (x64_test ty val val)
             (trap_if (CC.Z) (TrapCode.INTEGER_DIVISION_BY_ZERO)))))
         )
         val))
@@ -4914,7 +4907,7 @@
           (any_byte_zero Xmm (x64_pcmpeqb val (xmm_zero $I8X16)))
           (mask Gpr (x64_pmovmskb any_byte_zero))
         )
-        (icmp_cond_result (x64_cmp_imm (OperandSize.Size32) mask 0xffff)
+        (icmp_cond_result (x64_cmpl_mi mask 0xffff)
                           (CC.NZ))))
 
 ;; Rules for `vall_true` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -4936,7 +4929,7 @@
 (rule (emit_vall_true val @ (value_type ty))
       (let ((lanes_with_zero Xmm (x64_pcmpeq (vec_int_type ty) val (xmm_zero ty)))
             (mask Gpr (x64_pmovmskb lanes_with_zero)))
-        (icmp_cond_result (x64_test (OperandSize.Size32) mask mask)
+        (icmp_cond_result (x64_testl_mr mask mask)
                           (CC.Z))))
 
 ;; Rules for `vhigh_bits` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -24,6 +24,7 @@ use crate::machinst::{
 };
 use alloc::vec::Vec;
 use cranelift_assembler_x64 as asm;
+use cranelift_entity::{Signed, Unsigned};
 use regalloc2::PReg;
 use std::boxed::Box;
 
@@ -169,12 +170,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     fn put_in_reg_mem_imm(&mut self, val: Value) -> RegMemImm {
-        let inputs = self.lower_ctx.get_value_as_source_or_const(val);
-
-        if let Some(c) = inputs.constant {
-            let ty = self.lower_ctx.dfg().value_type(val);
-            if let Some(imm) = to_simm32(c as i64, ty) {
-                return imm.to_reg_mem_imm();
+        if let Some(imm) = self.i64_from_iconst(val) {
+            if let Ok(imm) = i32::try_from(imm) {
+                return RegMemImm::Imm {
+                    simm32: imm.unsigned(),
+                };
             }
         }
 
@@ -182,12 +182,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     fn put_in_xmm_mem_imm(&mut self, val: Value) -> XmmMemImm {
-        let inputs = self.lower_ctx.get_value_as_source_or_const(val);
-
-        if let Some(c) = inputs.constant {
-            let ty = self.lower_ctx.dfg().value_type(val);
-            if let Some(imm) = to_simm32(c as i64, ty) {
-                return XmmMemImm::unwrap_new(imm.to_reg_mem_imm());
+        if let Some(imm) = self.i64_from_iconst(val) {
+            if let Ok(imm) = i32::try_from(imm) {
+                return XmmMemImm::unwrap_new(RegMemImm::Imm {
+                    simm32: imm.unsigned(),
+                });
             }
         }
 
@@ -343,11 +342,10 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     #[inline]
     fn simm32_from_value(&mut self, val: Value) -> Option<GprMemImm> {
-        let inst = self.lower_ctx.dfg().value_def(val).inst()?;
-        let constant: u64 = self.lower_ctx.get_constant(inst)?;
-        let ty = self.lower_ctx.dfg().value_type(val);
-        let constant = constant as i64;
-        to_simm32(constant, ty)
+        let imm = self.i64_from_iconst(val)?;
+        Some(GprMemImm::unwrap_new(RegMemImm::Imm {
+            simm32: i32::try_from(imm).ok()?.unsigned(),
+        }))
     }
 
     fn sinkable_load(&mut self, val: Value) -> Option<SinkableLoad> {
@@ -977,35 +975,35 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
 
     fn is_imm8(&mut self, src: &GprMemImm) -> Option<u8> {
         match src.clone().to_reg_mem_imm() {
-            RegMemImm::Imm { simm32 } => Some(u8::try_from(simm32).ok()?),
+            RegMemImm::Imm { simm32 } => Some(i8::try_from(simm32.signed()).ok()?.unsigned()),
             _ => None,
         }
     }
 
     fn is_imm8_xmm(&mut self, src: &XmmMemImm) -> Option<u8> {
         match src.clone().to_reg_mem_imm() {
-            RegMemImm::Imm { simm32 } => Some(u8::try_from(simm32).ok()?),
+            RegMemImm::Imm { simm32 } => Some(i8::try_from(simm32.signed()).ok()?.unsigned()),
             _ => None,
         }
     }
 
     fn is_simm8(&mut self, src: &GprMemImm) -> Option<i8> {
         match src.clone().to_reg_mem_imm() {
-            RegMemImm::Imm { simm32 } => Some(i8::try_from(simm32).ok()?),
+            RegMemImm::Imm { simm32 } => Some(i8::try_from(simm32.signed()).ok()?),
             _ => None,
         }
     }
 
     fn is_imm16(&mut self, src: &GprMemImm) -> Option<u16> {
         match src.clone().to_reg_mem_imm() {
-            RegMemImm::Imm { simm32 } => Some(u16::try_from(simm32).ok()?),
+            RegMemImm::Imm { simm32 } => Some(i16::try_from(simm32.signed()).ok()?.unsigned()),
             _ => None,
         }
     }
 
     fn is_simm16(&mut self, src: &GprMemImm) -> Option<i16> {
         match src.clone().to_reg_mem_imm() {
-            RegMemImm::Imm { simm32 } => Some(i16::try_from(simm32).ok()?),
+            RegMemImm::Imm { simm32 } => Some(i16::try_from(simm32.signed()).ok()?),
             _ => None,
         }
     }
@@ -1225,14 +1223,3 @@ const I8X16_USHR_MASKS: [u8; 128] = [
     0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 ];
-
-#[inline]
-fn to_simm32(constant: i64, ty: Type) -> Option<GprMemImm> {
-    if ty.bits() <= 32 || constant == ((constant << 32) >> 32) {
-        Some(GprMemImm::unwrap_new(RegMemImm::Imm {
-            simm32: constant as u32,
-        }))
-    } else {
-        None
-    }
-}

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -8,7 +8,7 @@ use crate::isa::x64::inst::args::{
     Amode, CC, Gpr, RegMem, RegMemImm, SyntheticAmode, ToWritableReg,
 };
 use crate::machinst::pcc::*;
-use crate::machinst::{InsnIndex, VCode, VCodeConstantData};
+use crate::machinst::{InsnIndex, VCode};
 use crate::machinst::{Reg, Writable};
 use crate::trace;
 
@@ -91,47 +91,6 @@ pub(crate) fn check(
                 clamp_range(ctx, 64, bits, fact)
             })
         }
-
-        Inst::CmpRmiR {
-            size,
-            src1,
-            ref src2,
-            ..
-        } => match <&RegMemImm>::from(src2) {
-            RegMemImm::Mem {
-                addr: SyntheticAmode::ConstantOffset(k),
-            } => {
-                match vcode.constants.get(*k) {
-                    VCodeConstantData::U64(bytes) => {
-                        let value = u64::from_le_bytes(*bytes);
-                        let lhs = get_fact_or_default(vcode, src1.to_reg(), 64);
-                        let rhs = Fact::constant(64, value);
-                        state.cmp_flags = Some((lhs, rhs));
-                    }
-                    _ => {}
-                }
-                Ok(())
-            }
-            RegMemImm::Mem { addr } => {
-                if let Some(rhs) = check_load(ctx, None, addr, vcode, size.to_type(), 64)? {
-                    let lhs = get_fact_or_default(vcode, src1.to_reg(), 64);
-                    state.cmp_flags = Some((lhs, rhs));
-                }
-                Ok(())
-            }
-            RegMemImm::Reg { reg } => {
-                let rhs = get_fact_or_default(vcode, *reg, 64);
-                let lhs = get_fact_or_default(vcode, src1.to_reg(), 64);
-                state.cmp_flags = Some((lhs, rhs));
-                Ok(())
-            }
-            RegMemImm::Imm { simm32 } => {
-                let lhs = get_fact_or_default(vcode, src1.to_reg(), 64);
-                let rhs = Fact::constant(64, (*simm32 as i32) as i64 as u64);
-                state.cmp_flags = Some((lhs, rhs));
-                Ok(())
-            }
-        },
 
         Inst::Setcc { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
 

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -809,7 +809,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   setnle  %al
 ;   movq %rax, %r8
 ;   negb %r8b
@@ -843,7 +843,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   setnle  %al
 ;   negb %al
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -19,7 +19,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x2, %eax
@@ -68,7 +68,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x1, %eax
@@ -117,7 +117,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x2, %eax
@@ -315,7 +315,7 @@ block2:
 ; block0:
 ;   movl $0x2, %r10d
 ;   movl %edi, %r11d
-;   cmpl    %r10d, %r11d
+;   cmpl %r10d, %r11d
 ;   cmovbl  %r11d, %r10d, %r10d
 ;   br_table %r10, %rcx, %rdx
 ; block1:
@@ -383,7 +383,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testq   %rdi, %rdi
+;   testq %rdi, %rdi
 ;   jl      label2; j label1
 ; block1:
 ;   uninit  %rax
@@ -432,7 +432,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jl      label2; j label1
 ; block1:
 ;   uninit  %rax
@@ -481,7 +481,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testq   %rdi, %rdi
+;   testq %rdi, %rdi
 ;   jz      label2; j label1
 ; block1:
 ;   uninit  %rax
@@ -530,7 +530,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   uninit  %rax
@@ -579,7 +579,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testq   %rdi, %rdi
+;   testq %rdi, %rdi
 ;   jnle    label2; j label1
 ; block1:
 ;   uninit  %rax
@@ -702,7 +702,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x2, %eax
@@ -803,7 +803,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x2, %eax
@@ -962,7 +962,7 @@ block5(v5: i32):
 ; block0:
 ;   movl $0x4, %eax
 ;   movl %edi, %ecx
-;   cmpl    %eax, %ecx
+;   cmpl %eax, %ecx
 ;   cmovbl  %ecx, %eax, %eax
 ;   br_table %rax, %r9, %r10
 ; block1:
@@ -1049,7 +1049,7 @@ block1(v5: i32):
 ;   movl $0x4, %eax
 ;   movl $0x4, %esi
 ;   movl %edi, %edi
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   cmovbl  %edi, %esi, %esi
 ;   br_table %rsi, %r10, %r9
 ; block1:

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -16,7 +16,7 @@ block0(v0: i128):
 ;   lzcntq %rsi, %rcx
 ;   lzcntq %rdi, %rax
 ;   addq $0x40, %rax
-;   cmpq    $64, %rcx
+;   cmpq $0x40, %rcx
 ;   cmovnzq %rcx, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -25,7 +25,7 @@ block0(v0: i128):
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   addq $0x40, %rax
-;   cmpq    $64, %rdi
+;   cmpq $0x40, %rdi
 ;   cmovnzq %rdi, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -15,10 +15,10 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq (%rsi), %r9
-;   cmpq    %r9, %rdi
+;   cmpq %r9, %rdi
 ;   setz    %r10b
 ;   movzbq %r10b, %rax
-;   cmpq    %r9, %rdi
+;   cmpq %r9, %rdi
 ;   movq %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/x64/cold-blocks.clif
@@ -18,7 +18,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label1; j label2
 ; block1:
 ;   movq %rdi, %rax
@@ -64,7 +64,7 @@ block2 cold:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label1; j label2
 ; block1:
 ;   movq %rdi, %rax

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -11,7 +11,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   movq %rdx, %rax
 ;   cmovnzl %esi, %eax, %eax
 ;   movq %rbp, %rsp
@@ -45,7 +45,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   jnz     label2; j label1
 ; block1:
 ;   movl $0x2, %eax
@@ -91,7 +91,7 @@ block2:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   jnz     label2; j label1
 ; block1:
 ;   movl $0x1, %eax
@@ -141,7 +141,7 @@ block2:
 ;   movq %rsp, %rbp
 ; block0:
 ;   movl (%rdi), %edx
-;   cmpl    $1, %edx
+;   cmpl $0x1, %edx
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x1, %eax
@@ -192,7 +192,7 @@ block2:
 ;   movq %rsp, %rbp
 ; block0:
 ;   movl (%rdi), %edx
-;   cmpl    $1, %edx
+;   cmpl $0x1, %edx
 ;   jz      label2; j label1
 ; block1:
 ;   movl $0x1, %eax

--- a/cranelift/filetests/filetests/isa/x64/crit-edge.clif
+++ b/cranelift/filetests/filetests/isa/x64/crit-edge.clif
@@ -24,10 +24,10 @@ function %f(i32) -> i32 {
 ;   movq %rsp, %rbp
 ; block0:
 ;   lea     1(%rdi), %eax
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label4; j label1
 ; block1:
-;   testl   %eax, %eax
+;   testl %eax, %eax
 ;   jnz     label2; j label3
 ; block2:
 ;   jmp     label8
@@ -35,7 +35,7 @@ function %f(i32) -> i32 {
 ;   movq %rdi, %rax
 ;   jmp     label7
 ; block4:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label5; j label6
 ; block5:
 ;   movq %rdi, %rax

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -16,7 +16,7 @@ block0(v0: i128):
 ;   tzcntq %rdi, %rax
 ;   tzcntq %rsi, %r9
 ;   addq $0x40, %r9
-;   cmpq    $64, %rax
+;   cmpq $0x40, %rax
 ;   cmovzq  %r9, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -20,7 +20,7 @@ block0(v0: i128):
 ;   bsfq %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   addq $0x40, %rdx
-;   cmpq    $64, %rax
+;   cmpq $0x40, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -143,7 +143,7 @@ function %f1(i32) -> i32, f32, f64 {
 ;   movq %r14, 0x28(%rsp)
 ;   movq %r15, 0x30(%rsp)
 ; block0:
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label4; j label1
 ; block1:
 ;   movl $0x2a, %eax
@@ -151,7 +151,7 @@ function %f1(i32) -> i32, f32, f64 {
 ;   movd %ecx, %xmm0
 ;   movabsq $0x40d59e0000000000, %rcx
 ;   movq %rcx, %xmm1
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   jnz     label2; j label3
 ; block2:
 ;   movq %rax, %r11

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -336,35 +336,35 @@ block0(v0: i128, v1: i128):
 ;   xorq %rcx, %r9
 ;   orq %r9, %r8
 ;   setnz   %r9b
-;   cmpq    %rdx, %rdi
+;   cmpq %rdx, %rdi
 ;   movq %rsi, %r8
 ;   sbbq %rcx, %r8
 ;   setl    %r8b
-;   cmpq    %rdi, %rdx
+;   cmpq %rdi, %rdx
 ;   movq %rcx, %r10
 ;   sbbq %rsi, %r10
 ;   setnl   %r11b
-;   cmpq    %rdi, %rdx
+;   cmpq %rdi, %rdx
 ;   movq %rcx, %r10
 ;   sbbq %rsi, %r10
 ;   setl    %r10b
-;   cmpq    %rdx, %rdi
+;   cmpq %rdx, %rdi
 ;   movq %rsi, %rbx
 ;   sbbq %rcx, %rbx
 ;   setnl   %r14b
-;   cmpq    %rdx, %rdi
+;   cmpq %rdx, %rdi
 ;   movq %rsi, %r12
 ;   sbbq %rcx, %r12
 ;   setb    %r13b
-;   cmpq    %rdi, %rdx
+;   cmpq %rdi, %rdx
 ;   movq %rcx, %r15
 ;   sbbq %rsi, %r15
 ;   setnb   %bl
-;   cmpq    %rdi, %rdx
+;   cmpq %rdi, %rdx
 ;   movq %rcx, %r15
 ;   sbbq %rsi, %r15
 ;   setb    %r15b
-;   cmpq    %rdx, %rdi
+;   cmpq %rdx, %rdi
 ;   sbbq %rcx, %rsi
 ;   setnb   %dil
 ;   andl %r9d, %eax
@@ -1117,7 +1117,7 @@ block2(v8: i128):
 ; block0:
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testb   %dl, %dl
+;   testb %dl, %dl
 ;   jnz     label2; j label1
 ; block1:
 ;   addq $0x2, %rax
@@ -1352,7 +1352,7 @@ block0(v0: i128):
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   addq $0x40, %rax
-;   cmpq    $64, %rdi
+;   cmpq $0x40, %rdi
 ;   cmovnzq %rdi, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
@@ -1401,7 +1401,7 @@ block0(v0: i128):
 ;   bsfq %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   addq $0x40, %rdx
-;   cmpq    $64, %rax
+;   cmpq $0x40, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
@@ -1481,10 +1481,10 @@ block0(v0: i128, v1: i128):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -1539,10 +1539,10 @@ block0(v0: i128, v1: i128):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r10, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
@@ -1600,11 +1600,11 @@ block0(v0: i128, v1: i128):
 ;   shlq %cl, %r11
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %rdx
+;   testq $0x7f, %rdx
 ;   cmovzq  %rax, %r11, %r11
 ;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rdx
+;   testq $0x40, %rdx
 ;   movq %r10, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx
@@ -1668,10 +1668,10 @@ block0(v0: i128, v1: i128):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   movq %r9, %rcx
-;   testq   $127, %rcx
+;   testq $0x7f, %rcx
 ;   cmovzq  %rax, %r11, %r11
 ;   orq %r10, %r11
-;   testq   $64, %rcx
+;   testq $0x40, %rcx
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r11, %rdx, %rdx
 ;   movl $0x80, %ecx
@@ -1685,10 +1685,10 @@ block0(v0: i128, v1: i128):
 ;   shlq %cl, %rsi
 ;   uninit  %r8
 ;   xorq %r8, %r8
-;   testq   $127, %r10
+;   testq $0x7f, %r10
 ;   cmovzq  %r8, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %r10
+;   testq $0x40, %r10
 ;   movq %r11, %rdi
 ;   cmovzq  %rsi, %rdi, %rdi
 ;   cmovzq  %r11, %r8, %r8
@@ -1771,10 +1771,10 @@ block0(v0: i128, v1: i128):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %r9, %rcx
-;   testq   $127, %rcx
+;   testq $0x7f, %rcx
 ;   cmovzq  %rdx, %r11, %r11
 ;   orq %r8, %r11
-;   testq   $64, %rcx
+;   testq $0x40, %rcx
 ;   movq %r10, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
@@ -1790,10 +1790,10 @@ block0(v0: i128, v1: i128):
 ;   shrq %cl, %rdi
 ;   uninit  %r8
 ;   xorq %r8, %r8
-;   testq   $127, %r11
+;   testq $0x7f, %r11
 ;   cmovzq  %r8, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r11
+;   testq $0x40, %r11
 ;   cmovzq  %r10, %r8, %r8
 ;   cmovzq  %rdi, %r10, %r10
 ;   orq %r8, %rax
@@ -2172,7 +2172,7 @@ block0(v0: i128, v1: i128):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movl $0xc8, %eax
-;   cmpq    %rdx, %rdi
+;   cmpq %rdx, %rdi
 ;   sbbq %rcx, %rsi
 ;   cmovbl  const(0), %eax, %eax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -29,10 +29,10 @@ block0(v0: i128, v1: i8):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -86,10 +86,10 @@ block0(v0: i128, v1: i64):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -144,10 +144,10 @@ block0(v0: i128, v1: i32):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -202,10 +202,10 @@ block0(v0: i128, v1: i16):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -260,10 +260,10 @@ block0(v0: i128, v1: i8):
 ;   shrq %cl, %rdi
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %r8
+;   testq $0x7f, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq %rsi, %rdi
-;   testq   $64, %r8
+;   testq $0x40, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -219,7 +219,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpq    0(%rdi), %rdi
+;   cmpq (%rdi), %rdi
 ;   setz    %dl
 ;   movzbq %dl, %rax
 ;   movq %rbp, %rsp
@@ -250,7 +250,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq (%rdi), %rcx
-;   testq   %rcx, %rcx
+;   testq %rcx, %rcx
 ;   setz    %al
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -165,7 +165,7 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   setz    %al
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -157,7 +157,7 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   setz    %al
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -13,7 +13,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   movq %rdi, %rax
 ;   cbtw  ;; implicit: %ax
-;   testb   %sil, %sil
+;   testb %sil, %sil
 ;   jz #trap=int_divz
 ;   idivb %sil ;; implicit: %ax, trap=252
 ;   movq %rbp, %rsp
@@ -47,7 +47,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   movq %rdi, %rax
 ;   cwtd  ;; implicit: %dx, %ax
-;   testw   %si, %si
+;   testw %si, %si
 ;   jz #trap=int_divz
 ;   idivw %si ;; implicit: %ax, %dx, trap=252
 ;   movq %rbp, %rsp
@@ -81,7 +81,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   movq %rdi, %rax
 ;   cltd  ;; implicit: %edx, %eax
-;   testl   %esi, %esi
+;   testl %esi, %esi
 ;   jz #trap=int_divz
 ;   idivl %esi ;; implicit: %eax, %edx, trap=252
 ;   movq %rbp, %rsp
@@ -115,7 +115,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   movq %rdi, %rax
 ;   cqto  ;; implicit: %rdx, %rax
-;   testq   %rsi, %rsi
+;   testq %rsi, %rsi
 ;   jz #trap=int_divz
 ;   idivq %rsi ;; implicit: %rax, %rdx, trap=252
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -14,7 +14,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    $42, %edi
+;   cmpl $0x2a, %edi
 ;   movq %rcx, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   movq %rdx, %rdi

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -13,7 +13,7 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpl    %esi, %edi
+;   cmpl %esi, %edi
 ;   movq %rcx, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   movq %rbp, %rsp
@@ -75,7 +75,7 @@ block0(v0: i8, v1: f16, v2: f16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
 ;   movss %xmm0, %xmm0; jz $next; movss %xmm6, %xmm0; $next:
@@ -107,7 +107,7 @@ block0(v0: i8, v1: f32, v2: f32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
 ;   movss %xmm0, %xmm0; jz $next; movss %xmm6, %xmm0; $next:
@@ -139,7 +139,7 @@ block0(v0: i8, v1: f64, v2: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
 ;   movsd %xmm0, %xmm0; jz $next; movsd %xmm6, %xmm0; $next:
@@ -171,7 +171,7 @@ block0(v0: i8, v1: f128, v2: f128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testb   %dil, %dil
+;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
 ;   movdqa %xmm0, %xmm0; jz $next; movdqa %xmm6, %xmm0; $next:

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -29,11 +29,11 @@ block0(v0: i128, v1: i8):
 ;   shlq %cl, %r11
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testq   $127, %rdx
+;   testq $0x7f, %rdx
 ;   cmovzq  %rax, %r11, %r11
 ;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rdx
+;   testq $0x40, %rdx
 ;   movq %r10, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx
@@ -94,11 +94,11 @@ block0(v0: i128, v1: i64):
 ;   shlq %cl, %r10
 ;   uninit  %r11
 ;   xorq %r11, %r11
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %r11, %r10, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx
@@ -160,11 +160,11 @@ block0(v0: i128, v1: i32):
 ;   shlq %cl, %r10
 ;   uninit  %r11
 ;   xorq %r11, %r11
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %r11, %r10, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx
@@ -226,11 +226,11 @@ block0(v0: i128, v1: i16):
 ;   shlq %cl, %r10
 ;   uninit  %r11
 ;   xorq %r11, %r11
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %r11, %r10, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx
@@ -292,11 +292,11 @@ block0(v0: i128, v1: i8):
 ;   shlq %cl, %r10
 ;   uninit  %r11
 ;   xorq %r11, %r11
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %r11, %r10, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   movq %rsi, %rdx

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -23,7 +23,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ;   movq %rsi, %r10
 ;   addq $0x30, %r10
-;   cmpq    %rsp, %r10
+;   cmpq %rsp, %r10
 ;   jnbe #trap=stk_ovf
 ;   subq $0x30, %rsp
 ; block0:

--- a/cranelift/filetests/filetests/isa/x64/stackslot_alignment.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot_alignment.clif
@@ -18,7 +18,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ;   movq %rdi, %r10
 ;   addq $0x30, %r10
-;   cmpq    %rsp, %r10
+;   cmpq %rsp, %r10
 ;   jnbe #trap=stk_ovf
 ;   subq $0x30, %rsp
 ; block0:

--- a/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
@@ -21,7 +21,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128
 ;   movq %rsp, %rbp
 ;   movq %rdi, %r10
 ;   addq $0x10, %r10
-;   cmpq    %rsp, %r10
+;   cmpq %rsp, %r10
 ;   jnbe #trap=stk_ovf
 ;   subq $0x10, %rsp
 ; block0:

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -58,7 +58,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testq   %rdi, %rdi
+;   testq %rdi, %rdi
 ;   jz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -87,7 +87,7 @@ block0(v0: i128):
 ;   movq %rsp, %rbp
 ; block0:
 ;   orq %rdi, %rsi
-;   testq   %rsi, %rsi
+;   testq %rsi, %rsi
 ;   jz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -116,7 +116,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   testq   %rdi, %rdi
+;   testq %rdi, %rdi
 ;   jnz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -145,7 +145,7 @@ block0(v0: i128):
 ;   movq %rsp, %rbp
 ; block0:
 ;   orq %rdi, %rsi
-;   testq   %rsi, %rsi
+;   testq %rsi, %rsi
 ;   jnz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -175,7 +175,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpq    %rsi, %rdi
+;   cmpq %rsi, %rdi
 ;   jnz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -204,7 +204,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpq    %rsi, %rdi
+;   cmpq %rsi, %rdi
 ;   jz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -294,7 +294,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpq    %rsi, %rdi
+;   cmpq %rsi, %rdi
 ;   jnz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -324,7 +324,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   cmpq    %rsi, %rdi
+;   cmpq %rsi, %rdi
 ;   jz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -13,7 +13,7 @@ block0(v1: i32, v2: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movl (%rsi), %edx
-;   cmpl    %edi, %edx
+;   cmpl %edi, %edx
 ;   movq %rdi, %rax
 ;   cmovnbl %edx, %eax, %eax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -27,10 +27,10 @@ block0(v0: i128, v1: i8):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r10, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
@@ -86,10 +86,10 @@ block0(v0: i128, v1: i64):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
@@ -146,10 +146,10 @@ block0(v0: i128, v1: i32):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
@@ -206,10 +206,10 @@ block0(v0: i128, v1: i16):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
@@ -266,10 +266,10 @@ block0(v0: i128, v1: i8):
 ;   shlq %cl, %rsi
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
-;   testq   $127, %rax
+;   testq $0x7f, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
 ;   orq %rdi, %rsi
-;   testq   $64, %rax
+;   testq $0x40, %rax
 ;   movq %r9, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx

--- a/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
+++ b/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
@@ -13,7 +13,7 @@ block0(v0: i32, v1: f64, v2: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movsd (%rsi), %xmm5
-;   testl   %edi, %edi
+;   testl %edi, %edi
 ;   movsd %xmm0, %xmm0; jz $next; movsd %xmm5, %xmm0; $next:
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
@@ -1,14 +1,14 @@
 test compile
 set enable_pcc=true
 target aarch64
-target x86_64
+;; disabled until PCC is migrated to new assembler: target x86_64
 
 ;; Equivalent to a Wasm `i64.load` from a dynamic memory.
 function %f0(i64 vmctx, i32) -> i64 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned checked gv0+0 ;; base
     gv2 = load.i64 notrap aligned checked gv0+8 ;; size
-    
+
     ;; mock vmctx struct:
     mt0 = struct 16 {
         0: i64 readonly ! dynamic_mem(mt1, 0, 0),


### PR DESCRIPTION
This commit migrates the `cmp` and `test` family of instructions, the `CmpRmiR` variant in ISLE, to the new assembler. This required fiddling with various helpers for immediates and such throughout a few locations and refactoring various callsites of creating these instructions to fit nicely into these new idioms. EFLAGS-writing instructions with no other results are now also modeled in the assembler as `ProducesFlags` rather than `SideEffectNoResult` as their base case enabling using the generated constructors a bit more too.

No functional change is expected from this, it should just be internal refactoring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
