### PR TITLE
Update DWARF tests to Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -835,7 +835,7 @@ jobs:
     needs: determine
     if: needs.determine.outputs.run-dwarf
     name: Test DWARF debugging
-    runs-on: ubuntu-22.04 # FIXME: fails on `ubuntu-24.04` right now
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -848,14 +848,14 @@ jobs:
         tar -xzf wasi-sdk-25.0-x86_64-linux.tar.gz
         mv wasi-sdk-25.0-x86_64-linux wasi-sdk
     - run: |
-        sudo apt-get update && sudo apt-get install -y gdb lldb-15 llvm
+        sudo apt-get update && sudo apt-get install -y gdb lldb-18 llvm
         # workaround for https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855
         sudo mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb
         sudo ln -s /usr/lib/llvm-15/lib/python3.10/dist-packages/lldb/* /usr/lib/python3/dist-packages/lldb/
         # Only testing release since it is more likely to expose issues with our low-level symbol handling.
         cargo test --release --test all -- --ignored --test-threads 1 debug::
       env:
-        LLDB: lldb-15 # override default version, 14
+        LLDB: lldb-18
         WASI_SDK_PATH: /tmp/wasi-sdk
 
   build-preview1-component-adapter:

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -337,6 +337,10 @@ pub fn generate_simulated_dwarf(
 
         let id = out_strings.add(PRODUCER_NAME);
         root.set(gimli::DW_AT_producer, write::AttributeValue::StringRef(id));
+        root.set(
+            gimli::DW_AT_language,
+            write::AttributeValue::Language(gimli::DW_LANG_C11),
+        );
         root.set(gimli::DW_AT_name, write::AttributeValue::StringRef(name_id));
         root.set(
             gimli::DW_AT_stmt_list,

--- a/crates/cranelift/src/debug/transform/synthetic.rs
+++ b/crates/cranelift/src/debug/transform/synthetic.rs
@@ -69,6 +69,14 @@ impl ModuleSyntheticUnit {
             gimli::DW_AT_name,
             AttributeValue::StringRef(out_strings.add("WasmtimeModuleSyntheticUnit")),
         );
+        unit_die.set(
+            gimli::DW_AT_producer,
+            AttributeValue::StringRef(out_strings.add("wasmtime")),
+        );
+        unit_die.set(
+            gimli::DW_AT_language,
+            AttributeValue::Language(gimli::DW_LANG_C11),
+        );
         unit_id
     }
 


### PR DESCRIPTION
The gdb version in Ubuntu 24.04 fails on our synthetic DWARF because:

1. the synthetic DWARF unit has no DW_AT_language
2. synthetic types are referenced from a unit that does have DW_AT_language
3. this triggers https://sourceware.org/bugzilla/show_bug.cgi?id=32431

Workaround this issue by specifying DW_LANG_C11. This may not be exactly the right meaning, but it should be safe.

Closes #9731

I would like this change because my development system has this gdb version.