### PR TITLE
Propagate the `component-model-gc` feature from the fuzz config to `wasmtime::Config`

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -294,6 +294,7 @@ impl Config {
             Some(self.module_config.component_model_async_stackful);
         cfg.wasm.component_model_error_context =
             Some(self.module_config.component_model_error_context);
+        cfg.wasm.component_model_gc = Some(self.module_config.component_model_gc);
         cfg.wasm.custom_page_sizes = Some(self.module_config.config.custom_page_sizes_enabled);
         cfg.wasm.epoch_interruption = Some(self.wasmtime.epoch_interruption);
         cfg.wasm.extended_const = Some(self.module_config.config.extended_const_enabled);


### PR DESCRIPTION
Fixes https://oss-fuzz.com/testcase-detail/6524398096154624

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
