### PR TITLE
fuzzing: Temporarily disable `wide_arithmetic` in Wasmi

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -25,6 +25,8 @@ impl WasmiEngine {
         // FIXME: requires updating to a wasmi that contains
         // wasmi-labs/wasmi#1531.
         config.memory64_enabled = false;
+        // FIXME: until https://github.com/wasmi-labs/wasmi/issues/1544 is fixed.
+        config.wide_arithmetic_enabled = false;
 
         let mut wasmi_config = wasmi::Config::default();
         wasmi_config


### PR DESCRIPTION
The differential fuzzer found an incosistency between Wasmtime/Wasmi, related to the `wide_arithmetic`  proposal. I've reported the issue upstream (https://github.com/wasmi-labs/wasmi/issues/1544)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
