### PR TITLE
 x64: Migrate `lea` to the new assembler 

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/misc.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/misc.rs
@@ -1,5 +1,5 @@
 use crate::dsl::{Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex};
+use crate::dsl::{fmt, inst, r, rex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -14,5 +14,9 @@ pub fn list() -> Vec<Inst> {
 
         inst("retq", fmt("ZO", []), rex([0xC3]), _64b | compat),
         inst("retq", fmt("I", [r(imm16)]), rex([0xC2]).iw(), _64b | compat),
+
+        inst("leaw", fmt("RM", [w(r16), r(m16)]), rex([0x66, 0x8D]).r(), _64b | compat),
+        inst("leal", fmt("RM", [w(r32), r(m32)]), rex([0x8D]).r(), _64b | compat),
+        inst("leaq", fmt("RM", [w(r64), r(m64)]), rex([0x8D]).w().r(), _64b),
     ]
 }

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -69,17 +69,17 @@ impl CodeSink for Vec<u8> {
 }
 
 /// Wrap [`CodeSink`]-specific labels.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub struct Label(pub u32);
 
 /// Wrap [`CodeSink`]-specific constant keys.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub struct Constant(pub u32);
 
 /// Wrap [`CodeSink`]-specific trap codes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub struct TrapCode(pub NonZeroU8);
 

