### PR TITLE
[backport] fix: do not collect backtrace on each gc_runtime access

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -671,12 +671,8 @@ impl Engine {
         self.inner.allocator.as_ref()
     }
 
-    pub(crate) fn gc_runtime(&self) -> Result<&Arc<dyn GcRuntime>> {
-        if let Some(rt) = &self.inner.gc_runtime {
-            Ok(rt)
-        } else {
-            bail!("no GC runtime: GC disabled at compile time or configuration time")
-        }
+    pub(crate) fn gc_runtime(&self) -> Option<&Arc<dyn GcRuntime>> {
+        self.inner.gc_runtime.as_ref()
     }
 
     pub(crate) fn profiler(&self) -> &dyn crate::profiling_agent::ProfilingAgent {

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1377,12 +1377,13 @@ impl StoreOpaque {
 
             // Then, allocate the actual GC heap, passing in that memory
             // storage.
-            let (index, heap) = engine.allocator().allocate_gc_heap(
-                engine,
-                &**engine.gc_runtime()?,
-                mem_alloc_index,
-                mem,
-            )?;
+            let gc_runtime = engine
+                .gc_runtime()
+                .context("no GC runtime: GC disabled at compile time or configuration time")?;
+            let (index, heap) =
+                engine
+                    .allocator()
+                    .allocate_gc_heap(engine, &**gc_runtime, mem_alloc_index, mem)?;
 
             Ok(GcStore::new(index, heap))
         }

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -133,7 +133,7 @@ impl Engine {
 
         let engine = self.clone();
         let registry = engine.signatures();
-        let gc_runtime = engine.gc_runtime().ok().map(|rt| &**rt);
+        let gc_runtime = engine.gc_runtime().map(|rt| &**rt);
 
         // First, register these types in this engine's registry.
         let (rec_groups, types) = registry
@@ -336,7 +336,7 @@ impl RegisteredType {
         let (entry, index, ty, layout) = {
             log::trace!("RegisteredType::new({ty:?})");
 
-            let gc_runtime = engine.gc_runtime().ok().map(|rt| &**rt);
+            let gc_runtime = engine.gc_runtime().map(|rt| &**rt);
             let mut inner = engine.signatures().0.write();
 
             // It shouldn't be possible for users to construct non-canonical


### PR DESCRIPTION
This is a backport of #11068 to 34.0.0 release branch.
 
I am not entirely sure what's the standard procedure for backports, but hopefully this helps.

Zulip discussion: [#wasmtime > backporting the &#96;gc&#96; feature performance fix to 34](https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/backporting.20the.20.60gc.60.20feature.20performance.20fix.20to.2034/with/524857649)