### PR TITLE
Improve debug formatting for primary/secondary map

### DIFF
--- a/cranelift/entity/src/map.rs
+++ b/cranelift/entity/src/map.rs
@@ -5,6 +5,7 @@ use crate::iter::{Iter, IterMut};
 use crate::keys::Keys;
 use alloc::vec::Vec;
 use core::cmp::min;
+use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use core::slice;
@@ -23,7 +24,7 @@ use serde::{
 ///
 /// The map does not track if an entry for a key has been inserted or not. Instead it behaves as if
 /// all keys have a default entry from the beginning.
-#[derive(Debug, Clone, Hash)]
+#[derive(Clone, Hash)]
 pub struct SecondaryMap<K, V>
 where
     K: EntityRef,
@@ -279,6 +280,15 @@ where
         deserializer.deserialize_seq(SecondaryMapVisitor {
             unused: PhantomData {},
         })
+    }
+}
+
+impl<K: EntityRef + fmt::Debug, V: fmt::Debug + Clone> fmt::Debug for SecondaryMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecondaryMap")
+            .field("elems", &self.elems)
+            .field("default", &self.default)
+            .finish()
     }
 }
 

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -4,7 +4,6 @@ use crate::boxed_slice::BoxedSlice;
 use crate::iter::{IntoIter, Iter, IterMut};
 use crate::keys::Keys;
 use alloc::boxed::Box;
-use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
@@ -341,9 +340,8 @@ where
 impl<K: EntityRef + fmt::Debug, V: fmt::Debug> fmt::Debug for PrimaryMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut struct_ = f.debug_struct("PrimaryMap");
-        for (k, v) in self.iter() {
-            let name = core::format_args!("{k:?}").to_string();
-            struct_.field(&name, v);
+        for (k, v) in self {
+            struct_.field(&alloc::format!("{k:?}"), v);
         }
         struct_.finish()
     }

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -342,7 +342,7 @@ impl<K: EntityRef + fmt::Debug, V: fmt::Debug> fmt::Debug for PrimaryMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut struct_ = f.debug_struct("PrimaryMap");
         for (k, v) in self.iter() {
-            let name = core::format_args!("{:?}", k).to_string();
+            let name = core::format_args!("{k:?}").to_string();
             struct_.field(&name, v);
         }
         struct_.finish()

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -4,7 +4,9 @@ use crate::boxed_slice::BoxedSlice;
 use crate::iter::{IntoIter, Iter, IterMut};
 use crate::keys::Keys;
 use alloc::boxed::Box;
+use alloc::string::ToString;
 use alloc::vec::Vec;
+use core::fmt;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Index, IndexMut};
@@ -27,7 +29,7 @@ use serde_derive::{Deserialize, Serialize};
 /// that it only allows indexing with the distinct `EntityRef` key type, so converting to a
 /// plain slice would make it easier to use incorrectly. To make a slice of a `PrimaryMap`, use
 /// `into_boxed_slice`.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct PrimaryMap<K, V>
 where
@@ -333,6 +335,17 @@ where
             elems,
             unused: PhantomData,
         }
+    }
+}
+
+impl<K: EntityRef + fmt::Debug, V: fmt::Debug> fmt::Debug for PrimaryMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut struct_ = f.debug_struct("PrimaryMap");
+        for (k, v) in self.iter() {
+            let name = core::format_args!("{:?}", k).to_string();
+            struct_.field(&name, v);
+        }
+        struct_.finish()
     }
 }
 


### PR DESCRIPTION
Small contribution, but addresses a personal annoyance of mine. 

New formatting
```rs
PrimaryMap {
    outer0: PrimaryMap {
        inner0: 0,
        inner1: 1,
    },
    outer1: PrimaryMap {
        inner0: 2,
        inner1: 3,
    },
}
PrimaryMap {
    outer0: PrimaryMap {
        inner0: Point {
            x: 0,
            y: 1,
        },
    },
    outer1: PrimaryMap {
        inner0: Point {
            x: 2,
            y: 3,
        },
    },
}
SecondaryMap {
    elems: [
        0,
        2,
    ],
    default: 0,
}
```

Previous formatting
```rs
PrimaryMap {
    elems: [
        PrimaryMap {
            elems: [
                0,
                1,
            ],
            unused: PhantomData<temp::InnerKey>,
        },
        PrimaryMap {
            elems: [
                2,
                3,
            ],
            unused: PhantomData<temp::InnerKey>,
        },
    ],
    unused: PhantomData<temp::OuterKey>,
}
PrimaryMap {
    elems: [
        PrimaryMap {
            elems: [
                Point {
                    x: 0,
                    y: 1,
                },
            ],
            unused: PhantomData<temp::InnerKey>,
        },
        PrimaryMap {
            elems: [
                Point {
                    x: 2,
                    y: 3,
                },
            ],
            unused: PhantomData<temp::InnerKey>,
        },
    ],
    unused: PhantomData<temp::OuterKey>,
}
SecondaryMap {
    elems: [
        0,
        2,
    ],
    default: 0,
    unused: PhantomData<temp::InnerKey>,
}
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