--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -69,7 +69,7 @@ pub enum Size {
 ///
 /// This is due to avoid special cases of REX encodings, see Intel SDM Vol. 2A,
 /// table 2-5.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NonRspGpr<R: AsReg>(R);
 
 impl<R: AsReg> NonRspGpr<R> {

--- a/cranelift/assembler-x64/src/gpr.rs
+++ b/cranelift/assembler-x64/src/gpr.rs
@@ -96,6 +96,12 @@ impl<R: AsReg> NonRspGpr<R> {
     }
 }
 
+impl<R: AsReg> AsRef<R> for NonRspGpr<R> {
+    fn as_ref(&self) -> &R {
+        &self.0
+    }
+}
+
 impl<R: AsReg> AsMut<R> for NonRspGpr<R> {
     fn as_mut(&mut self) -> &mut R {
         &mut self.0

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -5,7 +5,7 @@ use crate::gpr::{self, NonRspGpr, Size};
 use crate::rex::{Disp, RexPrefix, encode_modrm, encode_sib};
 
 /// x64 memory addressing modes.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub enum Amode<R: AsReg> {
     ImmReg {
@@ -76,7 +76,7 @@ impl<R: AsReg> Amode<R> {
 }
 
 /// A 32-bit immediate for address offsets.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub struct AmodeOffset(i32);
 
@@ -126,7 +126,7 @@ impl std::fmt::LowerHex for AmodeOffset {
 /// happens immediately before emission:
 /// - the [`KnownOffset`] is looked up, mapping it to an offset value
 /// - the [`Simm32`] value is added to the offset value
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct AmodeOffsetPlusKnownOffset {
     pub simm32: AmodeOffset,
     pub offset: Option<KnownOffset>,
@@ -158,7 +158,7 @@ impl std::fmt::LowerHex for AmodeOffsetPlusKnownOffset {
 }
 
 /// For RIP-relative addressing, keep track of the [`CodeSink`]-specific target.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub enum DeferredTarget {
     Label(Label),
@@ -197,7 +197,7 @@ impl<R: AsReg> std::fmt::Display for Amode<R> {
 }
 
 /// The scaling factor for the index register in certain [`Amode`]s.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub enum Scale {
     One,
@@ -244,7 +244,7 @@ impl Scale {
 }
 
 /// A general-purpose register or memory operand.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 #[allow(
     clippy::module_name_repetitions,

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -81,8 +81,10 @@ impl<R: AsReg> Amode<R> {
 pub struct AmodeOffset(i32);
 
 impl AmodeOffset {
+    pub const ZERO: AmodeOffset = AmodeOffset::new(0);
+
     #[must_use]
-    pub fn new(value: i32) -> Self {
+    pub const fn new(value: i32) -> Self {
         Self(value)
     }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -487,7 +487,9 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn gen_get_stack_addr(mem: StackAMode, into_reg: Writable<Reg>) -> Self::I {
         let mem: SyntheticAmode = mem.into();
-        Inst::lea(mem, into_reg)
+        Inst::External {
+            inst: asm::inst::leaq_rm::new(into_reg, mem).into(),
+        }
     }
 
     fn get_stacklimit_reg(_call_conv: isa::CallConv) -> Reg {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -475,11 +475,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     fn gen_stack_lower_bound_trap(limit_reg: Reg) -> SmallInstVec<Self::I> {
         smallvec![
             Inst::External {
-                inst: asm::inst::cmpq_rm::new(
-                    Gpr::unwrap_new(limit_reg),
-                    Gpr::unwrap_new(regs::rsp())
-                )
-                .into(),
+                inst: asm::inst::cmpq_rm::new(Gpr::unwrap_new(limit_reg), Gpr::RSP,).into(),
             },
             Inst::TrapIf {
                 // NBE == "> unsigned"; args above are reversed; this tests limit_reg > rsp.
@@ -538,8 +534,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         _isa_flags: &x64_settings::Flags,
         frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
-        let r_rsp = Gpr::unwrap_new(regs::rsp());
-        let r_rbp = Gpr::unwrap_new(regs::rbp());
+        let r_rsp = Gpr::RSP;
+        let r_rbp = Gpr::RBP;
         let w_rbp = Writable::from_reg(r_rbp);
         let mut insts = SmallVec::new();
         // `push %rbp`
@@ -571,8 +567,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         _isa_flags: &x64_settings::Flags,
         _frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
-        let rbp = Gpr::unwrap_new(regs::rbp());
-        let rsp = Gpr::unwrap_new(regs::rsp());
+        let rbp = Gpr::RBP;
+        let rsp = Gpr::RSP;
 
         let mut insts = SmallVec::new();
         // `mov %rbp, %rsp`
@@ -667,8 +663,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
             // Make sure to keep the frame pointer and stack pointer in sync at
             // this point.
-            let rbp = Gpr::unwrap_new(regs::rbp());
-            let rsp = Gpr::unwrap_new(regs::rsp());
+            let rbp = Gpr::RBP;
+            let rsp = Gpr::RSP;
             insts.push(Inst::External {
                 inst: asm::inst::movq_mr::new(Writable::from_reg(rbp), rsp).into(),
             });
@@ -677,7 +673,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
             // Move the saved frame pointer down by `incoming_args_diff`.
             let addr = Amode::imm_reg(incoming_args_diff, regs::rsp());
-            let r11 = Writable::from_reg(Gpr::unwrap_new(regs::r11()));
+            let r11 = Writable::from_reg(Gpr::R11);
             let inst = asm::inst::movq_rm::new(r11, addr).into();
             insts.push(Inst::External { inst });
             let inst = asm::inst::movq_mr::new(Amode::imm_reg(0, regs::rsp()), r11.to_reg()).into();

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -39,11 +39,6 @@
        (MovToPReg (src Gpr)
                   (dst PReg))
 
-       ;; Loads the memory address of addr into dst.
-       (LoadEffectiveAddress (addr SyntheticAmode)
-                             (dst WritableGpr)
-                             (size OperandSize))
-
        ;; Materializes the requested condition code in the destination reg.
        (Setcc (cc CC)
               (dst WritableGpr))
@@ -3686,10 +3681,9 @@
       (provide (= result amode))
       (require (or (= ty 32) (= ty 64))))
 (decl x64_lea (Type SyntheticAmode) Gpr)
-(rule (x64_lea ty addr)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LoadEffectiveAddress addr dst (operand_size_of_type_32_64 ty)))))
-        dst))
+(rule (x64_lea $I16 addr) (x64_leaw_rm addr))
+(rule (x64_lea $I32 addr) (x64_leal_rm addr))
+(rule (x64_lea $I64 addr) (x64_leaq_rm addr))
 
 ;; Helper for creating `lzcnt` instructions.
 (decl x64_lzcnt (Type GprMem) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -304,6 +304,26 @@ newtype_of_reg!(
     |reg| reg.class() == RegClass::Int
 );
 
+#[expect(missing_docs, reason = "self-describing fields")]
+impl Gpr {
+    pub const RAX: Gpr = Gpr(regs::rax());
+    pub const RBX: Gpr = Gpr(regs::rbx());
+    pub const RCX: Gpr = Gpr(regs::rcx());
+    pub const RDX: Gpr = Gpr(regs::rdx());
+    pub const RSI: Gpr = Gpr(regs::rsi());
+    pub const RDI: Gpr = Gpr(regs::rdi());
+    pub const RSP: Gpr = Gpr(regs::rsp());
+    pub const RBP: Gpr = Gpr(regs::rbp());
+    pub const R8: Gpr = Gpr(regs::r8());
+    pub const R9: Gpr = Gpr(regs::r9());
+    pub const R10: Gpr = Gpr(regs::r10());
+    pub const R11: Gpr = Gpr(regs::r11());
+    pub const R12: Gpr = Gpr(regs::r12());
+    pub const R13: Gpr = Gpr(regs::r13());
+    pub const R14: Gpr = Gpr(regs::r14());
+    pub const R15: Gpr = Gpr(regs::r15());
+}
+
 // Define a newtype of `Reg` for XMM registers.
 newtype_of_reg!(
     Xmm,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -129,7 +129,6 @@ fn test_x64_emit() {
     let w_rcx = Writable::<Reg>::from_reg(rcx);
     let w_rdx = Writable::<Reg>::from_reg(rdx);
     let w_rsi = Writable::<Reg>::from_reg(rsi);
-    let w_rdi = Writable::<Reg>::from_reg(rdi);
     let _w_rsp = Writable::<Reg>::from_reg(rsp);
     let _w_rbp = Writable::<Reg>::from_reg(rbp);
     let w_r8 = Writable::<Reg>::from_reg(r8);
@@ -160,35 +159,6 @@ fn test_x64_emit() {
     // General tests for each insn.  Don't forget to follow the
     // guidelines commented just prior to `fn x64_emit`.
     //
-
-    // ========================================================
-    // LoadEffectiveAddress
-    insns.push((
-        Inst::lea(Amode::imm_reg(42, r10), w_r8),
-        "4D8D422A",
-        "lea     42(%r10), %r8",
-    ));
-    insns.push((
-        Inst::lea(Amode::imm_reg(42, r10), w_r15),
-        "4D8D7A2A",
-        "lea     42(%r10), %r15",
-    ));
-    insns.push((
-        Inst::lea(
-            Amode::imm_reg_reg_shift(179, Gpr::unwrap_new(r10), Gpr::unwrap_new(r9), 0),
-            w_r8,
-        ),
-        "4F8D840AB3000000",
-        "lea     179(%r10,%r9,1), %r8",
-    ));
-    insns.push((
-        Inst::lea(
-            Amode::rip_relative(MachLabel::from_block(BlockIndex::new(0))),
-            w_rdi,
-        ),
-        "488D3D00000000",
-        "lea     label0(%rip), %rdi",
-    ));
 
     // ========================================================
     // SetCC

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -2,7 +2,7 @@
 
 use super::{
     Amode, Gpr, Inst, LabelUse, MachBuffer, MachLabel, OperandVisitor, OperandVisitorImpl,
-    SyntheticAmode, VCodeConstant, WritableGpr, WritableXmm, Xmm, args::FromWritableReg, regs,
+    SyntheticAmode, VCodeConstant, WritableGpr, WritableXmm, Xmm, args::FromWritableReg,
 };
 use crate::{Reg, Writable, ir::TrapCode};
 use cranelift_assembler_x64 as asm;
@@ -340,7 +340,7 @@ impl From<SyntheticAmode> for asm::Amode<Gpr> {
         match amode {
             SyntheticAmode::Real(amode) => amode.into(),
             SyntheticAmode::IncomingArg { offset } => asm::Amode::ImmReg {
-                base: Gpr::unwrap_new(regs::rbp()),
+                base: Gpr::RBP,
                 simm32: asm::AmodeOffsetPlusKnownOffset {
                     simm32: (-i32::try_from(offset).unwrap()).into(),
                     offset: Some(offsets::KEY_INCOMING_ARG),
@@ -348,7 +348,7 @@ impl From<SyntheticAmode> for asm::Amode<Gpr> {
                 trap: None,
             },
             SyntheticAmode::SlotOffset { simm32 } => asm::Amode::ImmReg {
-                base: Gpr::unwrap_new(regs::rsp()),
+                base: Gpr::RSP,
                 simm32: asm::AmodeOffsetPlusKnownOffset {
                     simm32: simm32.into(),
                     offset: Some(offsets::KEY_SLOT_OFFSET),

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -641,7 +641,7 @@
 (extern constructor ishl_i8x16_mask_table ishl_i8x16_mask_table)
 (rule (ishl_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ishl_i8x16_mask_table))
-            (base_mask_addr Gpr (x64_lea $I64 mask_table))
+            (base_mask_addr Gpr (x64_leaq_rm mask_table))
             (mask_offset Gpr (x64_shlq_mi amt 4)))
         (Amode.ImmRegRegShift 0
                               base_mask_addr
@@ -745,7 +745,7 @@
 (extern constructor ushr_i8x16_mask_table ushr_i8x16_mask_table)
 (rule (ushr_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ushr_i8x16_mask_table))
-            (base_mask_addr Gpr (x64_lea $I64 mask_table))
+            (base_mask_addr Gpr (x64_leaq_rm mask_table))
             (mask_offset Gpr (x64_shlq_mi amt 4)))
         (Amode.ImmRegRegShift 0
                               base_mask_addr

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -75,23 +75,6 @@ pub(crate) fn check(
         Inst::MovFromPReg { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
         Inst::MovToPReg { .. } => Ok(()),
 
-        Inst::LoadEffectiveAddress {
-            ref addr,
-            dst,
-            size,
-        } => {
-            let addr = addr.clone();
-            let bits: u16 = size.to_bits().into();
-            check_output(ctx, vcode, dst.to_writable_reg(), &[], |vcode| {
-                let fact = if let SyntheticAmode::Real(amode) = &addr {
-                    compute_addr(ctx, vcode, amode, bits)
-                } else {
-                    None
-                };
-                clamp_range(ctx, 64, bits, fact)
-            })
-        }
-
         Inst::Setcc { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
 
         Inst::Cmove {

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -205,7 +205,7 @@ impl<T> Writable<T> {
     /// the documentation for `Writable`, this is not hidden or
     /// disallowed from the outside; anyone can perform the "cast";
     /// but it is explicit so that we can audit the use sites.
-    pub fn from_reg(reg: T) -> Writable<T> {
+    pub const fn from_reg(reg: T) -> Writable<T> {
         Writable { reg }
     }
 

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -243,7 +243,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rsi,%rdx,1), %r8d
+;   leal (%rsi, %rdx), %r8d
 ;   shll $0x2, %r8d
 ;   movq -1(%rdi, %r8), %rax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -11,7 +11,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,1), %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -982,7 +982,7 @@ block5(v5: i32):
 ;   movl $0x4, %esi
 ;   jmp     label7
 ; block7:
-;   lea     0(%rdi,%rsi,1), %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -364,7 +364,7 @@ block0(v0: i32, v1: i8x16):
 ;   movq %rsp, %rbp
 ;   subq $0x30, %rsp
 ; block0:
-;   lea     32(%rsp), %rcx
+;   leaq 0x20(%rsp), %rcx
 ;   movdqu %xmm0, (%rcx)
 ;   call    *%rdi
 ;   addq $0x30, %rsp
@@ -400,9 +400,9 @@ block0(v0: i32, v1: i32, v2: i8x16, v3: i64, v4: i8x16):
 ;   subq $0x40, %rsp
 ; block0:
 ;   movq %rdx, %r8
-;   lea     32(%rsp), %rdx
+;   leaq 0x20(%rsp), %rdx
 ;   movdqu %xmm0, (%rdx)
-;   lea     48(%rsp), %r9
+;   leaq 0x30(%rsp), %r9
 ;   movdqu %xmm1, (%r9)
 ;   movq %rsi, %rcx
 ;   call    *%rdi
@@ -443,7 +443,7 @@ block0(v0: i32, v1: i8x16):
 ;   movq %rsp, %rbp
 ;   subq $0x40, %rsp
 ; block0:
-;   lea     48(%rsp), %rcx
+;   leaq 0x30(%rsp), %rcx
 ;   movdqu %xmm0, (%rcx)
 ;   movq %rcx, 0x20(%rsp)
 ;   movq %rdi, %r9
@@ -487,10 +487,10 @@ block0(v0: i32, v1: i8x16):
 ;   movq %rsp, %rbp
 ;   subq $0x50, %rsp
 ; block0:
-;   lea     48(%rsp), %rcx
+;   leaq 0x30(%rsp), %rcx
 ;   movdqu %xmm0, (%rcx)
 ;   movq %rcx, 0x20(%rsp)
-;   lea     64(%rsp), %r10
+;   leaq 0x40(%rsp), %r10
 ;   movdqu %xmm0, (%r10)
 ;   movq %r10, 0x28(%rsp)
 ;   movq %rdi, %r9
@@ -537,12 +537,12 @@ block0(v0: i32, v1: i8x16):
 ;   movq %rsp, %rbp
 ;   subq $0x60, %rsp
 ; block0:
-;   lea     48(%rsp), %rdx
+;   leaq 0x30(%rsp), %rdx
 ;   movdqu %xmm0, (%rdx)
-;   lea     64(%rsp), %r9
+;   leaq 0x40(%rsp), %r9
 ;   movdqu %xmm0, (%r9)
 ;   movq %r9, 0x20(%rsp)
-;   lea     80(%rsp), %rax
+;   leaq 0x50(%rsp), %rax
 ;   movdqu %xmm0, (%rax)
 ;   movq %rax, 0x28(%rsp)
 ;   movq %rdi, %r9

--- a/cranelift/filetests/filetests/isa/x64/call-with-retval-insts.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-with-retval-insts.clif
@@ -44,41 +44,41 @@ block0(v0: i32):
 ;   movq %r15, 0x120(%rsp)
 ; block0:
 ;   movq %rdi, %rsi
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   load_ext_name %ext+0, %r10
 ;   call    *%r10
-;   lea     0(%rax,%rdx,1), %r8
-;   lea     0(%rbx,%r15,1), %r9
-;   lea     0(%r13,%r12,1), %r10
+;   leaq (%rax, %rdx), %r8
+;   leaq (%rbx, %r15), %r9
+;   leaq (%r13, %r12), %r10
 ;   movq <offset:1>+(%rsp), %rcx
-;   lea     0(%rcx,%r14,1), %r11
+;   leaq (%rcx, %r14), %r11
 ;   movq <offset:1>+8(%rsp), %rcx
 ;   movq <offset:1>+0x10(%rsp), %rdi
-;   lea     0(%rcx,%rdi,1), %rsi
+;   leaq (%rcx, %rdi), %rsi
 ;   movq <offset:1>+0x20(%rsp), %rdx
 ;   movq <offset:1>+0x18(%rsp), %rdi
-;   lea     0(%rdi,%rdx,1), %rdi
+;   leaq (%rdi, %rdx), %rdi
 ;   movq <offset:1>+0x28(%rsp), %rax
 ;   movq <offset:1>+0x30(%rsp), %rcx
-;   lea     0(%rax,%rcx,1), %rax
+;   leaq (%rax, %rcx), %rax
 ;   movq <offset:1>+0x40(%rsp), %rcx
 ;   movq <offset:1>+0x38(%rsp), %rdx
-;   lea     0(%rdx,%rcx,1), %rcx
+;   leaq (%rdx, %rcx), %rcx
 ;   movq <offset:1>+0x50(%rsp), %rdx
 ;   movq <offset:1>+0x48(%rsp), %r14
-;   lea     0(%r14,%rdx,1), %rdx
+;   leaq (%r14, %rdx), %rdx
 ;   movq <offset:1>+0x60(%rsp), %rbx
 ;   movq <offset:1>+0x58(%rsp), %r13
-;   lea     0(%r13,%rbx,1), %r14
-;   lea     0(%r8,%r9,1), %r8
-;   lea     0(%r10,%r11,1), %r9
-;   lea     0(%rsi,%rdi,1), %r10
-;   lea     0(%rax,%rcx,1), %r11
-;   lea     0(%rdx,%r14,1), %rsi
-;   lea     0(%r8,%r9,1), %r8
-;   lea     0(%r10,%r11,1), %r9
-;   lea     0(%rsi,%r8,1), %r8
-;   lea     0(%r9,%r8,1), %rax
+;   leaq (%r13, %rbx), %r14
+;   leaq (%r8, %r9), %r8
+;   leaq (%r10, %r11), %r9
+;   leaq (%rsi, %rdi), %r10
+;   leaq (%rax, %rcx), %r11
+;   leaq (%rdx, %r14), %rsi
+;   leaq (%r8, %r9), %r8
+;   leaq (%r10, %r11), %r9
+;   leaq (%rsi, %r8), %r8
+;   leaq (%r9, %r8), %rax
 ;   movq 0x100(%rsp), %rbx
 ;   movq 0x108(%rsp), %r12
 ;   movq 0x110(%rsp), %r13

--- a/cranelift/filetests/filetests/isa/x64/crit-edge.clif
+++ b/cranelift/filetests/filetests/isa/x64/crit-edge.clif
@@ -23,7 +23,7 @@ function %f(i32) -> i32 {
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     1(%rdi), %eax
+;   leal 1(%rdi), %eax
 ;   testl %edi, %edi
 ;   jnz     label4; j label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -49,7 +49,7 @@ function %f0(i32) -> i32, f32, f64 {
 ;   retq
 ; block2:
 ;   movdqu <offset:1>+(%rsp), %xmm1
-;   lea     1(%rax), %eax
+;   leal 1(%rax), %eax
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movq 0x10(%rsp), %rbx
@@ -184,7 +184,7 @@ function %f1(i32) -> i32, f32, f64 {
 ;   popq %rbp
 ;   retq
 ; block8:
-;   lea     1(%r11), %eax
+;   leal 1(%r11), %eax
 ;   movq %r11, %rsi
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
@@ -313,7 +313,7 @@ function %f2(i32) -> i32, f32, f64 {
 ;   retq
 ; block2:
 ;   movdqu <offset:1>+(%rsp), %xmm1
-;   lea     1(%rax), %eax
+;   leal 1(%rax), %eax
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   movq 0x10(%rsp), %rbx

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -438,16 +438,16 @@ block0(v0: f32):
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
 ;   jae 0x2d
-;   jp 0x4c
+;   jp 0x4b
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x47
+;   jge 0x46
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jl 0x4e
+;   jl 0x4d
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -521,16 +521,16 @@ block0(v0: f64):
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
 ;   jae 0x32
-;   jp 0x51
+;   jp 0x50
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x4c
+;   jge 0x4b
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jl 0x53
+;   jl 0x52
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -606,19 +606,19 @@ block0(v0: f32):
 ;   jae 0x39
 ;   jnp 0x25
 ;   xorl %eax, %eax
-;   jmp 0x5d
+;   jmp 0x5c
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x5d
+;   jge 0x5c
 ;   xorl %eax, %eax
-;   jmp 0x5d
+;   jmp 0x5c
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %eax
 ;   cmpl $0, %eax
 ;   jge 0x57
 ;   movl $0xffffffff, %eax
-;   jmp 0x5d
+;   jmp 0x5c
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -695,19 +695,19 @@ block0(v0: f64):
 ;   jae 0x3e
 ;   jnp 0x2a
 ;   xorl %eax, %eax
-;   jmp 0x62
+;   jmp 0x61
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x62
+;   jge 0x61
 ;   xorl %eax, %eax
-;   jmp 0x62
+;   jmp 0x61
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %eax
 ;   cmpl $0, %eax
 ;   jge 0x5c
 ;   movl $0xffffffff, %eax
-;   jmp 0x62
+;   jmp 0x61
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fmsub-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fmsub-inst.clif
@@ -457,7 +457,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovsd %xmm2, (%r8)
 ;   vfnmsub213sd %xmm0, %xmm1, 0(%r8), %xmm0
 ;   addq $0x10, %rsp
@@ -495,7 +495,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovsd %xmm2, (%r8)
 ;   vfmsub213sd %xmm0, %xmm1, 0(%r8), %xmm0
 ;   addq $0x10, %rsp
@@ -533,7 +533,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovss %xmm1, (%r8)
 ;   vfmsub132ss %xmm0, %xmm2, 0(%r8), %xmm0
 ;   addq $0x10, %rsp
@@ -573,7 +573,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovss %xmm1, (%r8)
 ;   vfnmsub132ss %xmm0, %xmm2, 0(%r8), %xmm0
 ;   addq $0x10, %rsp
@@ -597,7 +597,7 @@ block0(v0: f32, v1: f32, v2: f32):
 
 ;; negate first, then load
 ;; FIXME (see issue #8953): there is a missed optimization here due to the order
-;; of load and negation. This should really generate a vfmnsub instruction 
+;; of load and negation. This should really generate a vfmnsub instruction
 ;; removing the need to negate the argument explicitly
 function %fmnsub_f32(f32, f32, f32) -> f32 {
     ss0 = explicit_slot 4
@@ -616,7 +616,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r11
+;   leaq <offset:1>+(%rsp), %r11
 ;   movl $0x80000000, %r9d
 ;   vmovd %r9d, %xmm3
 ;   vxorps  %xmm1, %xmm3, %xmm3
@@ -660,7 +660,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovups %xmm0, (%r8)
 ;   movdqa %xmm1, %xmm0
 ;   vfmsub132ps %xmm0, %xmm2, 0(%r8), %xmm0

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
@@ -45,7 +45,7 @@ block0(v1: i64, v2: f32):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovss %xmm0, (%r8)
 ;   uninit  %xmm4
 ;   vxorpd  %xmm4, %xmm4, %xmm6
@@ -114,7 +114,7 @@ block0(v1: i64, v2: f64):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   vmovsd %xmm0, (%r8)
 ;   uninit  %xmm4
 ;   vxorps  %xmm4, %xmm4, %xmm6

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
@@ -49,7 +49,7 @@ block0(v1: i64, v2: f32):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   movss %xmm0, (%r8)
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
@@ -122,7 +122,7 @@ block0(v1: i64, v2: f64):
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %r8
+;   leaq <offset:1>+(%rsp), %r8
 ;   movsd %xmm0, (%r8)
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1296,7 +1296,7 @@ block0(v0: i128, v1: i128):
 ;   movq %r13, 0x18(%rsp)
 ; block0:
 ;   movq %rdi, %r13
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   load_ext_name %g+0, %r9
 ;   call    *%r9
 ;   movq %r13, %rdi

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -20,7 +20,7 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movabsq $0xffffeeeeddddcccc, %r10
-;   lea     0(%rdi,%r10,1), %r10
+;   leaq (%rdi, %r10), %r10
 ;   movq %r10, (%rsi)
 ;   movq %rdi, %r11
 ;   subq (%rip), %r11

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -21,7 +21,7 @@ block0:
 ;   movq %rsp, %rbp
 ;   subq $0x2000, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x2000, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -59,7 +59,7 @@ block0:
 ;   addq $0x30000, %rsp
 ;   subq $0x30000, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x30000, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -98,7 +98,7 @@ block0:
 ;   stack_probe_loop %r11, frame_size=2097152, guard_size=65536
 ;   subq $0x200000, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x200000, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -20,7 +20,7 @@ block0:
 ;   movq %rsp, %rbp
 ;   subq $0x800, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x800, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -58,7 +58,7 @@ block0:
 ;   addq $0x3000, %rsp
 ;   subq $0x3000, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x3000, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -97,7 +97,7 @@ block0:
 ;   stack_probe_loop %r11, frame_size=100000, guard_size=4096
 ;   subq $0x186a0, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x186a0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/lea.clif
+++ b/cranelift/filetests/filetests/isa/x64/lea.clif
@@ -11,7 +11,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,1), %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -36,7 +36,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,1), %rax
+;   leaq (%rdi, %rsi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -62,7 +62,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi), %eax
+;   leal 0x64(%rdi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -88,7 +88,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi), %rax
+;   leaq 0x64(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -115,7 +115,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi,%rsi,1), %eax
+;   leal 0x64(%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -142,7 +142,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi,%rsi,1), %rax
+;   leaq 0x64(%rdi, %rsi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -171,7 +171,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi,%rsi,4), %eax
+;   leal 0x64(%rdi, %rsi, 4), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -200,7 +200,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     100(%rdi,%rsi,4), %rax
+;   leaq 0x64(%rdi, %rsi, 4), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -227,7 +227,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,4), %eax
+;   leal (%rdi, %rsi, 4), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -254,7 +254,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,4), %rax
+;   leaq (%rdi, %rsi, 4), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -155,7 +155,7 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq (%rdi), %r8
-;   lea     0(%r8,%rdi,1), %r9
+;   leaq (%r8, %rdi), %r9
 ;   movq %r9, (%rsi)
 ;   movq (%r8, %rdi), %rax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -15,7 +15,7 @@ block0:
 ;   movq %rsp, %rbp
 ; block0:
 ;   movq    %r15, %rdi
-;   lea     1(%rdi), %rdi
+;   leaq 1(%rdi), %rdi
 ;   movq    %rdi, %r15
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -48,7 +48,7 @@ block0:
 ;   movq %rdi, (%rsp)
 ; block0:
 ;   movq    %r15, %rdi
-;   lea     1(%rdi), %rdi
+;   leaq 1(%rdi), %rdi
 ;   movq    %rdi, %r15
 ;   movq (%rsp), %rdi
 ;   addq $0x10, %rsp

--- a/cranelift/filetests/filetests/isa/x64/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/probestack.clif
@@ -17,7 +17,7 @@ block0:
 ;   call    LibCall(Probestack)
 ;   subq $0x186a0, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
+;   leaq <offset:1>+(%rsp), %rax
 ;   addq $0x186a0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     10(%rdi), %rax
+;   leaq 0xa(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     10(%rdi), %rax
+;   leaq 0xa(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -1384,7 +1384,7 @@ block0(v0: i8x16, v1: i32):
 ;   andq $0x7, %rdi
 ;   vmovd %edi, %xmm5
 ;   vpsllw  %xmm0, %xmm5, %xmm7
-;   lea     const(0), %rsi
+;   leaq (%rip), %rsi
 ;   shlq $0x4, %rdi
 ;   vmovdqu (%rsi, %rdi), %xmm5
 ;   vpand   %xmm7, %xmm5, %xmm0
@@ -1623,7 +1623,7 @@ block0(v0: i8x16, v1: i32):
 ;   andq $0x7, %rdi
 ;   vmovd %edi, %xmm5
 ;   vpsrlw  %xmm0, %xmm5, %xmm7
-;   lea     const(0), %rsi
+;   leaq (%rip), %rsi
 ;   shlq $0x4, %rdi
 ;   vpand   %xmm7, 0(%rsi,%rdi,1), %xmm0
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -328,7 +328,7 @@ block0(v0: i32):
 ;   andq $0x7, %rdi
 ;   movd %edi, %xmm5
 ;   psllw %xmm5, %xmm0
-;   lea     const(0), %rsi
+;   leaq (%rip), %rsi
 ;   shlq $0x4, %rdi
 ;   movdqu (%rsi, %rdi), %xmm5
 ;   pand %xmm5, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -217,27 +217,27 @@ block0(v0: i64, v1: i64):
 ;   movq (%rdx), %rdx
 ;   movq <offset:1>+8(%rsp), %rdi
 ;   movq <offset:1>+0x18(%rsp), %r9
-;   lea     0(%r9,%rdi,1), %rdi
+;   leaq (%r9, %rdi), %rdi
 ;   movq <offset:1>+0x10(%rsp), %r9
 ;   movq %rdi, <offset:1>+8(%rsp)
-;   lea     0(%r9,%r10,1), %r9
-;   lea     0(%r11,%rsi,1), %r10
-;   lea     0(%rax,%rbx,1), %r11
-;   lea     0(%r12,%r14,1), %rsi
-;   lea     0(%r15,%r8,1), %r8
-;   lea     0(%rsi,%r8,1), %r8
-;   lea     0(%r11,%r8,1), %r8
-;   lea     0(%r10,%r8,1), %r8
-;   lea     0(%rcx,%r13,1), %r10
+;   leaq (%r9, %r10), %r9
+;   leaq (%r11, %rsi), %r10
+;   leaq (%rax, %rbx), %r11
+;   leaq (%r12, %r14), %rsi
+;   leaq (%r15, %r8), %r8
+;   leaq (%rsi, %r8), %r8
+;   leaq (%r11, %r8), %r8
+;   leaq (%r10, %r8), %r8
+;   leaq (%rcx, %r13), %r10
 ;   movq <offset:1>+0x20(%rsp), %rcx
 ;   addq (%rcx), %rdx
 ;   movq <offset:1>+(%rsp), %rdi
-;   lea     0(%rdx,%rdi,1), %r11
-;   lea     0(%r10,%r11,1), %r10
-;   lea     0(%r8,%r10,1), %r8
-;   lea     0(%r9,%r8,1), %r8
+;   leaq (%rdx, %rdi), %r11
+;   leaq (%r10, %r11), %r10
+;   leaq (%r8, %r10), %r8
+;   leaq (%r9, %r8), %r8
 ;   movq <offset:1>+8(%rsp), %r9
-;   lea     0(%r9,%r8,1), %rax
+;   leaq (%r9, %r8), %rax
 ;   movq 0x90(%rsp), %rbx
 ;   movq 0x98(%rsp), %r12
 ;   movq 0xa0(%rsp), %r13

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -27,10 +27,10 @@ block0(v0: i64):
 ;   jnbe #trap=stk_ovf
 ;   subq $0x30, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
-;   lea     rsp(16 + virtual offset), %rdx
-;   lea     rsp(24 + virtual offset), %r8
-;   lea     rsp(32 + virtual offset), %r9
+;   leaq <offset:1>+(%rsp), %rax
+;   leaq <offset:1>+0x10(%rsp), %rdx
+;   leaq <offset:1>+0x18(%rsp), %r8
+;   leaq <offset:1>+0x20(%rsp), %r9
 ;   movq %r8, (%rdi)
 ;   movq %r9, 8(%rdi)
 ;   addq $0x30, %rsp

--- a/cranelift/filetests/filetests/isa/x64/stackslot_alignment.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot_alignment.clif
@@ -22,8 +22,8 @@ block0(v0: i64):
 ;   jnbe #trap=stk_ovf
 ;   subq $0x30, %rsp
 ; block0:
-;   lea     rsp(0 + virtual offset), %rax
-;   lea     rsp(16 + virtual offset), %rdx
+;   leaq <offset:1>+(%rsp), %rax
+;   leaq <offset:1>+0x10(%rsp), %rdx
 ;   addq $0x30, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     rbp(stack args max - 64), %rsi
+;   leaq <offset:0>+-0x40(%rbp), %rsi
 ;   movzbq (%rsi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -40,7 +40,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     rbp(stack args max - 64), %rcx
+;   leaq <offset:0>+-0x40(%rbp), %rcx
 ;   movzbq (%rdi), %rax
 ;   movzbq (%rcx), %r9
 ;   addl %r9d, %eax
@@ -75,7 +75,7 @@ block0(v0: i64):
 ;   subq $0x40, %rsp
 ; block0:
 ;   movq %rdi, %rsi
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   movl $0x40, %edx
 ;   load_ext_name %Memcpy+0, %r10
 ;   call    *%r10
@@ -117,7 +117,7 @@ block0(v0: i64, v1: i64):
 ;   movq %r14, 0x40(%rsp)
 ; block0:
 ;   movq %rdi, %r14
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   movl $0x40, %edx
 ;   load_ext_name %Memcpy+0, %r11
 ;   call    *%r11
@@ -161,8 +161,8 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   lea     rbp(stack args max - 192), %rsi
-;   lea     rbp(stack args max - 64), %rcx
+;   leaq <offset:0>+-0xc0(%rbp), %rsi
+;   leaq <offset:0>+-0x40(%rbp), %rcx
 ;   movzbq (%rsi), %rax
 ;   movzbq (%rcx), %r9
 ;   addl %r9d, %eax
@@ -201,11 +201,11 @@ block0(v0: i64, v1: i64, v2: i64):
 ; block0:
 ;   movq %rdx, %rbx
 ;   movq %rdi, %r13
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   movl $0x80, %edx
 ;   load_ext_name %Memcpy+0, %rax
 ;   call    *%rax
-;   lea     128(%rsp), %rdi
+;   leaq 0x80(%rsp), %rdi
 ;   movl $0x40, %edx
 ;   load_ext_name %Memcpy+0, %r10
 ;   movq %rbx, %rsi

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -387,7 +387,7 @@ block0:
 ;   movq %r14, 0x118(%rsp)
 ;   movq %r15, 0x120(%rsp)
 ; block0:
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   call    TestCase(%tail_callee_stack_rets)
 ;   movq <offset:1>+0x60(%rsp), %rax
 ;   movq 0x100(%rsp), %rbx
@@ -750,7 +750,7 @@ block0:
 ;   movq %r11, 0x98(%rsp)
 ;   movq <offset:1>+0x60(%rsp), %r11
 ;   movq %r11, 0xa0(%rsp)
-;   lea     176(%rsp), %rdi
+;   leaq 0xb0(%rsp), %rdi
 ;   load_ext_name %tail_callee_stack_args_and_rets+0, %r10
 ;   movq <offset:1>+0x48(%rsp), %rcx
 ;   movq <offset:1>+0x50(%rsp), %rdx

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -45,23 +45,23 @@ block0:
 ;   movq %rdi, %r14
 ;   movl $0x1, %r15d
 ;   movl $0x2, %ebx
-;   lea     rsp(0 + virtual offset), %rsi
+;   leaq <offset:1>+(%rsp), %rsi
 ;   movl $0x0, (%rsi)
-;   lea     rsp(4 + virtual offset), %rdi
+;   leaq <offset:1>+4(%rsp), %rdi
 ;   movl $0x1, (%rdi)
-;   lea     rsp(8 + virtual offset), %rax
+;   leaq <offset:1>+8(%rsp), %rax
 ;   movl $0x2, (%rax)
 ;   movq %r14, %rdi
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
-;   lea     rsp(0 + virtual offset), %rdx
+;   leaq <offset:1>+(%rsp), %rdx
 ;   movl $0x1, (%rdx)
-;   lea     rsp(4 + virtual offset), %r8
+;   leaq <offset:1>+4(%rsp), %r8
 ;   movl $0x2, (%r8)
 ;   movq %r14, %rdi
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
-;   lea     rsp(0 + virtual offset), %r10
+;   leaq <offset:1>+(%rsp), %r10
 ;   movl $0x2, (%r10)
 ;   movq %r15, %rdi
 ;   call    User(userextname0)
@@ -148,22 +148,22 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movq %r15, 0xa0(%rsp)
 ; block0:
 ;   movq %rdi, %r13
-;   lea     rsp(0 + virtual offset), %r9
+;   leaq <offset:1>+(%rsp), %r9
 ;   movb %sil, (%r9)
 ;   movq %rsi, %r15
-;   lea     rsp(8 + virtual offset), %r9
+;   leaq <offset:1>+8(%rsp), %r9
 ;   movw %dx, (%r9)
 ;   movq %rdx, %r12
-;   lea     rsp(16 + virtual offset), %r9
+;   leaq <offset:1>+0x10(%rsp), %r9
 ;   movl %ecx, (%r9)
 ;   movq %rcx, %rbx
-;   lea     rsp(20 + virtual offset), %r10
+;   leaq <offset:1>+0x14(%rsp), %r10
 ;   movss %xmm0, (%r10)
 ;   movdqu %xmm0, <offset:1>+0x60(%rsp)
-;   lea     rsp(24 + virtual offset), %r11
+;   leaq <offset:1>+0x18(%rsp), %r11
 ;   movq %r8, (%r11)
 ;   movq %r8, %r14
-;   lea     rsp(32 + virtual offset), %rsi
+;   leaq <offset:1>+0x20(%rsp), %rsi
 ;   movsd %xmm1, (%rsi)
 ;   movdqu %xmm1, <offset:1>+0x70(%rsp)
 ;   call    User(userextname0)

--- a/cranelift/filetests/filetests/isa/x64/winch.clif
+++ b/cranelift/filetests/filetests/isa/x64/winch.clif
@@ -298,7 +298,7 @@ block0(v0:i64):
 ;   movq %r14, 0x38(%rsp)
 ;   movq %r15, 0x40(%rsp)
 ; block0:
-;   lea     0(%rsp), %rdi
+;   leaq (%rsp), %rdi
 ;   load_ext_name %g+0, %r10
 ;   call    *%r10
 ;   movq <offset:1>+(%rsp), %rax

--- a/cranelift/filetests/filetests/pcc/fail/add.clif
+++ b/cranelift/filetests/filetests/pcc/fail/add.clif
@@ -1,7 +1,7 @@
 test compile expect-fail
 set enable_pcc=true
 target aarch64
-target x86_64
+;; disabled until PCC is migrated to new assembler: target x86_64
 
 function %f0(i32, i32) -> i32 {
 block0(v0 ! range(32, 0, 0x100): i32, v1 ! range(32, 0, 0x80): i32):

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -32,7 +32,7 @@
 ;;       movl    $0x20, %ecx
 ;;       movl    $8, %r8d
 ;;       movq    %rdi, %r13
-;;       callq   0x160
+;;       callq   0x15f
 ;;       movq    8(%r13), %r8
 ;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[0]
 ;;       movq    0x18(%r8), %r8

--- a/tests/disas/trunc.wat
+++ b/tests/disas/trunc.wat
@@ -62,27 +62,27 @@
 ;;       retq
 ;;   e8: movl    $6, %esi
 ;;   ed: movq    %r14, %rdi
-;;   f0: callq   0x284
+;;   f0: callq   0x283
 ;;   f5: movq    %r14, %rdi
-;;   f8: callq   0x2c8
+;;   f8: callq   0x2c6
 ;;   fd: ud2
 ;;   ff: movl    $6, %esi
 ;;  104: movq    %r14, %rdi
-;;  107: callq   0x284
+;;  107: callq   0x283
 ;;  10c: movq    %r14, %rdi
-;;  10f: callq   0x2c8
+;;  10f: callq   0x2c6
 ;;  114: ud2
 ;;  116: movl    $8, %esi
 ;;  11b: movq    %r14, %rdi
-;;  11e: callq   0x284
+;;  11e: callq   0x283
 ;;  123: movq    %r14, %rdi
-;;  126: callq   0x2c8
+;;  126: callq   0x2c6
 ;;  12b: ud2
 ;;  12d: xorl    %esi, %esi
 ;;  12f: movq    %r14, %rdi
-;;  132: callq   0x284
+;;  132: callq   0x283
 ;;  137: movq    %r14, %rdi
-;;  13a: callq   0x2c8
+;;  13a: callq   0x2c6
 ;;  13f: ud2
 ;;  141: ud2
 ;;  143: ud2

--- a/tests/disas/trunc32.wat
+++ b/tests/disas/trunc32.wat
@@ -111,7 +111,7 @@
 ;;       movq    0x10(%r10), %r10
 ;;       movq    %rsp, %r11
 ;;       cmpq    %r10, %r11
-;;       jb      0x122
+;;       jb      0x121
 ;;   29: xorpd   %xmm0, %xmm0
 ;;       movdqu  (%rsp), %xmm4
 ;;       cvtss2sd %xmm4, %xmm0
@@ -120,7 +120,7 @@
 ;;       setne   %al
 ;;       orl     %eax, %edi
 ;;       testb   %dil, %dil
-;;       jne     0x10b
+;;       jne     0x10a
 ;;   4d: movq    %r12, %rdi
 ;;       callq   0x232
 ;;       movabsq $13830554455654793216, %rax
@@ -128,65 +128,66 @@
 ;;       ucomisd %xmm0, %xmm7
 ;;       setae   %dl
 ;;       testb   %dl, %dl
-;;       jne     0xf4
+;;       jne     0xf3
 ;;   74: ucomisd 0xc4(%rip), %xmm0
 ;;       setae   %r10b
 ;;       testb   %r10b, %r10b
-;;       jne     0xdd
+;;       jne     0xdc
 ;;   89: movdqu  (%rsp), %xmm4
 ;;       movl    $0x4f000000, %esi
 ;;       movd    %esi, %xmm2
 ;;       ucomiss %xmm2, %xmm4
 ;;       jae     0xb5
-;;       jp      0x136
+;;       jp      0x135
 ;;   a6: cvttss2si %xmm4, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0xcf
+;;       jge     0xce
 ;;   b3: ud2
 ;;       movaps  %xmm4, %xmm3
 ;;       subss   %xmm2, %xmm3
 ;;       cvttss2si %xmm3, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x138
+;;       jl      0x137
 ;;   c9: addl    $0x80000000, %eax
 ;;       movq    0x10(%rsp), %r12
 ;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   dd: movl    $6, %esi
-;;   e2: movq    %r12, %rdi
-;;   e5: callq   0x272
-;;   ea: movq    %r12, %rdi
-;;   ed: callq   0x2b6
-;;   f2: ud2
-;;   f4: movl    $6, %esi
-;;   f9: movq    %r12, %rdi
-;;   fc: callq   0x272
-;;  101: movq    %r12, %rdi
-;;  104: callq   0x2b6
-;;  109: ud2
-;;  10b: movl    $8, %esi
-;;  110: movq    %r12, %rdi
-;;  113: callq   0x272
-;;  118: movq    %r12, %rdi
-;;  11b: callq   0x2b6
-;;  120: ud2
-;;  122: xorl    %esi, %esi
-;;  124: movq    %r12, %rdi
-;;  127: callq   0x272
-;;  12c: movq    %r12, %rdi
-;;  12f: callq   0x2b6
-;;  134: ud2
-;;  136: ud2
-;;  138: ud2
-;;  13a: addb    %al, (%rax)
-;;  13c: addb    %al, (%rax)
-;;  13e: addb    %al, (%rax)
-;;  140: addb    %al, (%rax)
-;;  142: addb    %al, (%rax)
-;;  144: addb    %al, (%rax)
-;;  146: lock addb %al, (%r8)
+;;   dc: movl    $6, %esi
+;;   e1: movq    %r12, %rdi
+;;   e4: callq   0x271
+;;   e9: movq    %r12, %rdi
+;;   ec: callq   0x2b4
+;;   f1: ud2
+;;   f3: movl    $6, %esi
+;;   f8: movq    %r12, %rdi
+;;   fb: callq   0x271
+;;  100: movq    %r12, %rdi
+;;  103: callq   0x2b4
+;;  108: ud2
+;;  10a: movl    $8, %esi
+;;  10f: movq    %r12, %rdi
+;;  112: callq   0x271
+;;  117: movq    %r12, %rdi
+;;  11a: callq   0x2b4
+;;  11f: ud2
+;;  121: xorl    %esi, %esi
+;;  123: movq    %r12, %rdi
+;;  126: callq   0x271
+;;  12b: movq    %r12, %rdi
+;;  12e: callq   0x2b4
+;;  133: ud2
+;;  135: ud2
+;;  137: ud2
+;;  139: addb    %al, (%rax)
+;;  13b: addb    %al, (%rax)
+;;  13d: addb    %al, (%rax)
+;;  13f: addb    %al, (%rax)
+;;  141: addb    %al, (%rax)
+;;  143: addb    %al, (%rax)
+;;  145: addb    %dh, %al
+;;  147: addb    %al, (%r8)
 ;;  14a: addb    %al, (%rax)
 ;;  14c: addb    %al, (%rax)
 ;;  14e: addb    %al, (%rax)

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load.wat
@@ -13,7 +13,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x60
+;;       ja      0x5f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -22,8 +22,8 @@
 ;;       movl    0xc(%rsp), %eax
 ;;       andl    $3, %eax
 ;;       cmpl    $0, %eax
-;;       jne     0x62
-;;   47: movl    0xc(%rsp), %eax
+;;       jne     0x61
+;;   46: movl    0xc(%rsp), %eax
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
@@ -31,5 +31,5 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   60: ud2
-;;   62: ud2
+;;   5f: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -13,7 +13,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x62
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -22,8 +22,8 @@
 ;;       movl    0xc(%rsp), %eax
 ;;       andw    $1, %ax
 ;;       cmpw    $0, %ax
-;;       jne     0x64
-;;   47: movl    0xc(%rsp), %eax
+;;       jne     0x63
+;;   46: movl    0xc(%rsp), %eax
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rcx
 ;;       addq    %rax, %rcx
@@ -31,5 +31,5 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   62: ud2
-;;   64: ud2
+;;   61: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5d
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,13 @@
 ;;       movl    $0, %eax
 ;;       andq    $7, %rax
 ;;       cmpq    $0, %rax
-;;       jne     0x5f
-;;   45: movl    $0, %eax
+;;       jne     0x5e
+;;   44: movl    $0, %eax
 ;;       movq    0x38(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movq    (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5d: ud2
-;;   5f: ud2
+;;   5c: ud2
+;;   5e: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5c
+;;       ja      0x5b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,13 @@
 ;;       movl    $0, %eax
 ;;       andw    $1, %ax
 ;;       cmpw    $0, %ax
-;;       jne     0x5e
-;;   43: movl    $0, %eax
+;;       jne     0x5d
+;;   42: movl    $0, %eax
 ;;       movq    0x38(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movzwq  (%rcx), %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5c: ud2
-;;   5e: ud2
+;;   5b: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load32_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5a
+;;       ja      0x59
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,13 +22,13 @@
 ;;       movl    $0, %eax
 ;;       andl    $3, %eax
 ;;       cmpl    $0, %eax
-;;       jne     0x5c
-;;   43: movl    $0, %eax
+;;       jne     0x5b
+;;   42: movl    $0, %eax
 ;;       movq    0x38(%r14), %rcx
 ;;       addq    %rax, %rcx
 ;;       movl    (%rcx), %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
-;;   5c: ud2
+;;   59: ud2
+;;   5b: ud2

--- a/tests/disas/winch/x64/atomic/notify/notify.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify.wat
@@ -27,7 +27,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x17b
+;;       callq   0x17a
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/notify/notify_offset.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify_offset.wat
@@ -28,7 +28,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x182
+;;       callq   0x181
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32.wat
@@ -30,7 +30,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x188
+;;       callq   0x187
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x18f
+;;       callq   0x18e
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64.wat
@@ -29,7 +29,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x180
+;;       callq   0x17f
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
@@ -33,7 +33,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x187
+;;       callq   0x186
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/br_if/save_state_before_br_emission.wat
+++ b/tests/disas/winch/x64/br_if/save_state_before_br_emission.wat
@@ -44,7 +44,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x58, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x131
+;;       ja      0x130
 ;;   1c: movq    %rsi, %r14
 ;;       subq    $0x40, %rsp
 ;;       movq    %rsi, 0x38(%rsp)
@@ -74,16 +74,16 @@
 ;;   b8: movl    (%rsp), %r11d
 ;;       movl    %r11d, 0x10(%rsp)
 ;;       addq    $0x10, %rsp
-;;       jmp     0x111
+;;       jmp     0x110
 ;;   cd: addq    $4, %rsp
 ;;       movsd   (%rsp), %xmm0
 ;;       addq    $8, %rsp
 ;;       movq    %xmm0, %rax
 ;;       xorq    $0, %rax
 ;;       addq    $8, %rsp
-;;       movsd   0x45(%rip), %xmm0
+;;       movsd   0x46(%rip), %xmm0
 ;;       subq    $4, %rsp
-;;       movss   0x2d(%rip), %xmm15
+;;       movss   0x2e(%rip), %xmm15
 ;;       movss   %xmm15, (%rsp)
 ;;       movq    0xc(%rsp), %rax
 ;;       movss   (%rsp), %xmm15
@@ -92,14 +92,15 @@
 ;;       addq    $0x40, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  131: ud2
-;;  133: addb    %al, (%rax)
-;;  135: addb    %al, (%rax)
-;;  137: addb    %al, (%rax)
-;;  139: addb    %al, (%rax)
-;;  13b: addb    %al, (%rax)
-;;  13d: addb    %al, (%rax)
-;;  13f: addb    %al, (%rax)
-;;  141: addb    %al, (%rax)
-;;  143: addb    %al, (%rax)
-;;  145: addb    %al, (%rax)
+;;  130: ud2
+;;  132: addb    %al, (%rax)
+;;  134: addb    %al, (%rax)
+;;  136: addb    %al, (%rax)
+;;  138: addb    %al, (%rax)
+;;  13a: addb    %al, (%rax)
+;;  13c: addb    %al, (%rax)
+;;  13e: addb    %al, (%rax)
+;;  140: addb    %al, (%rax)
+;;  142: addb    %al, (%rax)
+;;  144: addb    %al, (%rax)
+;;  146: addb    %al, (%rax)

--- a/tests/disas/winch/x64/br_table/use-innermost-frame.wat
+++ b/tests/disas/winch/x64/br_table/use-innermost-frame.wat
@@ -2026,7 +2026,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x980, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x4a8b
+;;       ja      0x4a84
 ;;  18c: movq    %rsi, %r14
 ;;       subq    $0x1c0, %rsp
 ;;       movq    %rsi, 0x1b8(%rsp)
@@ -2101,8 +2101,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x204(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x4836
-;;  376: subq    $0x4c, %rsp
+;;       je      0x482f
+;;  375: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2111,8 +2111,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x250(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x4612
-;;  3ab: subq    $0x4c, %rsp
+;;       je      0x460b
+;;  3aa: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2121,16 +2121,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x29c(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x43ee
-;;  3e0: subq    $0x4c, %rsp
+;;       je      0x43e7
+;;  3df: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x2e8(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x41ca
-;;  406: subq    $0x4c, %rsp
+;;       je      0x41c3
+;;  405: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2139,8 +2139,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x334(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x3fa6
-;;  43b: subq    $0x4c, %rsp
+;;       je      0x3f9f
+;;  43a: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2149,8 +2149,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x380(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x3d82
-;;  470: subq    $0x4c, %rsp
+;;       je      0x3d7b
+;;  46f: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2159,16 +2159,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x3cc(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x3b5e
-;;  4a5: subq    $0x4c, %rsp
+;;       je      0x3b57
+;;  4a4: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x418(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x393a
-;;  4cb: subq    $0x4c, %rsp
+;;       je      0x3933
+;;  4ca: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2177,8 +2177,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x464(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x3716
-;;  500: subq    $0x4c, %rsp
+;;       je      0x370f
+;;  4ff: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2187,8 +2187,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x4b0(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x34f2
-;;  535: subq    $0x4c, %rsp
+;;       je      0x34ec
+;;  534: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2197,16 +2197,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x4fc(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x32ce
-;;  56a: subq    $0x4c, %rsp
+;;       je      0x32c9
+;;  569: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x548(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x30aa
-;;  590: subq    $0x4c, %rsp
+;;       je      0x30a6
+;;  58f: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2215,8 +2215,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x594(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x2e86
-;;  5c5: subq    $0x4c, %rsp
+;;       je      0x2e82
+;;  5c4: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2225,8 +2225,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x5e0(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x2c62
-;;  5fa: subq    $0x4c, %rsp
+;;       je      0x2c5e
+;;  5f9: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2235,16 +2235,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x62c(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x2a3e
-;;  62f: subq    $0x4c, %rsp
+;;       je      0x2a3a
+;;  62e: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x678(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x281a
-;;  655: subq    $0x4c, %rsp
+;;       je      0x2816
+;;  654: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2253,8 +2253,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x6c4(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x25f6
-;;  68a: subq    $0x4c, %rsp
+;;       je      0x25f2
+;;  689: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2263,8 +2263,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x710(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x23d2
-;;  6bf: subq    $0x4c, %rsp
+;;       je      0x23ce
+;;  6be: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2273,16 +2273,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x75c(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x21ae
-;;  6f4: subq    $0x4c, %rsp
+;;       je      0x21aa
+;;  6f3: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x7a8(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x1f8a
-;;  71a: subq    $0x4c, %rsp
+;;       je      0x1f86
+;;  719: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2291,8 +2291,8 @@
 ;;       addq    $4, %rsp
 ;;       movq    0x7f4(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x1d66
-;;  74f: subq    $0x4c, %rsp
+;;       je      0x1d64
+;;  74e: subq    $0x4c, %rsp
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2301,8 +2301,8 @@
 ;;       addq    $8, %rsp
 ;;       movq    0x840(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x1b42
-;;  784: subq    $0x4c, %rsp
+;;       je      0x1b40
+;;  783: subq    $0x4c, %rsp
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2311,16 +2311,16 @@
 ;;       addq    $0xc, %rsp
 ;;       movq    0x88c(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x191e
-;;  7b9: subq    $0x4c, %rsp
+;;       je      0x191d
+;;  7b8: subq    $0x4c, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
 ;;       leaq    (%rsp), %rdi
 ;;       callq   0
 ;;       movq    0x8d8(%rsp), %r14
 ;;       testl   %eax, %eax
-;;       je      0x176f
-;;  7df: subq    $0x4c, %rsp
+;;       je      0x176e
+;;  7de: subq    $0x4c, %rsp
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rsi
 ;;       movq    %r14, %rdx
@@ -2390,13 +2390,13 @@
 ;;       movslq  (%r11, %rcx, 4), %rdx
 ;;       addq    %rdx, %r11
 ;;       jmpq    *%r11
-;;  952: rorb    $0, (%rsi)
+;;  951: rorb    $0, (%rsi)
 ;;       addb    %ch, (%rbp)
 ;;       addb    %al, (%rax)
 ;;       inl     $0, %eax
 ;;       addb    %al, (%rax)
-;;       jb      0x961
-;;  960: addb    %al, (%rax)
+;;       jb      0x960
+;;  95f: addb    %al, (%rax)
 ;;       incl    (%rcx)
 ;;       addb    %al, (%rax)
 ;;       movw    %es, (%rdx)

--- a/tests/disas/winch/x64/call/recursive.wat
+++ b/tests/disas/winch/x64/call/recursive.wat
@@ -30,7 +30,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xf0
+;;       ja      0xef
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -43,7 +43,7 @@
 ;;       testl   %eax, %eax
 ;;       je      0x55
 ;;   4c: movl    0xc(%rsp), %eax
-;;       jmp     0xe7
+;;       jmp     0xe6
 ;;   55: movl    0xc(%rsp), %eax
 ;;       subl    $1, %eax
 ;;       subq    $4, %rsp
@@ -77,4 +77,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   f0: ud2
+;;   ef: ud2

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -37,7 +37,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x22d
+;;       ja      0x22a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -50,7 +50,7 @@
 ;;       testl   %eax, %eax
 ;;       je      0x56
 ;;   4c: movl    $1, %eax
-;;       jmp     0x224
+;;       jmp     0x221
 ;;   56: movl    0xc(%rsp), %eax
 ;;       subl    $2, %eax
 ;;       subq    $4, %rsp
@@ -59,8 +59,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x22f
-;;   7f: movq    %rcx, %r11
+;;       jae     0x22c
+;;   7e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -69,27 +69,27 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0xdf
-;;   a5: subq    $4, %rsp
+;;       jne     0xde
+;;   a4: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x334
+;;       callq   0x331
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0xe6
-;;   df: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0xe4
+;;   de: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x231
-;;   ef: movq    0x28(%r14), %r11
+;;       je      0x22e
+;;   ed: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x233
-;;  101: pushq   %rax
+;;       jne     0x230
+;;   ff: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %r8
 ;;       movq    8(%rcx), %rbx
@@ -111,8 +111,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x235
-;;  164: movq    %rcx, %r11
+;;       jae     0x232
+;;  162: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -121,27 +121,27 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x1c4
-;;  18a: subq    $4, %rsp
+;;       jne     0x1c2
+;;  188: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x334
+;;       callq   0x331
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14
-;;       jmp     0x1cb
-;;  1c4: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x1c8
+;;  1c2: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x237
-;;  1d4: movq    0x28(%r14), %r11
+;;       je      0x234
+;;  1d1: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x239
-;;  1e6: pushq   %rax
+;;       jne     0x236
+;;  1e3: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %r8
 ;;       movq    8(%rcx), %rbx
@@ -160,10 +160,10 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  22d: ud2
-;;  22f: ud2
-;;  231: ud2
-;;  233: ud2
-;;  235: ud2
-;;  237: ud2
-;;  239: ud2
+;;  22a: ud2
+;;  22c: ud2
+;;  22e: ud2
+;;  230: ud2
+;;  232: ud2
+;;  234: ud2
+;;  236: ud2

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -42,7 +42,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x157
+;;       ja      0x156
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -55,7 +55,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x159
+;;       jae     0x158
 ;;   9e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
@@ -72,20 +72,20 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x315
+;;       callq   0x313
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0x105
+;;       jmp     0x104
 ;;   fe: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x15b
-;;  10e: movq    0x28(%r14), %r11
+;;       je      0x15a
+;;  10d: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x15d
-;;  120: movq    0x18(%rax), %rbx
+;;       jne     0x15c
+;;  11f: movq    0x18(%rax), %rbx
 ;;       movq    8(%rax), %rcx
 ;;       subq    $0xc, %rsp
 ;;       movq    %rbx, %rdi
@@ -98,7 +98,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  157: ud2
-;;  159: ud2
-;;  15b: ud2
-;;  15d: ud2
+;;  156: ud2
+;;  158: ud2
+;;  15a: ud2
+;;  15c: ud2

--- a/tests/disas/winch/x64/i16x8/shift/shl.wat
+++ b/tests/disas/winch/x64/i16x8/shift/shl.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i16x8/shift/shr_s.wat
+++ b/tests/disas/winch/x64/i16x8/shift/shr_s.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i16x8/shift/shr_u.wat
+++ b/tests/disas/winch/x64/i16x8/shift/shr_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32_add/const.wat
+++ b/tests/disas/winch/x64/i32_add/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_add/max.wat
+++ b/tests/disas/winch/x64/i32_add/max.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,4 +24,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_add/max_one.wat
+++ b/tests/disas/winch/x64/i32_add/max_one.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_add/mixed.wat
+++ b/tests/disas/winch/x64/i32_add/mixed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_add/signed.wat
+++ b/tests/disas/winch/x64/i32_add/signed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/x64/i32_add/unsigned_with_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_and/const.wat
+++ b/tests/disas/winch/x64/i32_and/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_clz/no_lzcnt_const.wat
+++ b/tests/disas/winch/x64/i32_clz/no_lzcnt_const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x55
+;;       ja      0x54
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -29,4 +29,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   55: ud2
+;;   54: ud2

--- a/tests/disas/winch/x64/i32_clz/no_lzcnt_local.wat
+++ b/tests/disas/winch/x64/i32_clz/no_lzcnt_local.wat
@@ -19,7 +19,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x66
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -37,4 +37,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   66: ud2

--- a/tests/disas/winch/x64/i32_clz/no_lzcnt_param.wat
+++ b/tests/disas/winch/x64/i32_clz/no_lzcnt_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x59
+;;       ja      0x58
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -30,4 +30,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   59: ud2
+;;   58: ud2

--- a/tests/disas/winch/x64/i32_or/const.wat
+++ b/tests/disas/winch/x64/i32_or/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_popcnt/fallback.wat
+++ b/tests/disas/winch/x64/i32_popcnt/fallback.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x73
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -39,4 +39,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   73: ud2
+;;   71: ud2

--- a/tests/disas/winch/x64/i32_popcnt/no_sse42.wat
+++ b/tests/disas/winch/x64/i32_popcnt/no_sse42.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x73
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -40,4 +40,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   73: ud2
+;;   71: ud2

--- a/tests/disas/winch/x64/i32_sub/const.wat
+++ b/tests/disas/winch/x64/i32_sub/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_sub/max.wat
+++ b/tests/disas/winch/x64/i32_sub/max.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,4 +24,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_sub/max_one.wat
+++ b/tests/disas/winch/x64/i32_sub/max_one.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_sub/mixed.wat
+++ b/tests/disas/winch/x64/i32_sub/mixed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_sub/signed.wat
+++ b/tests/disas/winch/x64/i32_sub/signed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/x64/i32_sub/unsigned_with_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x85
+;;       ja      0x84
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,23 +24,24 @@
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
 ;;       jae     0x61
-;;       jp      0x87
+;;       jp      0x86
 ;;   52: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x7c
+;;       jge     0x7b
 ;;   5f: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x89
+;;       jl      0x88
 ;;   76: addl    $0x80000000, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   85: ud2
-;;   87: ud2
-;;   89: ud2
-;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rax)
+;;   84: ud2
+;;   86: ud2
+;;   88: ud2
+;;   8a: addb    %al, (%rax)
+;;   8c: addb    %al, (%rax)
+;;   8e: addb    %al, (%rax)
+;;   90: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8d
+;;       ja      0x8c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -27,20 +27,20 @@
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
 ;;       jae     0x69
-;;       jp      0x8f
+;;       jp      0x8e
 ;;   5a: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x84
+;;       jge     0x83
 ;;   67: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x91
+;;       jl      0x90
 ;;   7e: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8d: ud2
-;;   8f: ud2
-;;   91: ud2
+;;   8c: ud2
+;;   8e: ud2
+;;   90: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8a
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
 ;;       jae     0x66
-;;       jp      0x8c
+;;       jp      0x8b
 ;;   57: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x81
+;;       jge     0x80
 ;;   64: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x8e
+;;       jl      0x8d
 ;;   7b: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8a: ud2
-;;   8c: ud2
-;;   8e: ud2
+;;   89: ud2
+;;   8b: ud2
+;;   8d: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8a
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,23 +24,24 @@
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
 ;;       jae     0x66
-;;       jp      0x8c
+;;       jp      0x8b
 ;;   57: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x81
+;;       jge     0x80
 ;;   64: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x8e
+;;       jl      0x8d
 ;;   7b: addl    $0x80000000, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8a: ud2
-;;   8c: ud2
-;;   8e: ud2
-;;   90: addb    %al, (%rax)
-;;   92: addb    %al, (%rax)
-;;   94: addb    %al, (%rax)
+;;   89: ud2
+;;   8b: ud2
+;;   8d: ud2
+;;   8f: addb    %al, (%rax)
+;;   91: addb    %al, (%rax)
+;;   93: addb    %al, (%rax)
+;;   95: addb    %dh, %al

--- a/tests/disas/winch/x64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x92
+;;       ja      0x91
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -27,20 +27,20 @@
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
 ;;       jae     0x6e
-;;       jp      0x94
+;;       jp      0x93
 ;;   5f: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x89
+;;       jge     0x88
 ;;   6c: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x96
+;;       jl      0x95
 ;;   83: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   92: ud2
-;;   94: ud2
-;;   96: ud2
+;;   91: ud2
+;;   93: ud2
+;;   95: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8f
+;;       ja      0x8e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
 ;;       jae     0x6b
-;;       jp      0x91
+;;       jp      0x90
 ;;   5c: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x86
+;;       jge     0x85
 ;;   69: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x93
+;;       jl      0x92
 ;;   80: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8f: ud2
-;;   91: ud2
-;;   93: ud2
+;;   8e: ud2
+;;   90: ud2
+;;   92: ud2

--- a/tests/disas/winch/x64/i32_xor/const.wat
+++ b/tests/disas/winch/x64/i32_xor/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x43
+;;       ja      0x42
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   43: ud2
+;;   42: ud2

--- a/tests/disas/winch/x64/i32x4/shift/shl.wat
+++ b/tests/disas/winch/x64/i32x4/shift/shl.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32x4/shift/shr_s.wat
+++ b/tests/disas/winch/x64/i32x4/shift/shr_s.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32x4/shift/shr_u.wat
+++ b/tests/disas/winch/x64/i32x4/shift/shr_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64_add/const.wat
+++ b/tests/disas/winch/x64/i64_add/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_add/max_one.wat
+++ b/tests/disas/winch/x64/i64_add/max_one.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x49
+;;       ja      0x48
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   49: ud2
+;;   48: ud2

--- a/tests/disas/winch/x64/i64_add/mixed.wat
+++ b/tests/disas/winch/x64/i64_add/mixed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x46
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   46: ud2
+;;   45: ud2

--- a/tests/disas/winch/x64/i64_add/signed.wat
+++ b/tests/disas/winch/x64/i64_add/signed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x46
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   46: ud2
+;;   45: ud2

--- a/tests/disas/winch/x64/i64_add/unsigned_with_zero.wat
+++ b/tests/disas/winch/x64/i64_add/unsigned_with_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_and/32_const.wat
+++ b/tests/disas/winch/x64/i64_and/32_const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_clz/no_lzcnt_const.wat
+++ b/tests/disas/winch/x64/i64_clz/no_lzcnt_const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x58
+;;       ja      0x57
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -29,4 +29,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   58: ud2
+;;   57: ud2

--- a/tests/disas/winch/x64/i64_clz/no_lzcnt_local.wat
+++ b/tests/disas/winch/x64/i64_clz/no_lzcnt_local.wat
@@ -19,7 +19,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x6b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -37,4 +37,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6c: ud2
+;;   6b: ud2

--- a/tests/disas/winch/x64/i64_clz/no_lzcnt_param.wat
+++ b/tests/disas/winch/x64/i64_clz/no_lzcnt_param.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -30,4 +30,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/i64_or/32_const.wat
+++ b/tests/disas/winch/x64/i64_or/32_const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_sub/const.wat
+++ b/tests/disas/winch/x64/i64_sub/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_sub/max.wat
+++ b/tests/disas/winch/x64/i64_sub/max.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x49
+;;       ja      0x48
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,4 +24,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   49: ud2
+;;   48: ud2

--- a/tests/disas/winch/x64/i64_sub/max_one.wat
+++ b/tests/disas/winch/x64/i64_sub/max_one.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x49
+;;       ja      0x48
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   49: ud2
+;;   48: ud2

--- a/tests/disas/winch/x64/i64_sub/mixed.wat
+++ b/tests/disas/winch/x64/i64_sub/mixed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x46
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   46: ud2
+;;   45: ud2

--- a/tests/disas/winch/x64/i64_sub/signed.wat
+++ b/tests/disas/winch/x64/i64_sub/signed.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x46
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   46: ud2
+;;   45: ud2

--- a/tests/disas/winch/x64/i64_sub/unsigned_with_zero.wat
+++ b/tests/disas/winch/x64/i64_sub/unsigned_with_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64_xor/32_const.wat
+++ b/tests/disas/winch/x64/i64_xor/32_const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x44
+;;       ja      0x43
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,4 +25,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   44: ud2
+;;   43: ud2

--- a/tests/disas/winch/x64/i64x2/shift/shl.wat
+++ b/tests/disas/winch/x64/i64x2/shift/shl.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64x2/shift/shr_s.wat
+++ b/tests/disas/winch/x64/i64x2/shift/shr_s.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x69
+;;       ja      0x68
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,7 +23,7 @@
 ;;       movdqu  0x34(%rip), %xmm0
 ;;       andl    $0x3f, %eax
 ;;       vmovd   %eax, %xmm15
-;;       vmovdqu 0x32(%rip), %xmm1
+;;       vmovdqu 0x33(%rip), %xmm1
 ;;       vpsrlq  %xmm15, %xmm1, %xmm1
 ;;       vpsrlq  %xmm15, %xmm0, %xmm0
 ;;       vpxor   %xmm1, %xmm0, %xmm0
@@ -31,21 +31,20 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
-;;   6b: addb    %al, (%rax)
-;;   6d: addb    %al, (%rax)
-;;   6f: addb    %al, (%rcx)
-;;   71: addb    %al, (%rax)
-;;   73: addb    %al, (%rax)
-;;   75: addb    %al, (%rax)
-;;   77: addb    %al, (%rdx)
-;;   79: addb    %al, (%rax)
-;;   7b: addb    %al, (%rax)
-;;   7d: addb    %al, (%rax)
-;;   7f: addb    %al, (%rax)
-;;   81: addb    %al, (%rax)
-;;   83: addb    %al, (%rax)
-;;   85: addb    %al, (%rax)
-;;   87: addb    $0, (%rax)
-;;   8a: addb    %al, (%rax)
+;;   68: ud2
+;;   6a: addb    %al, (%rax)
+;;   6c: addb    %al, (%rax)
+;;   6e: addb    %al, (%rax)
+;;   70: addl    %eax, (%rax)
+;;   72: addb    %al, (%rax)
+;;   74: addb    %al, (%rax)
+;;   76: addb    %al, (%rax)
+;;   78: addb    (%rax), %al
+;;   7a: addb    %al, (%rax)
+;;   7c: addb    %al, (%rax)
+;;   7e: addb    %al, (%rax)
+;;   80: addb    %al, (%rax)
+;;   82: addb    %al, (%rax)
+;;   84: addb    %al, (%rax)
+;;   86: addb    %al, (%rax)
 ;;   8c: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64x2/shift/shr_u.wat
+++ b/tests/disas/winch/x64/i64x2/shift/shr_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x54
+;;       ja      0x53
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -27,17 +27,17 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   54: ud2
-;;   56: addb    %al, (%rax)
-;;   58: addb    %al, (%rax)
-;;   5a: addb    %al, (%rax)
-;;   5c: addb    %al, (%rax)
-;;   5e: addb    %al, (%rax)
-;;   60: addl    %eax, (%rax)
-;;   62: addb    %al, (%rax)
-;;   64: addb    %al, (%rax)
-;;   66: addb    %al, (%rax)
-;;   68: addb    (%rax), %al
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
+;;   53: ud2
+;;   55: addb    %al, (%rax)
+;;   57: addb    %al, (%rax)
+;;   59: addb    %al, (%rax)
+;;   5b: addb    %al, (%rax)
+;;   5d: addb    %al, (%rax)
+;;   5f: addb    %al, (%rcx)
+;;   61: addb    %al, (%rax)
+;;   63: addb    %al, (%rax)
+;;   65: addb    %al, (%rax)
+;;   67: addb    %al, (%rdx)
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i8x16/shift/shl.wat
+++ b/tests/disas/winch/x64/i8x16/shift/shl.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x68
+;;       ja      0x67
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,22 +24,23 @@
 ;;       andl    $7, %eax
 ;;       vmovd   %eax, %xmm15
 ;;       vpsllw  %xmm15, %xmm0, %xmm0
-;;       leaq    0x2e(%rip), %r11
+;;       leaq    0x2f(%rip), %r11
 ;;       shll    $4, %eax
 ;;       vmovdqu (%r11, %rax), %xmm15
 ;;       vpand   %xmm0, %xmm15, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
-;;   70: addl    %eax, (%rax)
-;;   72: addb    %al, (%rax)
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
-;;   78: addb    (%rax), %al
-;;   7a: addb    %al, (%rax)
-;;   7c: addb    %al, (%rax)
-;;   7e: addb    %al, (%rax)
+;;   67: ud2
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)
+;;   6f: addb    %al, (%rcx)
+;;   71: addb    %al, (%rax)
+;;   73: addb    %al, (%rax)
+;;   75: addb    %al, (%rax)
+;;   77: addb    %al, (%rdx)
+;;   79: addb    %al, (%rax)
+;;   7b: addb    %al, (%rax)
+;;   7d: addb    %al, (%rax)
+;;   7f: addb    %bh, %bh

--- a/tests/disas/winch/x64/i8x16/shift/shr_s.wat
+++ b/tests/disas/winch/x64/i8x16/shift/shr_s.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6b
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -32,7 +32,8 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   69: ud2
+;;   6b: addb    %al, (%rax)
 ;;   6d: addb    %al, (%rax)
 ;;   6f: addb    %al, (%rcx)
 ;;   71: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i8x16/shift/shr_u.wat
+++ b/tests/disas/winch/x64/i8x16/shift/shr_u.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x68
+;;       ja      0x67
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,22 +24,23 @@
 ;;       andl    $7, %eax
 ;;       vmovd   %eax, %xmm15
 ;;       vpsrlw  %xmm15, %xmm0, %xmm0
-;;       leaq    0x2e(%rip), %r11
+;;       leaq    0x2f(%rip), %r11
 ;;       shll    $4, %eax
 ;;       vmovdqu (%r11, %rax), %xmm15
 ;;       vpand   %xmm0, %xmm15, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   68: ud2
-;;   6a: addb    %al, (%rax)
-;;   6c: addb    %al, (%rax)
-;;   6e: addb    %al, (%rax)
-;;   70: addl    %eax, (%rax)
-;;   72: addb    %al, (%rax)
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
-;;   78: addb    (%rax), %al
-;;   7a: addb    %al, (%rax)
-;;   7c: addb    %al, (%rax)
-;;   7e: addb    %al, (%rax)
+;;   67: ud2
+;;   69: addb    %al, (%rax)
+;;   6b: addb    %al, (%rax)
+;;   6d: addb    %al, (%rax)
+;;   6f: addb    %al, (%rcx)
+;;   71: addb    %al, (%rax)
+;;   73: addb    %al, (%rax)
+;;   75: addb    %al, (%rax)
+;;   77: addb    %al, (%rdx)
+;;   79: addb    %al, (%rax)
+;;   7b: addb    %al, (%rax)
+;;   7d: addb    %al, (%rax)
+;;   7f: addb    %bh, %bh

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x70, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x136
+;;       ja      0x135
 ;;   1c: movq    %rsi, %r14
 ;;       subq    $0x60, %rsp
 ;;       movq    %rsi, 0x58(%rsp)
@@ -74,11 +74,11 @@
 ;;       addq    %rax, %rcx
 ;;       addq    $0x23024, %rcx
 ;;       movsbq  (%rcx), %rax
-;;       movss   0x5b(%rip), %xmm0
+;;       movss   0x5c(%rip), %xmm0
 ;;       subq    $0xc, %rsp
-;;       movsd   0x53(%rip), %xmm15
+;;       movsd   0x54(%rip), %xmm15
 ;;       movsd   %xmm15, (%rsp)
-;;       movss   0x3c(%rip), %xmm15
+;;       movss   0x3d(%rip), %xmm15
 ;;       movss   %xmm15, 8(%rsp)
 ;;       movq    0x14(%rsp), %rax
 ;;       movsd   (%rsp), %xmm15
@@ -90,12 +90,12 @@
 ;;       addq    $0x60, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  136: ud2
-;;  138: addb    %al, (%rax)
-;;  13a: addb    %al, (%rax)
-;;  13c: addb    %al, (%rax)
-;;  13e: addb    %al, (%rax)
-;;  140: addb    %al, (%rax)
-;;  142: addb    %al, (%rax)
-;;  144: addb    %al, (%rax)
-;;  146: addb    %al, (%rax)
+;;  135: ud2
+;;  137: addb    %al, (%rax)
+;;  139: addb    %al, (%rax)
+;;  13b: addb    %al, (%rax)
+;;  13d: addb    %al, (%rax)
+;;  13f: addb    %al, (%rax)
+;;  141: addb    %al, (%rax)
+;;  143: addb    %al, (%rax)
+;;  145: addb    %al, (%rax)

--- a/tests/disas/winch/x64/loop/effects.wat
+++ b/tests/disas/winch/x64/loop/effects.wat
@@ -23,7 +23,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x85
+;;       ja      0x84
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -47,4 +47,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   85: ud2
+;;   84: ud2

--- a/tests/disas/winch/x64/loop/for.wat
+++ b/tests/disas/winch/x64/loop/for.wat
@@ -23,7 +23,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xab
+;;       ja      0xaa
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -42,7 +42,7 @@
 ;;       movl    $0, %ecx
 ;;       seta    %cl
 ;;       testl   %ecx, %ecx
-;;       jne     0x9d
+;;       jne     0x9c
 ;;   74: movq    8(%rsp), %rax
 ;;       movq    0x10(%rsp), %rcx
 ;;       imulq   %rax, %rcx
@@ -51,8 +51,8 @@
 ;;       addq    $1, %rax
 ;;       movq    %rax, 8(%rsp)
 ;;       jmp     0x56
-;;   9d: movq    0x10(%rsp), %rax
+;;   9c: movq    0x10(%rsp), %rax
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   ab: ud2
+;;   aa: ud2

--- a/tests/disas/winch/x64/loop/while.wat
+++ b/tests/disas/winch/x64/loop/while.wat
@@ -22,7 +22,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x94
+;;       ja      0x93
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -36,7 +36,7 @@
 ;;       movl    $0, %eax
 ;;       sete    %al
 ;;       testl   %eax, %eax
-;;       jne     0x87
+;;       jne     0x86
 ;;   60: movq    (%rsp), %rax
 ;;       movq    8(%rsp), %rcx
 ;;       imulq   %rax, %rcx
@@ -45,8 +45,8 @@
 ;;       subq    $1, %rax
 ;;       movq    %rax, 8(%rsp)
 ;;       jmp     0x46
-;;   87: movq    (%rsp), %rax
+;;   86: movq    (%rsp), %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   94: ud2
+;;   93: ud2

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -78,7 +78,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x1fa
+;;       ja      0x1f9
 ;;   dc: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -96,7 +96,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1fc
+;;       jae     0x1fb
 ;;  138: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
@@ -113,11 +113,11 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x498
+;;       callq   0x497
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x19f
+;;       jmp     0x19e
 ;;  198: andq    $0xfffffffffffffffe, %rax
 ;;       movq    %rax, 0xc(%rsp)
 ;;       movl    0x1c(%rsp), %r11d
@@ -133,11 +133,11 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x4d9
+;;       callq   0x4d8
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  1fa: ud2
-;;  1fc: ud2
+;;  1f9: ud2
+;;  1fb: ud2

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x10e
+;;       ja      0x10d
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -48,7 +48,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x110
+;;       jae     0x10f
 ;;   9e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
@@ -65,14 +65,14 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2db
+;;       callq   0x2da
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x105
+;;       jmp     0x104
 ;;   fe: andq    $0xfffffffffffffffe, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  10e: ud2
-;;  110: ud2
+;;  10d: ud2
+;;  10f: ud2

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x8ad
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x90c
+;;       callq   0x905
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x8ad
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x90c
+;;       callq   0x905
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x94b
+;;       callq   0x943
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x94b
+;;       callq   0x943
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x94b
+;;       callq   0x943
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x94b
+;;       callq   0x943
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x94b
+;;       callq   0x943
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -212,7 +212,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x3c6
+;;       ja      0x3c5
 ;;  2dc: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -226,7 +226,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0xb0(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x3c8
+;;       jae     0x3c7
 ;;  321: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xa8(%rdx), %rdx
@@ -243,20 +243,20 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x9aa
+;;       callq   0x9a1
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x38b
+;;       jmp     0x38a
 ;;  384: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x3ca
-;;  394: movq    0x28(%r14), %r11
+;;       je      0x3c9
+;;  393: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x3cc
-;;  3a6: pushq   %rax
+;;       jne     0x3cb
+;;  3a5: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %rbx
 ;;       movq    8(%rcx), %rdx
@@ -267,7 +267,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  3c6: ud2
-;;  3c8: ud2
-;;  3ca: ud2
-;;  3cc: ud2
+;;  3c5: ud2
+;;  3c7: ud2
+;;  3c9: ud2
+;;  3cb: ud2

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -39,7 +39,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xbd
+;;       ja      0xbc
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -51,7 +51,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xbf
+;;       jae     0xbe
 ;;   90: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
@@ -64,8 +64,8 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   bd: ud2
-;;   bf: ud2
+;;   bc: ud2
+;;   be: ud2
 ;;
 ;; wasm[0]::function[2]:
 ;;       pushq   %rbp
@@ -74,8 +74,8 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x1f0
-;;   ec: movq    %rdi, %r14
+;;       ja      0x1de
+;;   dc: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
@@ -92,8 +92,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1f2
-;;  142: movq    %rcx, %r11
+;;       jae     0x1e0
+;;  132: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -102,26 +102,26 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x1a2
-;;  168: subq    $4, %rsp
+;;       jne     0x192
+;;  158: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x4ae
+;;       callq   0x49c
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0x1a9
-;;  1a2: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x198
+;;  192: andq    $0xfffffffffffffffe, %rax
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1f4
-;;  1c3: movq    %rcx, %r11
+;;       jae     0x1e2
+;;  1b2: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -133,6 +133,6 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  1f0: ud2
-;;  1f2: ud2
-;;  1f4: ud2
+;;  1de: ud2
+;;  1e0: ud2
+;;  1e2: ud2


### PR DESCRIPTION
This PR has two commits which culminate in migrating `lea` to the new assembler. The main trickiness about `lea` is that we lower all `iadd` nodes to `lea` but rely on an optimization to turn `lea` back into `add` where possible. The first commit here adds infrastructure to use the results of register allocation to refine instruction selection and then the `lea` commit builds on top of that and uses it. There are a few other examples of using the results of register allocation such as `AND RAX, imm32` which ISLE never otherwise generates but can be selected after register allocation for a slightly more compact encoding.