### PR TITLE
Avoid running wasm-opt when compiling test programs

### DIFF
--- a/crates/test-programs/artifacts/build.rs
+++ b/crates/test-programs/artifacts/build.rs
@@ -290,6 +290,9 @@ impl Artifacts {
         cmd.args(&config.flags);
         cmd.arg("-o");
         cmd.arg(&wasm_path);
+        // If optimizations are enabled, clang will look for wasm-opt in PATH
+        // and run it. This will strip DWARF debug info, which we don't want.
+        cmd.env("PATH", "");
         println!("running: {cmd:?}");
         let result = cmd.status().expect("failed to spawn clang");
         assert!(result.success());


### PR DESCRIPTION
wasm-opt will strip DWARF debug info, which causes a test failure for `debug::lldb::dwarf_codegen_optimized_wasm_optimized`.

clang automatically runs wasm-opt if it is found in PATH and if optimization is enabled. clang-20 has a --no-wasm-opt option, but that doesn't work for wasi-sdk-25.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
